### PR TITLE
Frag grenades buff

### DIFF
--- a/code/game/objects/items/weapons/grenades/fragmentation.dm
+++ b/code/game/objects/items/weapons/grenades/fragmentation.dm
@@ -32,9 +32,15 @@
 
 //Fragmentation grenade projectile
 /obj/projectile/bullet/pellet/fragment
-	damage = 20
+	damage = 23
+	agony = 20
+	eyeblur = 2
 	armor_penetration = 35
+	embed_chance = 30
 	range_step = 2
+
+	ricochets_max = 2
+	ricochet_chance = 20
 
 	base_spread = 0 //causes it to be treated as a shrapnel explosion instead of cone
 	spread_step = 20

--- a/code/modules/overmap/ship_weaponry/weaponry/leviathan.dm
+++ b/code/modules/overmap/ship_weaponry/weaponry/leviathan.dm
@@ -164,10 +164,6 @@
 		target.visible_message(SPAN_DANGER("<font size=6>A giant, purple laser descends from the sky!</font>"))
 		explosion(target, 30, 30, 30)
 
-/obj/projectile/ship_ammo/leviathan/check_penetrate(atom/A)
-	on_hit(A)
-	return TRUE
-
 /obj/machinery/zat_lever
 	name = "activation lever"
 	desc = "An old-style lever that couples the Leviathan's capacitors. <span class='danger'>Flicking this will result in extreme power usage!</span>"

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -209,9 +209,6 @@
 
 	var/anti_materiel_potential = 1 //how much the damage of this bullet is increased against mechs
 
-	///If the projectile launches a secondary projectile in addition to itself.
-	var/secondary_projectile
-
 	/*########################################
 		END AURORA SNOWFLAKE VARS SECTION
 	########################################*/
@@ -1091,11 +1088,6 @@
 	if(!embed || damage_type != DAMAGE_BRUTE)
 		return FALSE
 	return TRUE
-
-//return TRUE if the projectile should be allowed to pass through after all, FALSE if not.
-/obj/projectile/proc/check_penetrate(atom/A)
-	return TRUE
-
 
 /obj/projectile/ex_act(var/severity = 2.0)
 	return //explosions probably shouldn't delete projectiles

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -29,37 +29,6 @@
 		return 0
 	return ..()
 
-/obj/projectile/bullet/check_penetrate(var/atom/A)
-	if(!A || !A.density) return 1 //if whatever it was got destroyed when we hit it, then I guess we can just keep going
-
-	if(ismob(A))
-		if(!mob_passthrough_check)
-			return 0
-		if(iscarbon(A))
-			damage *= 0.7 //squishy mobs absorb KE
-		return 1
-
-	var/chance = 0
-	if(istype(A, /turf/simulated/wall))
-		var/turf/simulated/wall/W = A
-		chance = round(damage/W.material.integrity*180)
-	else if(istype(A, /obj/machinery/door))
-		var/obj/machinery/door/D = A
-		chance = round(damage/D.maxhealth*180)
-		if(D.glass) chance *= 2
-	else if(istype(A, /obj/structure/girder))
-		chance = 100
-	else if(istype(A, /obj/machinery) || istype(A, /obj/structure))
-		chance = damage
-
-	if(prob(chance))
-		if(A.opacity)
-			//display a message so that people on the other side aren't so confused
-			A.visible_message(SPAN_WARNING("\The [src] pierces through \the [A]!"))
-		return 1
-
-	return 0
-
 /**
  * # Pellet projectiles
  *
@@ -281,7 +250,6 @@
 
 /obj/projectile/bullet/shotgun/moghes
 	name = "wall shot"
-	secondary_projectile = /obj/projectile/bullet/pellet/shotgun/canister
 
 //Should do about 80 damage at 1 tile distance (adjacent), and 50 damage at 3 tiles distance.
 //Overall less damage than slugs in exchange for more damage at very close range and more embedding
@@ -578,11 +546,6 @@
 	var/devastation_range = -1
 	var/heavy_impact_range = -1
 	var/light_impact_range = 2
-
-/obj/projectile/bullet/peac/check_penetrate(atom/hit_atom)
-	if(hit_atom == original)
-		return FALSE
-	return ..()
 
 /obj/projectile/bullet/peac/on_hit(atom/target, blocked, def_zone)
 	. = ..()

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -199,7 +199,7 @@
 	agony = 40
 	speed = 0.4
 	damage_type = DAMAGE_BURN
-	eyeblur = TRUE
+	eyeblur = 1
 	pass_flags = PASSTABLE | PASSRAILING
 	muzzle_type = /obj/effect/projectile/muzzle/bolt
 

--- a/code/modules/psionics/abilities/hollow_purple.dm
+++ b/code/modules/psionics/abilities/hollow_purple.dm
@@ -80,10 +80,6 @@
 	explosion(target, 5, 5, 5)
 	. = ..()
 
-/obj/projectile/hollow_purple/check_penetrate(atom/A)
-	on_hit(A)
-	return TRUE
-
 // /obj/projectile/hollow_purple/after_move()
 // 	for(var/a in range(3, src))
 // 		if(isliving(a) && a != firer)

--- a/html/changelogs/fluffyghost-fraggrenadebuff.yml
+++ b/html/changelogs/fluffyghost-fraggrenadebuff.yml
@@ -1,0 +1,62 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Frag grenades projectiles now apply some agony and eyeblur."
+  - balance: "Frag grenades projectiles have damage augmented by 3 points (~10%)."
+  - balance: "Frag grenades projectiles have an augmented chance of leaving a shrapnel (+30%)."
+  - balance: "Frag grenades projectiles have a chance to ricochet up to 2 times."
+  - code_imp: "Some code cleanup and removed some procs that were no longer used (nothing called them anymore) from the projectile refactor."


### PR DESCRIPTION
Frag grenades projectiles now apply some agony and eyeblur.
Frag grenades projectiles have damage augmented by 3 points (~10%).
Frag grenades projectiles have an augmented chance of leaving a shrapnel (+30%).
Frag grenades projectiles have a chance to ricochet up to 2 times.
Some code cleanup and removed some procs that were no longer used (nothing called them anymore) from the projectile refactor.