### PR TITLE
Fixed Atmospheric technician spawn count

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -146,7 +146,7 @@
 	department_flag = ENGSEC
 	faction = "Station"
 	total_positions = 3
-	spawn_positions = 2
+	spawn_positions = 3
 	intro_prefix = "an"
 	supervisors = "the chief engineer"
 	selection_color = "#c67519"

--- a/html/changelogs/fabiank3-bugfix-atmos-spawnpoints-count.yml
+++ b/html/changelogs/fabiank3-bugfix-atmos-spawnpoints-count.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed Atmospheric technician spawn slot count, now three out of three ATs can spawn at roundstart instead of two out of three."


### PR DESCRIPTION
### Description of the bug
The game is configured to allow three Atmos techs to spawn at roundstart, there are also three spawn markers in the engineering breakroom, but at round start only two out of three readied ATs spawn, one gets thrown back into the lobby.

### Changes implemented
In the job code configuration of the Atmospheric technician the number of spawn_positions was raised from two to the expected three.

### Testing
I am not aware on how the change can be tested locally. If it is testable somehow, let me know.

_Edit: ~~lobby~~ breakroom_