### PR TITLE
Small QoL & balance tweaks for some ghostroles

### DIFF
--- a/html/changelogs/hazelmouse-suggestions.yml
+++ b/html/changelogs/hazelmouse-suggestions.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Implemented several small quality-of-life improvements to the Lone Spacer, Orion Express, and Tramp Freighter ghostroles."

--- a/maps/away/ships/lone_spacer/lone_spacer.dmm
+++ b/maps/away/ships/lone_spacer/lone_spacer.dmm
@@ -957,13 +957,7 @@
 	pixel_y = 11
 	},
 /obj/item/spacecash/c1000{
-	pixel_y = 9
-	},
-/obj/item/spacecash/c1000{
 	pixel_y = 7
-	},
-/obj/item/spacecash/c1000{
-	pixel_y = 5
 	},
 /obj/item/spacecash/c1000{
 	pixel_y = 3

--- a/maps/away/ships/lone_spacer/lone_spacer.dmm
+++ b/maps/away/ships/lone_spacer/lone_spacer.dmm
@@ -127,6 +127,8 @@
 /obj/item/clothing/suit/space,
 /obj/item/clothing/head/helmet/space,
 /obj/item/clothing/shoes/magboots,
+/obj/item/tank/oxygen,
+/obj/item/tank/oxygen,
 /turf/simulated/floor/tiled/ridged,
 /area/shuttle/lone_spacer/port_storage)
 "aC" = (
@@ -918,12 +920,15 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/lone_spacer/fore_hall)
 "kx" = (
-/obj/structure/dispenser/oxygen,
 /obj/machinery/light/small{
 	dir = 8;
 	must_start_working = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cargo_receptacle{
+	desc = "An Orion Express automated cargo acceptance device. This one appears to be configured to receive cargo packages intended for the ship it's on.";
+	name = "ship cargo delivery point"
+	},
 /turf/simulated/floor/tiled/ridged,
 /area/shuttle/lone_spacer/port_storage)
 "kG" = (
@@ -2982,10 +2987,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/lone_spacer/storage)
-"UO" = (
-/obj/item/clothing/accessory/scarf/lone_spacer_green,
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/lone_spacer/fore_hall)
 "UQ" = (
 /obj/effect/map_effect/marker/airlock/shuttle/lone_spacer,
 /obj/machinery/airlock_sensor/airlock_exterior{
@@ -38139,7 +38140,7 @@ Wu
 Pg
 Wu
 IB
-UO
+Xn
 ks
 XE
 lB

--- a/maps/away/ships/lone_spacer/lone_spacer.dmm
+++ b/maps/away/ships/lone_spacer/lone_spacer.dmm
@@ -122,6 +122,7 @@
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/device/suit_cooling_unit,
 /turf/simulated/floor/tiled/ridged,
 /area/shuttle/lone_spacer/port_storage)
 "aC" = (
@@ -759,6 +760,16 @@
 /obj/item/clothing/accessory/wcoat_rec{
 	color = "#494949"
 	},
+/obj/item/clothing/under/syndicate/tacticool,
+/obj/item/clothing/accessory/dressshirt{
+	color = "#bbbbbb"
+	},
+/obj/item/clothing/under/pants/jeansblack,
+/obj/item/clothing/head/helmet/pilot,
+/obj/item/clothing/head/sidecap{
+	color = "#2E2E2E";
+	desc = "A simple cap, often worn by pilots. This one is faded with age."
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/lone_spacer/bridge)
 "hM" = (
@@ -922,11 +933,28 @@
 /area/shuttle/lone_spacer/port_nacelle)
 "ly" = (
 /obj/structure/table/wood,
-/obj/random/plushie{
-	pixel_y = 2
+/obj/effect/decal/cleanable/dirt,
+/obj/item/spacecash/c1000{
+	pixel_y = 11
+	},
+/obj/item/spacecash/c1000{
+	pixel_y = 9
+	},
+/obj/item/spacecash/c1000{
+	pixel_y = 7
+	},
+/obj/item/spacecash/c1000{
+	pixel_y = 5
+	},
+/obj/item/spacecash/c1000{
+	pixel_y = 3
 	},
 /obj/structure/sign/poster{
 	pixel_x = -32
+	},
+/obj/item/storage/wallet{
+	pixel_y = -1;
+	pixel_x = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/lone_spacer/bridge)
@@ -942,6 +970,11 @@
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/tank/hydrogen/shuttle,
+/obj/item/tank/hydrogen/shuttle{
+	pixel_y = 5;
+	pixel_x = -4
+	},
 /turf/simulated/floor/tiled/gridded,
 /area/shuttle/lone_spacer/starboard_nacelle)
 "mj" = (
@@ -1078,6 +1111,7 @@
 /obj/item/material/hatchet/lumber,
 /obj/item/clothing/accessory/holster/thigh/brown,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/armor/carrier/generic,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/lone_spacer/bridge_foyer)
 "pd" = (
@@ -1536,6 +1570,10 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/cell_charger,
+/obj/item/storage/firstaid/empty{
+	pixel_y = 14;
+	pixel_x = 15
+	},
 /turf/simulated/floor/tiled/gridded,
 /area/shuttle/lone_spacer/fore_hall)
 "wT" = (
@@ -2458,6 +2496,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/lone_spacer/storage)
+"Oa" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light/colored/decayed/lone_spacer_dimmed{
+	dir = 8
+	},
+/obj/vehicle/bike{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/lone_spacer/storage)
 "Ok" = (
 /obj/structure/closet/crate,
 /obj/item/mecha_equipment/mounted_system/plasmacutter,
@@ -2467,9 +2515,6 @@
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/console_screen,
 /obj/item/circuitboard/autolathe,
-/obj/item/tank/hydrogen/shuttle,
-/obj/item/tank/hydrogen/shuttle,
-/obj/item/tank/hydrogen/shuttle,
 /obj/item/cane/crutch,
 /obj/item/material/stool/chair/wheelchair,
 /obj/item/circuitboard/biogenerator,
@@ -2487,6 +2532,9 @@
 /obj/item/reagent_containers/glass/bottle/inaprovaline,
 /obj/item/reagent_containers/hypospray,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/circuitboard/oven,
+/obj/item/circuitboard/stove,
+/obj/item/reagent_containers/glass/bottle/antitoxin,
 /turf/simulated/floor/tiled/gridded,
 /area/shuttle/lone_spacer/fore_hall)
 "Os" = (
@@ -2532,6 +2580,13 @@
 "Pk" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/inhaler/space_drugs,
+/obj/item/reagent_containers/inhaler/space_drugs,
+/obj/item/reagent_containers/syringe/drugs,
+/obj/item/reagent_containers/hypospray/autoinjector/stimpack,
+/obj/item/reagent_containers/hypospray/autoinjector/night_juice,
+/obj/item/storage/pill_bottle/smart,
+/obj/item/reagent_containers/hypospray/autoinjector/impedrezene,
 /turf/simulated/floor/plating,
 /area/shuttle/lone_spacer/fore_hall)
 "PC" = (
@@ -3084,15 +3139,20 @@
 /area/shuttle/lone_spacer/washroom)
 "XJ" = (
 /obj/structure/table/wood,
+/obj/item/gamehelm/pink{
+	icon_state = "closed_pink";
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/dirt,
 /obj/item/device/flashlight/lamp/green{
 	pixel_y = 15;
 	pixel_x = 8
 	},
-/obj/item/gamehelm/pink{
-	icon_state = "closed_pink";
-	pixel_x = -1
+/obj/random/plushie{
+	pixel_y = 7;
+	pixel_x = -9
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/lone_spacer/bridge)
 "XU" = (
@@ -35755,7 +35815,7 @@ YV
 YV
 yc
 Bl
-yc
+Oa
 YV
 YV
 NY

--- a/maps/away/ships/lone_spacer/lone_spacer.dmm
+++ b/maps/away/ships/lone_spacer/lone_spacer.dmm
@@ -123,6 +123,10 @@
 /obj/item/stack/cable_coil,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/clothing/suit/space,
+/obj/item/clothing/head/helmet/space,
+/obj/item/clothing/shoes/magboots,
 /turf/simulated/floor/tiled/ridged,
 /area/shuttle/lone_spacer/port_storage)
 "aC" = (
@@ -676,6 +680,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/lone_spacer/storage)
+"hE" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light/colored/decayed/lone_spacer_dimmed{
+	dir = 8
+	},
+/obj/vehicle/bike{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/lone_spacer/storage)
 "hH" = (
 /obj/item/device/paicard,
 /obj/structure/closet/cabinet,
@@ -1110,8 +1124,8 @@
 /obj/item/melee/baton/loaded,
 /obj/item/material/hatchet/lumber,
 /obj/item/clothing/accessory/holster/thigh/brown,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/suit/armor/carrier/generic,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/lone_spacer/bridge_foyer)
 "pd" = (
@@ -2181,6 +2195,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/lone_spacer/bridge)
 "Ie" = (
@@ -2495,16 +2512,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/lone_spacer/storage)
-"Oa" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/light/colored/decayed/lone_spacer_dimmed{
-	dir = 8
-	},
-/obj/vehicle/bike{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/lone_spacer/storage)
 "Ok" = (
 /obj/structure/closet/crate,
@@ -35815,7 +35822,7 @@ YV
 YV
 yc
 Bl
-Oa
+hE
 YV
 YV
 NY

--- a/maps/away/ships/lone_spacer/lone_spacer_submaps.dmm
+++ b/maps/away/ships/lone_spacer/lone_spacer_submaps.dmm
@@ -179,6 +179,7 @@
 /obj/item/robot_parts/r_arm,
 /obj/item/robot_parts/r_arm,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/device/paint_sprayer,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/lone_spacer/storage)
 "t" = (

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -2342,7 +2342,7 @@
 /obj/structure/bed/handrail{
 	dir = 1
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "hxd" = (
 /obj/structure/cable/green{
@@ -2474,7 +2474,7 @@
 /obj/structure/bed/handrail{
 	dir = 4
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "ian" = (
 /obj/structure/table/stone/marble,
@@ -3047,7 +3047,7 @@
 	dir = 8;
 	pixel_x = 5
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "kiR" = (
 /obj/structure/cable/green{
@@ -3758,7 +3758,7 @@
 /area/ship/orion/cargo)
 "mSt" = (
 /obj/structure/lattice/catwalk,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "mSy" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -3856,7 +3856,7 @@
 /obj/structure/lattice/catwalk,
 /obj/item/hullbeacon/red,
 /obj/structure/bed/handrail,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "niD" = (
 /obj/machinery/vending/dinnerware,
@@ -4133,7 +4133,7 @@
 	dir = 8;
 	pixel_x = 5
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "nMR" = (
 /obj/machinery/door/airlock/external{
@@ -4505,7 +4505,7 @@
 	dir = 4;
 	pixel_x = -5
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "oVV" = (
 /obj/machinery/door/firedoor/noid,
@@ -4608,7 +4608,7 @@
 /obj/structure/bed/handrail{
 	dir = 8
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "ptP" = (
 /obj/effect/floor_decal/spline/plain/black{
@@ -4688,7 +4688,7 @@
 /obj/structure/bed/handrail{
 	dir = 1
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "pHQ" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -4987,7 +4987,7 @@
 /obj/structure/bed/handrail{
 	dir = 4
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "qEK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -5652,10 +5652,6 @@
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor,
 /area/ship/orion/bridge)
-"sAZ" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/template_noop,
-/area/space)
 "sBH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 2
@@ -6827,7 +6823,7 @@
 /obj/structure/bed/handrail{
 	dir = 8
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "vOd" = (
 /obj/structure/bed/stool/chair/shuttle,
@@ -34817,7 +34813,7 @@ xRX
 xRX
 xRX
 xRX
-sAZ
+xRX
 xRX
 xRX
 xRX

--- a/maps/away/ships/tramp_freighter/tramp_freighter.dmm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter.dmm
@@ -439,7 +439,10 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood,
 /area/tramp_freighter/captain_bed)
 "cl" = (
@@ -609,14 +612,12 @@
 /turf/simulated/floor/plating,
 /area/tramp_freighter/cargo)
 "ds" = (
-/obj/structure/closet/crate/secure,
+/obj/structure/closet/crate/secure{
+	req_access = list(242)
+	},
 /obj/item/stack/material/phoron/full,
 /obj/item/tank/phoron/shuttle,
 /obj/item/tank/phoron/shuttle,
-/obj/random/highvalue/no_weapon,
-/obj/random/highvalue/no_weapon,
-/obj/random/highvalue/no_weapon,
-/obj/random/highvalue/no_weapon,
 /obj/random/highvalue/no_weapon,
 /obj/random/highvalue/no_weapon,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -672,6 +673,10 @@
 	spawn_firedoor = 1;
 	spawn_grille = 1
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "tramp_windows"
+	},
 /turf/simulated/floor,
 /area/tramp_freighter/port_docking)
 "dI" = (
@@ -708,13 +713,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/wood,
 /area/tramp_freighter/captain_bed)
@@ -1185,6 +1190,10 @@
 	spawn_firedoor = 1;
 	spawn_grille = 1
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 8;
+	id = "tramp_windows"
+	},
 /turf/simulated/floor,
 /area/tramp_freighter/disposals)
 "fJ" = (
@@ -1518,6 +1527,10 @@
 	frame_color = "#BDB6AE";
 	spawn_firedoor = 1;
 	spawn_grille = 1
+	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 8;
+	id = "tramp_windows"
 	},
 /turf/simulated/floor,
 /area/tramp_freighter/captain_bed)
@@ -1954,6 +1967,10 @@
 	spawn_firedoor = 1;
 	spawn_grille = 1
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 8;
+	id = "tramp_windows"
+	},
 /turf/simulated/floor,
 /area/tramp_freighter/captain_bed)
 "kf" = (
@@ -2078,6 +2095,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/tramp_freighter/cargo)
+"kY" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/industrial/outline/operations,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/cargo_package/offship/to_horizon{
+	pixel_y = 10;
+	pixel_x = -1
+	},
+/obj/item/cargo_package/offship{
+	pixel_y = -2;
+	pixel_x = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/tramp_freighter/cargo)
 "la" = (
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, starboard docking arm"
@@ -2087,6 +2118,10 @@
 	frame_color = "#BDB6AE";
 	spawn_firedoor = 1;
 	spawn_grille = 1
+	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "tramp_windows"
 	},
 /turf/simulated/floor,
 /area/tramp_freighter/starboard_docking)
@@ -2406,12 +2441,18 @@
 /turf/simulated/floor/plating,
 /area/tramp_freighter/cargo)
 "mS" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/wood,
-/area/tramp_freighter/captain_bed)
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "tramp_windows"
+	},
+/turf/simulated/floor/plating,
+/area/tramp_freighter/bridge)
 "mT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -2535,25 +2576,17 @@
 	spawn_firedoor = 1;
 	spawn_grille = 1
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 8;
+	id = "tramp_windows"
+	},
 /turf/simulated/floor,
 /area/tramp_freighter/hydroponics)
 "nE" = (
-/obj/item/spacecash/c500,
-/obj/item/spacecash/c500,
-/obj/item/spacecash/c500,
-/obj/item/spacecash/c500,
-/obj/item/spacecash/c500,
-/obj/item/spacecash/c500,
-/obj/item/spacecash/c500,
-/obj/item/spacecash/c1000,
-/obj/item/spacecash/c1000,
-/obj/item/spacecash/c1000,
-/obj/item/spacecash/c1000,
 /obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
+	dir = 9
 	},
-/obj/structure/closet/cabinet,
-/obj/item/clothing/suit/armor/material/makeshift/trenchcoat,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/tramp_freighter/captain_bed)
 "nG" = (
@@ -2685,6 +2718,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tramp_freighter/port_docking_processing)
+"ob" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/industrial/outline/operations,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/cargo_package/offship{
+	pixel_y = 10;
+	pixel_x = -2
+	},
+/obj/item/cargo_package/offship{
+	pixel_y = -2;
+	pixel_x = 3
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/tramp_freighter/cargo)
 "od" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/structure/cable/green{
@@ -3104,6 +3151,10 @@
 	spawn_firedoor = 1;
 	spawn_grille = 1
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "tramp_windows"
+	},
 /turf/simulated/floor,
 /area/tramp_freighter/port_docking_processing)
 "qD" = (
@@ -3138,6 +3189,9 @@
 	},
 /obj/item/circuitboard/sleeper{
 	pixel_y = 9
+	},
+/obj/item/circuitboard/bodyscannerconsole{
+	pixel_y = 12
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tramp_freighter/engi)
@@ -3330,19 +3384,20 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/tramp_freighter/lounge)
 "rI" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 4
-	},
 /obj/structure/sign/staff_only{
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cargo_receptacle{
+	desc = "An Orion Express automated cargo acceptance device. This one appears to be configured to receive cargo packages intended for the ship it's on.";
+	name = "ship cargo delivery point"
+	},
+/obj/effect/floor_decal/industrial/outline/operations,
+/turf/simulated/floor/tiled/dark/full,
 /area/tramp_freighter/lounge)
 "rK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
@@ -3643,6 +3698,12 @@
 	},
 /turf/simulated/floor/tiled/ridged,
 /area/tramp_freighter/disposals)
+"tc" = (
+/obj/effect/floor_decal/industrial/outline/operations,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/loot,
+/turf/simulated/floor/tiled/dark/full,
+/area/tramp_freighter/cargo)
 "te" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -3873,6 +3934,10 @@
 	frame_color = "#BDB6AE";
 	spawn_firedoor = 1;
 	spawn_grille = 1
+	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "tramp_windows"
 	},
 /turf/simulated/floor,
 /area/tramp_freighter/port_docking)
@@ -4271,6 +4336,10 @@
 	spawn_firedoor = 1;
 	spawn_grille = 1
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "tramp_windows"
+	},
 /turf/simulated/floor,
 /area/tramp_freighter/port_docking)
 "vS" = (
@@ -4563,6 +4632,10 @@
 	spawn_firedoor = 1;
 	spawn_grille = 1
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 8;
+	id = "tramp_windows"
+	},
 /turf/simulated/floor/plating,
 /area/tramp_freighter/bridge)
 "xb" = (
@@ -4658,6 +4731,10 @@
 	frame_color = "#BDB6AE";
 	spawn_firedoor = 1;
 	spawn_grille = 1
+	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 8;
+	id = "tramp_windows"
 	},
 /turf/simulated/floor,
 /area/tramp_freighter/hydroponics)
