### PR TITLE
Adds some Golden Deep assets to the loadout

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/gear_loadout.dm
+++ b/code/game/objects/structures/crates_lockers/crates/gear_loadout.dm
@@ -1156,6 +1156,22 @@
 	new /obj/item/melee/energy/glaive(src)
 	new /obj/item/melee/energy/axe(src)
 	new /obj/item/melee/energy/axe(src)
+	new /obj/item/clothing/head/helmet/space/void/golden_deep/hoplan(src)
+	new /obj/item/clothing/head/helmet/space/void/golden_deep/hoplan(src)
+	new /obj/item/clothing/head/helmet/space/void/golden_deep/hoplan(src)
+	new /obj/item/clothing/head/helmet/space/void/golden_deep/hoplan(src)
+	new /obj/item/clothing/suit/space/void/golden_deep/hoplan(src)
+	new /obj/item/clothing/suit/space/void/golden_deep/hoplan(src)
+	new /obj/item/clothing/suit/space/void/golden_deep/hoplan(src)
+	new /obj/item/clothing/suit/space/void/golden_deep/hoplan(src)
+	new /obj/item/clothing/shoes/magboots(src)
+	new /obj/item/clothing/shoes/magboots(src)
+	new /obj/item/clothing/shoes/magboots(src)
+	new /obj/item/clothing/shoes/magboots(src)
+	new /obj/item/device/suit_cooling_unit(src)
+	new /obj/item/device/suit_cooling_unit(src)
+	new /obj/item/device/suit_cooling_unit(src)
+	new /obj/item/device/suit_cooling_unit(src)
 
 /obj/structure/closet/crate/secure/gear_loadout/hoplan/single/fill()
 	new /obj/item/clothing/shoes/jackboots(src)
@@ -1178,6 +1194,10 @@
 	new /obj/item/stack/nanopaste/surge(src)
 	new /obj/item/shield/energy/legion(src)
 	new /obj/item/melee/energy/glaive(src)
+	new /obj/item/clothing/head/helmet/space/void/golden_deep/hoplan(src)
+	new /obj/item/clothing/suit/space/void/golden_deep/hoplan(src)
+	new /obj/item/clothing/shoes/magboots(src)
+	new /obj/item/device/suit_cooling_unit(src)
 
 //ninja stuff
 /obj/structure/closet/crate/secure/gear_loadout/ninja

--- a/code/modules/client/preference_setup/loadout/items/xeno/machine.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/machine.dm
@@ -138,8 +138,6 @@
 	goldendeep["golden deep vest"] = /obj/item/clothing/under/goldendeep/vest
 	goldendeep["golden deep suit"] = /obj/item/clothing/under/goldendeep/suit
 	goldendeep["golden deep skirtsuit"] = /obj/item/clothing/under/goldendeep/skirtsuit
-	goldendeep["golden deep hoplan uniform"] = /obj/item/clothing/under/goldendeep/hoplan
-	goldendeep["golden deep porter uniform"] = /obj/item/clothing/under/goldendeep/porter
 	gear_tweaks += new /datum/gear_tweak/path(goldendeep)
 
 ABSTRACT_TYPE(/datum/gear/augment/machine)
@@ -262,10 +260,30 @@ ABSTRACT_TYPE(/datum/gear/augment/machine)
 	goldendeephat["golden deep cube hood"] = /obj/item/clothing/head/goldendeep/cubehood
 	gear_tweaks += new /datum/gear_tweak/path(goldendeephat)
 
+// Hoplan uniforms are restricted to Golden Deep Consulars and Diplomatic Aides. As military uniforms, they aren't something you'd see among the general crew.
+/datum/gear/uniform/goldendeephoplan
+	display_name = "golden deep hoplan uniform"
+	description = "An ornate piece of clothing usually worn by members of the Hoplan, but known to circulate elsewhere."
+	path = /obj/item/clothing/under/goldendeep/hoplan
+	whitelisted = list(SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL)
+	sort_category = "Xenowear - IPC"
+	allowed_roles = list("Consular Officer", "Diplomatic Aide")
+	culture_restriction = list(/singleton/origin_item/culture/golden_deep)
+
 /datum/gear/head/goldendeephoplan
 	display_name = "golden deep hoplan hat"
 	description = "A large poofy hat typically worn by members of the Hoplan, but known to circulate elsewhere."
 	path = /obj/item/clothing/head/goldendeep/hoplan
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
+	whitelisted = list(SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL)
+	sort_category = "Xenowear - IPC"
+	allowed_roles = list("Consular Officer", "Diplomatic Aide")
+	culture_restriction = list(/singleton/origin_item/culture/golden_deep)
+
+/datum/gear/uniform/goldendeepporter
+	display_name = "golden deep porter uniform"
+	description = "A plain and durable suit popular among the menial synthetics fo the Golden Deep, but known to ciculate elsewhere."
+	path = /obj/item/clothing/under/goldendeep/porter
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 	whitelisted = list(SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL)
 	sort_category = "Xenowear - IPC"

