### PR TITLE
Some Robot Fixes

### DIFF
--- a/code/modules/mob/living/silicon/robot/items/robot_parts.dm
+++ b/code/modules/mob/living/silicon/robot/items/robot_parts.dm
@@ -31,7 +31,7 @@
 /obj/item/robot_parts/get_examine_text(mob/user, distance, is_adjacent, infix, suffix)
 	. = ..()
 	if(is_adjacent)
-		. = report_missing_parts(user)
+		. += report_missing_parts(user)
 
 /obj/item/robot_parts/proc/report_missing_parts(var/mob/user)
 	. = list()
@@ -259,7 +259,7 @@
 				C.replace_cell(chest.cell)
 				//so people won't mess around with the chassis until it is deleted
 				forceMove(new_shell)
-				M.brainmob.mind.transfer_to(new_shell)
+				M.brainmob.mind?.transfer_to(new_shell)
 				qdel(M)
 				new_shell.add_language(LANGUAGE_EAL)
 				var/newname = sanitizeSafe( tgui_input_text(new_shell, "Enter a name, or leave blank for the default name.", "Name change", "", MAX_NAME_LEN), MAX_NAME_LEN )
@@ -289,7 +289,7 @@
 				O.custom_name = created_name
 				O.updatename("Default")
 
-				M.brainmob.mind.transfer_to(O)
+				M.brainmob.mind?.transfer_to(O)
 
 				O.job = "Cyborg"
 				O.cell = chest.cell

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -132,9 +132,9 @@
 	// Overlays
 	var/has_cut_eye_overlay
 	var/image/eye_overlay
-	var/list/image/cached_eye_overlays
+	var/list/image/cached_eye_overlays = list()
 	var/image/panel_overlay
-	var/list/image/cached_panel_overlays
+	var/list/image/cached_panel_overlays = list()
 	var/image/shield_overlay
 	var/datum/weakref/holo_map
 
@@ -399,6 +399,9 @@
 
 /mob/living/silicon/robot/verb/Namepick()
 	set category = "Robot Commands"
+
+	if(!src.mind)
+		return
 
 	spawn(0)
 		var/newname

--- a/html/changelogs/fluffyghost-fixrobotsdupe.yml
+++ b/html/changelogs/fluffyghost-fixrobotsdupe.yml
@@ -1,0 +1,61 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed robots duplication on insertion of posibrain without a player."
+  - bugfix: "Fixed runtime that caused the above."
+  - bugfix: "Fixed runtime on cyborg building inspection."
+  - bugfix: "Fixed runtime on cyborg building due to uninitalized list vars."


### PR DESCRIPTION
Fixed robots duplication on insertion of posibrain without a player.
Fixed runtime that caused the above.
Fixed runtime on cyborg building inspection.
Fixed runtime on cyborg building due to uninitalized list vars.

Fixes #20040 