@@ -4816,15 +4893,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/tramp_freighter/afthallway)
 "ys" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/effect/floor_decal/industrial/outline/operations,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/tramp_freighter/centralhallway)
+/obj/item/cargo_package/offship/to_horizon{
+	pixel_y = 10;
+	pixel_x = -1
+	},
+/obj/item/cargo_package/offship{
+	pixel_y = -2;
+	pixel_x = 3
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/tramp_freighter/cargo)
 "yt" = (
 /obj/effect/floor_decal/industrial/hatch/grey,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
@@ -5245,6 +5325,10 @@
 	spawn_firedoor = 1;
 	spawn_grille = 1
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 8;
+	id = "tramp_windows"
+	},
 /turf/simulated/floor,
 /area/tramp_freighter/disposals)
 "At" = (
@@ -5329,13 +5413,23 @@
 	dir = 9;
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/table/wood,
+/obj/random/pottedplant_small{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/random/lavalamp{
+	pixel_y = 4;
+	pixel_x = 7
+	},
+/obj/random/coin{
+	pixel_x = -8;
+	pixel_y = -1
 	},
 /turf/simulated/floor/wood,
 /area/tramp_freighter/captain_bed)
@@ -5734,14 +5828,26 @@
 /turf/simulated/floor/tiled/dark,
 /area/tramp_freighter/disposals)
 "Dx" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 5
