### PR TITLE
Only humans get adrenaline

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2089,7 +2089,7 @@
 		return TRUE
 
 /mob/living/carbon/human/proc/make_adrenaline(var/amount)
-	if(stat == CONSCIOUS)
+	if(stat == CONSCIOUS && species?.produces_adrenaline)
 		reagents.add_reagent(/singleton/reagent/adrenaline, amount)
 
 /mob/living/carbon/human/proc/gigashatter()

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -247,6 +247,8 @@
 	var/rarity_value = 1          // Relative rarity/collector value for this species.
 	var/ethanol_resistance = 1	  // How well the mob resists alcohol, lower values get drunk faster, higher values need to drink more
 	var/taste_sensitivity = TASTE_NORMAL // How sensitive the species is to minute tastes. Higher values means less sensitive. Lower values means more sensitive.
+	/// Whether the species' body can produce adrenaline (for example, when in pain).
+	var/produces_adrenaline = FALSE
 
 	var/stamina	=	100			  	// The maximum stamina this species has. Determines how long it can sprint
 	var/stamina_recovery = 3	  	// Flat amount of stamina species recovers per proc

--- a/code/modules/mob/living/carbon/human/species/station/human/human.dm
+++ b/code/modules/mob/living/carbon/human/species/station/human/human.dm
@@ -36,6 +36,7 @@
 	remains_type = /obj/effect/decal/remains/human
 	dust_remains_type = /obj/effect/decal/remains/human/burned
 
+	produces_adrenaline = TRUE
 	stamina = 130	// Humans can sprint for longer than any other species
 	stamina_recovery = 5
 	sprint_speed_factor = 0.9

--- a/html/changelogs/DreamySkrell-human-adrenaline.yml
+++ b/html/changelogs/DreamySkrell-human-adrenaline.yml
@@ -1,0 +1,7 @@
+
+author: DreamySkrell
+
+delete-after: True
+
+changes:
+  - rscadd: "Only the human species can produce adrenaline."


### PR DESCRIPTION
changes:
  - rscadd: "Only the human species can produce adrenaline."

reasoning:
 - This is not a meme PR, it was discussed on discord, and I do think this is a great idea to make it so other species aren't just humans but better. 
 - Humans aren't as fast as tajara, aren't as strong as unathi, don't have psychics. But they could just be more like resilient than all these other species, be able to get up and run, when other species would be too tired or too hurt to continue.
 - "Only humans can just keep getting up, even when hit again and again, or keep running, even when their legs are broken. They're unstoppable."
 - The actual gameplay changes are pretty minimal I think? I feel this would have a much bigger lore effect.
 - Uhhh. It's hard for me to describe this change now, but it vibes well with me.