### PR TITLE
Resolved some runtimes for mimic turfs on examine

### DIFF
--- a/code/game/gamemodes/technomancer/spell_objs.dm
+++ b/code/game/gamemodes/technomancer/spell_objs.dm
@@ -43,7 +43,7 @@
 	var/cast_sound = null			// Sound file played when this is used.
 	var/psi_cost = 0				// Psi complexus cost to use this spell.
 
-/obj/item/spell/examine(mob/user, distance, is_adjacent, show_extended) // Nothing on examine.
+/obj/item/spell/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended) // Nothing on examine.
 	SHOULD_CALL_PARENT(FALSE)
 
 	return TRUE

--- a/code/game/machinery/stasis_cage.dm
+++ b/code/game/machinery/stasis_cage.dm
@@ -137,7 +137,7 @@
 
 
 
-/obj/machinery/stasis_cage/examine(mob/user, distance, is_adjacent, infix, suffi, show_extended)
+/obj/machinery/stasis_cage/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
 	. = ..()
 	if (contained)
 		to_chat(user, SPAN_NOTICE("\The [contained] is kept inside."))

--- a/code/game/objects/items/holomenu.dm
+++ b/code/game/objects/items/holomenu.dm
@@ -73,7 +73,7 @@
 		return TRUE
 	return ..()
 
-/obj/item/holomenu/examine(mob/user, distance, is_adjacent, show_extended)
+/obj/item/holomenu/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
 	if(anchored && length(menu_text))
 		interact(user)
 		return TRUE

--- a/code/game/objects/structures/ECD.dm
+++ b/code/game/objects/structures/ECD.dm
@@ -13,7 +13,7 @@
 	slowdown = 10
 	layer = ABOVE_HUMAN_LAYER
 
-/obj/structure/ecd/examine(mob/living/user, distance, is_adjacent, infix, suffix, show_extended)
+/obj/structure/ecd/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
 	. = ..()
 	switch(state)
 		if(ECD_LOOSE)
@@ -22,8 +22,11 @@
 			to_chat(user, SPAN_NOTICE("\The [src] is bolted to the floor."))
 		if(ECD_WELDED)
 			to_chat(user, SPAN_NOTICE("\The [src] is bolted and welded to the floor."))
-	if(user.isSynthetic())
-		to_chat(user, SPAN_NOTICE("\The [src] does not seem to be doing anything, but you can feel it. A signal, beyond anything you can consciously understand, weaving and scratching a shield around the back of your mind."))
+
+	if(istype(user, /mob/living))
+		var/mob/living/living_user = user
+		if(living_user.isSynthetic())
+			to_chat(living_user, SPAN_NOTICE("\The [src] does not seem to be doing anything, but you can feel it. A signal, beyond anything you can consciously understand, weaving and scratching a shield around the back of your mind."))
 
 /obj/structure/ecd/attackby(obj/item/attacking_item, mob/user, params)
 	if(attacking_item.iswrench())

--- a/code/game/objects/structures/therapy.dm
+++ b/code/game/objects/structures/therapy.dm
@@ -22,7 +22,7 @@
 		playsound(src.loc, 'sound/weapons/blade_open.ogg', 50, 1)
 	closed = !closed
 
-/obj/item/pocketwatch/examine(mob/user, distance, is_adjacent, show_extended)
+/obj/item/pocketwatch/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
 	. = ..()
 	if (distance <= 1)
 		checktime()

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -12,7 +12,7 @@
 	var/obj/item/device/assembly_holder/bombassembly = null   //The first part of the bomb is an assembly holder, holding an igniter+some device
 	var/obj/item/tank/bombtank = null //the second part of the bomb is a phoron tank
 
-/obj/item/device/onetankbomb/examine(mob/user, show_extended)
+/obj/item/device/onetankbomb/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
 	. = ..()
 	examinate(user, bombtank, show_extended)
 

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -95,7 +95,7 @@
 		icon_state = "evidenceobj"
 	return
 
-/obj/item/evidencebag/examine(mob/user, show_extended)
+/obj/item/evidencebag/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
 	. = ..()
 	if (stored_item)
 		examinate(user, stored_item, show_extended)

--- a/code/modules/integrated_electronics/core/device.dm
+++ b/code/modules/integrated_electronics/core/device.dm
@@ -51,7 +51,7 @@
 		for(var/obj/item/integrated_circuit/built_in/device_input/I in EA.contents)
 			I.do_work()
 