-	},
+/obj/item/spacecash/c500,
+/obj/item/spacecash/c500,
+/obj/item/spacecash/c500,
+/obj/item/spacecash/c500,
+/obj/item/spacecash/c500,
+/obj/item/spacecash/c500,
+/obj/item/spacecash/c500,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/suit/armor/material/makeshift/trenchcoat,
+/obj/item/device/flash,
+/obj/item/storage/secure/briefcase,
 /obj/machinery/light_switch{
 	pixel_y = 30;
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/brown,
 /area/tramp_freighter/captain_bed)
 "Dy" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -5829,6 +5935,10 @@
 	frame_color = "#BDB6AE";
 	spawn_firedoor = 1;
 	spawn_grille = 1
+	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "tramp_windows"
 	},
 /turf/simulated/floor,
 /area/tramp_freighter/afthallway)
@@ -5950,6 +6060,13 @@
 	pixel_x = -6;
 	pixel_y = -1;
 	req_one_access = list(242)
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 6;
+	pixel_y = 10;
+	pixel_x = 6;
+	name = "Window Shutters";
+	id = "tramp_windows"
 	},
 /turf/simulated/floor/tiled/gunmetal/full,
 /area/tramp_freighter/bridge)
@@ -6313,14 +6430,6 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
 	},
