### PR TITLE
Armour value Changes

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -216,11 +216,11 @@
 	icon_state = "helm_heavy"
 	item_state = "helm_heavy"
 	armor = list(
-		melee = ARMOR_MELEE_VERY_HIGH,
-		bullet = ARMOR_BALLISTIC_RIFLE,
-		laser = ARMOR_LASER_MEDIUM,
-		energy = ARMOR_ENERGY_RESISTANT,
-		bomb = ARMOR_BOMB_PADDED
+		melee = ARMOR_MELEE_MAJOR,
+		bullet = ARMOR_BALLISTIC_MAJOR,
+		laser = ARMOR_LASER_RIFLE,
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_PADDED,
 	)
 	siemens_coefficient = 0.35
 

--- a/code/modules/clothing/suits/modular_armor.dm
+++ b/code/modules/clothing/suits/modular_armor.dm
@@ -282,6 +282,13 @@
 	desc = "A lighter version of the blue carapace of the Tau Ceti Armed Forces. Reserved for recruits, recon, and prissy officers in the field."
 	icon_state = "tcaf_plate_light"
 	item_state = "tcaf_plate_light"
+	armor = list(
+		melee = ARMOR_MELEE_KEVLAR,
+		bullet = ARMOR_BALLISTIC_MEDIUM,
+		laser = ARMOR_LASER_KEVLAR,
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_PADDED
+	)
 	slowdown = 0
 
 /obj/item/clothing/accessory/armor_plate/military/navy

--- a/code/modules/clothing/suits/modular_armor.dm
+++ b/code/modules/clothing/suits/modular_armor.dm
@@ -19,10 +19,11 @@
 	much to the dismay of officers."
 	icon_state = "dom_carrier"
 	armor = list(
-		melee = ARMOR_MELEE_KNIVES,
-		bullet = ARMOR_BALLISTIC_SMALL,
-		laser = ARMOR_LASER_MINOR,
-		energy = ARMOR_ENERGY_SMALL
+		melee = ARMOR_MELEE_KEVLAR,
+		bullet = ARMOR_BALLISTIC_MEDIUM,
+		laser = ARMOR_LASER_KEVLAR,
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_PADDED
 	)
 
 /obj/item/clothing/suit/armor/carrier/officer

--- a/html/changelogs/ClemTheDuck-Armourvaluetweaks.yml
+++ b/html/changelogs/ClemTheDuck-Armourvaluetweaks.yml
@@ -57,3 +57,4 @@ delete-after: True
 changes:
   - balance: "Changes the armour values of the Heavy Helmet to be in line with the Heavy Plate stats and other heavy armour stats."
   - balance: "Changes the armour values of the Imperial Flak Vest to be equal to Corporate Security plates, should make the imperial flak vest actually useful as armour."
+  - balance: "Changes the armour values of the TCAF Light carapce to be equal to Corporate Security plates, this is to make it actually have some tradeoff and stand out against the TCAF Heavy Carapce."

--- a/html/changelogs/ClemTheDuck-Armourvaluetweaks.yml
+++ b/html/changelogs/ClemTheDuck-Armourvaluetweaks.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ClemTheDuck
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Changes the armour values of the Heavy Helmet to be in line with the Heavy Plate stats and other heavy armour stats."
+  - balance: "Changes the armour values of the Imperial Flak Vest to be equal to Corporate Security plates, should make the imperial flak vest actually useful as armour."


### PR DESCRIPTION
- Changes the values of the Heavy Helmet normally given to mercs/traitors, for some reason it had ballistic armour bullet protection and riot armour melee protection, this was inconsistent with the accompanying plate carrier as well as other heavy armour sets.
- Changes the values of the dominian imperial army flak vest to be equal to corporate security armour and thus in line with other light armour.
- Changes the values of TCAF light carpace's to be in line with corporate security armour as well.

These changes aim to further distinguish light and heavy armour types and improve consistency in our modular armour system. 
