### PR TITLE
Modular computer programs preset support unit test

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -3747,6 +3747,7 @@
 #include "code\unit_tests\loadout_tests.dm"
 #include "code\unit_tests\map_tests.dm"
 #include "code\unit_tests\mob_tests.dm"
+#include "code\unit_tests\modular_computers_tests.dm"
 #include "code\unit_tests\object_tests.dm"
 #include "code\unit_tests\observation_tests.dm"
 #include "code\unit_tests\origins_tests.dm"

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -1,34 +1,84 @@
 // /program/ files are executable programs that do things.
-/datum/computer_file/program
+ABSTRACT_TYPE(/datum/computer_file/program)
 	filetype = "PRG"
-	filename = "UnknownProgram"								// File name. FILE NAME MUST BE UNIQUE IF YOU WANT THE PROGRAM TO BE DOWNLOADABLE FROM NTNET!
-	filedesc = "Unknown Program"						// User-friendly name of this program.
-	var/program_type = PROGRAM_NORMAL						// Program type, used to determine if program runs in background or not.
-	var/required_access_run									// List of required accesses to run the program.
-	var/required_access_download							// List of required accesses to download the program.
-	var/requires_access_to_run = PROGRAM_ACCESS_ONE			// Whether the program checks for required_access when run. (1 = requires single access, 2 = requires single access from list, 3 = requires all access from list)
-	var/requires_access_to_download = PROGRAM_ACCESS_ONE	// Whether the program checks for required_access when downloading. (1 = requires single access, 2 = requires single access from list, 3 = requires all access from list)
-	var/program_state = PROGRAM_STATE_KILLED				// PROGRAM_STATE_KILLED or PROGRAM_STATE_BACKGROUND or PROGRAM_STATE_ACTIVE - specifies whether this program is running.
-	var/obj/item/modular_computer/computer					// Device that runs this program.
-	var/extended_desc = "N/A"								// Short description of this program's function.
-	var/program_icon_state									// Program-specific screen icon state
-	var/program_key_icon_state								// Program-specific keyboard icon state (really only applies to consoles but can be used for other purposes like having mix-n-match screens)
-	var/requires_ntnet = FALSE								// Set to TRUE for program to require nonstop NTNet connection to run. If NTNet connection is lost program crashes.
-	var/requires_ntnet_feature = FALSE						// Optional, if above is set to TRUE checks for specific function of NTNet (currently NTNET_SOFTWAREDOWNLOAD, NTNET_PEERTOPEER, NTNET_SYSTEMCONTROL and NTNET_COMMUNICATION)
-	var/ntnet_status = TRUE									// NTNet status, updated every tick by computer running this program. Don't use this for checks if NTNet works, computers do that. Use this for calculations, etc.
-	var/usage_flags = PROGRAM_ALL							// Bitflags (PROGRAM_CONSOLE, PROGRAM_LAPTOP, PROGRAM_TABLET combination) or PROGRAM_ALL
-	var/network_destination									// Optional string that describes what NTNet server/system this program connects to. Used in default logging.
-	var/available_on_ntnet = TRUE							// Whether the program can be downloaded from NTNet. Set to 0 to disable.
-	var/available_on_syndinet = FALSE						// Whether the program can be downloaded from SyndiNet (accessible via emagging the computer). Set to 1 to enable.
-	var/computer_emagged = FALSE							// Set to TRUE if computer that's running us was emagged. Computer updates this every Process() tick
-	var/ui_header											// Example: "something.gif" - a header image that will be rendered in computer's UI when this program is running at background. Images are taken from /nano/images/status_icons. Be careful not to use too large images!
-	var/color = "#FFFFFF"									// The color of light the computer should emit when this program is open.
-	var/service_state = PROGRAM_STATE_DISABLED				// PROGRAM_STATE_KILLED or PROGRAM_STATE_ACTIVE - specifies whether this program's service is running.
+
+	/// File name. FILE NAME MUST BE UNIQUE IF YOU WANT THE PROGRAM TO BE DOWNLOADABLE FROM NTNET!
+	filename = "UnknownProgram"
+
+	/// User-friendly name of this program.
+	filedesc = "Unknown Program"
+
+	/// Program type, used to determine if program runs in background or not.
+	var/program_type = PROGRAM_NORMAL
+
+	/// List of required accesses to run the program.
+	var/required_access_run
+
+	/// List of required accesses to download the program.
+	var/required_access_download
+
+	/// Whether the program checks for required_access when run. (1 = requires single access, 2 = requires single access from list, 3 = requires all access from list)
+	var/requires_access_to_run = PROGRAM_ACCESS_ONE
+
+	/// Whether the program checks for required_access when downloading. (1 = requires single access, 2 = requires single access from list, 3 = requires all access from list)
+	var/requires_access_to_download = PROGRAM_ACCESS_ONE
+
+	/// PROGRAM_STATE_KILLED or PROGRAM_STATE_BACKGROUND or PROGRAM_STATE_ACTIVE - specifies whether this program is running.
+	var/program_state = PROGRAM_STATE_KILLED
+
+	/// Device that runs this program.
+	var/obj/item/modular_computer/computer
+
+	/// Short description of this program's function.
+	var/extended_desc = "N/A"
+
+	/// Program-specific screen icon state
+	var/program_icon_state
+
+	/// Program-specific keyboard icon state (really only applies to consoles but can be used for other purposes like having mix-n-match screens)
+	var/program_key_icon_state
+
+	/// Set to TRUE for program to require nonstop NTNet connection to run. If NTNet connection is lost program crashes.
+	var/requires_ntnet = FALSE
+
+	/// Optional, if above is set to TRUE checks for specific function of NTNet (currently NTNET_SOFTWAREDOWNLOAD, NTNET_PEERTOPEER, NTNET_SYSTEMCONTROL and NTNET_COMMUNICATION)
+	var/requires_ntnet_feature = FALSE
+
+	/// NTNet status, updated every tick by computer running this program. Don't use this for checks if NTNet works, computers do that. Use this for calculations, etc.
+	var/ntnet_status = TRUE
+
+	/// Bitflags (PROGRAM_CONSOLE, PROGRAM_LAPTOP, PROGRAM_TABLET combination) or PROGRAM_ALL
+	var/usage_flags = PROGRAM_ALL
+
+	/// Optional string that describes what NTNet server/system this program connects to. Used in default logging.
+	var/network_destination
+
+	/// Whether the program can be downloaded from NTNet. Set to 0 to disable.
+	var/available_on_ntnet = TRUE
+
+	/// Whether the program can be downloaded from SyndiNet (accessible via emagging the computer). Set to 1 to enable.
+	var/available_on_syndinet = FALSE
+
+	/// Set to TRUE if computer that's running us was emagged. Computer updates this every Process() tick
+	var/computer_emagged = FALSE
+
+	/// Example: "something.gif" - a header image that will be rendered in computer's UI when this program is running at background. Images are taken from /nano/images/status_icons. Be careful not to use too large images!
+	var/ui_header
+
+	/// The color of light the computer should emit when this program is open.
+	var/color = "#FFFFFF"
+
+	/// PROGRAM_STATE_KILLED or PROGRAM_STATE_ACTIVE - specifies whether this program's service is running.
+	var/service_state = PROGRAM_STATE_DISABLED
+
 	var/silent = FALSE
