### PR TITLE
Columbo Buffs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/commanded/guard_dog.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/guard_dog.dm
@@ -78,12 +78,12 @@
 /mob/living/simple_animal/hostile/commanded/dog/columbo
 	name = "Lt. Columbo"
 	short_name = "Columbo"
-	desc = "A dog trained to listen and obey its owner commands. This one looks about three days from retirement."
+	desc = "A dog trained to listen and obey its owner's commands. This one looks about three days from retirement."
 	named = TRUE
 	gender = MALE
 
-	melee_damage_lower = 5
-	melee_damage_upper = 10
+	health = 125
+	maxHealth = 125
 
 	icon_state = "columbo"
 	icon_living = "columbo"

--- a/html/changelogs/OolongCow-columbo-buffs.yml
+++ b/html/changelogs/OolongCow-columbo-buffs.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: OolongCow
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Un-nerfed Columbo's damage and increased his health. Good boy."


### PR DESCRIPTION
Removes the confusingly unnecessary nerf to Columbo's damage (he did as much as just punching someone) from the parent mob and increases his health from 75 to 125 so he can withstand at least a little more punishment.

The poor guy is quite literally never let out of his enclosure because he's less useful than just throwing a floor tile at someone. He's also the only "unique" thing the Head of Security has left, and people seem warm to the idea of an actual incentive to bring him out more. With these buffs he stands an actual chance of being able to fight and take down someone unarmed and unarmored.