-/obj/item/device/assembly/electronic_assembly/examine(mob/user, show_extended)
+/obj/item/device/assembly/electronic_assembly/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
 	. = ..()
 	if(EA)
 		for(var/obj/item/integrated_circuit/IC in EA.contents)

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -3,7 +3,7 @@
 a creative player the means to solve many problems.  Circuits are held inside an electronic assembly, and are wired using special tools.
 */
 
-/obj/item/integrated_circuit/examine(mob/user, show_extended)
+/obj/item/integrated_circuit/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
 	interact(user)
 	external_examine(user)
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/items/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/items/gripper.dm
@@ -35,10 +35,10 @@
 
 	var/force_holder
 
-/obj/item/gripper/examine(mob/user, show_extended)
+/obj/item/gripper/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
 	. = ..()
 	if(wrapped)
-		wrapped.examine(user, show_extended = show_extended)
+		wrapped.examine(arglist(args))
 
 /obj/item/gripper/get_examine_text(mob/user, distance, is_adjacent, infix, suffix)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/morph.dm
+++ b/code/modules/mob/living/simple_animal/hostile/morph.dm
@@ -102,7 +102,7 @@
 
 /mob/living/simple_animal/hostile/morph/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
 	if(morphed)
-		return form.examine(user)
+		return form.examine(arglist(args))
 	else
 		return ..()
 

--- a/code/modules/mob/living/simple_animal/illusion.dm
+++ b/code/modules/mob/living/simple_animal/illusion.dm
@@ -34,7 +34,7 @@
 	SHOULD_CALL_PARENT(FALSE)
 
 	if(copying)
-		return copying.examine(user, distance, is_adjacent, infix, suffix, show_extended)
+		return copying.examine(arglist(args))
 	else
 		return list("???")
 

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -152,7 +152,7 @@
 /atom/movable/openspace/mimic/attack_hand(mob/user)
 	to_chat(user, SPAN_NOTICE("You cannot reach \the [src] from here."))
 
-/atom/movable/openspace/mimic/examine(..., show_extended)
+/atom/movable/openspace/mimic/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
 	SHOULD_CALL_PARENT(FALSE)
 	. = associated_atom.examine(arglist(args))	// just pass all the args to the copied atom
 
@@ -187,9 +187,9 @@
 /atom/movable/openspace/turf_proxy/attack_generic(mob/user as mob)
 	loc.attack_generic(user)
 
-/atom/movable/openspace/turf_proxy/examine(mob/examiner, show_extended)
+/atom/movable/openspace/turf_proxy/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
 	SHOULD_CALL_PARENT(FALSE)
-	. = loc.examine(examiner, show_extended = show_extended)
+	. = loc.examine(arglist(args))
 
 
 // -- TURF MIMIC --
@@ -214,6 +214,6 @@
 /atom/movable/openspace/turf_mimic/attack_generic(mob/user as mob)
 	to_chat(user, SPAN_NOTICE("You cannot reach \the [src] from here."))
 
-/atom/movable/openspace/turf_mimic/examine(mob/examiner, show_extended)
+/atom/movable/openspace/turf_mimic/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
 	SHOULD_CALL_PARENT(FALSE)
-	. = delegate.examine(examiner, show_extended = show_extended)
+	. = delegate.examine(arglist(args))

--- a/code/modules/overmap/ship_weaponry/_ship_gun.dm
+++ b/code/modules/overmap/ship_weaponry/_ship_gun.dm
@@ -280,7 +280,7 @@
 	SHOULD_CALL_PARENT(FALSE)
 
 	if(connected)
-		return connected.examine(user, distance, is_adjacent, infix, suffix, show_extended)
+		return connected.examine(arglist(args))
 	else
 		return TRUE
 

--- a/code/modules/psionics/abilities/mirror_shade.dm
+++ b/code/modules/psionics/abilities/mirror_shade.dm
@@ -76,7 +76,7 @@
 /mob/living/simple_animal/hostile/mirror_shade/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
 	if(!QDELETED(owner))
 		/// Technically suspicious, but these have 30 seconds of lifetime so it's probably fine.
-		return owner.examine(user)
+		return owner.examine(arglist(args))
 	return ..()
 
 /mob/living/simple_animal/hostile/mirror_shade/Destroy()

--- a/html/changelogs/fluffyghost-examinetweakfixes.yml
+++ b/html/changelogs/fluffyghost-examinetweakfixes.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Resolved some runtimes for mimic turfs on examine."
+  - code_imp: "All examine headers respect the proc signature."
+  - code_imp: "All examine that do not explicitly need not to, passthrough the arglist to references examine target procs."


### PR DESCRIPTION
Resolved some runtimes for mimic turfs on examine.
All examine headers respect the proc signature.
All examine that do not explicitly need not to, passthrough the arglist to references examine target procs.