+
 	/// Name of the TGUI Interface
 	var/tgui_id
+
 	/// Theme of this TGUI interface
 	var/tgui_theme = "scc"
+
 	/// If this TGUI should autoupdate or not.
 	var/ui_auto_update = TRUE
 

--- a/code/modules/modular_computers/file_system/programs/app_presets_.dm
+++ b/code/modules/modular_computers/file_system/programs/app_presets_.dm
@@ -8,6 +8,8 @@ ABSTRACT_TYPE(/datum/modular_computer_app_presets)
 	 * A `/list` of `/datum/computer_file/program` _typepaths_ that constitute this preset
 	 *
 	 * Is instantiated and returned by `return_install_programs()` on the computers that request it
+	 *
+	 * **Do not set this directly**, add or remove tye typepaths to it in New() **only**
 	 */
 	var/list/program_list = list()
 

--- a/code/modules/modular_computers/file_system/programs/app_presets_.dm
+++ b/code/modules/modular_computers/file_system/programs/app_presets_.dm
@@ -1,11 +1,25 @@
-/datum/modular_computer_app_presets
+ABSTRACT_TYPE(/datum/modular_computer_app_presets)
 	var/name = "default_preset"
 	var/display_name = "default preset"
 	var/description = "Description of the preset."
 	var/available = FALSE
 
-/datum/modular_computer_app_presets/proc/return_install_programs(var/obj/item/modular_computer/comp)
-	return list()
+	/**
+	 * A `/list` of `/datum/computer_file/program` _typepaths_ that constitute this preset
+	 *
+	 * Is instantiated and returned by `return_install_programs()` on the computers that request it
+	 */
+	var/list/program_list = list()
+
+/datum/modular_computer_app_presets/proc/return_install_programs(obj/item/modular_computer/comp)
+	SHOULD_NOT_SLEEP(TRUE)
+	SHOULD_CALL_PARENT(TRUE)
+
+	. = list()
+
+	for(var/program_typepath in program_list)
+		. += new program_typepath(comp)
+
 
 /datum/modular_computer_app_presets/all
 	name = "all"
@@ -14,54 +28,52 @@
 	available = FALSE
 
 /datum/modular_computer_app_presets/all/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list()
-	for(var/F in typesof(/datum/computer_file/program))
-		var/datum/computer_file/program/prog = new F(comp)
-		_prg_list += prog
-	return flatten_list(_prg_list)
+	SHOULD_CALL_PARENT(FALSE) //Special snowflake case
 
-#define COMPUTER_APP_PRESET_SYSTEM list(\
-	new /datum/computer_file/program/ntnetdownload(comp),\
-	new /datum/computer_file/program/filemanager(comp),\
-)
+	. = list()
+	for(var/F in subtypesof(/datum/computer_file/program))
+		var/datum/computer_file/program/prog = new F(comp)
+		. += prog
+
+#define COMPUTER_APP_PRESET_SYSTEM list(/datum/computer_file/program/ntnetdownload, /datum/computer_file/program/filemanager)
 
 #define COMPUTER_APP_PRESET_HORIZON_CIVILIAN list(\
-	new /datum/computer_file/program/newsbrowser(comp),\
-	new /datum/computer_file/program/manifest(comp),\
-	new /datum/computer_file/program/chat_client(comp),\
-	new /datum/computer_file/program/civilian/cargoorder(comp),\
-	new /datum/computer_file/program/map(comp),\
+	/datum/computer_file/program/newsbrowser,\
+	/datum/computer_file/program/manifest,\
+	/datum/computer_file/program/chat_client,\
+	/datum/computer_file/program/civilian/cargoorder,\
+	/datum/computer_file/program/map,\
 )
 
 #define COMPUTER_APP_PRESET_HORIZON_ENGINEERING list(\
-	new /datum/computer_file/program/power_monitor(comp),\
-	new /datum/computer_file/program/alarm_monitor/engineering(comp),\
-	new /datum/computer_file/program/atmos_control(comp),\
-	new /datum/computer_file/program/rcon_console(comp),\
-	new /datum/computer_file/program/camera_monitor(comp),\
-	new /datum/computer_file/program/lighting_control(comp)\
+	/datum/computer_file/program/power_monitor,\
+	/datum/computer_file/program/alarm_monitor/engineering,\
+	/datum/computer_file/program/atmos_control,\
+	/datum/computer_file/program/rcon_console,\
+	/datum/computer_file/program/camera_monitor,\
+	/datum/computer_file/program/lighting_control,\
 )
 
 #define COMPUTER_APP_PRESET_HORIZON_MEDICAL list(\
-	new /datum/computer_file/program/suit_sensors(comp),\
-	new /datum/computer_file/program/records/medical(comp),\
-	new /datum/computer_file/program/chemistry_codex(comp),\
-	new /datum/computer_file/program/scanner/medical(comp),\
-)
+	/datum/computer_file/program/suit_sensors,\
+	/datum/computer_file/program/records/medical,\
+	/datum/computer_file/program/chemistry_codex,\
+	/datum/computer_file/program/scanner/medical,\
+	)
 
 #define COMPUTER_APP_PRESET_HORIZON_RESEARCH list(\
-	new /datum/computer_file/program/ntnetmonitor(comp),\
-	new /datum/computer_file/program/aidiag(comp),\
-	new /datum/computer_file/program/chemistry_codex(comp),\
-	new /datum/computer_file/program/scanner/science(comp),\
-	new /datum/computer_file/program/scanner/gas(comp),\
-	new /datum/computer_file/program/away_manifest(comp),\
+	/datum/computer_file/program/ntnetmonitor,\
+	/datum/computer_file/program/aidiag,\
+	/datum/computer_file/program/chemistry_codex,\
+	/datum/computer_file/program/scanner/science,\
+	/datum/computer_file/program/scanner/gas,\
+	/datum/computer_file/program/away_manifest,\
 )
 
 #define COMPUTER_APP_PRESET_HORIZON_SECURITY list(\
-	new /datum/computer_file/program/alarm_monitor/security(comp),\
-	new /datum/computer_file/program/camera_monitor(comp),\
-	new /datum/computer_file/program/digitalwarrant(comp),\
-	new /datum/computer_file/program/records/security(comp),\
-	new /datum/computer_file/program/guntracker(comp),\
+	/datum/computer_file/program/alarm_monitor/security,\
+	/datum/computer_file/program/camera_monitor,\
+	/datum/computer_file/program/digitalwarrant,\
+	/datum/computer_file/program/records/security,\
+	/datum/computer_file/program/guntracker,\
 )

