### PR TITLE
Added force name change dropdown menu option to rename living mobs

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -11,5 +11,8 @@
 #define VV_HK_CALLPROC "proc_call"
 #define VV_HK_MARK "mark"
 
+// /mob/living
+#define VV_HK_ADMIN_RENAME "admin_rename"
+
 //Helpers for vv_get_dropdown() - yes this is different from the tg one, cope
 #define VV_DROPDOWN_OPTION(href_key, name) . += "<option value='?_src_=vars;[href_key]=[REF(src)]'>[name]</option>"

--- a/code/modules/admin/view_variables/helpers.dm
+++ b/code/modules/admin/view_variables/helpers.dm
@@ -50,6 +50,10 @@
 	VV_DROPDOWN_OPTION("explode", "Trigger explosion")
 	VV_DROPDOWN_OPTION("emp", "Trigger EM pulse")
 
+/mob/living/vv_get_dropdown()
+	. = ..()
+	VV_DROPDOWN_OPTION(VV_HK_ADMIN_RENAME, "Force Change Name")
+
 /mob/living/carbon/human/vv_get_dropdown()
 	. = ..()
 	VV_DROPDOWN_OPTION("setspecies", "Set Species")

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -6,28 +6,29 @@
 	if(href_list["Vars"])
 		debug_variables(locate(href_list["Vars"]))
 
-	//~CARN: for renaming mobs (updates their name, real_name, mind.name, their ID/PDA and datacore records).
-	else if(href_list["rename"])
+	// For admin renaming mobs (updates their name, real_name, mind.name, their ID/PDA and datacore records)
+	if(href_list[VV_HK_ADMIN_RENAME])
 		if(!check_rights(R_VAREDIT|R_DEV|R_MOD))
 			return
 
-		var/mob/M = locate(href_list["rename"])
-		if(!istype(M))
+		var/mob/living/mob_to_rename = locate(href_list[VV_HK_ADMIN_RENAME])
+		if(!istype(mob_to_rename))
 			to_chat(usr, "This can only be used on instances of type /mob")
 			return
 
-		var/new_name = sanitize(input(usr,"What would you like to name this mob?","Input a name",M.real_name) as text|null, MAX_NAME_LEN)
-		if( !new_name || !M )	return
+		var/new_name = sanitize(input(usr,"What would you like to name this mob?","Input a name", mob_to_rename.real_name) as text|null, MAX_NAME_LEN)
+		if(!new_name || !mob_to_rename)
+			return
 
-		message_admins("Admin [key_name_admin(usr)] renamed [key_name_admin(M)] to [new_name].")
-		M.fully_replace_character_name(M.real_name,new_name)
+		message_admins("Admin [key_name_admin(usr)] renamed [key_name_admin(mob_to_rename)] to [new_name].")
+		mob_to_rename.fully_replace_character_name(mob_to_rename.real_name, new_name)
 
-		if (issilicon(M) && alert(usr, "Synth detected. Would you like to run rename silicon verb automatically?",, "Yes", "No") == "Yes")
-			var/mob/living/silicon/S = M
+		if (issilicon(mob_to_rename) && alert(usr, "Synth detected. Would you like to run rename silicon verb automatically?",, "Yes", "No") == "Yes")
+			var/mob/living/silicon/S = mob_to_rename
 			S.SetName(new_name)
 			to_chat(usr, SPAN_NOTICE("Silicon properly renamed."))
 
-		href_list["datumrefresh"] = href_list["rename"]
+		href_list["datumrefresh"] = href_list[VV_HK_ADMIN_RENAME]
 
 	else if(href_list["varnameedit"] && href_list[VV_HK_BASIC_EDIT])
 		if(!check_rights(R_VAREDIT|R_DEV))	return

--- a/html/changelogs/fluffyghost-addedforcenamechange.yml
+++ b/html/changelogs/fluffyghost-addedforcenamechange.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - server: "Added force name change dropdown menu option to rename living mobs."


### PR DESCRIPTION
Added force name change dropdown menu option to rename living mobs

![immagine](https://github.com/user-attachments/assets/31ddf454-27b1-487b-b3ea-0cb1eb709518)

Fixes #20132 