### PR TITLE
First Aid Kits in First Aid Lockers 2

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/walllocker.dm
@@ -84,12 +84,12 @@
 
 /obj/structure/closet/walllocker/medical //wall mounted medical closet
 	name = "medical closet"
-	desc = "It's wall-mounted storage unit for medical supplies."
+	desc = "It's a wall-mounted storage unit for medical supplies."
 	icon_state = "medical_wall"
 
 /obj/structure/closet/walllocker/medical/firstaid
 	name = "first-aid closet"
-	desc = "It's wall-mounted storage unit for first aid supplies."
+	desc = "It's a wall-mounted storage unit for first aid supplies."
 
 /obj/structure/closet/walllocker/medical/firstaid/fill()
 	new /obj/item/storage/firstaid/regular

--- a/code/game/objects/structures/crates_lockers/closets/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/walllocker.dm
@@ -83,9 +83,16 @@
 	new /obj/item/storage/bag/inflatable/emergency(src)
 
 /obj/structure/closet/walllocker/medical //wall mounted medical closet
+	name = "medical closet"
+	desc = "It's wall-mounted storage unit for medical supplies."
+	icon_state = "medical_wall"
+
+/obj/structure/closet/walllocker/medical/firstaid
 	name = "first-aid closet"
 	desc = "It's wall-mounted storage unit for first aid supplies."
-	icon_state = "medical_wall"
+
+/obj/structure/closet/walllocker/medical/firstaid/fill()
+	new /obj/item/storage/firstaid/regular
 
 /obj/structure/closet/walllocker/medical/secure
 	desc = "It's a secure wall-mounted storage unit for first aid supplies."

--- a/html/changelogs/example copy.yml
+++ b/html/changelogs/example copy.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: OolongCow
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "First aid wall lockers now consistently contain a basic first aid kit."
+  - rscadd: "Several out-of-the-way or dangerous locations have received basic (white) first aid kits."


### PR DESCRIPTION
White first aid wall lockers now consistently contain a basic first aid kit rather than mapper-placed basic supplies. Spawning moved to code rather than hand-placed items on the map. High-risk (even if only flavorfully) areas and areas far from any other kit/medical have had a wall locker added. Lockers using the same /obj for other purposes (usually blood lockers) have been swapped to use the medical/secure variant. Meant to accompany changes to basic first aid kit contents in #20187 

I changed the branch name at one point and that made my commits refuse to appear in #20186, thus the new PR.

![image](https://github.com/user-attachments/assets/3cea50be-f7ba-4d7f-ab2d-18146125c44d)

![image](https://github.com/user-attachments/assets/f053f356-2fda-4a6f-be1f-ede828487a3f)


