### PR TITLE
Revert "Fixes wieldable items un-wielding when hovered over a compatible storage slot."

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -813,15 +813,14 @@
 #undef LYING_DOWN_FIRE_DELAY_AND_RECOIL_STAT_MULTIPLIER
 #undef LYING_DOWN_ACCURACY_STAT_MULTIPLIER
 
-/obj/item/gun/on_slotmove(mob/user, slot, disable_warning, ignore_blocked)
-	. = ..()
-	if(!.)
-		return
+/obj/item/gun/mob_can_equip(mob/user, slot, disable_warning, ignore_blocked)
+	//Cannot equip wielded items.
 	if(wielded)
 		unwield()
 		var/obj/item/offhand/O = user.get_inactive_hand()
 		if(istype(O))
 			O.unwield()
+	return ..()
 
 /obj/item/gun/throw_at()
 	..()


### PR DESCRIPTION
Reverts Aurorastation/Aurora.3#20102

The aforementioned PR essentially broke the proc, since the parent proc doesn't set any return value; this in turn breaks the offhand item from being deleted when you move a gun from the hand to eg. the backpack, leaving you with the offhand item occupying the other hand despite you not holding the gun

Since the fix is essentially a reversion, and since the parent proc doesn't set any return value so it doesn't make sense to check it, I'm opening a reversion directly.