### PR TITLE
Tajaran Religion Banner Sets Added to Loadout

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -1031,6 +1031,29 @@
 	illustration = "paper"
 	starts_with = list(/obj/item/device/versebook/nka = 6)
 
+/obj/item/storage/box/suns_flags
+	name = "s'rand'marr Worship flag box"
+	desc = "A box filled with flags of the S'rend'marr faith."
+	illustration = "flags"
+	starts_with = list(
+		/obj/item/flag/srendarr = 1,
+		/obj/item/flag/messa = 1
+	)
+
+/obj/item/storage/box/matake_flags
+	name = "ma'ta'ke pantheon flag box"
+	desc = "A box filled to the brim with the various flags of the Ma'ta'ke Pantheon."
+	illustration = "flags"
+	starts_with = list(
+		/obj/item/flag/matake = 1,
+		/obj/item/flag/marryam = 1,
+		/obj/item/flag/rredouane = 1,
+		/obj/item/flag/shumaila = 1,
+		/obj/item/flag/kraszar = 1,
+		/obj/item/flag/dhrarmela = 1,
+		/obj/item/flag/azubarre = 1
+	)
+
 /obj/item/storage/box/dominia_honor
 	name = "dominian honor codex box"
 	desc = "A box full of dominian honor codices."

--- a/code/modules/client/preference_setup/loadout/items/xeno/tajara.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/tajara.dm
@@ -645,6 +645,21 @@ ABSTRACT_TYPE(/datum/gear/shoes/tajara)
 	banner["Azubarre Banner"] = /obj/item/flag/azubarre
 	gear_tweaks += new /datum/gear_tweak/path(banner)
 
+/datum/gear/accessory/tajara_god_banners_set
+	display_name = "tajaran deity banners (set)"
+	description = "A selection of religious flag sets representing Adhomian faiths."
+	path = /obj/item/storage/box/suns_flags
+	cost = 2
+	whitelisted = list(SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI)
+	sort_category = "Xenowear - Tajara"
+
+/datum/gear/accessory/tajara_god_banners_set/New()
+	..()
+	var/list/banners = list()
+	banners["S'rand'marr Worship Banners"] = /obj/item/storage/box/suns_flags
+	banners["Ma'ta'ke Pantheon Banners"] = /obj/item/storage/box/matake_flags
+	gear_tweaks += new /datum/gear_tweak/path(banners)
+
 /datum/gear/tajara_god_altars
 	display_name = "matakae deity altars"
 	description = "A selection of small altars used to worship the matake gods."

--- a/code/modules/clothing/head/xenos/tajara.dm
+++ b/code/modules/clothing/head/xenos/tajara.dm
@@ -53,6 +53,9 @@
 /obj/item/clothing/head/tajaran/raskara
 	name = "raskariim mask"
 	desc = "A face concealing mask worn by the members of the cult of Raskara."
+	desc_extended = "Raskariim, commonly known as The Cult of Raskara are a prolific cult on Adhomai. The religion has been created on Adhomai but with the free commerce, a few human \
+	members have been recorded. While Raskara may seem like a single deity it is in fact split into three aspects, each one leading down a different path and seemingly every path \
+	subverting something S'rendarr and Messa stands for."
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
 	species_restricted = list(BODYTYPE_TAJARA)

--- a/html/changelogs/Ben10083 - Banner Sets.yml
+++ b/html/changelogs/Ben10083 - Banner Sets.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "New loadout options in Tajara loadout for getting sets of Religious banners (S'rand'marr and Ma'ta'ke)."
+  - spellcheck: "Fixed incorrect extended description for Raskariim mask."


### PR DESCRIPTION
Title

Banner sets for Tajaran religions (Suns and Ma'ta'ke) added to loadout with 2 point cost

Useful for roles like chaplain that wants representation of more members of the pantheon/ both suns