-/obj/random/pottedplant_small{
-	pixel_x = -4;
-	pixel_y = 10
-	},
-/obj/random/lavalamp{
-	pixel_y = 5;
-	pixel_x = 6
-	},
 /obj/machinery/power/apc/south{
 	req_access = list(242)
 	},
@@ -6329,7 +6438,14 @@
 	pixel_x = -6;
 	pixel_y = -4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	pixel_y = 18;
+	pixel_x = -1
+	},
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 17
+	},
 /turf/simulated/floor/wood,
 /area/tramp_freighter/captain_bed)
 "Hf" = (
@@ -6355,7 +6471,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/tramp_freighter/port_docking)
 "Hy" = (
-/obj/structure/closet/crate,
 /obj/item/stack/material/steel/full,
 /obj/item/stack/material/steel/full,
 /obj/item/stack/material/steel/full,
@@ -6368,6 +6483,9 @@
 /obj/item/stack/material/plasteel/full,
 /obj/effect/floor_decal/industrial/outline/operations,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/drop{
+	name = "material resources"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/tramp_freighter/cargo)
 "HA" = (
@@ -6485,18 +6603,11 @@
 /obj/structure/closet/crate/tool,
 /obj/random/rig_module,
 /obj/random/rig_module,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
 /obj/random/bomb_supply,
 /obj/random/bomb_supply,
 /obj/random/bomb_supply,
 /obj/random/bomb_supply,
-/obj/random/technology_scanner,
 /obj/item/device/robotanalyzer,
-/obj/random/vault_rig,
 /obj/item/storage/bag/circuits/basic,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -6504,6 +6615,7 @@
 /obj/item/clothing/under/circuitry,
 /obj/item/clothing/glasses/circuitry,
 /obj/item/device/paicard,
+/obj/item/ipc_tag_scanner,
 /turf/simulated/floor/tiled/dark/full,
 /area/tramp_freighter/cargo)
 "HX" = (
@@ -6694,11 +6806,7 @@
 /turf/space/dynamic,
 /area/space)
 "Jn" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/brown,
 /area/tramp_freighter/captain_bed)
 "Jo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -6823,9 +6931,6 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/tramp_freighter/cargo)
 "JZ" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 9
