### PR TITLE
Fixes SSMD shuttle pump

### DIFF
--- a/html/changelogs/OolongCow-MaybelleAurora.yml
+++ b/html/changelogs/OolongCow-MaybelleAurora.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: OolongCow
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes the SSMD ship's shuttle having a backwards fuel pump."

--- a/maps/away/ships/sol/sol_ssmd/ssmd_ship.dmm
+++ b/maps/away/ships/sol/sol_ssmd/ssmd_ship.dmm
@@ -895,7 +895,7 @@
 "cFy" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 4;
+	dir = 8;
 	name = "Fuel to Thrusters"
 	},
 /turf/simulated/floor/tiled/dark/full,


### PR DESCRIPTION
Flips the pump on the SSMD ship's shuttle so that the thrusters function correctly. The red line is the side it flows towards. Fixes #20148 

Old: 
![Screenshot 2024-11-08 064049](https://github.com/user-attachments/assets/a1360ddd-0a38-40b9-8b8d-81dfb26d7137)

New: 
![Screenshot 2024-11-08 065911](https://github.com/user-attachments/assets/83b4e244-b172-4abf-9ddd-6c7e30638235)