--- a/code/modules/modular_computers/file_system/programs/app_presets_antag.dm
+++ b/code/modules/modular_computers/file_system/programs/app_presets_antag.dm
@@ -5,15 +5,14 @@
 	description = "Contains the most common command programs and has a special teleporter control program loaded."
 	available = FALSE
 
-/datum/modular_computer_app_presets/command/teleporter/ninja/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		new /datum/computer_file/program/comm(comp, FALSE),
-		new /datum/computer_file/program/records/employment(comp),
-		new /datum/computer_file/program/teleporter/ninja(comp)
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/command/teleporter/ninja/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM + COMPUTER_APP_PRESET_HORIZON_CIVILIAN
+	program_list += list(/datum/computer_file/program/comm,
+						/datum/computer_file/program/records/employment,
+						/datum/computer_file/program/teleporter/ninja
+						)
+
 
 /datum/modular_computer_app_presets/merc
 	name = "merc"
@@ -21,14 +20,15 @@
 	description = "Preset for the Merc Console."
 	available = FALSE
 
-/datum/modular_computer_app_presets/merc/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		new /datum/computer_file/program/newsbrowser(comp),
-		new /datum/computer_file/program/manifest(comp),
-		new /datum/computer_file/program/camera_monitor/hacked(comp)
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/merc/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM
+	program_list += list(/datum/computer_file/program/newsbrowser,
+						/datum/computer_file/program/manifest,
+						/datum/computer_file/program/camera_monitor/hacked
+						)
+
+
 
 /datum/modular_computer_app_presets/ert
 	name = "ert"
@@ -36,15 +36,14 @@
 	description = "Preset for the ERT Console."
 	available = FALSE
 
-/datum/modular_computer_app_presets/ert/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		new /datum/computer_file/program/camera_monitor/hacked(comp),
-		new /datum/computer_file/program/comm(comp, FALSE),
-		new /datum/computer_file/program/suit_sensors(comp),
-		new /datum/computer_file/program/alarm_monitor/all(comp),
-		new /datum/computer_file/program/lighting_control(comp),
-		new /datum/computer_file/program/aidiag(comp),
-		new /datum/computer_file/program/records(comp)
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/ert/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM
+	program_list += list(/datum/computer_file/program/camera_monitor/hacked,
+						/datum/computer_file/program/comm,
+						/datum/computer_file/program/suit_sensors,
+						/datum/computer_file/program/alarm_monitor/all,
+						/datum/computer_file/program/lighting_control,
+						/datum/computer_file/program/aidiag,
+						/datum/computer_file/program/records
+						)

--- a/code/modules/modular_computers/file_system/programs/app_presets_antag.dm
+++ b/code/modules/modular_computers/file_system/programs/app_presets_antag.dm
@@ -7,11 +7,7 @@
 
 /datum/modular_computer_app_presets/command/teleporter/ninja/New()
 	. = ..()
-	program_list += COMPUTER_APP_PRESET_SYSTEM + COMPUTER_APP_PRESET_HORIZON_CIVILIAN
-	program_list += list(/datum/computer_file/program/comm,
-						/datum/computer_file/program/records/employment,
-						/datum/computer_file/program/teleporter/ninja
-						)
+	program_list += /datum/computer_file/program/teleporter/ninja
 
 
 /datum/modular_computer_app_presets/merc

--- a/code/modules/modular_computers/file_system/programs/app_presets_crew.dm
+++ b/code/modules/modular_computers/file_system/programs/app_presets_crew.dm
@@ -263,7 +263,7 @@
 
 /datum/modular_computer_app_presets/supply/mining/New()
 	. = ..()
-	program_list += COMPUTER_APP_PRESET_SYSTEM + COMPUTER_APP_PRESET_HORIZON_CIVILIAN + /datum/computer_file/program/away_manifest
+	program_list -= list(/datum/computer_file/program/civilian/cargocontrol, /datum/computer_file/program/civilian/cargodelivery) //Snowflake
 
 
 /datum/modular_computer_app_presets/supply/machinist

--- a/code/modules/modular_computers/file_system/programs/app_presets_crew.dm
+++ b/code/modules/modular_computers/file_system/programs/app_presets_crew.dm
@@ -1,32 +1,27 @@
 
+/*##########################
+	ENGINEERING PRESETS
+##########################*/
 /datum/modular_computer_app_presets/engineering
 	name = "engineering"
 	display_name = "Engineering"
 	description = "Contains the most common engineering programs."
 	available = TRUE
 
-/datum/modular_computer_app_presets/engineering/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		COMPUTER_APP_PRESET_HORIZON_ENGINEERING,
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/engineering/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM + COMPUTER_APP_PRESET_HORIZON_CIVILIAN + COMPUTER_APP_PRESET_HORIZON_ENGINEERING
+
 
 /datum/modular_computer_app_presets/engineering/atmos
 	name = "atmos"
 	display_name = "Engineering - Atmospherics"
 	description = "Contains the most common engineering programs and atmospheric monitoring software."
-	available = TRUE
 
-/datum/modular_computer_app_presets/engineering/atmos/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		COMPUTER_APP_PRESET_HORIZON_ENGINEERING,
-		new /datum/computer_file/program/scanner/gas(comp)
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/engineering/atmos/New()
+	. = ..()
+	program_list += /datum/computer_file/program/scanner/gas
+
 
 /datum/modular_computer_app_presets/engineering/ce
 	name = "engineering_head"
@@ -34,30 +29,24 @@
 	description = "Contains the most common engineering programs and command software."
 	available = FALSE
 