-	},
 /obj/structure/bed,
 /obj/item/bedsheet/rd{
 	desc = "A surprisingly soft linen bedsheet.";
@@ -6841,7 +6946,7 @@
 /obj/machinery/alarm/north{
 	req_one_access = list(242)
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/brown,
 /area/tramp_freighter/captain_bed)
 "Ka" = (
 /obj/machinery/light,
@@ -7659,6 +7764,10 @@
 	spawn_firedoor = 1;
 	spawn_grille = 1
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "tramp_windows"
+	},
 /turf/simulated/floor/plating,
 /area/tramp_freighter/bridge)
 "Ou" = (
@@ -7714,6 +7823,10 @@
 	frame_color = "#BDB6AE";
 	spawn_firedoor = 1;
 	spawn_grille = 1
+	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "tramp_windows"
 	},
 /turf/simulated/floor,
 /area/tramp_freighter/starboard_docking)
@@ -7994,6 +8107,7 @@
 /obj/random/melee/highvalue,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt,
+/obj/random/survival_weapon,
 /turf/simulated/floor/tiled/dark/full,
 /area/tramp_freighter/cargo)
 "Qh" = (
@@ -8050,9 +8164,7 @@
 /turf/simulated/floor/airless,
 /area/shuttle/freighter_shuttle)
 "Qv" = (
-/obj/machinery/biogenerator{
-	icon_state = "biogen-empty"
-	},
+/obj/machinery/biogenerator,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light{
 	dir = 1
@@ -8473,6 +8585,10 @@
 	spawn_firedoor = 1;
 	spawn_grille = 1
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "tramp_windows"
+	},
 /turf/simulated/floor,
 /area/tramp_freighter/starboard_docking_processing)
 "Sn" = (
@@ -8604,7 +8720,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/tramp_freighter/lounge)
@@ -9213,6 +9328,10 @@
 	spawn_firedoor = 1;
 	spawn_grille = 1
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 8;
+	id = "tramp_windows"
+	},
 /turf/simulated/floor/plating,
 /area/tramp_freighter/bridge)
 "VW" = (
@@ -9490,11 +9609,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/tramp_freighter/port_docking_processing)
 "Xo" = (
-/mob/living/bot/farmbot{
-	req_one_access = list()
-	},
 /obj/effect/floor_decal/industrial/outline/operations,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/animal/adhomai/schlorrgo,
 /turf/simulated/floor/tiled/dark/full,
 /area/tramp_freighter/cargo)
 "Xp" = (
@@ -9630,6 +9747,10 @@
 	frame_color = "#BDB6AE";
 	spawn_firedoor = 1;
 	spawn_grille = 1
+	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 8;
+	id = "tramp_windows"
 	},
 /turf/simulated/floor/plating,
 /area/tramp_freighter/bridge)
