### PR TITLE
Fixed grippers icon not displaying the content of the gripper

### DIFF
--- a/code/modules/mob/living/silicon/robot/items/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/items/gripper.dm
@@ -85,12 +85,13 @@
 /obj/item/gripper/update_icon()
 	underlays.Cut()
 	grippersafety(src)
-	if(wrapped && wrapped.icon)
-		var/mutable_appearance/MA = new(wrapped)
-		MA.layer = FLOAT_LAYER
+	if(wrapped)
+		var/mutable_appearance/MA = new (wrapped)
 		MA.pixel_y = -8
-
+		MA.plane = src.plane
+		MA.layer = FLOAT_LAYER
 		underlays += MA
+
 
 /obj/item/gripper/attack_self(mob/user)
 	if(wrapped)
@@ -151,11 +152,18 @@
 	if(wrapped) //The force of the wrapped obj gets set to zero during the attack() and afterattack().
 		force_holder = wrapped.force
 		wrapped.force = 0
+
 		var/resolved = wrapped.attack(target_mob, user)
+
 		if(QDELETED(wrapped))
 			drop(get_turf(src), user, FALSE)
+
+		update_icon()
+
 		return resolved
+
 	else // mob interactions
+
 		switch(user.a_intent)
 			if(I_HELP)
 				user.visible_message("\The [user] [pick("boops", "squeezes", "pokes", "prods", "strokes", "bonks")] \the [target_mob] with \the [src]")
@@ -165,17 +173,24 @@
 				user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN * 3)
 				playsound(user, 'sound/effects/attackblob.ogg', 60, 1)
 				//Slow,powerful attack for borgs. No spamclicking
+
 	return FALSE
 
 /obj/item/gripper/attackby(obj/item/attacking_item, mob/user)
 	var/resolved = FALSE
+
 	if(wrapped)
 		if(attacking_item == wrapped)
 			attack_self(user) //Allows gripper to be clicked to use item.
 			return TRUE
+
 		resolved = wrapped.attackby(attacking_item,user)
+
 		if(!resolved)
 			attacking_item.afterattack(wrapped, user, TRUE)//We pass along things targeting the gripper, to objects inside the gripper. So that we can draw chemicals from held beakers for instance
+
+		update_icon()
+
 	return resolved
 
 /obj/item/gripper/afterattack(var/atom/target, var/mob/living/user, proximity, params)

--- a/html/changelogs/fluffyghost-fixgrippericon.yml
+++ b/html/changelogs/fluffyghost-fixgrippericon.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed grippers icon not displaying the content of the gripper."
+  - bugfix: "Gripper icon now updates when the item content changes (in most situations?)."


### PR DESCRIPTION
Fixed grippers icon not displaying the content of the gripper.
Gripper icon now updates when the item content changes (in most situations?).

Fixes #19592 
Fixes #19738 