### PR TITLE
Disables the FSF ship

### DIFF
--- a/html/changelogs/Snowy1237-FSF_removal.yml
+++ b/html/changelogs/Snowy1237-FSF_removal.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Snowy1237
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Removed the FSF ship from possible spawns, and replaced it with the SSRM patrol ship in Valley Hale."

--- a/maps/away/ships/sol/sol_merc/fsf_patrol_ship.dm
+++ b/maps/away/ships/sol/sol_merc/fsf_patrol_ship.dm
@@ -6,7 +6,7 @@
 	suffix = "fsf_patrol_ship.dmm"
 
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
-	spawn_weight = 0 // The FSF no longer exists, verify with human lore before re-adding!
+	spawn_weight = 0 // The FSF no longer exists as a separate entity outside of the Alliance, verify with human lore before re-adding!
 	ship_cost = 1
 	id = "fsf_patrol_ship"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/fsf_shuttle)

--- a/maps/away/ships/sol/sol_merc/fsf_patrol_ship.dm
+++ b/maps/away/ships/sol/sol_merc/fsf_patrol_ship.dm
@@ -6,7 +6,7 @@
 	suffix = "fsf_patrol_ship.dmm"
 
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
-	spawn_weight = 1
+	spawn_weight = 0 // The FSF no longer exists, verify with human lore before re-adding!
 	ship_cost = 1
 	id = "fsf_patrol_ship"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/fsf_shuttle)

--- a/maps/away/ships/sol/sol_ssmd/ssmd_ship.dm
+++ b/maps/away/ships/sol/sol_ssmd/ssmd_ship.dm
@@ -6,7 +6,7 @@
 	prefix = "ships/sol/sol_ssmd/"
 	suffix = "ssmd_ship.dmm"
 
-	sectors = list(SECTOR_BADLANDS)
+	sectors = list(SECTOR_BADLANDS, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
 	ship_cost = 1
 	id = "ssmd_corvette"


### PR DESCRIPTION
After verifying with human lore, the FSF ship was disabled from spawning and replaced by the SSRM ship in Valley Hale.