### PR TITLE
Adds Assunzionii voidsuit modkits to loadout

### DIFF
--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -374,7 +374,7 @@
 		"Gadpathurian Vulture-GP" = /obj/item/clothing/suit/space/void/coalition/gadpathur,
 		"Himean Buzzard" = /obj/item/clothing/suit/space/void/coalition/himeo,
 		"Galatean Jackdaw" = /obj/item/clothing/suit/space/void/coalition/galatea,
-		"Assunzionii Rook" = /obj/item/clothing/suit/space/void/coalition/assunzione
+		"Assunzionii Rook" = /obj/item/clothing/suit/space/void/sci/assunzione
 	)
 	helmet_options = list(
 		"Coalition Vulture" = /obj/item/clothing/head/helmet/space/void/coalition,
@@ -382,7 +382,7 @@
 		"Gadpathurian Vulture-GP" = /obj/item/clothing/head/helmet/space/void/coalition/gadpathur,
 		"Himean Buzzard" = /obj/item/clothing/head/helmet/space/void/coalition/himeo,
 		"Galatean Jackdaw" = /obj/item/clothing/head/helmet/space/void/coalition/galatea,
-		"Assunzionii Rook" = /obj/item/clothing/head/helmet/space/void/coalition/assunzione
+		"Assunzionii Rook" = /obj/item/clothing/head/helmet/space/void/sci/assunzione
 	)
 
 /obj/item/storage/box/unathi_pirate
@@ -404,6 +404,22 @@
 	name = "coalition of colonies modkit box"
 	desc = "Contains modkits to convert Coalition voidsuits into member-state variants."
 	starts_with = list(/obj/item/voidsuit_modkit_multi/coalition = 4)
+
+/obj/item/voidsuit_modkit/assunzione
+	name = "assunzionii voidsuit kit"
+	desc = "A simple cardboard box containing the requisition forms, permits, and decal kits for an Assunzionii research voidsuit."
+	suit_options = list(
+		/obj/item/clothing/suit/space/void/sci = /obj/item/clothing/suit/space/void/sci/assunzione,
+		/obj/item/clothing/head/helmet/space/void/sci = /obj/item/clothing/head/helmet/space/void/sci/assunzione,
+	)
+
+/obj/item/voidsuit_modkit/assunzione/ipc
+	name = "synthetic assunzionii voidsuit kit"
+	desc = "A simple cardboard box containing the requisition forms, permits, and decal kits for an Assunzionii research voidsuit fitted for an IPC."
+	suit_options = list(
+		/obj/item/clothing/suit/space/void/sci = /obj/item/clothing/suit/space/void/sci/assunzione/ipc,
+		/obj/item/clothing/head/helmet/space/void/sci = /obj/item/clothing/head/helmet/space/void/sci/assunzione/ipc,
+	)
 
 #undef MODKIT_HELMET
 #undef MODKIT_SUIT

