### PR TITLE
Update the armory roles to account for the removal of the crew armory.

### DIFF
--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -169,9 +169,6 @@ var/list/armory_positions = list(
 	"Captain",
 	"Executive Officer",
 	"Head of Security",
-	"Chief Engineer",
-	"Research Director",
-	"Chief Medical Officer",
 	"Operations Manager"
 )
 

--- a/html/changelogs/GeneralCamo - Update Armory Roles.yml
+++ b/html/changelogs/GeneralCamo - Update Armory Roles.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: GeneralCamo
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/GeneralCamo - Update Armory Roles.yml
+++ b/html/changelogs/GeneralCamo - Update Armory Roles.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Removed the Chief Medical Officer, Chief Engineer, and Research Director from the list of armory roles."


### PR DESCRIPTION
This updates the armory roles to account for the removal of the crew armory in #19728. In particular, these roles no longer have the role:

- Chief Engineer
- Chief Medical Officer
- Research Director

The rest of the roles on the list can access the security armory, or can at least provide the access to the armory via an ID change.

The Operations Manager remains on the list. While they do not have direct access to the armory, their department is allowed to distribute guns, and this is an intended function of their role as stated in #19728.