-/datum/modular_computer_app_presets/engineering/ce/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		COMPUTER_APP_PRESET_HORIZON_ENGINEERING,
-		new /datum/computer_file/program/scanner/gas(comp),
-		new /datum/computer_file/program/comm(comp, FALSE),
-		new /datum/computer_file/program/records/employment(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/engineering/ce/New()
+	. = ..()
+	program_list += list(/datum/computer_file/program/comm,	/datum/computer_file/program/records/employment)
 
+
+/*##########################
+	MEDICAL PRESETS
+##########################*/
 /datum/modular_computer_app_presets/medical
 	name = "medical"
 	display_name = "Medical"
 	description = "Contains the most common medical programs."
 	available = TRUE
 
-/datum/modular_computer_app_presets/medical/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		COMPUTER_APP_PRESET_HORIZON_MEDICAL,
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/medical/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM + COMPUTER_APP_PRESET_HORIZON_CIVILIAN + COMPUTER_APP_PRESET_HORIZON_MEDICAL
+
 
 /datum/modular_computer_app_presets/medical/cmo
 	name = "medical_head"
@@ -65,30 +54,24 @@
 	description = "Contains the most common medical programs and command software."
 	available = FALSE
 
-/datum/modular_computer_app_presets/medical/cmo/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		COMPUTER_APP_PRESET_HORIZON_MEDICAL,
-		new /datum/computer_file/program/comm(comp, FALSE),
-		new /datum/computer_file/program/records/employment(comp),
-		new /datum/computer_file/program/scanner/science(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/medical/cmo/New()
+	. = ..()
+	program_list += list(/datum/computer_file/program/records/employment, /datum/computer_file/program/scanner/science, /datum/computer_file/program/comm)
 
+
+/*##########################
+	RESEARCH PRESETS
+##########################*/
 /datum/modular_computer_app_presets/research
 	name = "research"
 	display_name = "Research"
 	description = "Contains the most common research programs."
 	available = TRUE
 
-/datum/modular_computer_app_presets/research/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		COMPUTER_APP_PRESET_HORIZON_RESEARCH,
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/research/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM + COMPUTER_APP_PRESET_HORIZON_CIVILIAN + COMPUTER_APP_PRESET_HORIZON_RESEARCH
+
 
 /datum/modular_computer_app_presets/research/rd
 	name = "research_head"
@@ -96,47 +79,44 @@
 	description = "Contains the most common research programs and command software."
 	available = FALSE
 
-/datum/modular_computer_app_presets/research/rd/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		COMPUTER_APP_PRESET_HORIZON_RESEARCH,
-		new /datum/computer_file/program/comm(comp, FALSE),
-		new /datum/computer_file/program/records/employment(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/research/rd/New()
+	. = ..()
+	program_list += list(/datum/computer_file/program/comm,	/datum/computer_file/program/records/employment)
 
+
+/*##########################
+	BRIDGE CREW PRESETS
+##########################*/
 /datum/modular_computer_app_presets/bridge
 	name = "bridge"
 	display_name = "Bridge"
 	description = "Contains the most common bridge programs"
 	available = TRUE
 
-/datum/modular_computer_app_presets/bridge/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		new /datum/computer_file/program/away_manifest(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/bridge/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM + COMPUTER_APP_PRESET_HORIZON_CIVILIAN + /datum/computer_file/program/away_manifest
 
+
+/*##########################
+	COMMAND PRESETS
+##########################*/
 /datum/modular_computer_app_presets/command
 	name = "command"
 	display_name = "Command"
 	description = "Contains the most common command programs."
 	available = TRUE
 
-/datum/modular_computer_app_presets/command/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		new /datum/computer_file/program/card_mod(comp),
-		new /datum/computer_file/program/comm(comp, TRUE),
-		new /datum/computer_file/program/docks(comp),
-		new /datum/computer_file/program/away_manifest(comp),
-		new /datum/computer_file/program/records/employment(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/command/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM + COMPUTER_APP_PRESET_HORIZON_CIVILIAN
+	program_list += list(/datum/computer_file/program/card_mod,
+						/datum/computer_file/program/comm,
+						/datum/computer_file/program/docks,
+						/datum/computer_file/program/away_manifest,
+						/datum/computer_file/program/records/employment,
+						)
+
 
 /datum/modular_computer_app_presets/command/hop
 	name = "command_hop"
@@ -144,19 +124,10 @@
 	description = "Contains the most common command programs."
 	available = FALSE
 
-/datum/modular_computer_app_presets/command/hop/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		new /datum/computer_file/program/civilian/cargocontrol(comp),
-		new /datum/computer_file/program/card_mod(comp),
-		new /datum/computer_file/program/comm(comp, FALSE),
-		new /datum/computer_file/program/docks(comp),
-		new /datum/computer_file/program/away_manifest(comp),
-		new /datum/computer_file/program/records/employment(comp),
-		new /datum/computer_file/program/records/security(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/command/hop/New()
+	. = ..()
+	program_list += list(/datum/computer_file/program/civilian/cargocontrol, /datum/computer_file/program/records/security)
+
 
 /datum/modular_computer_app_presets/command/captain
 	name = "captain"
@@ -164,37 +135,30 @@
 	description = "Contains the most important programs for the Captain."
 	available = FALSE
 
-/datum/modular_computer_app_presets/command/captain/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		new /datum/computer_file/program/card_mod(comp),
-		new /datum/computer_file/program/comm(comp, TRUE),
-		new /datum/computer_file/program/docks(comp),
-		new /datum/computer_file/program/away_manifest(comp),
-		new /datum/computer_file/program/camera_monitor(comp),
-		new /datum/computer_file/program/digitalwarrant(comp),
-		new /datum/computer_file/program/civilian/cargocontrol(comp),
-		new /datum/computer_file/program/alarm_monitor/all(comp),
-		new /datum/computer_file/program/records/employment(comp),
-		new /datum/computer_file/program/records/medical(comp),
-		new /datum/computer_file/program/records/security(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/command/captain/New()
+	. = ..()
+	program_list += list(/datum/computer_file/program/camera_monitor,
+						/datum/computer_file/program/digitalwarrant,
+						/datum/computer_file/program/civilian/cargocontrol,
+						/datum/computer_file/program/alarm_monitor/all,
+						/datum/computer_file/program/records/medical,
+						/datum/computer_file/program/records/security,
+						)
 
+
+/*##########################
+	SECURITY PRESETS
+##########################*/
 /datum/modular_computer_app_presets/security
 	name = "security"
 	display_name = "Security"
 	description = "Contains the most common security programs."
 	available = TRUE
 
-/datum/modular_computer_app_presets/security/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		COMPUTER_APP_PRESET_HORIZON_SECURITY,
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/security/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM + COMPUTER_APP_PRESET_HORIZON_CIVILIAN + COMPUTER_APP_PRESET_HORIZON_SECURITY
+
 
 /datum/modular_computer_app_presets/security/armory
 	name = "security_arm"
@@ -202,33 +166,21 @@
 	description = "Contains the most common security and armory programs."
 	available = FALSE
 
-/datum/modular_computer_app_presets/security/armory/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		COMPUTER_APP_PRESET_HORIZON_SECURITY,
-		new /datum/computer_file/program/implant_tracker(comp),
-		new /datum/computer_file/program/comm(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/security/armory/New()
+	. = ..()
+	program_list += list(/datum/computer_file/program/implant_tracker, /datum/computer_file/program/comm)
+
 
 /datum/modular_computer_app_presets/security/investigations
 	name = "security_inv"
 	display_name = "Security - Investigations"
 	description = "Contains the most common security and forensics programs."
-	available = TRUE
 
-/datum/modular_computer_app_presets/security/investigations/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		new /datum/computer_file/program/alarm_monitor/security(comp),
-		new /datum/computer_file/program/camera_monitor(comp),
-		new /datum/computer_file/program/digitalwarrant(comp),
-		new /datum/computer_file/program/records/security(comp),
-		new /datum/computer_file/program/records/medical(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/security/investigations/New()
+	. = ..()
+	program_list += /datum/computer_file/program/records/medical
+	program_list -= /datum/computer_file/program/guntracker //Remove the guntracker, investigators don't have access to it
+
 
 /datum/modular_computer_app_presets/security/hos
 	name = "security_head"
@@ -236,77 +188,62 @@
 	description = "Contains the most common security programs and command software."
 	available = FALSE
 
-/datum/modular_computer_app_presets/security/hos/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		COMPUTER_APP_PRESET_HORIZON_SECURITY,
-		new /datum/computer_file/program/comm(comp, FALSE),
-		new /datum/computer_file/program/records/employment(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/security/hos/New()
+	. = ..()
+	program_list += list(/datum/computer_file/program/comm,	/datum/computer_file/program/records/employment)
 
+
+/*##########################
+	CIVILIAN PRESETS
+##########################*/
 /datum/modular_computer_app_presets/civilian
 	name = "service"
 	display_name = "Service"
 	description = "Contains the most common service programs."
 	available = TRUE
 
-/datum/modular_computer_app_presets/civilian/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		new /datum/computer_file/program/game/arcade(comp),
-		new /datum/computer_file/program/cooking_codex(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/civilian/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM + COMPUTER_APP_PRESET_HORIZON_CIVILIAN
+	program_list += list(/datum/computer_file/program/game/arcade, /datum/computer_file/program/cooking_codex)
+
 
 /datum/modular_computer_app_presets/civilian/janitor
 	name = "janitor"
 	display_name = "Janitor"
 	description = "Contains programs for janitorial service."
-	available = TRUE
 
-/datum/modular_computer_app_presets/civilian/janitor/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		new /datum/computer_file/program/civilian/janitor(comp),
-		new /datum/computer_file/program/game/arcade(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/civilian/janitor/New()
+	. = ..()
+	program_list += /datum/computer_file/program/civilian/janitor
 
 /datum/modular_computer_app_presets/civilian/miner
 	name = "miner"
 	display_name = "Miner"
 	description = "Contains programs for miners."
-	available = TRUE
 
-/datum/modular_computer_app_presets/civilian/miner/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		new /datum/computer_file/program/game/arcade(comp),
-		new /datum/computer_file/program/cooking_codex(comp),
-		new /datum/computer_file/program/away_manifest(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/civilian/miner/New()
+	. = ..()
+	program_list += /datum/computer_file/program/away_manifest
 
+
+/*##########################
+	SUPPLY PRESETS
+##########################*/
 /datum/modular_computer_app_presets/supply
 	name = "supply"
 	display_name = "Supply"
 	description = "Contains the most common cargo programs."
 	available = TRUE
 
-/datum/modular_computer_app_presets/supply/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		new /datum/computer_file/program/civilian/cargocontrol(comp),
-		new /datum/computer_file/program/civilian/cargodelivery(comp),
-		new /datum/computer_file/program/away_manifest(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/supply/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM + COMPUTER_APP_PRESET_HORIZON_CIVILIAN
+	program_list += list(/datum/computer_file/program/civilian/cargocontrol,
+						/datum/computer_file/program/civilian/cargodelivery,
+						/datum/computer_file/program/away_manifest,
+						)
+
 
 /datum/modular_computer_app_presets/supply/om
 	name = "operations manager"
@@ -314,59 +251,42 @@
 	description = "Contains the most common cargo programs as well as the OM's ones."
 	available = FALSE
 
-/datum/modular_computer_app_presets/supply/om/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		new /datum/computer_file/program/civilian/cargocontrol(comp),
-		new /datum/computer_file/program/civilian/cargodelivery(comp),
-		new /datum/computer_file/program/away_manifest(comp),
-		new /datum/computer_file/program/comm(comp, FALSE),
-		new /datum/computer_file/program/docks(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/supply/om/New()
+	. = ..()
+	program_list += list(/datum/computer_file/program/comm, /datum/computer_file/program/docks)
+
 
 /datum/modular_computer_app_presets/supply/mining
 	name = "operations_mining"
 	display_name = "Mining"
 	description = "Contains the most common EVA programs."
-	available = TRUE
 
-/datum/modular_computer_app_presets/supply/mining/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		new /datum/computer_file/program/away_manifest(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/supply/mining/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM + COMPUTER_APP_PRESET_HORIZON_CIVILIAN + /datum/computer_file/program/away_manifest
+
 
 /datum/modular_computer_app_presets/supply/machinist
 	name = "operations_machinist"
 	display_name = "Operations - Machinist"
 	description = "Contains the most common supply programs and medical record software."
-	available = TRUE
 
-/datum/modular_computer_app_presets/supply/machinist/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		new /datum/computer_file/program/aidiag(comp),
-		new /datum/computer_file/program/records/medical(comp),
-		new /datum/computer_file/program/scanner/science(comp),
-		new /datum/computer_file/program/scanner/gas(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/supply/machinist/New()
+	. = ..()
+	program_list += list(/datum/computer_file/program/records/medical, /datum/computer_file/program/scanner/science)
+	//Machinist is the bastard child of supply/operation, it doesn't have access to shit essentially
+	program_list -= list(/datum/computer_file/program/civilian/cargocontrol, /datum/computer_file/program/civilian/cargodelivery, /datum/computer_file/program/away_manifest)
 
+
+/*#############################
+	REPRESENTATIVE PRESETS
+#############################*/
 /datum/modular_computer_app_presets/representative
 	name = "representative"
 	display_name = "Representative"
 	description = "Contains software intended for representatives."
 	available = FALSE
 
-/datum/modular_computer_app_presets/representative/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		new /datum/computer_file/program/records/employment(comp),
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/representative/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM + COMPUTER_APP_PRESET_HORIZON_CIVILIAN + /datum/computer_file/program/records/employment

--- a/code/modules/modular_computers/file_system/programs/app_presets_equipment.dm
+++ b/code/modules/modular_computers/file_system/programs/app_presets_equipment.dm
@@ -35,11 +35,7 @@
 
 /datum/modular_computer_app_presets/command/teleporter/New()
 	. = ..()
-	program_list += COMPUTER_APP_PRESET_SYSTEM + COMPUTER_APP_PRESET_HORIZON_CIVILIAN
-	program_list += list(/datum/computer_file/program/comm,
-						/datum/computer_file/program/records/employment,
-						/datum/computer_file/program/teleporter
-						)
+	program_list += /datum/computer_file/program/teleporter
 
 /datum/modular_computer_app_presets/command/account
 	name = "command_accounting"
@@ -49,12 +45,10 @@
 
 /datum/modular_computer_app_presets/command/account/New()
 	. = ..()
-	program_list += COMPUTER_APP_PRESET_SYSTEM
 	program_list += list(/datum/computer_file/program/newsbrowser,
 						/datum/computer_file/program/manifest,
 						/datum/computer_file/program/civilian/cargoorder,
 						/datum/computer_file/program/civilian/cargocontrol,
-						/datum/computer_file/program/records/employment,
 						/datum/computer_file/program/account_db
 						)
 

--- a/code/modules/modular_computers/file_system/programs/app_presets_equipment.dm
+++ b/code/modules/modular_computers/file_system/programs/app_presets_equipment.dm
@@ -5,16 +5,16 @@
 	description = "A generic preset for the wall console."
 	available = FALSE
 
-/datum/modular_computer_app_presets/wall_generic/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		new /datum/computer_file/program/manifest(comp),
-		new /datum/computer_file/program/chat_client(comp),
-		new /datum/computer_file/program/civilian/cargoorder(comp),
-		new /datum/computer_file/program/camera_monitor(comp),
-		new /datum/computer_file/program/alarm_monitor/engineering(comp)
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/wall_generic/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM
+	program_list += list(/datum/computer_file/program/manifest,
+						/datum/computer_file/program/chat_client,
+						/datum/computer_file/program/civilian/cargoorder,
+						/datum/computer_file/program/camera_monitor,
+						/datum/computer_file/program/alarm_monitor/engineering
+						)
+
 
 /datum/modular_computer_app_presets/ai
 	name = "ai"
@@ -22,11 +22,10 @@
 	description = "A preset for the AI consoles."
 	available = FALSE
 
-/datum/modular_computer_app_presets/ai/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/ai/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM
+
 
 /datum/modular_computer_app_presets/command/teleporter
 	name = "command_teleporter"
@@ -34,15 +33,13 @@
 	description = "Contains the most common command programs and has a special teleporter control program loaded."
 	available = FALSE
 
-/datum/modular_computer_app_presets/command/teleporter/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		new /datum/computer_file/program/comm(comp, FALSE),
-		new /datum/computer_file/program/records/employment(comp),
-		new /datum/computer_file/program/teleporter(comp)
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/command/teleporter/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM + COMPUTER_APP_PRESET_HORIZON_CIVILIAN
+	program_list += list(/datum/computer_file/program/comm,
+						/datum/computer_file/program/records/employment,
+						/datum/computer_file/program/teleporter
+						)
 
 /datum/modular_computer_app_presets/command/account
 	name = "command_accounting"
@@ -50,29 +47,26 @@
 	description = "Contains all the programs you would need to become a god-tier accountant."
 	available = FALSE
 
-/datum/modular_computer_app_presets/command/account/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		new /datum/computer_file/program/newsbrowser(comp),
-		new /datum/computer_file/program/manifest(comp),
-		new /datum/computer_file/program/civilian/cargoorder(comp),
-		new /datum/computer_file/program/civilian/cargocontrol(comp),
-		new /datum/computer_file/program/records/employment(comp),
-		new /datum/computer_file/program/account_db(comp)
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/command/account/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM
+	program_list += list(/datum/computer_file/program/newsbrowser,
+						/datum/computer_file/program/manifest,
+						/datum/computer_file/program/civilian/cargoorder,
+						/datum/computer_file/program/civilian/cargocontrol,
+						/datum/computer_file/program/records/employment,
+						/datum/computer_file/program/account_db
+						)
+
+/datum/modular_computer_app_presets/command/account/centcomm
+	name = "command_accounting_centcomm"
+	display_name = "Command - Accounting - CentComm"
+	description = "Contains all the programs you would need to become a god-tier accountant."
+	available = FALSE
 
 /datum/modular_computer_app_presets/command/account/centcomm/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		new /datum/computer_file/program/newsbrowser(comp),
-		new /datum/computer_file/program/manifest(comp),
-		new /datum/computer_file/program/civilian/cargoorder(comp),
-		new /datum/computer_file/program/civilian/cargocontrol(comp),
-		new /datum/computer_file/program/records/employment(comp),
-		new /datum/computer_file/program/account_db(comp, TRUE)
-	)
-	return flatten_list(_prg_list)
+	. = ..()
+	. += new /datum/computer_file/program/account_db(comp, TRUE)
 
 /datum/modular_computer_app_presets/trashcompactor
 	name = "trashcompactor"
@@ -80,11 +74,9 @@
 	description = "A preset for the Trash Compactor Wall Console."
 	available = FALSE
 
-/datum/modular_computer_app_presets/trashcompactor/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		new /datum/computer_file/program/crushercontrol(comp)
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/trashcompactor/New()
+	. = ..()
+	program_list += /datum/computer_file/program/crushercontrol
 
 /datum/modular_computer_app_presets/cargo_delivery
 	name = "cargo_delivery"
@@ -92,10 +84,7 @@
 	description = "Contains the Delivery App."
 	available = FALSE
 
-/datum/modular_computer_app_presets/cargo_delivery/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		COMPUTER_APP_PRESET_SYSTEM,
-		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
-		new /datum/computer_file/program/civilian/cargodelivery(comp)
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/cargo_delivery/New()
+	. = ..()
+	program_list += COMPUTER_APP_PRESET_SYSTEM + COMPUTER_APP_PRESET_HORIZON_CIVILIAN
+	program_list += /datum/computer_file/program/civilian/cargodelivery

--- a/code/modules/modular_computers/file_system/programs/app_presets_equipment.dm
+++ b/code/modules/modular_computers/file_system/programs/app_presets_equipment.dm
@@ -45,10 +45,7 @@
 
 /datum/modular_computer_app_presets/command/account/New()
 	. = ..()
-	program_list += list(/datum/computer_file/program/newsbrowser,
-						/datum/computer_file/program/manifest,
-						/datum/computer_file/program/civilian/cargoorder,
-						/datum/computer_file/program/civilian/cargocontrol,
+	program_list += list(/datum/computer_file/program/civilian/cargocontrol,
 						/datum/computer_file/program/account_db
 						)
 
@@ -58,9 +55,12 @@
 	description = "Contains all the programs you would need to become a god-tier accountant."
 	available = FALSE
 
-/datum/modular_computer_app_presets/command/account/centcomm/return_install_programs(obj/item/modular_computer/comp)
+/datum/modular_computer_app_presets/command/account/centcomm/New()
 	. = ..()
-	. += new /datum/computer_file/program/account_db(comp, TRUE)
+
+	//Remove the default accounting program and add the centcomm version
+	program_list -= /datum/computer_file/program/account_db
+	program_list += /datum/computer_file/program/account_db/centcomm
 
 /datum/modular_computer_app_presets/trashcompactor
 	name = "trashcompactor"

--- a/code/modules/modular_computers/file_system/programs/app_presets_third_party.dm
+++ b/code/modules/modular_computers/file_system/programs/app_presets_third_party.dm
@@ -5,43 +5,40 @@
 	description = "A preset for the merchant console."
 	available = FALSE
 
-/datum/modular_computer_app_presets/merchant/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		new /datum/computer_file/program/filemanager(comp),
-		new /datum/computer_file/program/manifest(comp),
-		new /datum/computer_file/program/newsbrowser(comp),
-		new /datum/computer_file/program/chat_client(comp),
-		new /datum/computer_file/program/merchant(comp)
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/merchant/New()
+	. = ..()
+	program_list += list(/datum/computer_file/program/filemanager,
+						/datum/computer_file/program/manifest,
+						/datum/computer_file/program/newsbrowser,
+						/datum/computer_file/program/chat_client,
+						/datum/computer_file/program/merchant
+						)
 
-/datum/modular_computer_app_presets/merchant/nka/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		new /datum/computer_file/program/filemanager(comp),
-		new /datum/computer_file/program/manifest(comp),
-		new /datum/computer_file/program/newsbrowser(comp),
-		new /datum/computer_file/program/chat_client(comp),
-		new /datum/computer_file/program/merchant/nka(comp)
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/merchant/nka
+	name = "merchant_nka"
+	display_name = "Merchant - NKA"
+	description = "A preset for the merchant console for the new kingdom of adhomai."
 
-/datum/modular_computer_app_presets/merchant/guild/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		new /datum/computer_file/program/filemanager(comp),
-		new /datum/computer_file/program/manifest(comp),
-		new /datum/computer_file/program/newsbrowser(comp),
-		new /datum/computer_file/program/chat_client(comp),
-		new /datum/computer_file/program/merchant/guild(comp)
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/merchant/nka/New()
+	. = ..()
+	program_list += /datum/computer_file/program/merchant/nka
 
 
-/datum/modular_computer_app_presets/merchant/golden_deep/return_install_programs(obj/item/modular_computer/comp)
-	var/list/_prg_list = list(
-		new /datum/computer_file/program/filemanager(comp),
-		new /datum/computer_file/program/manifest(comp),
-		new /datum/computer_file/program/newsbrowser(comp),
-		new /datum/computer_file/program/chat_client(comp),
-		new /datum/computer_file/program/merchant/golden_deep(comp)
-	)
-	return flatten_list(_prg_list)
+/datum/modular_computer_app_presets/merchant/guild
+	name = "merchant_guild"
+	display_name = "Merchant - Guild"
+	description = "A preset for the merchant console for the guild."
+
+/datum/modular_computer_app_presets/merchant/guild/New()
+	. = ..()
+	program_list += /datum/computer_file/program/merchant/guild
+
+
+/datum/modular_computer_app_presets/merchant/golden_deep
+	name = "merchant_golden_deep"
+	display_name = "Merchant - Golden Deep"
+	description = "A preset for the merchant console for the golden deep."
+
+/datum/modular_computer_app_presets/merchant/golden_deep/New()
+	. = ..()
+	program_list += /datum/computer_file/program/merchant/golden_deep

--- a/code/modules/modular_computers/file_system/programs/command/account_database.dm
+++ b/code/modules/modular_computers/file_system/programs/command/account_database.dm
@@ -16,14 +16,12 @@
 	var/machine_id = ""
 	var/centcomm_db = FALSE
 
-/datum/computer_file/program/account_db/New(obj/item/modular_computer/comp, var/is_centcomm_db = FALSE)
+/datum/computer_file/program/account_db/New(obj/item/modular_computer/comp)
 	..()
 	if(SSatlas.current_map)
 		machine_id = "[station_name()] Acc. DB #[SSeconomy.num_financial_terminals++]"
 	else
 		machine_id = "NT-Net Relay Back-up Software DB" // created during map generation inside the ntnet relay, not used by players
-
-	centcomm_db = is_centcomm_db
 
 /datum/computer_file/program/account_db/proc/get_held_card()
 	var/obj/item/card/id/held_card
@@ -260,5 +258,15 @@
 
 			var/obj/item/paper/P = computer.nano_printer.print_text("", pname, "#deebff")
 			P.set_content_unsafe(pname, text)
+
+
+/*#############
+	SUBTYPES
+#############*/
+
+/datum/computer_file/program/account_db/centcomm
+	filename = "accdb_centcomm"
+	filedesc = "Account Database - CentComm"
+	centcomm_db = TRUE
 
 #undef FUND_CAP

--- a/code/modules/modular_computers/file_system/programs/generic/records.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/records.dm
@@ -92,10 +92,6 @@
 	program_key_icon_state = "lightblue_key"
 	color = LIGHT_COLOR_BLUE
 
-/datum/computer_file/program/records/employment/Destroy()
-	. = ..()
-
-
 /datum/computer_file/program/records/pai
 	available_on_ntnet = 1
 	extended_desc = "This program is used to view crew records."

--- a/code/unit_tests/modular_computers_tests.dm
+++ b/code/unit_tests/modular_computers_tests.dm
@@ -1,0 +1,41 @@
+/*
+ *  Unit Tests for various recipes.
+ *
+ */
+
+ABSTRACT_TYPE(/datum/unit_test/modular_computers)
+	name = "MOD COMP: Template"
+	groups = list("generic")
+
+/datum/unit_test/modular_computers/presets_contain_only_compatible_programs
+	name = "MOD COMP: Presets contain only compatible programs"
+
+/datum/unit_test/modular_computers/presets_contain_only_compatible_programs/start_test()
+	var/test_result = UNIT_TEST_PASSED
+
+	for(var/obj/item/modular_computer/modular_computer_typepath in subtypesof(/obj/item/modular_computer))
+		//We don't care about abstracts
+		if(is_abstract(modular_computer_typepath))
+			continue
+
+		var/obj/item/modular_computer/sample_modular_computer = new modular_computer_typepath()
+
+		//No need for nulls
+		if(isnull(sample_modular_computer._app_preset_type))
+			continue
+
+		if(!ispath(sample_modular_computer._app_preset_type, /datum/modular_computer_app_presets))
+			test_result = TEST_FAIL("Modular computer typepath '[modular_computer_typepath]' has an invalid _app_preset_type! - [sample_modular_computer._app_preset_type]")
+			continue
+
+		//Check that all the programs are supported by the hardwares that use those presets
+		var/list/programs = sample_modular_computer.get_preset_programs(sample_modular_computer._app_preset_type)
+		for(var/datum/computer_file/program/prog in programs)
+			if(!prog.is_supported_by_hardware(sample_modular_computer.hardware_flag, FALSE))
+				test_result = TEST_FAIL("Found program [prog.type] in preset [sample_modular_computer._app_preset_type] that is used by [modular_computer_typepath], \
+										but is not supported by its hardware!")
+
+	if(test_result == UNIT_TEST_PASSED)
+		TEST_PASS("All modular computers supports all the programs referenced in their _app_preset_type.")
+
+	return test_result

--- a/code/unit_tests/modular_computers_tests.dm
+++ b/code/unit_tests/modular_computers_tests.dm
@@ -44,6 +44,7 @@ ABSTRACT_TYPE(/datum/unit_test/modular_computers)
 /datum/unit_test/modular_computers/presets_contain_only_compatible_programs
 	name = "MOD COMP: Presets contain only compatible programs"
 	disabled = TRUE //There's 400+ fuckups and i'm not fixing all that shit myself
+	why_disabled = "There's over 400 programs that cannot run where they are installed, a large effort is required to fix them all."
 
 /datum/unit_test/modular_computers/presets_contain_only_compatible_programs/start_test()
 	var/test_result = UNIT_TEST_PASSED

--- a/code/unit_tests/modular_computers_tests.dm
+++ b/code/unit_tests/modular_computers_tests.dm
@@ -16,6 +16,9 @@ ABSTRACT_TYPE(/datum/unit_test/modular_computers)
 	var/obj/item/modular_computer/test_computer = new()
 
 	for(var/preset_typepath in subtypesof(/datum/modular_computer_app_presets))
+		TEST_DEBUG("Testing preset [preset_typepath]")
+
+		//Instance the preset
 		var/datum/modular_computer_app_presets/preset = new preset_typepath()
 
 		//Get installed programs
@@ -27,9 +30,10 @@ ABSTRACT_TYPE(/datum/unit_test/modular_computers)
 
 		for(var/datum/computer_file/program/program in installed_programs)
 			if(program.type in programs_present)
-				test_result = TEST_FAIL("Found multiple instances of program [program.type] in preset [preset.name]!")
+				test_result = TEST_FAIL("Found multiple instances of program [program.type] in preset [preset_typepath]!")
 			else
 				programs_present += program.type
+				TEST_DEBUG("Found one instance of program [program.type] in preset [preset_typepath]")
 
 	if(test_result == UNIT_TEST_PASSED)
 		TEST_PASS("All programs in modular computer presets are only present once.")

--- a/code/unit_tests/modular_computers_tests.dm
+++ b/code/unit_tests/modular_computers_tests.dm
@@ -13,7 +13,7 @@ ABSTRACT_TYPE(/datum/unit_test/modular_computers)
 /datum/unit_test/modular_computers/presets_contain_only_compatible_programs/start_test()
 	var/test_result = UNIT_TEST_PASSED
 
-	for(var/obj/item/modular_computer/modular_computer_typepath in subtypesof(/obj/item/modular_computer))
+	for(var/modular_computer_typepath in subtypesof(/obj/item/modular_computer))
 		//We don't care about abstracts
 		if(is_abstract(modular_computer_typepath))
 			continue
@@ -22,6 +22,7 @@ ABSTRACT_TYPE(/datum/unit_test/modular_computers)
 
 		//No need for nulls
 		if(isnull(sample_modular_computer._app_preset_type))
+			TEST_DEBUG("[modular_computer_typepath] _app_preset_type is null and won't be tested")
 			continue
 
 		if(!ispath(sample_modular_computer._app_preset_type, /datum/modular_computer_app_presets))
@@ -31,6 +32,7 @@ ABSTRACT_TYPE(/datum/unit_test/modular_computers)
 		//Check that all the programs are supported by the hardwares that use those presets
 		var/list/programs = sample_modular_computer.get_preset_programs(sample_modular_computer._app_preset_type)
 		for(var/datum/computer_file/program/prog in programs)
+			TEST_DEBUG("Will now test [prog.type] in preset [sample_modular_computer._app_preset_type] used by [modular_computer_typepath]")
 			if(!prog.is_supported_by_hardware(sample_modular_computer.hardware_flag, FALSE))
 				test_result = TEST_FAIL("Found program [prog.type] in preset [sample_modular_computer._app_preset_type] that is used by [modular_computer_typepath], \
 										but is not supported by its hardware!")

--- a/code/unit_tests/modular_computers_tests.dm
+++ b/code/unit_tests/modular_computers_tests.dm
@@ -7,8 +7,39 @@ ABSTRACT_TYPE(/datum/unit_test/modular_computers)
 	name = "MOD COMP: Template"
 	groups = list("generic")
 
+/datum/unit_test/modular_computers/modular_computer_app_presets_contain_programs_only_once
+	name = "MOD COMP: Preset contain programs only once"
+
+/datum/unit_test/modular_computers/modular_computer_app_presets_contain_programs_only_once/start_test()
+	var/test_result = UNIT_TEST_PASSED
+
+	var/obj/item/modular_computer/test_computer = new()
+
+	for(var/preset_typepath in subtypesof(/datum/modular_computer_app_presets))
+		var/datum/modular_computer_app_presets/preset = new preset_typepath()
+
+		//Get installed programs
+		var/list/datum/computer_file/program/installed_programs = preset.return_install_programs(test_computer)
+
+		//Second list to see if we're finding the same programs twice
+		//A list of types
+		var/list/programs_present = list()
+
+		for(var/datum/computer_file/program/program in installed_programs)
+			if(program.type in programs_present)
+				test_result = TEST_FAIL("Found multiple instances of program [program.type] in preset [preset.name]!")
+			else
+				programs_present += program.type
+
+	if(test_result == UNIT_TEST_PASSED)
+		TEST_PASS("All programs in modular computer presets are only present once.")
+
+	return test_result
+
+
 /datum/unit_test/modular_computers/presets_contain_only_compatible_programs
 	name = "MOD COMP: Presets contain only compatible programs"
+	disabled = TRUE //There's 400+ fuckups and i'm not fixing all that shit myself
 
 /datum/unit_test/modular_computers/presets_contain_only_compatible_programs/start_test()
 	var/test_result = UNIT_TEST_PASSED

--- a/code/unit_tests/ss_test.dm
+++ b/code/unit_tests/ss_test.dm
@@ -163,19 +163,21 @@ SUBSYSTEM_DEF(unit_tests)
 		var/datum/unit_test/test = curr[curr.len]
 		curr.len--
 
+		TEST_GROUP_OPEN("[test.name]")
+
 		if (test.map_path && SSatlas.current_map && SSatlas.current_map.path != test.map_path)
 			test.pass("[ascii_red]Check Disabled: This test is not allowed to run on this map.", __FILE__, __LINE__)
+			TEST_GROUP_CLOSE("[test.name]")
 			if (MC_TICK_CHECK)
 				return
 			continue
 
 		if (test.disabled)
 			test.pass("[ascii_red]Check Disabled: [test.why_disabled]", __FILE__, __LINE__)
+			TEST_GROUP_CLOSE("[test.name]")
 			if (MC_TICK_CHECK)
 				return
 			continue
-
-		TEST_GROUP_OPEN("[test.name]")
 
 		var/current_test_result = null
 

--- a/html/changelogs/fluffyghost-modularcomputermadness.yml
+++ b/html/changelogs/fluffyghost-modularcomputermadness.yml
@@ -1,0 +1,62 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - code_imp: "Added some modular computer program preset tests."
+  - code_imp: "Fixed some modular computer program preset that had duplicate programs."
+  - refactor: "Refactored how the computer program presets generate the list of programs to install."
+  - code_imp: "Turned some comments into DMDocs, some cleanup around."
+  - code_imp: "Tests disabled reasons are now enclosed in the group correctly."


### PR DESCRIPTION
Added some modular computer program preset tests.
Fixed some modular computer program preset that had duplicate programs.
Refactored how the computer program presets generate the list of programs to install.
Turned some comments into DMDocs, some cleanup around.
Tests disabled reasons are now enclosed in the group correctly.