--- a/code/modules/client/preference_setup/loadout/items/utility.dm
+++ b/code/modules/client/preference_setup/loadout/items/utility.dm
@@ -110,6 +110,13 @@
 	allowed_roles = list("Shaft Miner", "Operations Manager", "Engineer", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice", "Engineering Personnel", "Operations Personnel")
 	origin_restriction = list(/singleton/origin_item/origin/himeo, /singleton/origin_item/origin/ipc_himeo, /singleton/origin_item/origin/free_council)
 
+// See the IPC-exclusive tab for the human variant.
+/datum/gear/utility/assunzione_kit
+	display_name = "assunzionii voidsuit kit"
+	path = /obj/item/voidsuit_modkit/assunzione
+	allowed_roles = list("Research Director", "Scientist", "Xenoarchaeologist", "Xenobiologist", "Xenobotanist", "Lab Assistant", "Science Personnel")
+	origin_restriction = list(/singleton/origin_item/origin/assunzione, /singleton/origin_item/origin/ipc_assunzione)
+
 /datum/gear/utility/wheelchair/color
 	display_name = "wheelchair"
 	path = /obj/item/material/stool/chair/wheelchair

--- a/code/modules/client/preference_setup/loadout/items/xeno/machine.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/machine.dm
@@ -330,3 +330,12 @@ ABSTRACT_TYPE(/datum/gear/augment/machine)
 	sacredicon["golden deep sacred icon"] = /obj/item/storage/backpack/goldendeep
 	sacredicon["golden deep sacred icon (baseline)"] = /obj/item/storage/backpack/goldendeep/baseline
 	gear_tweaks += new /datum/gear_tweak/path(sacredicon)
+
+// See the utility tab for the human variant.
+/datum/gear/utility/ipc_assunzione_kit
+	display_name = "synthetic assunzionii voidsuit kit"
+	path = /obj/item/voidsuit_modkit/assunzione/ipc
+	allowed_roles = list("Research Director", "Scientist", "Xenoarchaeologist", "Xenobiologist", "Xenobotanist", "Lab Assistant", "Science Personnel")
+	origin_restriction = list(/singleton/origin_item/origin/ipc_assunzione)
+	whitelisted = list(SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL)
+	sort_category = "Xenowear - IPC"

--- a/code/modules/clothing/spacesuits/void/misc.dm
+++ b/code/modules/clothing/spacesuits/void/misc.dm
@@ -1086,64 +1086,32 @@
 	brightness_on = 6
 	siemens_coefficient = 0.35
 
-/obj/item/clothing/head/helmet/space/void/coalition/assunzione
-	name = "\improper Assunzionii rook voidsuit helmet"
-	desc = "Based on the common Coalition Vulture design, the ZH-A45 'Rook' has rapidly become commonplace equipment among the Republic of Assunzione's scientific and military forces. In addition to being a servicable combat voidsuit model, it is equipped with state-of-the-art anomalous energy shielding developed by Zeng-Hu Pharmaceuticals."
-	desc_extended = "Rook suits are largely seen in the hands of Assunzionii military patrols in Light's Edge, as well as scientific expeditions into the darkness of the Lemurian Sea. The current model was developed in 2412 as a joint effort between Assunzionii government R&D and Zeng-Hu Parmaceuticals."
-	icon_state = "assunzione_helmet"
-	item_state = "assunzione_helmet"
-	species_restricted = list(BODYTYPE_HUMAN, BODYTYPE_IPC_INDUSTRIAL, BODYTYPE_IPC_ZENGHU, BODYTYPE_IPC_BISHOP)
-	refittable_species = list(BODYTYPE_HUMAN, BODYTYPE_IPC)
-	icon_supported_species_tags = list("ipc")
-	anomaly_protection = 0.2
-	armor = list(
-		melee = ARMOR_MELEE_RESISTANT,
-		bullet = ARMOR_BALLISTIC_MEDIUM,
-		laser = ARMOR_LASER_PISTOL,
-		energy = ARMOR_ENERGY_MINOR,
-		bomb = ARMOR_BOMB_PADDED,
-		bio = ARMOR_BIO_SHIELDED,
-		rad = ARMOR_RAD_SHIELDED
-	)
-
-/obj/item/clothing/suit/space/void/coalition/assunzione
-	name = "\improper Assunzionii rook voidsuit"
-	desc = "Based on the common Coalition Vulture design, the ZH-A45 'Rook' has rapidly become commonplace equipment among the Republic of Assunzione's scientific and military forces. In addition to being a servicable combat voidsuit model, it is equipped with state-of-the-art anomalous energy shielding developed by Zeng-Hu Pharmaceuticals."
-	desc_extended = "Rook suits are largely seen in the hands of Assunzionii military patrols in Light's Edge, as well as scientific expeditions into the darkness of the Lemurian Sea. The current model was developed in 2412 as a joint effort between Assunzionii government R&D and Zeng-Hu Parmaceuticals."
-	icon_state = "assunzione_suit"
-	item_state = "assunzione_suit"
-	icon_supported_species_tags = list("ipc")
-	anomaly_protection = 0.5
-	armor = list(
-		melee = ARMOR_MELEE_RESISTANT,
-		bullet = ARMOR_BALLISTIC_MEDIUM,
-		laser = ARMOR_LASER_PISTOL,
-		energy = ARMOR_ENERGY_MINOR,
-		bomb = ARMOR_BOMB_PADDED,
-		bio = ARMOR_BIO_SHIELDED,
-		rad = ARMOR_RAD_SHIELDED
-	)
-
-	species_restricted = list(BODYTYPE_HUMAN, BODYTYPE_IPC_INDUSTRIAL, BODYTYPE_IPC_ZENGHU, BODYTYPE_IPC_BISHOP, BODYTYPE_IPC, BODYTYPE_SKRELL)
-	refittable_species = list(BODYTYPE_HUMAN, BODYTYPE_IPC)
-
 /obj/item/clothing/head/helmet/space/void/sci/assunzione
 	name = "\improper Assunzionii research voidsuit helmet"
-	desc = "Based on the common Coalition Vulture design, the ZH-A45 'Rook' has rapidly become commonplace equipment among the Republic of Assunzione's scientific and military forces. In addition to being a servicable combat voidsuit model, it is equipped with state-of-the-art anomalous energy shielding developed by Zeng-Hu Pharmaceuticals."
-	desc_extended = "Rook suits are largely seen in the hands of Assunzionii military patrols in Light's Edge, as well as scientific expeditions into the darkness of the Lemurian Sea. The current model was developed in 2412 as a joint effort between Assunzionii government R&D and Zeng-Hu Parmaceuticals."
+	desc = "Designed to be lightweight and maneuverable, the ZH-A45 'Rook' has rapidly become commonplace equipment among the Republic of Assunzione's greatest scientific minds."
+	desc_extended = "Rook suits are largely seen in the hands of scientific expeditions into the darkness of the Lemurian Sea, although the design is well-respected enough that it's widely permitted for use by Assunzionii scientists across the spur. The current model was developed in 2412 as a joint effort between Assunzionii government R&D and Zeng-Hu Parmaceuticals."
 	icon = 'icons/obj/clothing/voidsuit/coalition.dmi'
 	icon_state = "assunzione_helmet"
 	item_state = "assunzione_helmet"
-	species_restricted = list(BODYTYPE_HUMAN, BODYTYPE_IPC_INDUSTRIAL, BODYTYPE_IPC_ZENGHU, BODYTYPE_IPC_BISHOP)
-	refittable_species = list(BODYTYPE_HUMAN, BODYTYPE_IPC)
+	species_restricted = list(BODYTYPE_HUMAN)
 	icon_supported_species_tags = list("ipc")
 
 /obj/item/clothing/suit/space/void/sci/assunzione
 	name = "\improper Assunzionii research voidsuit"
-	desc = "Based on the common Coalition Vulture design, the ZH-A45 'Rook' has rapidly become commonplace equipment among the Republic of Assunzione's scientific and military forces. In addition to being a servicable combat voidsuit model, it is equipped with state-of-the-art anomalous energy shielding developed by Zeng-Hu Pharmaceuticals."
-	desc_extended = "Rook suits are largely seen in the hands of Assunzionii military patrols in Light's Edge, as well as scientific expeditions into the darkness of the Lemurian Sea. The current model was developed in 2412 as a joint effort between Assunzionii government R&D and Zeng-Hu Parmaceuticals."
+	desc = "Designed to be lightweight and maneuverable, the ZH-A45 'Rook' has rapidly become commonplace equipment among the Republic of Assunzione's greatest scientific minds."
+	desc_extended = "Rook suits are largely seen in the hands of scientific expeditions into the darkness of the Lemurian Sea, although the design is well-respected enough that it's widely permitted for use by Assunzionii scientists across the spur. The current model was developed in 2412 as a joint effort between Assunzionii government R&D and Zeng-Hu Parmaceuticals."
 	icon = 'icons/obj/clothing/voidsuit/coalition.dmi'
 	icon_state = "assunzione_suit"
 	item_state = "assunzione_suit"
-	icon_supported_species_tags = list("ipc")
+	species_restricted = list(BODYTYPE_HUMAN)
+	refittable_species = null
 
+/obj/item/clothing/head/helmet/space/void/sci/assunzione/ipc
+	icon_state = "ipc_assunzione_helmet"
+	item_state = "ipc_assunzione_helmet"
+	species_restricted = list(BODYTYPE_IPC, BODYTYPE_IPC_INDUSTRIAL, BODYTYPE_IPC_ZENGHU, BODYTYPE_IPC_BISHOP)
+
+/obj/item/clothing/suit/space/void/sci/assunzione/ipc
+	icon_state = "ipc_assunzione_suit"
+	item_state = "ipc_assunzione_suit"
+	species_restricted = list(BODYTYPE_IPC, BODYTYPE_IPC_INDUSTRIAL, BODYTYPE_IPC_ZENGHU, BODYTYPE_IPC_BISHOP)

--- a/code/modules/clothing/spacesuits/void/misc.dm
+++ b/code/modules/clothing/spacesuits/void/misc.dm
@@ -1094,7 +1094,6 @@
 	icon_state = "assunzione_helmet"
 	item_state = "assunzione_helmet"
 	species_restricted = list(BODYTYPE_HUMAN)
-	icon_supported_species_tags = list("ipc")
 
 /obj/item/clothing/suit/space/void/sci/assunzione
 	name = "\improper Assunzionii research voidsuit"
@@ -1104,7 +1103,6 @@
 	icon_state = "assunzione_suit"
 	item_state = "assunzione_suit"
 	species_restricted = list(BODYTYPE_HUMAN)
-	refittable_species = null
 
 /obj/item/clothing/head/helmet/space/void/sci/assunzione/ipc
 	icon_state = "ipc_assunzione_helmet"

--- a/code/modules/clothing/spacesuits/void/misc.dm
+++ b/code/modules/clothing/spacesuits/void/misc.dm
@@ -1126,3 +1126,24 @@
 
 	species_restricted = list(BODYTYPE_HUMAN, BODYTYPE_IPC_INDUSTRIAL, BODYTYPE_IPC_ZENGHU, BODYTYPE_IPC_BISHOP, BODYTYPE_IPC, BODYTYPE_SKRELL)
 	refittable_species = list(BODYTYPE_HUMAN, BODYTYPE_IPC)
+
+/obj/item/clothing/head/helmet/space/void/sci/assunzione
+	name = "\improper Assunzionii research voidsuit helmet"
+	desc = "Based on the common Coalition Vulture design, the ZH-A45 'Rook' has rapidly become commonplace equipment among the Republic of Assunzione's scientific and military forces. In addition to being a servicable combat voidsuit model, it is equipped with state-of-the-art anomalous energy shielding developed by Zeng-Hu Pharmaceuticals."
+	desc_extended = "Rook suits are largely seen in the hands of Assunzionii military patrols in Light's Edge, as well as scientific expeditions into the darkness of the Lemurian Sea. The current model was developed in 2412 as a joint effort between Assunzionii government R&D and Zeng-Hu Parmaceuticals."
+	icon = 'icons/obj/clothing/voidsuit/coalition.dmi'
+	icon_state = "assunzione_helmet"
+	item_state = "assunzione_helmet"
+	species_restricted = list(BODYTYPE_HUMAN, BODYTYPE_IPC_INDUSTRIAL, BODYTYPE_IPC_ZENGHU, BODYTYPE_IPC_BISHOP)
+	refittable_species = list(BODYTYPE_HUMAN, BODYTYPE_IPC)
+	icon_supported_species_tags = list("ipc")
+
+/obj/item/clothing/suit/space/void/sci/assunzione
+	name = "\improper Assunzionii research voidsuit"
+	desc = "Based on the common Coalition Vulture design, the ZH-A45 'Rook' has rapidly become commonplace equipment among the Republic of Assunzione's scientific and military forces. In addition to being a servicable combat voidsuit model, it is equipped with state-of-the-art anomalous energy shielding developed by Zeng-Hu Pharmaceuticals."
+	desc_extended = "Rook suits are largely seen in the hands of Assunzionii military patrols in Light's Edge, as well as scientific expeditions into the darkness of the Lemurian Sea. The current model was developed in 2412 as a joint effort between Assunzionii government R&D and Zeng-Hu Parmaceuticals."
+	icon = 'icons/obj/clothing/voidsuit/coalition.dmi'
+	icon_state = "assunzione_suit"
+	item_state = "assunzione_suit"
+	icon_supported_species_tags = list("ipc")
+

--- a/html/changelogs/hazelmouse-assunzioniisuit.yml
+++ b/html/changelogs/hazelmouse-assunzioniisuit.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Transitions the Assunzionii Rook voidsuit into a pure science voidsuit, rather than a combat-capable suit."
+  - rscadd: "Adds the Assunzionii Rook voidsuit to the loadout via a modkit available to Assunzionii humans and synthetics, allowing research voidsuits to be transformed into the Assunzionii Rook."


### PR DESCRIPTION
This creates two modkits for the Assunzionii 'Rook' voidsuit, one for the human variant and one for the IPC variant, available in the loadout to any character with an Assunzionii origin. It's only applicable to research voidsuits.

IPCs have access to both variants so human-shaped synthetics can still get a suit they can use.

In current code, the Rook is a military voidsuit descended from the Coalition Vulture. As this allows you to transfer it from research voidsuits, it has been shifted to be a mechanically identical subtype of the standard research suit. Anything in the description alluding to its military uses or its anomaly resistance have been removed to reflect this.

This should be a relatively clean change, the Rook isn't currently used substantially in the uplink or for any ghostroles. My thought is that, if someone ever does make an Assunzione military offship, they could resprite this suit for a new armoured variety. The implementation should otherwise resemble the implementation of the Himean modkits.