### PR TITLE
Headmaster Ship Autocannon

### DIFF
--- a/html/changelogs/Ben10083 - Headmaster-Cannon.yml
+++ b/html/changelogs/Ben10083 - Headmaster-Cannon.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Headmaster ship now has an Autocannon."

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dmm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dmm
@@ -29,7 +29,7 @@
 "ag" = (
 /obj/structure/ship_weapon_dummy/barrel,
 /turf/template_noop,
-/area/space)
+/area/headmaster_ship/gun_deck)
 "ai" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/window/reinforced{
@@ -749,9 +749,7 @@
 	},
 /area/headmaster_ship/commissar_quarters)
 "bU" = (
-/obj/machinery/ammunition_loader/grauwolf{
-	weapon_id = "Headmaster Grauwolf Flak Battery"
-	},
+/obj/machinery/ammunition_loader/autocannon,
 /turf/simulated/floor/reinforced/cooled,
 /area/headmaster_ship/gun_deck)
 "bV" = (
@@ -1022,11 +1020,6 @@
 /area/headmaster_ship/engine)
 "cG" = (
 /obj/structure/ship_weapon_dummy,
-/obj/machinery/ship_weapon/grauwolf{
-	pixel_x = -32;
-	pixel_y = -192;
-	weapon_id = "Headmaster Grauwolf Flak Battery"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -2911,13 +2904,13 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/ship_ammunition/grauwolf_bundle/ap,
-/obj/item/ship_ammunition/grauwolf_bundle/ap,
-/obj/item/ship_ammunition/grauwolf_bundle/ap,
-/obj/item/ship_ammunition/grauwolf_bundle/ap,
 /obj/machinery/door/window{
 	dir = 1
 	},
+/obj/item/ship_ammunition/autocannon,
+/obj/item/ship_ammunition/autocannon,
+/obj/item/ship_ammunition/autocannon,
+/obj/item/ship_ammunition/autocannon,
 /turf/simulated/floor/reinforced/cooled,
 /area/headmaster_ship/gun_deck)
 "iS" = (
@@ -4752,7 +4745,7 @@
 /area/headmaster_ship/engineering)
 "rS" = (
 /obj/effect/landmark/entry_point/starboard{
-	name = "starboard, grauwolf compartment"
+	name = "starboard, goshawk compartment"
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/headmaster_ship/gun_deck)
@@ -4875,6 +4868,13 @@
 	temperature = 278.15
 	},
 /area/headmaster_ship/eva)
+"tc" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/structure/ship_weapon_dummy,
+/turf/simulated/floor/reinforced/airless,
+/area/headmaster_ship/gun_deck)
 "th" = (
 /mob/living/heavy_vehicle/premade/ripley/loader{
 	faction = "PRA"
@@ -5643,12 +5643,13 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/ship_ammunition/grauwolf_bundle,
-/obj/item/ship_ammunition/grauwolf_bundle,
-/obj/item/ship_ammunition/grauwolf_bundle,
 /obj/machinery/door/window{
 	dir = 1
 	},
+/obj/item/ship_ammunition/autocannon/frag,
+/obj/item/ship_ammunition/autocannon/frag,
+/obj/item/ship_ammunition/autocannon/frag,
+/obj/item/ship_ammunition/autocannon/frag,
 /turf/simulated/floor/reinforced/cooled,
 /area/headmaster_ship/gun_deck)
 "Co" = (
@@ -6483,13 +6484,19 @@
 	},
 /area/headmaster_ship/commissar_quarters)
 "KX" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	spawn_firedoor = 1;
+	spawn_grille = 1;
+	color = "#6C7364";
+	frame_color = "#6C7364";
+	req_one_access = list(209)
+	},
 /obj/machinery/door/blast/regular/open{
 	id = "headmaster_gun";
 	dir = 8
 	},
 /obj/effect/landmark/entry_point/fore{
-	name = "fore, grauwolf compartment"
+	name = "fore, goshawk compartment"
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -6622,13 +6629,14 @@
 /obj/structure/sign/nosmoking_1{
 	pixel_y = -32
 	},
-/obj/item/ship_ammunition/grauwolf_bundle,
-/obj/item/ship_ammunition/grauwolf_bundle,
-/obj/item/ship_ammunition/grauwolf_bundle,
 /obj/machinery/door/window{
 	dir = 1
 	},
 /obj/machinery/light/small/emergency,
+/obj/item/ship_ammunition/autocannon/he,
+/obj/item/ship_ammunition/autocannon/he,
+/obj/item/ship_ammunition/autocannon/he,
+/obj/item/ship_ammunition/autocannon/he,
 /turf/simulated/floor/reinforced/cooled,
 /area/headmaster_ship/gun_deck)
 "Nb" = (
@@ -6743,6 +6751,9 @@
 	temperature = 278.15
 	},
 /area/headmaster_ship/hangar)
+"NL" = (
+/turf/template_noop,
+/area/headmaster_ship/gun_deck)
 "NM" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	use_power = 1;
@@ -6953,6 +6964,10 @@
 	temperature = 278.15
 	},
 /area/headmaster_ship/hangar)
+"PM" = (
+/obj/machinery/ship_weapon/autocannon,
+/turf/template_noop,
+/area/space)
 "PO" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -37279,11 +37294,11 @@ hK
 iB
 Mm
 rS
-Mm
+tc
 Dx
 ei
-ei
-ag
+NL
+PM
 iB
 iB
 iB
@@ -37796,8 +37811,8 @@ Mm
 aE
 RT
 ei
-ei
-ag
+NL
+iB
 iB
 iB
 iB

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dmm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dmm
@@ -298,6 +298,11 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
+/obj/machinery/ship_weapon/autocannon{
+	weapon_id = "Headmaster Goshawk Heavy Autocannon";
+	pixel_x = -65;
+	pixel_y = -125
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/headmaster_ship/gun_deck)
 "aF" = (
@@ -749,7 +754,9 @@
 	},
 /area/headmaster_ship/commissar_quarters)
 "bU" = (
-/obj/machinery/ammunition_loader/autocannon,
+/obj/machinery/ammunition_loader/autocannon{
+	weapon_id = "Headmaster Goshawk Heavy Autocannon"
+	},
 /turf/simulated/floor/reinforced/cooled,
 /area/headmaster_ship/gun_deck)
 "bV" = (
@@ -6964,10 +6971,6 @@
 	temperature = 278.15
 	},
 /area/headmaster_ship/hangar)
-"PM" = (
-/obj/machinery/ship_weapon/autocannon,
-/turf/template_noop,
-/area/space)
 "PO" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -37298,7 +37301,7 @@ tc
 Dx
 ei
 NL
-PM
+iB
 iB
 iB
 iB


### PR DESCRIPTION
Headmaster Ship flak battery replaced with autocannon to better reflect lore as a long range fire support ship (IDEALY it would have a cannon, but despite having 2 different awayship cannons in code, they are not generic so can't use them...)