### PR TITLE
Chemmaster and chemdispenser UI disables if the machine is not operable

### DIFF
--- a/code/modules/power/power_usage.dm
+++ b/code/modules/power/power_usage.dm
@@ -28,10 +28,13 @@ This is /obj/machinery level code to properly manage power usage from the area.
 		chan = power_channel
 	return check_area.powered(chan)			// return power status of the area
 
-// called whenever the power settings of the containing area change
-// by default, check equipment channel & set flag can override if needed
-// This is NOT for when the machine's own status changes; update_use_power for that.
+/// called whenever the power settings of the containing area change
+/// by default, check equipment channel & set flag can override if needed
+/// This is NOT for when the machine's own status changes; update_use_power for that.
 /obj/machinery/proc/power_change()
+	SHOULD_NOT_SLEEP(TRUE)
+	SHOULD_CALL_PARENT(TRUE)
+
 	var/oldstat = stat
 
 	if(powered(power_channel))

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -299,6 +299,11 @@
 		return TRUE
 	return TRUE
 
+/obj/machinery/chem_master/ui_status(mob/user, datum/ui_state/state)
+	if(!operable())
+		return UI_DISABLED
+
+	. = ..()
 
 
 /obj/machinery/chem_master/Topic(href, href_list)

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -202,6 +202,12 @@
 
 	add_fingerprint(usr)
 
+/obj/machinery/chemical_dispenser/ui_status(mob/user, datum/ui_state/state)
+	if(!operable())
+		return UI_DISABLED
+
+	. = ..()
+
 /obj/machinery/chemical_dispenser/attack_ai(mob/user as mob)
 	if(!ai_can_interact(user))
 		return

--- a/html/changelogs/fluffyghost-chemmasterdispenseruidisableinoperable.yml
+++ b/html/changelogs/fluffyghost-chemmasterdispenseruidisableinoperable.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Chemmaster and chemdispenser UI disables if the machine is not operable."
+  - code_imp: "Turned a comment into a DMDoc."


### PR DESCRIPTION
Chemmaster and chemdispenser UI disables if the machine is not operable.
Turned a comment into a DMDoc.

Fixes #19825 