--- a/code/modules/client/preference_setup/loadout/items/xeno/machine.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/machine.dm
@@ -125,7 +125,7 @@
 
 /datum/gear/uniform/goldendeep
 	display_name = "golden deep outfit selection"
-	description = "A selection of formal outfits and uniforms worn by members of the Golden Deep."
+	description = "A selection of formal outfits worn by members of the Golden Deep."
 	path = /obj/item/clothing/under/goldendeep
 	whitelisted = list(SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL)
 	sort_category = "Xenowear - IPC"

--- a/code/modules/client/preference_setup/loadout/items/xeno/machine.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/machine.dm
@@ -125,7 +125,7 @@
 
 /datum/gear/uniform/goldendeep
 	display_name = "golden deep outfit selection"
-	description = "A selection of formal outfits worn by members of the Golden Deep."
+	description = "A selection of formal outfits and uniforms worn by members of the Golden Deep."
 	path = /obj/item/clothing/under/goldendeep
 	whitelisted = list(SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL)
 	sort_category = "Xenowear - IPC"
@@ -138,6 +138,8 @@
 	goldendeep["golden deep vest"] = /obj/item/clothing/under/goldendeep/vest
 	goldendeep["golden deep suit"] = /obj/item/clothing/under/goldendeep/suit
 	goldendeep["golden deep skirtsuit"] = /obj/item/clothing/under/goldendeep/skirtsuit
+	goldendeep["golden deep hoplan uniform"] = /obj/item/clothing/under/goldendeep/hoplan
+	goldendeep["golden deep porter uniform"] = /obj/item/clothing/under/goldendeep/porter
 	gear_tweaks += new /datum/gear_tweak/path(goldendeep)
 
 ABSTRACT_TYPE(/datum/gear/augment/machine)
@@ -259,6 +261,22 @@ ABSTRACT_TYPE(/datum/gear/augment/machine)
 	goldendeephat["golden deep cowl"] = /obj/item/clothing/head/goldendeep/cowl
 	goldendeephat["golden deep cube hood"] = /obj/item/clothing/head/goldendeep/cubehood
 	gear_tweaks += new /datum/gear_tweak/path(goldendeephat)
+
+/datum/gear/head/goldendeephoplan
+	display_name = "golden deep hoplan hat"
+	description = "A large poofy hat typically worn by members of the Hoplan, but known to circulate elsewhere."
+	path = /obj/item/clothing/head/goldendeep/hoplan
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
+	whitelisted = list(SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL)
+	sort_category = "Xenowear - IPC"
+
+/datum/gear/head/goldendeepporter
+	display_name = "golden deep porter hat"
+	description = "A plain and durable piece of headwear popular among the menial synthetics of the Golden Deep, but known to circulate elsewhere."
+	path = /obj/item/clothing/head/goldendeep/porter
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
+	whitelisted = list(SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL)
+	sort_category = "Xenowear - IPC"
 
 /datum/gear/head/goldendeepchainjewelry
 	display_name = "golden deep chain jewelry"

--- a/html/changelogs/hazelmouse-goldendeepstuff.yml
+++ b/html/changelogs/hazelmouse-goldendeepstuff.yml
@@ -55,5 +55,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Adds the Golden Deep Hoplan and Porter uniforms to the loadout, available to all IPC characters."
+  - rscadd: "Adds the Golden Deep Hoplan and Porter uniforms to the loadout."
   - rscadd: "Adds the Golden Deep Hoplan voidsuit to the appropriate uplink kit."

--- a/html/changelogs/hazelmouse-goldendeepstuff.yml
+++ b/html/changelogs/hazelmouse-goldendeepstuff.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds the Golden Deep Hoplan and Porter uniforms to the loadout, available to all IPC characters."
+  - rscadd: "Adds the Golden Deep Hoplan voidsuit to the appropriate uplink kit."


### PR DESCRIPTION
Adds the Golden Deep Hoplan and Porter uniforms, added in https://github.com/Aurorastation/Aurora.3/pull/20031, to the loadout at request of synthetic lore. Adds the Hoplan voidsuits to the GD uplink kits. 