### PR TITLE
Makes the available ghostrole list display properly

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -143,6 +143,7 @@ var/datum/controller/subsystem/ticker/SSticker
 	total_players = length(GLOB.player_list)
 
 	if (current_state == GAME_STATE_PREGAME && pregame_timeleft == GLOB.config.vote_autogamemode_timeleft)
+		welcome()
 		SSvote.autogamemode()
 		pregame_timeleft--
 		return
@@ -453,6 +454,10 @@ var/datum/controller/subsystem/ticker/SSticker
 
 		setup_player_ready_list()
 
+	callHook("pregame_start")
+
+/// Handles welcome message and prints out ghostrole information. Should be called after offsites have spawned.
+/datum/controller/subsystem/ticker/proc/welcome()
 	to_world("<B><span class='notice'>Welcome to the pre-game lobby!</span></B>")
 	to_world("Please, setup your character and select ready. Game will start in [pregame_timeleft] seconds.")
 
@@ -488,8 +493,6 @@ var/datum/controller/subsystem/ticker/SSticker
 		</span>\
 	"}
 	to_world(html)
-
-	callHook("pregame_start")
 
 /datum/controller/subsystem/ticker/proc/setup()
 	//Create and announce mode

--- a/html/changelogs/hazelmouse-ghostrolethingy.yml
+++ b/html/changelogs/hazelmouse-ghostrolethingy.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Available ghostroles now appear correctly at roundstart."


### PR DESCRIPTION
The pregame() proc was shuffled around in init order after the ghostrole list was implemented into it, so it currently procs before the ghostroles the list should reference have spawned in. This shifts all of the 'cosmetic' elements of pregame over to a new welcome proc which is called much later, so it properly reads out the available ghostroles. The welcome message should also be a little more visible to users now that it isn't so early in initialisation.

Current:
![image](https://github.com/user-attachments/assets/99aef9df-86a8-4f24-806c-4fe46e12ad2d)

With this PR:
![image](https://github.com/user-attachments/assets/c6f4b536-257f-4923-ab56-aa75f4e53484)