@@ -9826,7 +9947,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/tramp_freighter/lounge)
@@ -41224,7 +41344,7 @@ rd
 Ul
 Yb
 wZ
-wZ
+mS
 aK
 hX
 hX
@@ -41481,10 +41601,10 @@ rd
 Yy
 bJ
 hy
+mS
 wZ
 wZ
-wZ
-wZ
+mS
 hX
 hX
 hX
@@ -41742,7 +41862,7 @@ dX
 Cv
 tE
 wZ
-wZ
+mS
 hX
 hX
 hX
@@ -42256,7 +42376,7 @@ KW
 EQ
 jZ
 wZ
-wZ
+mS
 hX
 hX
 hX
@@ -42497,7 +42617,7 @@ rT
 rB
 ui
 aG
-ui
+Mz
 YC
 KZ
 ZP
@@ -42512,7 +42632,7 @@ ek
 rd
 wZ
 wZ
-wZ
+mS
 hX
 hX
 hX
@@ -42759,14 +42879,14 @@ Co
 Ql
 GG
 PK
-ys
+HO
 np
 TE
 Sz
 TW
 mu
 zM
-wZ
+mS
 ZL
 hX
 hX
@@ -42996,7 +43116,7 @@ MW
 Fm
 JO
 sS
-eD
+ob
 xW
 eh
 pA
