### PR TITLE
Fixed missing ringer terminal in XO office and removed duplicate holopad

### DIFF
--- a/html/changelogs/fabiank3-update-xo-office-ringer-and-holopad.yml
+++ b/html/changelogs/fabiank3-update-xo-office-ringer-and-holopad.yml
@@ -3,5 +3,5 @@ author: FabianK3
 delete-after: True
 
 changes:
-  - rscadd: "Added the missing ringer terminal to the XO office. Now the ringer is functional."
-  - rscdel: "Removed duplicate standard holopad from the XO office."
+  - bugfix: "Added the missing ringer terminal to the XO office. Now the ringer is functional."
+  - bugfix: "Removed duplicate standard holopad from the XO office."

--- a/html/changelogs/fabiank3-update-xo-office-ringer-and-holopad.yml
+++ b/html/changelogs/fabiank3-update-xo-office-ringer-and-holopad.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
   - rscadd: "Added the missing ringer terminal to the XO office. Now the ringer is functional."
-  - rscdel: "Removed the standard holopad from the XO office, they already have a long-range pad."
+  - rscdel: "Removed duplicate standard holopad from the XO office."

--- a/html/changelogs/fabiank3-update-xo-office-ringer-and-holopad.yml
+++ b/html/changelogs/fabiank3-update-xo-office-ringer-and-holopad.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
   - rscadd: "Added the missing ringer terminal to the XO office. Now the ringer is functional."
-  - rscdel: "Removed the standard holopad from the XO office, they already have long-range pad."
+  - rscdel: "Removed the standard holopad from the XO office, they already have a long-range pad."

--- a/html/changelogs/fabiank3-update-xo-office-ringer-and-holopad.yml
+++ b/html/changelogs/fabiank3-update-xo-office-ringer-and-holopad.yml
@@ -1,0 +1,7 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - rscadd: "Added the missing ringer terminal to the XO office. Now the ringer is functional."
+  - rscdel: "Removed the standard holopad from the XO office, they already have long-range pad."


### PR DESCRIPTION
### Changes
Fixes #18106 

### Preview
(Ringer in the top left, duplicate standard holopad in the middle gone)
![image](https://github.com/user-attachments/assets/59195632-af12-4924-9383-f034e8659bcd)
