### PR TITLE
Offship minor QoL fixes

### DIFF
--- a/html/changelogs/hazelmouse-minorqol.yml
+++ b/html/changelogs/hazelmouse-minorqol.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Implemented mundane QoL changes to the Dominian Science ship and Hephaestus Cyclops ship. "

--- a/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel.dmm
+++ b/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel.dmm
@@ -1741,7 +1741,9 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
-/obj/structure/extinguisher_cabinet/north,
+/obj/structure/extinguisher_cabinet/north{
+	pixel_y = 28
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},

--- a/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel.dmm
+++ b/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel.dmm
@@ -6,8 +6,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/armory)
 "aaJ" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
@@ -24,6 +26,12 @@
 /obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/dominian_science_shuttle)
+"agR" = (
+/obj/structure/platform_deco{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/ship/dominian_science_vessel/bridge)
 "ahu" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -40,12 +48,17 @@
 /turf/simulated/wall/shuttle,
 /area/shuttle/dominian_science_shuttle)
 "ajL" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/mapped{
+/obj/effect/floor_decal/corner{
+	dir = 10
+	},
+/obj/structure/platform_deco{
 	dir = 8
 	},
-/turf/template_noop,
-/area/ship/dominian_science_vessel/exterior)
+/obj/structure/platform_deco{
+	icon_state = "ledge_deco"
+	},
+/turf/simulated/floor/marble/dark,
+/area/ship/dominian_science_vessel/chapel)
 "akl" = (
 /obj/structure/ship_weapon_dummy,
 /turf/template_noop,
@@ -59,7 +72,10 @@
 /obj/machinery/access_button{
 	pixel_x = 28
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "amZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -69,6 +85,9 @@
 	dir = 8;
 	icon_state = "tube_empty"
 	},
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "ans" = (
@@ -76,11 +95,10 @@
 /obj/structure/table/rack,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/electrical,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "aou" = (
 /obj/machinery/door/airlock/external,
-/obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 4
 	},
@@ -96,7 +114,10 @@
 	name = "airlock_dominian_science_shuttle";
 	cycle_to_external_air = 1
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
 "aqS" = (
 /obj/structure/closet/secure_closet/guncabinet{
@@ -127,7 +148,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "arN" = (
 /obj/effect/floor_decal/corner/purple/diagonal,
@@ -153,11 +174,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "atQ" = (
 /obj/structure/survey_probe/dominia,
+/obj/effect/floor_decal/corner/blue/full{
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/outline/research,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
@@ -180,7 +204,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/hangar)
 "azm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -188,7 +212,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "aAX" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -228,6 +252,9 @@
 /turf/simulated/wall/shuttle,
 /area/ship/dominian_science_vessel/atmospherics)
 "aHs" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/center_hall)
 "aHt" = (
@@ -246,15 +273,12 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/shuttle_landmark/dominian_science_shuttle/hangar,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/hangar)
 "aHw" = (
-/obj/machinery/computer/ship/navigation{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/bridge)
 "aHL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -274,6 +298,9 @@
 	id_tag = "dominian_science_shuttle_dock";
 	frequency = 1380
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/hangar)
 "aLz" = (
@@ -289,7 +316,10 @@
 	dir = 4;
 	pixel_y = -28
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "aMc" = (
 /obj/structure/cable/pink{
@@ -297,7 +327,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "aMY" = (
@@ -312,7 +342,8 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/hangar)
 "aOU" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -327,7 +358,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/hangar)
 "aPi" = (
@@ -339,6 +370,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
@@ -371,6 +405,18 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/dominian_science_shuttle)
+"aWj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/dominian_science_vessel/mess)
 "aXn" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -402,6 +448,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "bac" = (
@@ -411,7 +458,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "bcf" = (
@@ -426,7 +473,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/hangar)
 "bjV" = (
@@ -437,7 +484,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "bkQ" = (
 /obj/structure/cable/pink{
@@ -450,7 +497,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "bon" = (
@@ -472,7 +519,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "bpc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -484,7 +531,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/center_hall)
 "bpq" = (
@@ -497,7 +544,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/mess)
 "bpG" = (
 /obj/structure/table/steel,
@@ -514,15 +561,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "brM" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /obj/effect/landmark/entry_point/port{
 	name = "port, bridge"
 	},
@@ -539,7 +588,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/engineering)
 "bvi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
@@ -547,11 +596,16 @@
 	dir = 8;
 	icon_state = "tube_empty"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "bxu" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /obj/effect/landmark/entry_point/port{
 	dir = 4;
 	name = "port, medical"
@@ -575,12 +629,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "bIL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/quarters)
 "bJH" = (
 /obj/structure/toilet{
@@ -602,7 +656,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/quarters)
 "bRh" = (
 /obj/effect/map_effect/marker/airlock{
@@ -618,6 +672,7 @@
 /obj/machinery/light{
 	icon_state = "tube_empty"
 	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "bSl" = (
@@ -628,15 +683,17 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/light{
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/center_hall)
 "bTa" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, bridge"
 	},
@@ -651,7 +708,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "bUF" = (
 /obj/structure/closet/emcloset,
@@ -670,6 +727,10 @@
 /area/shuttle/dominian_science_shuttle)
 "cjK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "ckh" = (
@@ -704,7 +765,7 @@
 	req_access = list(226);
 	req_one_access = null
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -726,6 +787,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
 "ctK" = (
@@ -733,7 +797,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/eva)
 "cua" = (
@@ -742,8 +806,10 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/dominian_science_vessel/officer)
 "cuJ" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/door/blast/regular/open{
 	name = "Bridge Lockdown";
@@ -790,12 +856,22 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/dominian_science_vessel/showers)
+"cAQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/dominian_science_vessel/aft_dock)
 "cCV" = (
 /obj/effect/floor_decal/corner{
 	dir = 6
 	},
 /turf/simulated/floor/marble/dark,
 /area/ship/dominian_science_vessel/chapel)
+"cDG" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/hangar)
 "cHM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 8
@@ -812,7 +888,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "cKb" = (
@@ -836,6 +912,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_propulsion)
 "cPn" = (
@@ -850,6 +929,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
@@ -886,7 +968,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/dominian_science_vessel/exterior)
 "cTu" = (
 /obj/effect/floor_decal/corner/purple/diagonal,
@@ -915,12 +997,15 @@
 	req_access = list(226);
 	req_one_access = null
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_propulsion)
 "cYw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "cYy" = (
@@ -941,6 +1026,9 @@
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/dominian_science_shuttle)
 "cZR" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/starboard_hall)
 "dbx" = (
@@ -961,13 +1049,14 @@
 	icon_state = "tube_empty"
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "dck" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -986,15 +1075,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/hangar)
 "dfe" = (
-/obj/machinery/computer/ship/targeting{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/dominian_science_vessel/bridge)
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/dominian_science_vessel/port_hall)
 "dhW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
 	dir = 1
@@ -1048,6 +1134,9 @@
 	desc = "An energy saber with Imperial Fleet heraldry on its hilt. This likely belongs to a low-ranking officer, and likely a Ma’zal at that: any real officer would’ve purchased a legitimate blade, not this.";
 	desc_antag = "Swords are common symbols of office and ceremonial implements throughout the human navies of the Orion Spur, and the Empire of Dominia is no exception. Energy-based daggers and swords of various styles are often carried by officers and personnel as both tools and, if the situation demands it, weaponry. Fleet officers take particular pride in their blades and are known to go through the painstaking process of having a legitimate sword forged, even though said sword is likely far less practical than the “lesser” energy-based counterpart it is intended to replace."
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "dnN" = (
@@ -1061,7 +1150,10 @@
 	pixel_y = 28;
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "dol" = (
 /obj/machinery/door/airlock/external{
@@ -1076,12 +1168,15 @@
 	pixel_y = -28;
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "doI" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/dominian_science_vessel/exterior)
 "doM" = (
 /turf/simulated/wall/shuttle,
@@ -1097,7 +1192,7 @@
 /obj/structure/cable/pink{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "dsC" = (
@@ -1134,7 +1229,7 @@
 	dir = 8;
 	icon_state = "tube_empty"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/hangar)
 "dzA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1143,6 +1238,9 @@
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube_empty"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/starboard_hall)
@@ -1161,7 +1259,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "dEE" = (
@@ -1171,7 +1269,7 @@
 /obj/item/ship_ammunition/grauwolf_bundle,
 /obj/item/ship_ammunition/grauwolf_bundle,
 /obj/item/ship_ammunition/grauwolf_bundle,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "dEM" = (
 /obj/structure/table/steel,
@@ -1221,6 +1319,9 @@
 	icon_state = "0-4"
 	},
 /obj/random/pottedplant,
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/mess)
 "dKg" = (
@@ -1232,7 +1333,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/starboard_hall)
 "dMj" = (
@@ -1250,6 +1351,7 @@
 	icon_state = "tube_empty"
 	},
 /obj/structure/closet/toolcloset,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
 "dQg" = (
@@ -1265,10 +1367,13 @@
 /obj/structure/bed/stool/chair{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/mess)
 "dQP" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "dRM" = (
 /obj/machinery/reagentgrinder,
@@ -1281,9 +1386,6 @@
 	req_one_access = null
 	},
 /obj/structure/bed/roller,
-/obj/machinery/iv_drip{
-	pixel_x = 7
-	},
 /obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
@@ -1305,6 +1407,7 @@
 	name = "airlock_dominian_science_shuttle";
 	cycle_to_external_air = 1
 	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "dTD" = (
@@ -1317,7 +1420,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/starboard_hall)
 "dWx" = (
@@ -1325,21 +1428,31 @@
 	dir = 9
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_propulsion)
 "dWZ" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "dZw" = (
 /obj/structure/bed/stool/chair{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/mess)
 "edO" = (
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/hatch_door/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "efe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1354,9 +1467,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/eva)
+"ekw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/dominian_science_vessel/port_hall)
 "ekH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/window/reinforced{
@@ -1387,7 +1504,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/engineering)
 "elq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1412,7 +1529,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "eqS" = (
@@ -1427,11 +1544,16 @@
 	pixel_y = 6;
 	pixel_x = 20
 	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/armory)
 "etL" = (
 /turf/space/transit/north,
 /area/space)
+"euR" = (
+/obj/machinery/iv_drip,
+/turf/simulated/floor/tiled/white,
+/area/ship/dominian_science_vessel/infirmary)
 "ewT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1453,7 +1575,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "eze" = (
@@ -1501,6 +1623,9 @@
 /obj/item/clothing/head/helmet/space/void/sci,
 /obj/item/clothing/suit/space/void/sci,
 /obj/item/clothing/suit/space/void/sci,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "eFo" = (
@@ -1508,7 +1633,7 @@
 	name = "Ammunition Storage"
 	},
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "eGa" = (
 /obj/structure/closet/crate,
@@ -1529,6 +1654,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
 "eIb" = (
@@ -1536,7 +1662,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/dominian_science_vessel/exterior)
 "eIn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1567,7 +1693,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/hangar)
 "eKj" = (
@@ -1593,6 +1719,9 @@
 /obj/machinery/alarm/north{
 	req_access = list(226);
 	req_one_access = null
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
@@ -1634,6 +1763,9 @@
 /area/ship/dominian_science_vessel/infirmary)
 "eQC" = (
 /obj/structure/extinguisher_cabinet/south,
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/hangar)
 "eRr" = (
@@ -1642,12 +1774,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/engineering)
 "eUJ" = (
 /obj/structure/table/stone/marble,
 /obj/item/material/knife{
-	pixel_x = -9
+	pixel_x = -4;
+	pixel_y = 5
 	},
 /obj/machinery/reagentgrinder{
 	pixel_x = 7;
@@ -1688,7 +1821,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/mess)
 "eYC" = (
 /obj/machinery/power/apc/west{
@@ -1698,6 +1831,9 @@
 	icon_state = "0-4"
 	},
 /obj/structure/undies_wardrobe,
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "eYR" = (
@@ -1737,7 +1873,10 @@
 	pixel_y = 28;
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "fii" = (
 /obj/structure/sign/nosmoking_1,
@@ -1750,7 +1889,6 @@
 /area/ship/dominian_science_vessel/bridge)
 "fnY" = (
 /obj/machinery/door/airlock/external,
-/obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 9
 	},
@@ -1764,7 +1902,10 @@
 	name = "airlock_dominian_science_shuttle";
 	cycle_to_external_air = 1
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
 "foH" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -1775,7 +1916,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/starboard_hall)
 "fpC" = (
@@ -1785,6 +1926,10 @@
 	req_access = list(226);
 	req_one_access = null
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "fsO" = (
@@ -1797,7 +1942,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/hangar)
 "fvv" = (
@@ -1806,12 +1951,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "fws" = (
 /obj/machinery/door/airlock/external,
-/obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/atmospherics/pipe/manifold/hidden/red,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1826,7 +1970,10 @@
 	name = "airlock_dominian_science_shuttle";
 	cycle_to_external_air = 1
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
 "fxK" = (
 /obj/structure/closet/cabinet,
@@ -1876,7 +2023,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "fDv" = (
@@ -1901,6 +2048,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/ship/dominian_science_vessel/officer)
+"fMn" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/aft_dock)
 "fMI" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -1909,15 +2062,15 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/hangar)
 "fNZ" = (
-/obj/structure/platform,
-/obj/structure/platform{
-	dir = 8
+/obj/effect/floor_decal/corner/red{
+	dir = 10
 	},
-/turf/simulated/floor/carpet/rubber,
-/area/ship/dominian_science_vessel/bridge)
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/quarters)
 "fPm" = (
 /obj/structure/bed/stool/chair{
 	dir = 4
@@ -1927,15 +2080,16 @@
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
 	},
+/obj/effect/floor_decal/corner/red/full{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/mess)
 "fRv" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/machinery/computer/ship/targeting,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/bridge)
 "fUz" = (
@@ -1951,20 +2105,23 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "fYJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
 "fZq" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "fZB" = (
@@ -1973,7 +2130,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "gcq" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot,
@@ -1997,7 +2154,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/engineering)
 "gns" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2028,6 +2185,9 @@
 /area/ship/dominian_science_vessel/officer)
 "gtV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2075,7 +2235,7 @@
 /area/ship/dominian_science_vessel/port_hall)
 "gTb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/quarters)
 "gTO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2083,7 +2243,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/starboard_hall)
 "gUd" = (
@@ -2094,7 +2254,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "gUu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
@@ -2115,11 +2275,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "gYL" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2129,11 +2287,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch_door/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "gZq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
@@ -2162,7 +2327,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/hangar)
 "hbi" = (
@@ -2170,7 +2335,7 @@
 	req_access = list(226);
 	req_one_access = null
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "hcl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2196,7 +2361,10 @@
 	pixel_x = -28;
 	pixel_y = -28
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "hgc" = (
 /obj/structure/table/steel,
@@ -2218,7 +2386,10 @@
 /obj/machinery/access_button{
 	pixel_x = -28
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "hlW" = (
 /obj/machinery/door/airlock/service{
@@ -2227,7 +2398,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/officer)
 "hmP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -2235,6 +2406,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
@@ -2324,6 +2498,9 @@
 	},
 /turf/simulated/floor/marble,
 /area/ship/dominian_science_vessel/mess)
+"hzX" = (
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/dominian_science_shuttle)
 "hBa" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -2353,6 +2530,9 @@
 	name = "igs - house_volvalaad_voidsman";
 	identifier = "house_volvalaad_voidsman"
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "hFf" = (
@@ -2370,6 +2550,9 @@
 /area/shuttle/dominian_science_shuttle)
 "hHG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/aft_dock)
 "hHI" = (
@@ -2387,7 +2570,10 @@
 	pixel_y = -28;
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "hHN" = (
 /obj/machinery/light{
@@ -2399,11 +2585,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "hIB" = (
 /obj/machinery/light{
 	icon_state = "tube_empty"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/hangar)
@@ -2426,14 +2616,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/glass_command{
 	dir = 4;
 	id_tag = "cockpitdoor";
 	name = "Cockpit"
 	},
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
 "hJt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2457,7 +2648,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/atmospherics)
 "hMa" = (
 /obj/effect/map_effect/marker/airlock/docking{
@@ -2473,6 +2667,7 @@
 	dir = 4;
 	pixel_y = 6
 	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "hOQ" = (
@@ -2488,8 +2683,16 @@
 	dir = 8;
 	icon_state = "tube_empty"
 	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
+"hOY" = (
+/obj/random/pottedplant,
+/obj/effect/floor_decal/corner/red/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/quarters)
 "hWr" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2516,14 +2719,12 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "hZq" = (
 /obj/machinery/hologram/holopad/long_range,
 /obj/effect/overmap/visitable/ship/dominian_science_vessel,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/bridge)
 "hZH" = (
 /obj/machinery/door/window/northleft,
@@ -2534,11 +2735,17 @@
 /area/shuttle/dominian_science_shuttle)
 "hZN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
 "ibh" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/dominian_science_vessel/bridge)
+/area/ship/dominian_science_vessel/mess)
 "iej" = (
 /turf/simulated/floor/tiled/white,
 /area/ship/dominian_science_vessel/officer)
@@ -2586,14 +2793,17 @@
 	dir = 1;
 	pixel_y = -19
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "iio" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/eva)
 "iix" = (
@@ -2606,7 +2816,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/quarters)
 "ijI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -2628,6 +2838,9 @@
 /obj/item/deck/cards{
 	pixel_x = 3;
 	pixel_y = -11
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/mess)
@@ -2676,7 +2889,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
@@ -2686,8 +2899,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch_door/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "ivx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2695,7 +2911,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "iwB" = (
@@ -2704,6 +2920,9 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
 "ixH" = (
@@ -2731,7 +2950,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/hangar)
 "iJb" = (
@@ -2814,7 +3033,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "iWi" = (
@@ -2827,7 +3046,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "iXb" = (
@@ -2838,6 +3057,14 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/dominian_science_vessel/bridge)
+"iYb" = (
+/obj/machinery/atmospherics/pipe/tank/carbon_dioxide,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/ship/dominian_science_vessel/atmospherics)
 "iZq" = (
 /obj/machinery/alarm/east{
 	req_access = list(226);
@@ -2866,12 +3093,23 @@
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 26
 	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "jeW" = (
 /obj/random/pottedplant,
+/obj/effect/floor_decal/corner/red/full{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
+"jhF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/port_hall)
 "jhH" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/door/window/eastleft,
@@ -2884,13 +3122,13 @@
 	},
 /obj/structure/railing/mapped,
 /obj/item/hullbeacon/red,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/dominian_science_vessel/exterior)
 "jjy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "jjX" = (
@@ -2902,12 +3140,15 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_propulsion)
 "jkM" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "jnx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2919,9 +3160,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch_door/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "jpW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2932,6 +3175,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/mess)
@@ -2953,7 +3199,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "jxb" = (
 /obj/structure/cable/green{
@@ -2962,6 +3211,9 @@
 /obj/machinery/alarm/west{
 	req_access = list(226);
 	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/engineering)
@@ -2979,6 +3231,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
 "jzp" = (
@@ -3025,7 +3278,10 @@
 /area/ship/dominian_science_vessel/bridge)
 "jLI" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "jOW" = (
@@ -3037,6 +3293,10 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "jQE" = (
@@ -3048,7 +3308,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/mess)
 "jVD" = (
 /turf/simulated/wall/shuttle,
@@ -3073,6 +3333,9 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/dominian_science_shuttle)
 "jZe" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/hangar)
 "kam" = (
@@ -3095,6 +3358,13 @@
 	},
 /turf/simulated/wall/shuttle,
 /area/shuttle/dominian_science_shuttle)
+"kdP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/port_hall)
 "ken" = (
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "airlock_dominian_science_dock_aft";
@@ -3106,6 +3376,7 @@
 	dir = 8;
 	icon_state = "tube_empty"
 	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "keG" = (
@@ -3121,10 +3392,17 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "kfB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/effect/floor_decal/corner/red{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
 "khk" = (
@@ -3171,6 +3449,7 @@
 	pixel_y = 20;
 	pixel_x = -6
 	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "knI" = (
@@ -3181,7 +3460,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 6
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "kps" = (
@@ -3191,7 +3470,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "kpN" = (
@@ -3205,7 +3484,6 @@
 /area/ship/dominian_science_vessel/chapel)
 "kpR" = (
 /obj/machinery/door/airlock/external,
-/obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 8
 	},
@@ -3224,16 +3502,22 @@
 	name = "airlock_dominian_science_shuttle";
 	cycle_to_external_air = 1
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
 "krH" = (
 /obj/structure/bed/stool/chair/office/bridge,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/bridge)
 "ktm" = (
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube_empty"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/hangar)
@@ -3244,7 +3528,7 @@
 /obj/machinery/light{
 	icon_state = "tube_empty"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/mess)
 "kyc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
@@ -3277,6 +3561,9 @@
 /area/ship/dominian_science_vessel/isolation)
 "kAl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/center_hall)
 "kAZ" = (
@@ -3338,6 +3625,7 @@
 	name = "airlock_dominian_science_shuttle";
 	cycle_to_external_air = 1
 	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "kRK" = (
@@ -3381,7 +3669,8 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "kXV" = (
 /obj/effect/floor_decal/corner/yellow/full,
@@ -3394,11 +3683,18 @@
 "leu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "lfS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_propulsion)
@@ -3417,14 +3713,19 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/wood,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/officer)
 "lme" = (
 /obj/effect/shuttle_landmark/dominian_science_vessel/nav4,
 /turf/template_noop,
 /area/space)
 "lml" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
 "loJ" = (
@@ -3440,6 +3741,7 @@
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_propulsion)
 "lpa" = (
@@ -3449,7 +3751,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/eva)
 "lpV" = (
@@ -3465,8 +3767,10 @@
 /turf/simulated/floor/carpet,
 /area/ship/dominian_science_vessel/officer)
 "lqn" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/officer)
@@ -3496,6 +3800,12 @@
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "lul" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "lvo" = (
@@ -3507,7 +3817,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
@@ -3531,6 +3841,7 @@
 	dir = 8;
 	icon_state = "tube_empty"
 	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/armory)
 "lxi" = (
@@ -3540,7 +3851,7 @@
 /turf/simulated/wall/r_wall,
 /area/ship/dominian_science_vessel/officer)
 "lCD" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3555,6 +3866,9 @@
 "lCK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 5
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
@@ -3575,6 +3889,10 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/engineering)
 "lHw" = (
@@ -3588,7 +3906,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "lLG" = (
 /obj/structure/table/steel,
@@ -3616,11 +3934,16 @@
 	name = "Research Lockdown";
 	id = "lockdown"
 	},
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/research)
 "lUe" = (
 /obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "lXp" = (
@@ -3644,7 +3967,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/engineering)
 "meg" = (
 /turf/simulated/wall/shuttle,
@@ -3662,6 +3985,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "mit" = (
@@ -3680,8 +4004,10 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/dominian_science_vessel/research)
 "mqx" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/door/blast/regular/open{
 	name = "Bridge Lockdown";
@@ -3691,8 +4017,11 @@
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/bridge)
 "mtZ" = (
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch_door/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "mwJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3722,7 +4051,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/hangar)
 "mBb" = (
@@ -3738,7 +4067,7 @@
 /obj/structure/bed/stool/chair{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/mess)
 "mBX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3750,7 +4079,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "mEJ" = (
@@ -3762,7 +4091,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/hangar)
 "mET" = (
@@ -3786,7 +4115,7 @@
 /obj/machinery/light{
 	icon_state = "tube_empty"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3807,11 +4136,15 @@
 	cycle_to_external_air = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "mLM" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/hangar)
@@ -3840,7 +4173,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/quarters)
 "mRv" = (
 /obj/structure/closet/crate/tool,
@@ -3857,6 +4190,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
 "mSJ" = (
@@ -3866,7 +4200,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "mUR" = (
 /turf/simulated/floor/tiled/white,
@@ -3884,13 +4218,19 @@
 	pixel_y = 28;
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "mWV" = (
 /obj/machinery/light{
 	dir = 1;
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/starboard_hall)
@@ -3918,7 +4258,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "ncD" = (
@@ -3929,7 +4269,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/hangar)
 "ndX" = (
 /obj/machinery/power/apc/north{
@@ -3947,6 +4287,9 @@
 	pixel_y = 32;
 	pixel_x = 16;
 	name = "Bridge Blast Doors"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/bridge)
@@ -3970,19 +4313,27 @@
 /obj/item/storage/bag/inflatable{
 	pixel_y = 5
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
 "njl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/aft_dock)
 "njv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/bridge)
 "nke" = (
 /obj/machinery/computer/ship/helm{
@@ -4013,9 +4364,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/eva)
 "ntu" = (
 /obj/structure/closet/secure_closet/guncabinet{
@@ -4097,6 +4447,9 @@
 /obj/item/clothing/accessory/holster/waist,
 /obj/item/clothing/accessory/holster/waist/brown,
 /obj/item/clothing/accessory/holster/waist/brown,
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "nDY" = (
@@ -4131,7 +4484,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "nKh" = (
 /turf/simulated/wall/r_wall,
@@ -4140,7 +4493,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "nKK" = (
 /obj/structure/window/reinforced{
@@ -4156,7 +4510,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "nSw" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/mess)
 "nSM" = (
 /obj/machinery/alarm/north{
@@ -4164,6 +4518,9 @@
 	req_one_access = null
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
 "nTU" = (
@@ -4178,8 +4535,12 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
+"nVi" = (
+/obj/effect/floor_decal/corner/blue/full,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/eva)
 "nVP" = (
 /turf/simulated/wall/r_wall,
 /area/ship/dominian_science_vessel/research)
@@ -4239,11 +4600,17 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "ojK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/hangar)
@@ -4251,13 +4618,17 @@
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "ojZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -4273,7 +4644,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/light{
 	dir = 8;
 	inserted_light = /obj/item/light/tube/colored/blue;
@@ -4281,6 +4652,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/starboard_hall)
+"olJ" = (
+/obj/structure/platform,
+/obj/structure/platform_stairs/full/east_west_cap,
+/obj/structure/platform{
+	dir = 1
+	},
+/turf/simulated/floor/marble/dark,
+/area/ship/dominian_science_vessel/chapel)
 "oog" = (
 /obj/effect/landmark/entry_point/fore{
 	dir = 2;
@@ -4302,7 +4681,9 @@
 	dir = 4;
 	name = "Bathroom"
 	},
-/obj/machinery/door/firedoor/noid,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/dominian_science_vessel/showers)
 "oqw" = (
@@ -4310,7 +4691,10 @@
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/hatch_door/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "ouP" = (
 /obj/machinery/door/airlock/service{
@@ -4322,7 +4706,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/marble/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "oxg" = (
 /obj/structure/ship_weapon_dummy/barrel,
@@ -4347,7 +4731,7 @@
 "oBu" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/hangar)
 "oBB" = (
 /obj/item/storage/belt/archaeology,
@@ -4373,9 +4757,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/eva)
 "oCE" = (
 /turf/simulated/wall/r_wall,
@@ -4389,7 +4772,10 @@
 /obj/machinery/access_button{
 	pixel_x = -28
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "oDy" = (
 /obj/machinery/door/airlock/command{
@@ -4403,7 +4789,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/bridge)
 "oEd" = (
 /obj/structure/sign/vacuum,
@@ -4423,7 +4809,10 @@
 	pixel_x = -24;
 	pixel_y = 28
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "oGe" = (
 /obj/structure/table/stone/marble,
@@ -4444,7 +4833,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/bridge)
 "oNj" = (
 /obj/machinery/sleeper,
@@ -4466,7 +4855,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/light{
 	icon_state = "tube_empty"
 	},
@@ -4493,7 +4882,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/hangar)
 "oXc" = (
 /obj/effect/floor_decal/industrial/outline/operations,
@@ -4517,7 +4906,7 @@
 	name = "Cockpit"
 	},
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
 "pat" = (
 /obj/structure/bed/stool/chair{
@@ -4544,7 +4933,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/hangar)
 "peI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -4571,15 +4960,17 @@
 /obj/machinery/access_button{
 	pixel_x = -28
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "pfE" = (
-/obj/structure/platform{
-	dir = 4
+/obj/effect/floor_decal/corner/red{
+	dir = 10
 	},
-/obj/structure/platform,
-/turf/simulated/floor/carpet/rubber,
-/area/ship/dominian_science_vessel/bridge)
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/hangar)
 "pge" = (
 /obj/machinery/vending/engivend{
 	req_access = null
@@ -4595,6 +4986,12 @@
 "pgn" = (
 /turf/simulated/floor/wood,
 /area/ship/dominian_science_vessel/officer)
+"pnT" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/simulated/floor/marble/dark,
+/area/ship/dominian_science_vessel/chapel)
 "poc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -4606,7 +5003,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/table/steel,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/mess)
 "psP" = (
 /obj/machinery/power/apc/east{
@@ -4630,7 +5027,10 @@
 /obj/machinery/access_button{
 	pixel_x = 28
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "puI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4639,7 +5039,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
@@ -4655,6 +5055,8 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/warning/cee,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "pyW" = (
@@ -4685,7 +5087,10 @@
 /obj/machinery/access_button{
 	pixel_x = 28
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "pKo" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
@@ -4705,13 +5110,23 @@
 	name = "airlock_dominian_science_shuttle";
 	cycle_to_external_air = 1
 	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
+"pMm" = (
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/ship/dominian_science_vessel/aft_dock)
 "pNy" = (
 /obj/machinery/cryopod,
 /obj/machinery/computer/cryopod{
 	pixel_x = 28;
 	pixel_y = -6
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
@@ -4733,14 +5148,15 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "pXP" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/mapped,
-/turf/space,
-/area/ship/dominian_science_vessel/exterior)
+/obj/effect/floor_decal/corner/blue/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/eva)
 "pYs" = (
 /obj/structure/closet/secure_closet/medical2{
 	req_access = list(226)
@@ -4789,7 +5205,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "qdL" = (
@@ -4808,16 +5224,24 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/hangar)
 "qhl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/machinery/meter,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "qll" = (
 /obj/structure/reagent_dispensers/coolanttank,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/engineering)
 "qqr" = (
@@ -4879,7 +5303,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "qzk" = (
@@ -4891,7 +5315,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "qzZ" = (
 /turf/simulated/wall/r_wall,
@@ -4910,7 +5334,8 @@
 	req_access = list(226);
 	req_one_access = null
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "qHO" = (
 /obj/structure/ship_weapon_dummy,
@@ -4942,13 +5367,14 @@
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "qKW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "qLo" = (
@@ -4975,10 +5401,13 @@
 /obj/item/clothing/suit/storage/toggle/labcoat/accent{
 	accent_color = "#0066FF"
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "qLH" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/quarters)
 "qMS" = (
 /obj/effect/floor_decal/industrial/outline/operations,
@@ -4998,7 +5427,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/starboard_hall)
 "qTV" = (
@@ -5022,8 +5451,11 @@
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "qYW" = (
-/obj/effect/floor_decal/industrial/outline/research,
 /obj/structure/survey_probe/dominia,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/research,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "rex" = (
@@ -5033,10 +5465,14 @@
 /obj/structure/closet/crate/bin{
 	name = "trashbin"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "rfO" = (
 /obj/structure/closet/firecloset,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
@@ -5045,12 +5481,17 @@
 	name = "Hangar";
 	dir = 4
 	},
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/hangar)
 "ril" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/machinery/meter,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_propulsion)
 "riv" = (
@@ -5065,6 +5506,9 @@
 /obj/item/device/versebook/tribunal,
 /obj/item/device/versebook/tribunal,
 /obj/item/device/versebook/tribunal,
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "rkg" = (
@@ -5076,6 +5520,9 @@
 /area/ship/dominian_science_vessel/atmospherics)
 "rkM" = (
 /obj/effect/floor_decal/corner/full{
+	dir = 4
+	},
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/marble/dark,
@@ -5119,6 +5566,9 @@
 	dir = 8;
 	icon_state = "tube_empty"
 	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "ryv" = (
@@ -5131,7 +5581,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/hangar)
 "rzJ" = (
 /obj/effect/floor_decal/industrial/outline/red,
@@ -5140,7 +5590,7 @@
 /obj/item/ship_ammunition/grauwolf_bundle/ap,
 /obj/item/ship_ammunition/grauwolf_bundle/ap,
 /obj/item/ship_ammunition/grauwolf_bundle/ap,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "rzP" = (
 /obj/machinery/alarm/east{
@@ -5175,6 +5625,7 @@
 	pixel_y = 3;
 	pixel_x = 5
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
 "rDL" = (
@@ -5193,12 +5644,10 @@
 /turf/simulated/floor/marble/dark,
 /area/ship/dominian_science_vessel/chapel)
 "rMW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/machinery/computer/ship/navigation,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/bridge)
 "rNv" = (
@@ -5207,6 +5656,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/center_hall)
@@ -5236,6 +5688,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "seO" = (
@@ -5255,7 +5711,7 @@
 	dir = 4
 	},
 /obj/item/hullbeacon/red,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/dominian_science_vessel/exterior)
 "siX" = (
 /obj/machinery/door/blast/regular{
@@ -5313,7 +5769,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/mess)
 "srf" = (
 /obj/machinery/body_scanconsole{
@@ -5341,16 +5797,17 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "svV" = (
 /obj/machinery/atmospherics/portables_connector/aux,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "sxg" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -5378,7 +5835,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/center_hall)
 "szV" = (
@@ -5388,7 +5845,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
@@ -5403,6 +5860,7 @@
 	name = "airlock_dominian_science_dock_port"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "sFI" = (
@@ -5415,21 +5873,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "sFQ" = (
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "sGi" = (
-/obj/structure/platform_stairs,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/platform_deco{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
 /area/ship/dominian_science_vessel/bridge)
 "sGw" = (
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube_empty"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
@@ -5448,7 +5915,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/engineering)
 "sJp" = (
 /obj/structure/window/reinforced{
@@ -5466,6 +5933,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/hangar)
 "sLx" = (
@@ -5482,8 +5952,10 @@
 /turf/simulated/floor/carpet,
 /area/ship/dominian_science_vessel/officer)
 "sOb" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, bridge"
 	},
@@ -5509,7 +5981,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/noid,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "sVI" = (
@@ -5517,6 +5991,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/corner{
+	dir = 10
 	},
 /turf/simulated/floor/marble/dark,
 /area/ship/dominian_science_vessel/chapel)
@@ -5526,6 +6003,12 @@
 "tav" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/platform_stairs/full/south_north_cap{
+	dir = 4
+	},
+/obj/structure/platform{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/bridge)
@@ -5544,6 +6027,9 @@
 	name = "igs - house_volvalaad_voidsman";
 	identifier = "house_volvalaad_voidsman"
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "tfK" = (
@@ -5560,7 +6046,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/eva)
 "tkL" = (
@@ -5574,7 +6060,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/engineering)
 "tlP" = (
 /obj/structure/railing/mapped{
@@ -5586,7 +6072,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/hangar)
 "toh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5617,7 +6103,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/hangar)
 "tqq" = (
@@ -5632,7 +6118,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/center_hall)
 "trE" = (
@@ -5648,7 +6134,10 @@
 	dir = 1;
 	pixel_y = 12
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "trF" = (
 /obj/structure/table/rack{
@@ -5670,6 +6159,9 @@
 /obj/item/tank/emergency_oxygen/engi{
 	pixel_x = 5
 	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "tsC" = (
@@ -5686,6 +6178,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "tuK" = (
@@ -5701,7 +6194,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/armory)
 "tyS" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/eva)
 "tAo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -5716,7 +6209,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -5760,7 +6253,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/starboard_hall)
 "tLp" = (
@@ -5768,6 +6261,9 @@
 	dir = 8;
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
@@ -5791,8 +6287,24 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/engineering)
+"tXG" = (
+/obj/effect/floor_decal/corner{
+	dir = 5
+	},
+/obj/structure/platform_deco{
+	dir = 8
+	},
+/obj/structure/platform_deco{
+	icon_state = "ledge_deco"
+	},
+/turf/simulated/floor/marble/dark,
+/area/ship/dominian_science_vessel/chapel)
 "uaC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
@@ -5801,6 +6313,9 @@
 	dir = 1;
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/aft_dock)
@@ -5816,6 +6331,9 @@
 /area/ship/dominian_science_vessel/port_propulsion)
 "ugK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/aft_dock)
 "uic" = (
@@ -5830,6 +6348,19 @@
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/tiled/white,
 /area/ship/dominian_science_vessel/showers)
+"uke" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/red/full,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/quarters)
 "ulB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -5846,13 +6377,16 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/starboard_hall)
 "umM" = (
 /obj/machinery/alarm/east{
 	req_access = list(226);
 	req_one_access = null
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/hangar)
@@ -5870,8 +6404,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/quarters)
 "urz" = (
 /obj/effect/shuttle_landmark/dominian_science_vessel/nav1,
@@ -5894,7 +6430,10 @@
 	icon_state = "0-4"
 	},
 /obj/structure/dispenser/oxygen,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "uwQ" = (
@@ -5906,6 +6445,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "uAj" = (
@@ -5962,6 +6502,7 @@
 "uDw" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "uDy" = (
@@ -5976,11 +6517,17 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "uEm" = (
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/aft_dock)
@@ -5992,14 +6539,16 @@
 	req_access = list(226);
 	req_one_access = null
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "uGG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/platform_stairs/full/south_north_cap,
+/obj/structure/platform{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/bridge)
@@ -6015,7 +6564,10 @@
 	pixel_x = 28;
 	pixel_y = 28
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "uJi" = (
 /obj/machinery/computer/ship/sensors,
@@ -6038,6 +6590,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
 "uVq" = (
@@ -6051,12 +6606,16 @@
 	name = "igs - house_volvalaad_scientist";
 	identifier = "house_volvalaad_scientist"
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "uWe" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "uYh" = (
@@ -6072,7 +6631,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "uZo" = (
 /obj/structure/cable/green{
@@ -6081,6 +6640,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/engineering)
 "uZz" = (
@@ -6099,7 +6659,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/starboard_hall)
 "vcN" = (
 /obj/machinery/alarm/north{
@@ -6107,6 +6667,9 @@
 	req_one_access = null
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/center_hall)
 "vfS" = (
@@ -6125,6 +6688,7 @@
 	dir = 4
 	},
 /obj/structure/closet/toolcloset,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
 "vha" = (
@@ -6145,13 +6709,17 @@
 /area/ship/dominian_science_vessel/research)
 "vjT" = (
 /obj/random/pottedplant,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/mess)
 "vmg" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "vnT" = (
@@ -6177,11 +6745,28 @@
 /area/ship/dominian_science_vessel/exterior)
 "vqe" = (
 /obj/structure/table/stone/marble,
-/obj/item/storage/box/fancy/candle_box,
-/obj/item/flame/lighter/zippo/dominia,
+/obj/item/storage/box/fancy/candle_box{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/flame/lighter/zippo/dominia{
+	pixel_x = 8;
+	pixel_y = 2
+	},
 /obj/effect/floor_decal/corner/full,
 /turf/simulated/floor/marble/dark,
 /area/ship/dominian_science_vessel/chapel)
+"vrP" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/port_hall)
+"vrQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/dominian_science_vessel/aft_dock)
 "vty" = (
 /obj/item/reagent_containers/glass/bucket{
 	pixel_y = 16;
@@ -6193,11 +6778,17 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/engineering)
 "vtK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
@@ -6251,7 +6842,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/hangar)
 "vCe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6262,6 +6853,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
@@ -6305,16 +6899,19 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/starboard_hall)
 "vGK" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "vMS" = (
 /obj/structure/lattice/catwalk,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/dominian_science_vessel/exterior)
 "vMT" = (
 /obj/machinery/shower{
@@ -6335,6 +6932,9 @@
 /area/ship/dominian_science_vessel/officer)
 "vPD" = (
 /obj/structure/extinguisher_cabinet/west,
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/mess)
 "vTv" = (
@@ -6352,19 +6952,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
 "vVA" = (
-/obj/effect/floor_decal/corner{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/marble/dark,
-/area/ship/dominian_science_vessel/chapel)
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/dominian_science_vessel/armory)
+"wbz" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/dominian_science_vessel/aft_dock)
 "wbT" = (
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "wcv" = (
@@ -6381,6 +6985,9 @@
 	name = "igs - house_volvalaad_scientist";
 	identifier = "house_volvalaad_scientist"
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "wgJ" = (
@@ -6396,7 +7003,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "wji" = (
@@ -6420,11 +7027,22 @@
 	},
 /turf/simulated/floor/marble/dark,
 /area/ship/dominian_science_vessel/chapel)
+"wmG" = (
+/obj/structure/survey_probe/dominia,
+/obj/effect/floor_decal/corner/blue/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/research,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/eva)
 "wny" = (
 /turf/simulated/wall/shuttle,
 /area/shuttle/dominian_science_shuttle)
 "wpQ" = (
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/corner/red/full{
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
@@ -6450,7 +7068,9 @@
 	name = "Containment Blast Doors";
 	id = "containment"
 	},
-/obj/machinery/door/firedoor/noid,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -6460,7 +7080,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/isolation)
 "wvN" = (
 /obj/structure/table/steel,
@@ -6474,8 +7094,15 @@
 /obj/item/crowbar/rescue_axe,
 /obj/item/pen/drafting,
 /obj/item/blueprints/outpost,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
+"wwT" = (
+/obj/effect/floor_decal/corner/red/full,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/starboard_hall)
 "wzs" = (
 /obj/machinery/door/airlock/service{
 	dir = 4;
@@ -6490,14 +7117,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "wAa" = (
 /obj/structure/bed/roller,
-/obj/machinery/iv_drip{
-	pixel_x = 7
-	},
 /obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
@@ -6537,13 +7163,17 @@
 	},
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
 "wCJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/bridge)
 "wCU" = (
 /obj/effect/floor_decal/corner/red/full{
@@ -6577,6 +7207,7 @@
 	dir = 8;
 	pixel_x = 19
 	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "wGu" = (
@@ -6596,7 +7227,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/dominian_science_vessel/exterior)
 "wIQ" = (
 /obj/structure/closet/emcloset,
@@ -6620,6 +7251,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "wKq" = (
@@ -6647,6 +7279,10 @@
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "wOl" = (
@@ -6669,7 +7305,10 @@
 	pixel_y = 12
 	},
 /obj/effect/shuttle_landmark/dominian_science_vessel/dock/aft,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "wPB" = (
 /obj/machinery/power/apc/south{
@@ -6678,7 +7317,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -6708,6 +7347,9 @@
 	pixel_y = 32;
 	stand_icon = "banner"
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "wTR" = (
@@ -6720,6 +7362,9 @@
 /obj/effect/ghostspawpoint{
 	name = "igs - house_volvalaad_armsman";
 	identifier = "house_volvalaad_armsman"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
@@ -6747,7 +7392,8 @@
 /area/ship/dominian_science_vessel/armory)
 "xaL" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/hangar)
 "xaN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6763,8 +7409,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/infirmary)
 "xbd" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot{
@@ -6784,6 +7432,7 @@
 /area/ship/dominian_science_vessel/exterior)
 "xeU" = (
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "xfT" = (
@@ -6800,7 +7449,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/hangar)
@@ -6811,7 +7460,8 @@
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "xjp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6823,7 +7473,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/starboard_hall)
 "xjM" = (
@@ -6833,7 +7483,7 @@
 	dir = 8
 	},
 /obj/structure/cable/green,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/engineering)
 "xjP" = (
 /obj/machinery/alarm/north{
@@ -6842,6 +7492,9 @@
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/bridge)
@@ -6872,7 +7525,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/quarters)
 "xmC" = (
 /obj/structure/closet/emcloset,
@@ -6888,7 +7541,8 @@
 "xqX" = (
 /obj/machinery/atmospherics/portables_connector/aux,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "xsa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6900,7 +7554,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "xsm" = (
 /obj/machinery/alarm/north{
@@ -6908,6 +7562,9 @@
 	req_one_access = null
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
@@ -6937,6 +7594,10 @@
 	dir = 10
 	},
 /obj/machinery/pipedispenser,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "xvv" = (
@@ -6963,6 +7624,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "xyC" = (
@@ -6973,7 +7637,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -6987,6 +7651,9 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "xzG" = (
@@ -7003,19 +7670,30 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/center_hall)
 "xGk" = (
 /obj/structure/table/steel,
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/dom,
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/dom,
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/dom,
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/dom,
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/dom,
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/dom,
-/obj/machinery/chemical_dispenser/coffee/full,
-/turf/simulated/floor/tiled/dark,
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/dom{
+	pixel_x = -1
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/dom{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/dom{
+	pixel_x = 11;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/dom{
+	pixel_x = -9;
+	pixel_y = -1
+	},
+/obj/machinery/chemical_dispenser/coffee/full{
+	pixel_y = 13
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/mess)
 "xHl" = (
 /turf/simulated/wall/shuttle,
@@ -7062,6 +7740,10 @@
 /area/ship/dominian_science_vessel/showers)
 "xJb" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "xNk" = (
@@ -7098,7 +7780,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/hangar)
 "xPN" = (
@@ -7110,6 +7792,9 @@
 "xQH" = (
 /obj/effect/floor_decal/corner/full{
 	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/marble/dark,
 /area/ship/dominian_science_vessel/chapel)
@@ -7139,6 +7824,9 @@
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/head/helmet/space/void/dominia,
 /obj/item/clothing/suit/space/void/dominia,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "xXN" = (
@@ -7176,7 +7864,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 
 (1,1,1) = {"
@@ -31417,7 +32105,7 @@ xRX
 xRX
 xRX
 doM
-dQP
+fMn
 xPu
 sZn
 bzK
@@ -32445,7 +33133,7 @@ xRX
 xRX
 doM
 dbC
-dQP
+fMn
 nKE
 sZn
 qry
@@ -32702,7 +33390,7 @@ xRX
 xRX
 doM
 reI
-dQP
+fMn
 nKE
 sZn
 vuF
@@ -33216,7 +33904,7 @@ nht
 xOs
 amZ
 sZn
-dQP
+fMn
 qBt
 sZn
 tEo
@@ -33473,7 +34161,7 @@ qVe
 xOs
 cjK
 fZB
-dQP
+fMn
 sxg
 sZn
 lLG
@@ -33730,7 +34418,7 @@ nht
 xOs
 fpC
 sZn
-dQP
+fMn
 lCD
 sZn
 qbT
@@ -34244,7 +34932,7 @@ doM
 xeU
 qhl
 sZn
-dQP
+fMn
 lCD
 sZn
 hgc
@@ -34755,7 +35443,7 @@ xRX
 xRX
 xRX
 doM
-lul
+pMm
 lul
 sZn
 cwv
@@ -35271,8 +35959,8 @@ xRX
 doM
 xiZ
 dQP
-dQP
-dQP
+wbz
+fMn
 dck
 bjV
 eRr
@@ -35283,7 +35971,7 @@ tCg
 lxi
 cZR
 cZR
-cZR
+wwT
 xjp
 lBn
 sNM
@@ -35527,8 +36215,8 @@ xRX
 xRX
 doM
 svV
-njl
-njl
+cAQ
+vrQ
 gtV
 uYJ
 sZn
@@ -36554,8 +37242,8 @@ xRX
 xRX
 xRX
 xzG
-kQy
-kQy
+xzG
+xzG
 kQy
 kQy
 kQy
@@ -36810,27 +37498,27 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 xzG
 uOY
 uOY
 vEu
 uOY
 uOY
-uOY
-uOY
 dzw
 xaL
-jZe
-jZe
+cDG
+cDG
 ktm
-jZe
+cDG
 ojK
-jZe
-jZe
-jZe
+cDG
+cDG
+cDG
 ktm
-jZe
-jZe
+cDG
+cDG
 oBu
 kQy
 wCU
@@ -37067,9 +37755,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 oEd
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -37088,14 +37776,14 @@ mEJ
 mEJ
 mEJ
 dez
-jZe
+pfE
 kQy
 nKh
 nKh
 nKh
 quW
 gUd
-itH
+vVA
 pDc
 eqS
 pub
@@ -37324,9 +38012,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 siX
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -37581,9 +38269,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 siX
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -37602,10 +38290,10 @@ ogz
 uOY
 uOY
 haa
-jZe
+pfE
 kQy
 rzJ
-itH
+vVA
 eFo
 itH
 nKe
@@ -37838,9 +38526,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 siX
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -37859,7 +38547,7 @@ kyc
 wny
 wny
 haa
-jZe
+pfE
 kQy
 ans
 lLC
@@ -37873,8 +38561,8 @@ xfT
 vMS
 vMS
 vMS
-ajL
-ajL
+wIx
+wIx
 cTq
 xRX
 xRX
@@ -38095,9 +38783,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 siX
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -38116,7 +38804,7 @@ huE
 xwj
 lri
 haa
-jZe
+pfE
 tjB
 tjB
 tjB
@@ -38352,9 +39040,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 siX
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -38373,13 +39061,13 @@ diE
 xPN
 uBe
 haa
-jZe
+pfE
 tjB
-tyS
+pXP
 trF
 rvU
 lUe
-tyS
+nVi
 tjB
 oNY
 bpc
@@ -38609,9 +39297,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 siX
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -38649,7 +39337,7 @@ wGu
 mqx
 mqx
 aSJ
-pXP
+doI
 xRX
 xRX
 xRX
@@ -38866,9 +39554,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 siX
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -38901,12 +39589,12 @@ xyE
 xjP
 aHw
 rMW
-fNZ
+mFl
 gcq
 tCH
 mqx
 pAh
-pXP
+doI
 xRX
 xRX
 xRX
@@ -39123,9 +39811,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 hIP
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -39380,9 +40068,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 siX
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -39393,8 +40081,8 @@ wny
 wny
 oBB
 sFI
-rex
-rex
+hzX
+hzX
 kpq
 aou
 kRG
@@ -39413,9 +40101,9 @@ vcN
 xDU
 oNi
 wCJ
-ibh
+aHw
 tav
-sGi
+agR
 kwe
 fnE
 sOb
@@ -39637,9 +40325,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 siX
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -39650,7 +40338,7 @@ eYR
 wny
 oXc
 sFI
-rex
+hzX
 eBK
 bYr
 wny
@@ -39670,9 +40358,9 @@ kAl
 bSl
 xyE
 ndX
-dfe
+aHw
 fRv
-pfE
+mFl
 gcq
 sBA
 mqx
@@ -39894,9 +40582,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 siX
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -39915,12 +40603,12 @@ vTv
 wBq
 lri
 qdL
-jZe
+pfE
 tjB
-qYW
+wmG
 qYW
 wvN
-atQ
+qYW
 atQ
 tjB
 str
@@ -40151,9 +40839,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 siX
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -40162,17 +40850,17 @@ rOg
 pWg
 rex
 oYG
-rex
-rex
-rex
-rex
+hzX
+hzX
+hzX
+hzX
 hZH
 wIV
 xoc
 xPN
 luj
 qdL
-jZe
+pfE
 tjB
 tjB
 tjB
@@ -40408,9 +41096,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 siX
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -40429,16 +41117,16 @@ nEY
 cMo
 lri
 qdL
-jZe
+pfE
 rrA
-jeW
+hOY
 tfg
 hEL
 wTR
 tLp
 eYC
 riv
-vCe
+uke
 jVD
 cuJ
 cuJ
@@ -40665,9 +41353,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 siX
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -40686,7 +41374,7 @@ wny
 wny
 wny
 qdL
-jZe
+pfE
 rrA
 djH
 qLH
@@ -40922,9 +41610,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 siX
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -40943,7 +41631,7 @@ uOY
 uOY
 uOY
 qdL
-jZe
+pfE
 rrA
 wQc
 qLH
@@ -40952,7 +41640,7 @@ bLW
 qLH
 qLH
 qLH
-qLH
+fNZ
 kJp
 xRX
 xRX
@@ -41179,9 +41867,9 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 siX
-uOY
-uOY
 uOY
 uOY
 uOY
@@ -41436,12 +42124,12 @@ xRX
 xRX
 xRX
 xRX
+xRX
+xRX
 oEd
 uOY
 uOY
 uAj
-uOY
-uOY
 uOY
 uOY
 pdm
@@ -41457,7 +42145,7 @@ iDY
 xPF
 xPF
 mwP
-jZe
+pfE
 rrA
 rrA
 rrA
@@ -41693,11 +42381,11 @@ xRX
 xRX
 xRX
 xRX
-xHl
-xdL
-xdL
-xdL
-xdL
+xzG
+xzG
+xzG
+kQy
+kQy
 kQy
 uOY
 uOY
@@ -42229,9 +42917,9 @@ lml
 bUF
 qzZ
 dJN
-nSw
+ibh
 dQv
-jpW
+aWj
 nSw
 nSw
 qAQ
@@ -43241,12 +43929,12 @@ pat
 rJK
 vnT
 gRZ
-lml
+vrP
 mBX
 ryv
 oNj
-wHI
-wHI
+euR
+euR
 hXR
 wHI
 wHI
@@ -43493,12 +44181,12 @@ xRX
 xRX
 xRX
 xHl
-oMn
-gQl
-gQl
-xXU
+tXG
+pnT
+pnT
+ajL
 gRZ
-lml
+vrP
 mBX
 ryv
 gZs
@@ -43750,12 +44438,12 @@ xRX
 xRX
 xRX
 xHl
-oMn
-gQl
-gQl
-xXU
+olJ
+uic
+oGe
+olJ
 gRZ
-lml
+vrP
 mBX
 ryv
 qwk
@@ -44008,8 +44696,8 @@ xRX
 xRX
 xHl
 oMn
-uic
-oGe
+gQl
+gQl
 xXU
 gRZ
 cqC
@@ -44266,7 +44954,7 @@ xRX
 xHl
 xQH
 cCV
-vVA
+cCV
 rkM
 gRZ
 hZN
@@ -44790,10 +45478,10 @@ fYJ
 fYJ
 iwB
 cQn
-kfB
-kfB
-kfB
-kfB
+jhF
+jhF
+jhF
+jhF
 uDy
 aZo
 alp
@@ -45297,10 +45985,10 @@ dWx
 cNM
 tfK
 keG
-lml
+dfe
 wgJ
 mEX
-sFQ
+iYb
 hmP
 leu
 bvi
@@ -45554,7 +46242,7 @@ gJx
 tfK
 tfK
 bUF
-lml
+dfe
 wgJ
 mEX
 sFQ
@@ -45809,9 +46497,9 @@ xRX
 xRX
 wLq
 dWZ
-lml
-lml
-lml
+dfe
+vrP
+dfe
 wgJ
 mEX
 jOW
@@ -46067,8 +46755,8 @@ xRX
 wLq
 wLq
 kXR
-lml
-lml
+vrP
+dfe
 qdb
 hKv
 xwk
@@ -46324,8 +47012,8 @@ xRX
 xRX
 wLq
 xqX
-kfB
-kfB
+kdP
+ekw
 lCK
 mEX
 uFw
@@ -46582,7 +47270,7 @@ xRX
 wLq
 wLq
 wLq
-lml
+dfe
 vUO
 mEX
 kfu
@@ -46839,7 +47527,7 @@ xRX
 xRX
 xRX
 wLq
-lml
+dfe
 vUO
 mEX
 aBY

--- a/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel.dmm
+++ b/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel.dmm
@@ -61,7 +61,8 @@
 /area/ship/dominian_science_vessel/chapel)
 "akl" = (
 /obj/structure/ship_weapon_dummy,
-/turf/template_noop,
+/obj/structure/lattice/catwalk,
+/turf/space/dynamic,
 /area/ship/dominian_science_vessel/armory)
 "alp" = (
 /obj/machinery/door/airlock/external,
@@ -75,6 +76,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "amZ" = (
@@ -88,6 +90,7 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "ans" = (
@@ -117,8 +120,13 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
+"aqs" = (
+/obj/random/dirt_75,
+/turf/simulated/wall/r_wall,
+/area/ship/dominian_science_vessel/hangar)
 "aqS" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	name = "Gun Cabinet (Sidearms)";
@@ -142,6 +150,7 @@
 /obj/item/gun/projectile/pistol/dominia,
 /obj/item/ammo_magazine/c45m/dominia,
 /obj/item/ammo_magazine/c45m/dominia,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/armory)
 "arh" = (
@@ -183,6 +192,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/research,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "axE" = (
@@ -255,6 +265,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/center_hall)
 "aHt" = (
@@ -303,6 +314,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/hangar)
+"aIj" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/dominian_science_vessel/eva)
+"aLv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/port_hall)
 "aLz" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker/airlock/docking{
@@ -343,6 +366,7 @@
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/hangar)
 "aOU" = (
@@ -449,6 +473,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "bac" = (
@@ -460,6 +485,10 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
+/area/shuttle/dominian_science_shuttle)
+"bbh" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/dominian_science_shuttle)
 "bcf" = (
 /obj/structure/window/reinforced{
@@ -512,6 +541,16 @@
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
+"boo" = (
+/obj/machinery/light{
+	icon_state = "tube_empty"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/hangar)
 "bos" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -582,6 +621,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/bridge)
+"bsq" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube_empty"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/port_hall)
 "bvh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -599,6 +649,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "bxu" = (
@@ -723,7 +774,8 @@
 	icon_state = "tube_empty"
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
 "cjK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
@@ -731,6 +783,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "ckh" = (
@@ -847,7 +900,7 @@
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
 "cxU" = (
 /obj/machinery/door/window/westleft,
@@ -858,6 +911,7 @@
 /area/ship/dominian_science_vessel/showers)
 "cAQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "cCV" = (
@@ -871,6 +925,12 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/hangar)
+"cHw" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/hangar)
 "cHM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -933,6 +993,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
 "cQs" = (
@@ -1029,6 +1090,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/starboard_hall)
 "dbx" = (
@@ -1092,6 +1154,7 @@
 	dir = 9
 	},
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "djH" = (
@@ -1139,6 +1202,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
+"dma" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/port_hall)
 "dnN" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker/airlock{
@@ -1153,6 +1223,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "dol" = (
@@ -1199,6 +1270,13 @@
 /obj/effect/shuttle_landmark/dominian_science_vessel/nav2,
 /turf/template_noop,
 /area/space)
+"dvF" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/hangar)
 "dxv" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -1322,6 +1400,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/mess)
 "dKg" = (
@@ -1352,6 +1431,7 @@
 	},
 /obj/structure/closet/toolcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
 "dQg" = (
@@ -1408,6 +1488,7 @@
 	cycle_to_external_air = 1
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "dTD" = (
@@ -1436,6 +1517,7 @@
 "dWZ" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "dZw" = (
@@ -1545,8 +1627,19 @@
 	pixel_x = 20
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/armory)
+"etE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/port_hall)
 "etL" = (
 /turf/space/transit/north,
 /area/space)
@@ -1591,6 +1684,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/dominian_science_shuttle)
 "ezV" = (
@@ -1655,6 +1749,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
 "eIb" = (
@@ -1768,6 +1863,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/hangar)
 "eRr" = (
@@ -1836,6 +1932,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "eYR" = (
@@ -1845,6 +1942,10 @@
 /obj/effect/floor_decal/corner/blue/full,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/dominian_science_shuttle)
+"eZZ" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/ship/dominian_science_vessel/hangar)
 "fbn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/service{
@@ -1878,6 +1979,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "fii" = (
@@ -1907,6 +2009,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
 "foH" = (
@@ -1932,6 +2035,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "fsO" = (
@@ -1975,6 +2079,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
 "fxK" = (
@@ -2017,6 +2122,7 @@
 /obj/machinery/light{
 	icon_state = "tube_empty"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/armory)
 "fCh" = (
@@ -2071,6 +2177,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "fPm" = (
@@ -2110,6 +2217,10 @@
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
+"fYq" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/dominian_science_vessel/aft_dock)
 "fYJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2223,8 +2334,15 @@
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/tiled/white,
 /area/ship/dominian_science_vessel/showers)
+"gHm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/dominian_science_vessel/aft_dock)
 "gJh" = (
-/turf/template_noop,
+/obj/structure/lattice/catwalk,
+/turf/space/dynamic,
 /area/ship/dominian_science_vessel/armory)
 "gJx" = (
 /turf/simulated/wall/shuttle,
@@ -2366,6 +2484,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "hgc" = (
@@ -2391,6 +2510,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "hlW" = (
@@ -2412,6 +2532,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "hqr" = (
@@ -2448,6 +2569,8 @@
 	dir = 5
 	},
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/random/dirt_75,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "huX" = (
@@ -2535,6 +2658,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "hFf" = (
@@ -2548,6 +2672,8 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/random/dirt_75,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "hHG" = (
@@ -2575,6 +2701,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "hHN" = (
@@ -2686,6 +2813,7 @@
 	icon_state = "tube_empty"
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "hOY" = (
@@ -2693,6 +2821,7 @@
 /obj/effect/floor_decal/corner/red/full{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "hWr" = (
@@ -2755,7 +2884,8 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, weapon system"
 	},
-/turf/template_noop,
+/obj/structure/lattice/catwalk,
+/turf/space/dynamic,
 /area/ship/dominian_science_vessel/armory)
 "igL" = (
 /obj/item/bodybag/cryobag,
@@ -2851,6 +2981,7 @@
 /obj/machinery/floodlight{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/dominian_science_shuttle)
 "iqQ" = (
@@ -2925,6 +3056,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
 "ixH" = (
@@ -2996,6 +3128,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "iRI" = (
@@ -3015,6 +3148,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/engineering)
 "iVk" = (
@@ -3103,6 +3237,7 @@
 /obj/effect/floor_decal/corner/red/full{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "jhF" = (
@@ -3150,6 +3285,7 @@
 "jkM" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "jnx" = (
@@ -3181,6 +3317,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/mess)
 "jrS" = (
@@ -3204,6 +3341,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "jxb" = (
@@ -3217,6 +3355,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/engineering)
 "jxr" = (
@@ -3234,6 +3373,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
 "jzp" = (
@@ -3270,7 +3410,7 @@
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
 "jHZ" = (
 /obj/structure/table/steel,
@@ -3310,6 +3450,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/mess)
 "jVD" = (
@@ -3365,6 +3506,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
 "ken" = (
@@ -3398,6 +3540,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "kfB" = (
@@ -3405,6 +3548,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
 "khk" = (
@@ -3429,6 +3573,7 @@
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/armory)
 "klb" = (
@@ -3452,6 +3597,7 @@
 	pixel_x = -6
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "knI" = (
@@ -3507,6 +3653,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
 "krH" = (
@@ -3546,6 +3693,7 @@
 /obj/item/device/flashlight/heavy,
 /obj/item/device/flashlight/marshallingwand,
 /obj/item/device/flashlight,
+/obj/random/dirt_75,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/dominian_science_shuttle)
 "kAa" = (
@@ -3628,6 +3776,7 @@
 	cycle_to_external_air = 1
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "kRK" = (
@@ -3664,6 +3813,8 @@
 	},
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/random/dirt_75,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "kXR" = (
@@ -3672,6 +3823,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "kXV" = (
@@ -3680,6 +3832,7 @@
 /obj/machinery/cell_charger,
 /obj/item/blueprints,
 /obj/item/pen/drafting,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
 "leu" = (
@@ -3689,6 +3842,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "lfS" = (
@@ -3808,6 +3962,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "lvo" = (
@@ -3844,11 +3999,16 @@
 	icon_state = "tube_empty"
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/armory)
 "lxi" = (
 /turf/simulated/wall/r_wall,
 /area/ship/dominian_science_vessel/engineering)
+"lAx" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/dominian_science_vessel/port_hall)
 "lBn" = (
 /turf/simulated/wall/r_wall,
 /area/ship/dominian_science_vessel/officer)
@@ -3946,6 +4106,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "lXp" = (
@@ -3959,6 +4120,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/armory)
+"maQ" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/port_hall)
 "maT" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
@@ -3988,6 +4156,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "mit" = (
@@ -4139,6 +4308,7 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "mLM" = (
@@ -4316,6 +4486,7 @@
 	pixel_y = 5
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
 "njl" = (
@@ -4344,6 +4515,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/dominian_science_shuttle)
+"nob" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/aft_dock)
 "noq" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -4383,6 +4561,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/armory)
 "ntA" = (
@@ -4392,6 +4571,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/armory)
 "nwc" = (
@@ -4467,13 +4647,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "nEY" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
+/obj/random/dirt_75,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "nKe" = (
@@ -4537,10 +4719,12 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "nVi" = (
 /obj/effect/floor_decal/corner/blue/full,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "nVP" = (
@@ -4712,7 +4896,8 @@
 /area/ship/dominian_science_vessel/port_hall)
 "oxg" = (
 /obj/structure/ship_weapon_dummy/barrel,
-/turf/template_noop,
+/obj/structure/lattice/catwalk,
+/turf/space/dynamic,
 /area/ship/dominian_science_vessel/armory)
 "oza" = (
 /obj/structure/cable{
@@ -4777,6 +4962,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "oDy" = (
@@ -4814,6 +5000,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "oGe" = (
@@ -4822,6 +5009,13 @@
 /obj/item/device/versebook/tribunal,
 /turf/simulated/floor/marble/dark,
 /area/ship/dominian_science_vessel/chapel)
+"oLe" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/hangar)
 "oMn" = (
 /obj/effect/floor_decal/corner{
 	dir = 5
@@ -4868,6 +5062,13 @@
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/center_hall)
+"oSL" = (
+/obj/machinery/atmospherics/portables_connector/aux,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/dominian_science_vessel/aft_dock)
 "oVO" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -5032,6 +5233,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "puI" = (
@@ -5059,6 +5261,7 @@
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/floor_decal/industrial/warning/cee,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "pyW" = (
@@ -5092,6 +5295,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/armory)
 "pKo" = (
@@ -5113,12 +5317,14 @@
 	cycle_to_external_air = 1
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "pMm" = (
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "pNy" = (
@@ -5130,6 +5336,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "pWg" = (
@@ -5308,6 +5515,16 @@
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
+"qyJ" = (
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/dominian_science_vessel/hangar)
 "qzk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 10
@@ -5344,7 +5561,8 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, weapon system"
 	},
-/turf/template_noop,
+/obj/structure/lattice/catwalk,
+/turf/space/dynamic,
 /area/ship/dominian_science_vessel/armory)
 "qIu" = (
 /obj/machinery/atmospherics/portables_connector/aux{
@@ -5352,6 +5570,7 @@
 	},
 /obj/effect/floor_decal/corner/red/full,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/armory)
 "qJb" = (
@@ -5372,11 +5591,23 @@
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
+"qJZ" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/structure/sign/flag/volvalaad{
+	pixel_y = 32;
+	stand_icon = "banner"
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/bridge)
 "qKW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "qLo" = (
@@ -5458,8 +5689,16 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/outline/research,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
+"rdR" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/hangar)
 "rex" = (
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/dominian_science_shuttle)
@@ -5476,6 +5715,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "rij" = (
@@ -5518,6 +5758,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "rkM" = (
@@ -5535,7 +5776,7 @@
 	req_access = list(226);
 	req_one_access = null
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
 "rrA" = (
 /turf/simulated/wall/r_wall,
@@ -5571,6 +5812,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "ryv" = (
@@ -5673,6 +5915,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/dominian_science_shuttle)
+"rPl" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/port_hall)
 "rRI" = (
 /turf/simulated/wall/shuttle,
 /area/ship/dominian_science_vessel/isolation)
@@ -5789,7 +6037,7 @@
 	pixel_y = 32;
 	stand_icon = "banner"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
 "svf" = (
 /obj/structure/cable/pink{
@@ -5863,6 +6111,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux,
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "sFI" = (
@@ -5917,6 +6166,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/engineering)
 "sJp" = (
@@ -5938,6 +6188,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/hangar)
 "sLx" = (
@@ -5969,6 +6220,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/bridge)
+"sOW" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/dominian_science_shuttle)
 "sTK" = (
 /obj/machinery/door/airlock/service{
 	dir = 4;
@@ -6032,6 +6287,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "tfK" = (
@@ -6074,6 +6330,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/hangar)
 "toh" = (
@@ -6169,6 +6426,7 @@
 "tsC" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/dominian_science_shuttle)
 "ttW" = (
@@ -6181,6 +6439,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/port_hall)
 "tuK" = (
@@ -6195,6 +6454,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/armory)
+"twP" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube_empty"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/hangar)
 "tyS" = (
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/eva)
@@ -6225,6 +6495,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
 "tCH" = (
@@ -6267,6 +6538,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "tRp" = (
@@ -6293,6 +6565,7 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/engineering)
 "tXG" = (
@@ -6415,6 +6688,13 @@
 /obj/effect/shuttle_landmark/dominian_science_vessel/nav1,
 /turf/template_noop,
 /area/space)
+"usR" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/armory)
 "usU" = (
 /obj/structure/bed/stool/chair{
 	dir = 4
@@ -6499,12 +6779,14 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
 "uDw" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "uDy" = (
@@ -6522,6 +6804,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "uEm" = (
@@ -6531,6 +6814,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/aft_dock)
 "uFw" = (
@@ -6545,6 +6829,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "uGG" = (
@@ -6583,6 +6868,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/bridge)
 "uOY" = (
@@ -6597,6 +6883,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
+"uTl" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_science_vessel/aft_dock)
 "uVq" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/purple,
@@ -6618,6 +6912,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "uYh" = (
@@ -6627,6 +6922,7 @@
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "uYJ" = (
@@ -6691,6 +6987,7 @@
 	},
 /obj/structure/closet/toolcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
 "vha" = (
@@ -6722,6 +7019,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "vnT" = (
@@ -6834,7 +7132,8 @@
 	desc = "A Zhurong Armaments flak battery developed in 2451. Its barrels may look smaller than larger weapons, but don't let that fool you: this gun will shred through smaller ships."
 	},
 /obj/structure/ship_weapon_dummy,
-/turf/template_noop,
+/obj/structure/lattice/catwalk,
+/turf/space/dynamic,
 /area/ship/dominian_science_vessel/armory)
 "vBE" = (
 /obj/structure/railing/mapped{
@@ -6904,6 +7203,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/starboard_hall)
 "vGK" = (
@@ -6937,6 +7237,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/mess)
 "vTv" = (
@@ -6948,6 +7249,7 @@
 	req_one_access = null;
 	req_access = list(226)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "vUO" = (
@@ -6957,6 +7259,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/port_hall)
 "vVA" = (
@@ -6964,6 +7267,7 @@
 /area/ship/dominian_science_vessel/armory)
 "wbz" = (
 /obj/effect/floor_decal/industrial/warning,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "wbT" = (
@@ -6971,6 +7275,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "wcv" = (
@@ -6990,6 +7295,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "wgJ" = (
@@ -7035,17 +7341,29 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/research,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "wny" = (
 /turf/simulated/wall/shuttle,
 /area/shuttle/dominian_science_shuttle)
+"woI" = (
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/dominian_science_vessel/hangar)
 "wpQ" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/corner/red/full{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/quarters)
 "wrJ" = (
@@ -7166,6 +7484,7 @@
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/engineering)
 "wCJ" = (
@@ -7237,6 +7556,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/bridge)
 "wIV" = (
@@ -7285,6 +7605,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "wOl" = (
@@ -7435,6 +7756,7 @@
 "xeU" = (
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "xfT" = (
@@ -7463,6 +7785,7 @@
 	icon_state = "tube_empty"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "xjp" = (
@@ -7519,7 +7842,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "xmz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7538,12 +7861,14 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "xqX" = (
 /obj/machinery/atmospherics/portables_connector/aux,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "xsa" = (
@@ -7600,6 +7925,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "xvv" = (
@@ -7656,6 +7982,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "xzG" = (
@@ -7746,6 +8073,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/atmospherics)
 "xNk" = (
@@ -7758,7 +8086,7 @@
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/dominian_science_shuttle)
 "xOs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -7768,7 +8096,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/aft_dock)
 "xPF" = (
 /obj/structure/railing/mapped{
@@ -7803,6 +8132,7 @@
 "xRu" = (
 /obj/effect/floor_decal/industrial/outline/research,
 /obj/machinery/suspension_gen,
+/obj/random/dirt_75,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/dominian_science_shuttle)
 "xRX" = (
@@ -7829,6 +8159,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_science_vessel/eva)
 "xXN" = (
@@ -7836,6 +8167,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
 "xXU" = (
@@ -7866,6 +8198,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 
@@ -32107,7 +32440,7 @@ xRX
 xRX
 xRX
 doM
-fMn
+nob
 xPu
 sZn
 bzK
@@ -32365,7 +32698,7 @@ xRX
 xRX
 doM
 uEm
-xPu
+gHm
 sZn
 mZz
 kAk
@@ -32621,7 +32954,7 @@ xRX
 xRX
 doM
 doM
-hHG
+uTl
 nEE
 sZn
 bpG
@@ -35960,7 +36293,7 @@ xRX
 xRX
 doM
 xiZ
-dQP
+fYq
 wbz
 fMn
 dck
@@ -36216,7 +36549,7 @@ xRX
 xRX
 xRX
 doM
-svV
+oSL
 cAQ
 vrQ
 gtV
@@ -36734,7 +37067,7 @@ ken
 hMa
 pfq
 arh
-dQP
+fYq
 sZn
 lDQ
 uZo
@@ -36759,7 +37092,7 @@ xfT
 sLx
 sLx
 akl
-akl
+gJh
 qHO
 xRX
 xRX
@@ -37253,7 +37586,7 @@ kQy
 kQy
 kQy
 kQy
-kQy
+aqs
 kQy
 kQy
 kQy
@@ -37517,15 +37850,15 @@ cDG
 ojK
 cDG
 cDG
-cDG
-ktm
-cDG
+dvF
+twP
+dvF
 cDG
 oBu
 kQy
 wCU
 ntu
-xax
+usR
 tEV
 xsa
 bTi
@@ -37767,8 +38100,8 @@ uOY
 uOY
 oVO
 fMI
-ryV
-ryV
+woI
+woI
 ryV
 vBE
 eJw
@@ -38035,7 +38368,7 @@ uOY
 uOY
 uOY
 haa
-hIB
+boo
 kQy
 dEE
 hbi
@@ -38292,7 +38625,7 @@ ogz
 uOY
 uOY
 haa
-pfE
+rdR
 kQy
 rzJ
 vVA
@@ -38549,7 +38882,7 @@ kyc
 wny
 wny
 haa
-pfE
+rdR
 kQy
 ans
 lLC
@@ -38799,7 +39132,7 @@ mET
 ckh
 dMj
 rex
-rex
+bbh
 kXm
 lDj
 huE
@@ -39325,13 +39658,13 @@ tjB
 jLI
 tyS
 tyS
-tyS
+aIj
 xUD
 tjB
 aHs
 bpc
 xyE
-xSb
+qJZ
 krH
 eKR
 mFl
@@ -39570,14 +39903,14 @@ bkQ
 svf
 cHM
 atj
-rex
+hzX
 uCK
 ahw
 aMY
 aMY
 kaR
 haa
-hIB
+boo
 tjB
 uuN
 tyS
@@ -40852,8 +41185,8 @@ rOg
 pWg
 rex
 oYG
-hzX
-hzX
+sOW
+sOW
 hzX
 hzX
 hZH
@@ -41630,8 +41963,8 @@ wny
 wny
 uOY
 uOY
-uOY
-uOY
+eZZ
+eZZ
 qdL
 pfE
 rrA
@@ -41886,7 +42219,7 @@ uOY
 uOY
 uOY
 uOY
-uOY
+eZZ
 uOY
 uOY
 qdL
@@ -42136,7 +42469,7 @@ uOY
 uOY
 pdm
 aOT
-axT
+qyJ
 axT
 axT
 ncD
@@ -42147,7 +42480,7 @@ iDY
 xPF
 xPF
 mwP
-pfE
+rdR
 rrA
 rrA
 rrA
@@ -42398,13 +42731,13 @@ jZe
 mLM
 umM
 sLr
-jZe
-jZe
+oLe
+oLe
 fuL
 mLM
 jZe
-jZe
-oBu
+oLe
+cHw
 qzZ
 fPm
 dZw
@@ -42906,8 +43239,8 @@ gRZ
 vGK
 aPi
 uQd
-lml
-lml
+maQ
+maQ
 lml
 sGw
 lml
@@ -42915,8 +43248,8 @@ lml
 lml
 lml
 kps
-lml
-bUF
+maQ
+rPl
 qzZ
 dJN
 ibh
@@ -43931,7 +44264,7 @@ pat
 rJK
 vnT
 gRZ
-vrP
+dma
 mBX
 ryv
 oNj
@@ -44188,7 +44521,7 @@ pnT
 pnT
 ajL
 gRZ
-vrP
+dma
 mBX
 ryv
 gZs
@@ -45223,8 +45556,8 @@ sGw
 lml
 uQd
 vtK
-sGw
-lml
+bsq
+maQ
 lml
 lml
 dnN
@@ -45476,12 +45809,12 @@ xqX
 kfB
 ojZ
 oqw
-fYJ
+etE
 fYJ
 iwB
 cQn
-jhF
-jhF
+aLv
+aLv
 jhF
 jhF
 uDy
@@ -46499,7 +46832,7 @@ xRX
 xRX
 wLq
 dWZ
-dfe
+lAx
 vrP
 dfe
 wgJ
@@ -46757,7 +47090,7 @@ xRX
 wLq
 wLq
 kXR
-vrP
+dma
 dfe
 qdb
 hKv

--- a/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel_areas.dm
+++ b/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel_areas.dm
@@ -5,7 +5,7 @@
 
 /area/ship/dominian_science_vessel/hangar
 	name = "Dominian Science Vessel Hangar"
-	icon_state = "hangar"
+	icon_state = "yellow"
 
 /area/ship/dominian_science_vessel/infirmary
 	name = "Dominian Science Vessel Infirmary"

--- a/maps/away/ships/heph/cyclops/cyclops.dmm
+++ b/maps/away/ships/heph/cyclops/cyclops.dmm
@@ -8,6 +8,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "ae" = (
@@ -19,6 +20,7 @@
 /obj/item/stack/material/plastic/full,
 /obj/item/stack/material/aluminium/full,
 /obj/item/stack/material/lead/full,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "af" = (
@@ -33,6 +35,7 @@
 /obj/effect/map_effect/marker/airlock/heph_cyclops/starboard{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "ap" = (
@@ -56,6 +59,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/outline/operations,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/cyclops_shuttle)
 "ax" = (
@@ -200,6 +204,7 @@
 /obj/effect/map_effect/marker/airlock/heph_cyclops/port{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "bD" = (
@@ -210,6 +215,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "bT" = (
@@ -218,6 +224,13 @@
 	},
 /turf/template_noop,
 /area/space)
+"bX" = (
+/obj/effect/floor_decal/corner/orange{
+	dir = 9
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/hephmining_ship/cyclops)
 "ce" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -272,7 +285,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/industrial/hatch_door/operations,
+/obj/effect/floor_decal/industrial/hatch_door/operations{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops/bathroom)
 "cv" = (
@@ -283,12 +299,13 @@
 	dir = 6
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/floor_decal/industrial/hatch_door/red{
-	dir = 1
-	},
 /obj/effect/map_effect/marker/airlock/heph_cyclops/port{
 	req_one_access = list(216)
 	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 4
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "cN" = (
@@ -314,12 +331,13 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
-/obj/effect/floor_decal/industrial/hatch_door/red{
-	dir = 1
-	},
 /obj/effect/map_effect/marker/airlock/heph_cyclops/starboard{
 	req_one_access = list(216)
 	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 4
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "cU" = (
@@ -329,6 +347,7 @@
 /obj/machinery/power/apc/west{
 	req_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_starboard_thrust)
 "cW" = (
@@ -347,6 +366,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "de" = (
@@ -359,6 +379,7 @@
 	pixel_y = 32
 	},
 /obj/item/deck/cards,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "di" = (
@@ -392,6 +413,7 @@
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "dr" = (
@@ -402,6 +424,18 @@
 /obj/structure/railing/mapped,
 /turf/space/dynamic,
 /area/space)
+"dv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/orange{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/hephmining_ship/cyclops)
 "dD" = (
 /obj/machinery/mineral/processing_unit_console{
 	id = "processing_3";
@@ -410,6 +444,7 @@
 /obj/effect/floor_decal/corner/orange/full{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "dE" = (
@@ -443,6 +478,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_vault)
 "dH" = (
@@ -479,6 +515,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle/cyclops_shuttle/shuttle{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/cyclops_shuttle)
 "dO" = (
@@ -497,11 +534,14 @@
 	name = "Recreation";
 	req_access = list(216)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/hatch_door/operations,
+/obj/effect/floor_decal/industrial/hatch_door/operations{
+	dir = 8
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops)
 "ec" = (
@@ -516,9 +556,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
 /obj/effect/floor_decal/industrial/hatch_door/operations{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_captain)
@@ -530,6 +572,7 @@
 /obj/effect/floor_decal/corner/orange{
 	dir = 5
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "ef" = (
@@ -553,8 +596,13 @@
 /obj/machinery/atmospherics/binary/pump/scrubber/on{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/cyclops_shuttle)
+"el" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/hephmining_ship/cyclops/cyclops_hangar)
 "eo" = (
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	spawn_firedoor = 1;
@@ -590,6 +638,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "eF" = (
@@ -665,11 +714,12 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch_door/red{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/map_effect/marker/airlock/heph_cyclops/starboard{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "fi" = (
@@ -699,6 +749,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "fB" = (
@@ -735,6 +786,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle/cyclops_shuttle/shuttle{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/cyclops_shuttle)
 "fV" = (
@@ -767,6 +819,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "gm" = (
@@ -776,6 +829,7 @@
 /obj/effect/map_effect/marker/airlock/heph_cyclops/starboard{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "gn" = (
@@ -791,6 +845,7 @@
 	name = "carbon dioxide supply"
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_port_thrust)
 "gs" = (
@@ -824,6 +879,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/cyclops_shuttle)
 "gH" = (
@@ -832,8 +888,24 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_vault)
+"gJ" = (
+/obj/structure/bed/padded,
+/obj/structure/curtain/open/bed{
+	color = "#4c6324"
+	},
+/obj/effect/floor_decal/corner/orange{
+	dir = 9
+	},
+/obj/effect/ghostspawpoint{
+	name = "cyclops_crew";
+	identifier = "cyclops_crew"
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/hephmining_ship/cyclops/cyclops_barracks)
 "gL" = (
 /obj/machinery/conveyor{
 	id = "heph_1"
@@ -883,6 +955,7 @@
 	},
 /obj/item/device/gps/mining,
 /obj/item/device/suit_cooling_unit,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "hK" = (
@@ -956,6 +1029,7 @@
 	},
 /obj/machinery/power/portgen/basic/advanced,
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "iL" = (
@@ -964,6 +1038,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/medical,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "iM" = (
@@ -973,8 +1048,12 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch_door/operations{
-	dir = 1
+	dir = 4
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "iR" = (
@@ -987,6 +1066,7 @@
 /obj/machinery/power/apc/north{
 	req_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "iT" = (
@@ -997,6 +1077,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "iU" = (
@@ -1049,6 +1130,7 @@
 	},
 /obj/structure/dispenser/phoron,
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "jF" = (
@@ -1085,12 +1167,13 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
-/obj/effect/floor_decal/industrial/hatch_door/red{
-	dir = 1
-	},
 /obj/effect/map_effect/marker/airlock/heph_cyclops/starboard{
 	req_one_access = list(216)
 	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 4
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "kD" = (
@@ -1140,6 +1223,35 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
+"kU" = (
+/obj/item/clothing/under/rank/miner/heph,
+/obj/item/clothing/under/rank/miner/heph,
+/obj/item/clothing/suit/storage/toggle/corp/heph,
+/obj/item/clothing/suit/storage/toggle/corp/heph,
+/obj/item/card/id/hephaestus,
+/obj/item/card/id/hephaestus,
+/obj/item/flag/heph,
+/obj/item/flag/heph,
+/obj/effect/floor_decal/corner/orange{
+	dir = 9
+	},
+/obj/item/clothing/accessory/storage/webbing,
+/obj/item/clothing/accessory/storage/webbing,
+/obj/item/clothing/accessory/storage/pouches/brown,
+/obj/structure/closet/cabinet{
+	anchored = 1
+	},
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/accessory/offworlder/bracer{
+	accent_color = "38531D"
+	},
+/obj/item/clothing/accessory/poncho/unathimantle/hephaestus{
+	accent_color = "#995108"
+	},
+/obj/item/storage/backpack/cloak/klax,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/hephmining_ship/cyclops/cyclops_barracks)
 "kV" = (
 /obj/machinery/light{
 	dir = 8
@@ -1152,6 +1264,7 @@
 	name = "carbon dioxide supply"
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_starboard_thrust)
 "kY" = (
@@ -1166,12 +1279,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/hatch_door/operations{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_captain)
@@ -1190,6 +1305,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_bridge)
+"ly" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/item/clothing/head/cone,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/hephmining_ship/cyclops/cyclops_hangar)
 "lz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1216,6 +1339,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/outline/operations,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/cyclops_shuttle)
 "lV" = (
@@ -1228,6 +1352,7 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/outline/medical,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "lY" = (
@@ -1257,14 +1382,23 @@
 	dir = 5
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/floor_decal/industrial/hatch_door/red{
-	dir = 1
-	},
 /obj/effect/map_effect/marker/airlock/heph_cyclops/port{
 	req_one_access = list(216)
 	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 4
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_engineering)
+"mf" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/effect/map_effect/perma_light/starlight/wide,
+/turf/space/dynamic,
+/area/space)
 "mn" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 6
@@ -1276,11 +1410,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "mv" = (
-/obj/machinery/vending/dinnerware{
-	pixel_x = 11;
-	pixel_y = -2
-	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/closet/crate{
+	name = "DANGER - CONTAINS K'OIS"
+	},
+/obj/item/reagent_containers/food/snacks/koisbar_clean,
+/obj/item/reagent_containers/food/snacks/koisbar_clean,
+/obj/item/reagent_containers/food/snacks/koisbar_clean,
+/obj/item/reagent_containers/food/snacks/koisbar_clean,
+/obj/item/reagent_containers/food/snacks/koisbar_clean,
+/obj/item/reagent_containers/food/snacks/koisbar_clean,
 /turf/simulated/floor/tiled/white,
 /area/hephmining_ship/cyclops/cyclops_kitchen)
 "mA" = (
@@ -1334,6 +1473,7 @@
 /obj/structure/closet/secure_closet/engineering_electrical{
 	req_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "nb" = (
@@ -1364,12 +1504,13 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/floor_decal/industrial/hatch_door/red{
-	dir = 1
-	},
 /obj/effect/map_effect/marker/airlock/heph_cyclops/port{
 	req_one_access = list(216)
 	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 4
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "ne" = (
@@ -1408,6 +1549,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/cyclops_shuttle)
+"nG" = (
+/obj/effect/floor_decal/corner/orange{
+	dir = 6
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/hephmining_ship/cyclops)
 "nJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
@@ -1435,6 +1583,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/firealarm/south,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_vault)
 "oh" = (
@@ -1444,11 +1593,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/hatch_door/operations,
+/obj/effect/floor_decal/industrial/hatch_door/operations{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_bridge)
 "on" = (
@@ -1505,8 +1656,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/industrial/hatch_door/operations,
+/obj/machinery/door/firedoor/noid,
+/obj/effect/floor_decal/industrial/hatch_door/operations{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops)
 "pc" = (
@@ -1524,6 +1677,7 @@
 	name = "emergency fuel crate"
 	},
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "pf" = (
@@ -1567,6 +1721,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "pw" = (
@@ -1600,6 +1755,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle/cyclops_shuttle/shuttle{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/cyclops_shuttle)
 "pG" = (
@@ -1636,6 +1792,7 @@
 	req_one_access = null;
 	req_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_port_thrust)
 "pW" = (
@@ -1665,6 +1822,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/cyclops_shuttle)
 "qn" = (
@@ -1725,6 +1883,7 @@
 	req_one_access = null;
 	req_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops/bathroom)
 "qF" = (
@@ -1744,6 +1903,7 @@
 /obj/machinery/computer/ship/engines/terminal{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/cyclops_shuttle)
 "qJ" = (
@@ -1763,8 +1923,11 @@
 	name = "Recreation";
 	req_access = list(216)
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/industrial/hatch_door/operations,
+/obj/machinery/door/firedoor/noid,
+/obj/effect/floor_decal/industrial/hatch_door/operations{
+	dir = 8
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops)
 "qU" = (
@@ -1787,6 +1950,7 @@
 	pixel_y = -23
 	},
 /obj/effect/floor_decal/corner/orange/full,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "rr" = (
@@ -1820,15 +1984,7 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/light,
-/obj/structure/closet/crate{
-	name = "DANGER - CONTAINS K'OIS"
-	},
-/obj/item/reagent_containers/food/snacks/koisbar_clean,
-/obj/item/reagent_containers/food/snacks/koisbar_clean,
-/obj/item/reagent_containers/food/snacks/koisbar_clean,
-/obj/item/reagent_containers/food/snacks/koisbar_clean,
-/obj/item/reagent_containers/food/snacks/koisbar_clean,
-/obj/item/reagent_containers/food/snacks/koisbar_clean,
+/obj/structure/table/stone/marble,
 /turf/simulated/floor/tiled/white,
 /area/hephmining_ship/cyclops/cyclops_kitchen)
 "rG" = (
@@ -1839,6 +1995,7 @@
 /obj/machinery/suit_cycler/mining/prepared{
 	req_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "rJ" = (
@@ -1951,6 +2108,17 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
+"sQ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark/full,
+/area/hephmining_ship/cyclops/cyclops_hangar)
 "tb" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/portables_connector{
@@ -1960,6 +2128,7 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "td" = (
@@ -1976,8 +2145,16 @@
 "tn" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/firealarm/south,
+/obj/structure/table/stone/marble,
 /turf/simulated/floor/tiled/white,
 /area/hephmining_ship/cyclops/cyclops_kitchen)
+"to" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/hephmining_ship/cyclops/cyclops_hangar)
 "tw" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -2018,6 +2195,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle/cyclops_shuttle/shuttle{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/cyclops_shuttle)
 "ua" = (
@@ -2040,6 +2218,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle/cyclops_shuttle/shuttle{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/cyclops_shuttle)
 "uj" = (
@@ -2077,6 +2256,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_starboard_thrust)
 "uy" = (
@@ -2107,6 +2287,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "uL" = (
@@ -2118,18 +2299,13 @@
 /area/hephmining_ship/cyclops/cyclops_barracks)
 "uN" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/alarm{
-	pixel_x = -32;
-	pixel_y = 30;
-	req_one_access = null;
-	req_access = list(216)
-	},
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/north{
 	req_access = list(216)
 	},
+/obj/machinery/vending/dinnerware,
 /turf/simulated/floor/tiled/white,
 /area/hephmining_ship/cyclops/cyclops_kitchen)
 "uO" = (
@@ -2187,6 +2363,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "vj" = (
@@ -2405,6 +2582,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "xG" = (
@@ -2478,6 +2656,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "yo" = (
@@ -2563,6 +2742,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "yD" = (
@@ -2585,6 +2765,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "yL" = (
@@ -2597,9 +2778,15 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_engineering)
+"yM" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/hephmining_ship/cyclops/cyclops_hangar)
 "yW" = (
 /obj/machinery/computer/ship/engines/terminal,
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_port_thrust)
 "yX" = (
@@ -2607,10 +2794,10 @@
 	dir = 4;
 	name = "Fuel Tank to Thrusters"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_starboard_thrust)
 "yY" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -2625,8 +2812,9 @@
 	req_access = list(216);
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/hatch_door/engineering{
-	dir = 1
+/obj/effect/floor_decal/industrial/hatch_door/engineering,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_engineering)
@@ -2638,6 +2826,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "ze" = (
@@ -2651,6 +2840,7 @@
 /obj/machinery/computer/shuttle_control/explore/terminal/cyclops_shuttle{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/cyclops_shuttle)
 "zi" = (
@@ -2685,6 +2875,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "zW" = (
@@ -2746,6 +2937,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/vending/cigarette,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "Aw" = (
@@ -2758,14 +2950,14 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "Ax" = (
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
-	},
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch_door/service{
-	dir = 1
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_kitchen)
@@ -2792,15 +2984,16 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/floor_decal/industrial/hatch_door/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/effect/map_effect/marker/airlock/heph_cyclops/port{
 	req_one_access = list(216)
 	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 4
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "AH" = (
@@ -2826,6 +3019,7 @@
 	},
 /obj/item/gun/energy/gun,
 /obj/item/gun/energy/gun,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_vault)
 "AL" = (
@@ -2841,6 +3035,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "AO" = (
@@ -2865,6 +3060,7 @@
 /obj/effect/floor_decal/corner/orange{
 	dir = 6
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "AX" = (
@@ -2892,6 +3088,7 @@
 	req_access = null;
 	pixel_y = -26
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "AY" = (
@@ -2899,6 +3096,14 @@
 	color = "#4c4324"
 	},
 /area/hephmining_ship/cyclops/cyclops_barracks)
+"Ba" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/map_effect/perma_light/starlight/wide,
+/turf/space/dynamic,
+/area/space)
 "Bf" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -2910,6 +3115,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "Bg" = (
@@ -2940,6 +3146,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "Bn" = (
@@ -2997,6 +3204,17 @@
 	color = "#4c4324"
 	},
 /area/shuttle/cyclops_shuttle)
+"BD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark/full,
+/area/hephmining_ship/cyclops/cyclops_hangar)
 "BH" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -3006,6 +3224,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle/cyclops_shuttle/shuttle{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/cyclops_shuttle)
 "BM" = (
@@ -3019,6 +3238,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_starboard_thrust)
 "BV" = (
@@ -3053,6 +3273,7 @@
 	},
 /obj/item/device/gps/mining,
 /obj/item/device/suit_cooling_unit,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "BX" = (
@@ -3077,8 +3298,11 @@
 /obj/effect/floor_decal/corner/orange{
 	dir = 9
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/industrial/hatch_door/operations,
+/obj/machinery/door/firedoor/noid,
+/obj/effect/floor_decal/industrial/hatch_door/operations{
+	dir = 8
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "Ch" = (
@@ -3096,6 +3320,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle/cyclops_shuttle/shuttle{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/cyclops_shuttle)
 "Ck" = (
@@ -3120,6 +3345,7 @@
 /area/hephmining_ship/cyclops/cyclops_bridge)
 "CB" = (
 /obj/machinery/atmospherics/binary/pump/fuel,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/cyclops_shuttle)
 "CD" = (
@@ -3139,6 +3365,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/suit_cycler/offship/hephaestus,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "CT" = (
@@ -3147,6 +3374,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/autolathe,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "CV" = (
@@ -3172,6 +3400,7 @@
 /obj/effect/map_effect/marker/airlock/heph_cyclops/port{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "Dc" = (
@@ -3183,8 +3412,13 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_port_thrust)
+"Dq" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark/full,
+/area/hephmining_ship/cyclops)
 "Dt" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/airlock_sensor{
@@ -3195,6 +3429,7 @@
 /obj/effect/map_effect/marker/airlock/heph_cyclops/port{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "DJ" = (
@@ -3223,6 +3458,7 @@
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "DO" = (
@@ -3245,11 +3481,12 @@
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/hatch_door/red{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/map_effect/marker/airlock/heph_cyclops/starboard{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "DW" = (
@@ -3297,6 +3534,7 @@
 /obj/effect/map_effect/marker/airlock/heph_cyclops/port{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "EF" = (
@@ -3315,7 +3553,10 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/hatch_door/operations{
-	dir = 1
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops/bathroom)
@@ -3348,6 +3589,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "EK" = (
@@ -3391,6 +3633,7 @@
 /obj/item/storage/bag/ore,
 /obj/item/device/gps/mining,
 /obj/item/device/suit_cooling_unit,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "EW" = (
@@ -3413,6 +3656,7 @@
 /obj/machinery/power/apc/east{
 	req_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_port_thrust)
 "Ff" = (
@@ -3478,9 +3722,11 @@
 	req_access = list(216);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
 /obj/effect/floor_decal/industrial/hatch_door/operations{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_barracks)
@@ -3510,7 +3756,10 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/hatch_door/service{
-	dir = 1
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_kitchen)
@@ -3556,6 +3805,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "GU" = (
@@ -3567,6 +3817,7 @@
 	dir = 4
 	},
 /obj/machinery/meter,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_starboard_thrust)
 "Hc" = (
@@ -3623,7 +3874,10 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/hatch_door/engineering,
+/obj/effect/floor_decal/industrial/hatch_door/engineering{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_starboard_thrust)
 "HM" = (
@@ -3718,6 +3972,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/operations,
 /obj/effect/floor_decal/industrial/loading/operations,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "IN" = (
@@ -3733,6 +3988,7 @@
 	color = "#ff9900";
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "IP" = (
@@ -3744,6 +4000,7 @@
 	req_access = list(216)
 	},
 /obj/structure/closet/crate/bin,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "IS" = (
@@ -3797,6 +4054,7 @@
 /obj/effect/floor_decal/corner/orange{
 	dir = 9
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "Jk" = (
@@ -3855,11 +4113,13 @@
 	req_access = list(216)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/hatch_door/engineering,
+/obj/effect/floor_decal/industrial/hatch_door/engineering{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_port_thrust)
 "JE" = (
@@ -3868,6 +4128,7 @@
 	color = "#ff9900";
 	dir = 9
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "JH" = (
@@ -3889,6 +4150,7 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/outline/security,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_vault)
 "JL" = (
@@ -3908,6 +4170,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "JN" = (
@@ -3922,12 +4185,14 @@
 	req_access = list(216);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/hatch_door/operations{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_barracks)
@@ -4009,6 +4274,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "KJ" = (
@@ -4019,6 +4285,7 @@
 	req_one_access = null;
 	req_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "KL" = (
@@ -4037,6 +4304,7 @@
 /obj/effect/map_effect/marker/airlock/heph_cyclops/port{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "KV" = (
@@ -4048,6 +4316,15 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/tiled/dark,
+/area/hephmining_ship/cyclops)
+"Lb" = (
+/obj/structure/bed/stool/bar/padded/orange,
+/obj/effect/floor_decal/spline/fancy{
+	color = "#ff9900";
+	dir = 5
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "Ld" = (
@@ -4065,6 +4342,7 @@
 	req_one_access = null;
 	req_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_vault)
 "Ln" = (
@@ -4106,6 +4384,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle/cyclops_shuttle/shuttle{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/cyclops_shuttle)
 "Mg" = (
@@ -4120,6 +4399,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/operations,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/cyclops_shuttle)
 "Mm" = (
@@ -4155,6 +4435,7 @@
 	accent_color = "#995108"
 	},
 /obj/item/storage/backpack/cloak/klax,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_barracks)
 "Mx" = (
@@ -4190,6 +4471,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_barracks)
 "Nc" = (
@@ -4219,7 +4501,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/chemical_dispenser/coffeemaster/full,
+/obj/machinery/chemical_dispenser/coffeemaster/full{
+	pixel_y = 15
+	},
+/obj/machinery/alarm/north{
+	req_one_access = list(216)
+	},
 /turf/simulated/floor/tiled/white,
 /area/hephmining_ship/cyclops/cyclops_kitchen)
 "Nt" = (
@@ -4264,7 +4551,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch_door/red{
-	dir = 1
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_vault)
@@ -4298,6 +4588,7 @@
 /obj/effect/floor_decal/corner/orange{
 	dir = 5
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "Ob" = (
@@ -4367,6 +4658,7 @@
 /obj/effect/floor_decal/corner/orange{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_barracks)
 "Pc" = (
@@ -4385,6 +4677,7 @@
 /obj/effect/floor_decal/corner/orange{
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_starboard_thrust)
 "Pg" = (
@@ -4395,6 +4688,7 @@
 /turf/space/dynamic,
 /area/space)
 "Pp" = (
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_hangar)
 "Pv" = (
@@ -4489,11 +4783,12 @@
 /obj/structure/closet/crate,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "QY" = (
 /obj/structure/lattice,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "Rg" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -4524,6 +4819,15 @@
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/plating,
 /area/hephmining_ship/cyclops/cyclops_hangar)
+"RS" = (
+/obj/structure/dispenser/oxygen,
+/obj/effect/floor_decal/corner/orange{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/hephmining_ship/cyclops)
 "RZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4533,11 +4837,14 @@
 "Sf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/hatch_door/operations,
+/obj/effect/floor_decal/industrial/hatch_door/operations{
+	dir = 8
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops)
 "Sh" = (
@@ -4569,6 +4876,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_port_thrust)
 "SD" = (
@@ -4648,6 +4956,7 @@
 	dir = 10
 	},
 /obj/machinery/light,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops/bathroom)
 "SS" = (
@@ -4680,6 +4989,7 @@
 /obj/item/pen/drafting/blue{
 	pixel_y = 5
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "SW" = (
@@ -4724,6 +5034,7 @@
 /obj/item/clothing/shoes/magboots/vaurca,
 /obj/item/device/gps/mining,
 /obj/item/device/suit_cooling_unit,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "Tb" = (
@@ -4746,6 +5057,7 @@
 	},
 /obj/effect/floor_decal/corner/orange/full,
 /obj/machinery/firealarm/south,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "Tu" = (
@@ -4788,6 +5100,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/phoron_scarce,
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "TC" = (
@@ -4799,6 +5112,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "TD" = (
@@ -4819,8 +5133,16 @@
 "TG" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_starboard_thrust)
+"TN" = (
+/obj/effect/floor_decal/corner/orange{
+	dir = 10
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark,
+/area/hephmining_ship/cyclops)
 "TP" = (
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	spawn_firedoor = 1;
@@ -4888,6 +5210,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "UA" = (
@@ -4926,6 +5249,7 @@
 	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "Vz" = (
@@ -4944,11 +5268,13 @@
 	name = "Atmospherics";
 	req_one_access = list(216)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/hatch_door/operations,
+/obj/effect/floor_decal/industrial/hatch_door/operations{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops)
 "VE" = (
@@ -5062,7 +5388,6 @@
 /area/hephmining_ship/cyclops/cyclops_barracks)
 "Xe" = (
 /obj/machinery/door/window,
-/obj/structure/curtain/open/shower,
 /turf/simulated/floor/tiled/freezer,
 /area/hephmining_ship/cyclops/cyclops/bathroom)
 "Xu" = (
@@ -5095,6 +5420,7 @@
 /obj/structure/sign/flag/heph{
 	pixel_y = 32
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "XT" = (
@@ -5121,6 +5447,7 @@
 	req_one_access = null;
 	req_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_barracks)
 "Yc" = (
@@ -5167,6 +5494,7 @@
 	},
 /obj/machinery/cryopod,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_barracks)
 "YE" = (
@@ -5217,8 +5545,11 @@
 /obj/effect/floor_decal/corner/orange{
 	dir = 6
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/industrial/hatch_door/operations,
+/obj/machinery/door/firedoor/noid,
+/obj/effect/floor_decal/industrial/hatch_door/operations{
+	dir = 8
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops)
 "Zg" = (
@@ -5237,6 +5568,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/cyclops_shuttle)
 "Zn" = (
@@ -5276,6 +5608,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "ZB" = (
@@ -5286,6 +5619,7 @@
 /obj/effect/map_effect/marker/airlock/heph_cyclops/port{
 	req_one_access = list(216)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/hephmining_ship/cyclops/cyclops_engineering)
 "ZE" = (
@@ -32412,41 +32746,41 @@ CE
 CE
 Bn
 if
+mf
 if
 if
 if
 if
+mf
 if
 if
 if
 if
+mf
 if
 if
 if
 if
-if
-if
-if
-if
+mf
 if
 if
 Ag
 Ag
+mf
+if
+if
+if
+mf
 if
 if
 if
 if
+mf
 if
 if
 if
 if
-if
-if
-if
-if
-if
-if
-if
+mf
 if
 if
 CE
@@ -34236,8 +34570,8 @@ AY
 Ul
 Iz
 ZV
-Iz
-ZV
+kU
+gJ
 Nt
 AY
 AY
@@ -35505,21 +35839,21 @@ Pe
 HB
 zL
 fi
-uT
-DO
+BD
+sQ
 Kq
 fi
 uT
 DO
 fi
 bD
-uT
+BD
 pW
 aB
 Qd
 iH
 pc
-Fk
+bX
 ae
 AY
 AY
@@ -36031,7 +36365,7 @@ wL
 lY
 IS
 Qd
-sP
+RS
 zi
 qU
 rG
@@ -36283,7 +36617,7 @@ BH
 BC
 bc
 zn
-zn
+el
 uL
 vs
 Ry
@@ -36540,8 +36874,8 @@ pE
 gw
 gw
 gw
-zn
-uL
+el
+yM
 Je
 Mx
 Qd
@@ -37062,7 +37396,7 @@ Qd
 hy
 Yo
 xo
-qu
+dv
 dU
 KV
 xo
@@ -37319,7 +37653,7 @@ Qd
 EV
 yp
 SL
-Mm
+TN
 qT
 hK
 qU
@@ -37327,7 +37661,7 @@ SS
 Za
 gc
 Bi
-XE
+nG
 Ku
 Tb
 lu
@@ -37832,7 +38166,7 @@ Pv
 Qd
 Ut
 nK
-qU
+Dq
 AX
 Qd
 JE
@@ -38082,8 +38416,8 @@ eo
 eo
 gw
 gw
-zn
-uL
+el
+yM
 fb
 tO
 Qd
@@ -38329,17 +38663,17 @@ Iy
 SD
 cp
 MV
+to
+to
+to
 MV
 MV
 MV
 MV
 MV
 MV
-MV
-MV
-MV
-MV
-cp
+to
+ly
 wi
 EI
 UA
@@ -38349,7 +38683,7 @@ GG
 il
 rJ
 Qd
-Zr
+Lb
 fz
 kT
 FP
@@ -41407,41 +41741,41 @@ CE
 CE
 tj
 tj
+Ba
 tj
 tj
 tj
 tj
+Ba
 tj
 tj
 tj
 tj
+Ba
 tj
 tj
 tj
 tj
-tj
-tj
-tj
-tj
+Ba
 tj
 tj
 Ag
 Ag
+Ba
 tj
 tj
 tj
 tj
+Ba
+tj
+tj
+tj
+Ba
 tj
 tj
 tj
 tj
-tj
-tj
-tj
-tj
-tj
-tj
-tj
+Ba
 tj
 kO
 CE


### PR DESCRIPTION
Implements some minor QoL fixes to the Dominian Science ship and the Hephaestus mining ship, including orienting shutters correctly, using light markers so distant EVA catwalks don't end up completely dark, use of decals in more rooms for visual interest, and removing non-3/4 shuttle windows.