### PR TITLE
Exosuit Power Cell Install Fix

### DIFF
--- a/code/modules/heavy_vehicle/components/body.dm
+++ b/code/modules/heavy_vehicle/components/body.dm
@@ -67,7 +67,7 @@
 	. = ..()
 
 	if(!cell)
-		. += SPAN_WARNING("It is missing a <a href='?src=[REF(src)];info=cell'>power cell</a>.")
+		. += SPAN_WARNING("It is missing a <a href='?src=[REF(src)];info=cell'>power core</a>.")
 	if(!diagnostics)
 		. += SPAN_WARNING("It is missing a <a href='?src=[REF(src)];info=diagnostics'>diagnostics unit</a>.")
 	if(!mech_armor)
@@ -79,7 +79,7 @@
 		return
 	switch(href_list["info"])
 		if("cell")
-			to_chat(usr, SPAN_NOTICE("A power cell can be created at a mechatronic fabricator."))
+			to_chat(usr, SPAN_NOTICE("A power core can be created at a mechatronic fabricator."))
 		if("diagnostics")
 			to_chat(usr, SPAN_NOTICE("A diagnostics unit can be created at a mechatronic fabricator."))
 		if("armor")
@@ -132,9 +132,9 @@
 			return
 		if(install_component(attacking_item, user))
 			diagnostics = attacking_item
-	else if(istype(attacking_item, /obj/item/cell))
+	else if(istype(attacking_item, /obj/item/cell/mecha))
 		if(cell)
-			to_chat(user, SPAN_WARNING("\The [src] already has a cell installed."))
+			to_chat(user, SPAN_WARNING("\The [src] already has a core installed."))
 			return
 		if(install_component(attacking_item,user))
 			cell = attacking_item

--- a/html/changelogs/Ben10083 - Exosuit_Core_Fix.yml
+++ b/html/changelogs/Ben10083 - Exosuit_Core_Fix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Players can no longer actidently insert power cells instead of power cores into exosuit chassis. Chassis description updated to reflect this."


### PR DESCRIPTION
Fixes https://github.com/Aurorastation/Aurora.3/issues/20039

Power cells can no longer be put into exosuits, this fixes the oversight where someone could install a power cell anyways, which results in it becoming useable when removed. 

Description of chassis updated to make it clear you need a power core