### PR TITLE
Synthetic Access to Shuttle Manifest

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/dev_silicon_subtypes.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_silicon_subtypes.dm
@@ -13,7 +13,7 @@
 	hard_drive.store_file(new /datum/computer_file/program/rcon_console(src))
 	hard_drive.store_file(new /datum/computer_file/program/suit_sensors(src))
 	hard_drive.store_file(new /datum/computer_file/program/power_monitor(src))
-	hard_drive.store_file(new /datum/computer_file/program/docks(src))
+	hard_drive.store_file(new /datum/computer_file/program/away_manifest(src))
 	hard_drive.store_file(new /datum/computer_file/program/implant_tracker(src))
 	hard_drive.store_file(new /datum/computer_file/program/guntracker(src))
 	hard_drive.store_file(new /datum/computer_file/program/comm(src))

--- a/code/modules/modular_computers/file_system/programs/command/away_manifest.dm
+++ b/code/modules/modular_computers/file_system/programs/command/away_manifest.dm
@@ -79,7 +79,7 @@
 	if(!istype(usr))
 		return
 	var/obj/item/card/id/I = usr.GetIdCard()
-	if(!istype(I) || !I.registered_name || issilicon(usr) || (!(ACCESS_HEADS in I.access) && !(ACCESS_RESEARCH in I.access) && !(ACCESS_MINING in I.access)))
+	if(!istype(I) || !I.registered_name || (!(ACCESS_HEADS in I.access) && !(ACCESS_RESEARCH in I.access) && !(ACCESS_MINING in I.access)))
 		to_chat(usr, SPAN_WARNING("Authentication error: Unable to locate ID with appropriate access to allow this operation."))
 		return
 

--- a/html/changelogs/Ben10083 AI Shuttle.yml
+++ b/html/changelogs/Ben10083 AI Shuttle.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Replaces Docking port program for AI internal computer with Shuttle Manifest."
+  - rscadd: "Synthetics can now use Shuttle Manifest."


### PR DESCRIPTION
Fixes https://github.com/Aurorastation/Aurora.3/issues/19899 that was mostly fixed by https://github.com/Aurorastation/Aurora.3/pull/19860 by replacing docking port program with shuttle manifest

I should be fine for AI to edit shuttle manifest considering it already can edit records

Cyborgs given access to shuttle manifest considering that modules such as Mining go on expeditions