@@ -43023,7 +43143,7 @@ xP
 cO
 fe
 LX
-wZ
+mS
 hX
 hX
 hX
@@ -43251,9 +43371,9 @@ JY
 ol
 WF
 Jz
-xs
+kY
 rF
-Ml
+ys
 dd
 Hy
 Wj
@@ -43280,7 +43400,7 @@ cM
 sK
 cZ
 Es
-wZ
+mS
 hX
 hX
 hX
@@ -43537,7 +43657,7 @@ Yp
 AC
 XX
 Nx
-wZ
+mS
 hX
 hX
 hX
@@ -43765,9 +43885,9 @@ Ml
 Bp
 Ml
 Jz
-JY
+tc
 QZ
-JY
+tc
 YN
 Xo
 Wj
@@ -44556,7 +44676,7 @@ nz
 xy
 as
 JZ
-mS
+Jn
 nE
 dO
 vV


### PR DESCRIPTION
Implements a few small tweaks to the Lone Spacer, Tramp Freighter, and OE Ship that I've been sitting on for a while.

- Lone Spacer: opens up a few more clothing options, adds a suit cooler for IPCs, adds dylovene, adds an Orion Express package receptacle, adds some credits.
- Tramp Freighter: added OE packages, toned down the loot a little so we're less likely to see an entire freighter crew parading in military hardsuits, added shutters to the windows.
- OE Ship: removed a stray grate, added dynamic space under catwalks.

