### PR TITLE
SCCV Intrepid remap

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -594,11 +594,11 @@
 /obj/structure/closet/crate/field_kitchen
 
 /obj/structure/closet/crate/field_kitchen/fill()
-	for(var/i=1, i<=6, i++)
+	for(var/_ in 1 to 6)
 		new /obj/item/stock_parts/capacitor(src)
-	for(var/i=1, i<=4, i++)
+	for(var/_ in 1 to 4)
 		new /obj/item/stock_parts/matter_bin(src)
-	for(var/i=1, i<=2, i++)
+	for(var/_ in 1 to 2)
 		new /obj/item/stock_parts/scanning_module(src)
 	new /obj/item/circuitboard/oven(src)
 	new /obj/item/circuitboard/stove(src)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -588,7 +588,25 @@
 //	new /obj/item/pestspray(src)
 //	new /obj/item/pestspray(src)
 
+// Spawns with everything you need to make your very own field kitchen! (assuming you have power)
+// Contains enough to create a stove and oven. Using loops for anything above one for readability. Best paired with a freezer with ingredients.
+// Intended to provide enough equipment that more than just chefs can function as field cooks on expeditions.
+/obj/structure/closet/crate/field_kitchen
 
+/obj/structure/closet/crate/field_kitchen/fill()
+	for(var/i=1, i<=6, i++)
+		new /obj/item/stock_parts/capacitor(src)
+	for(var/i=1, i<=4, i++)
+		new /obj/item/stock_parts/matter_bin(src)
+	for(var/i=1, i<=2, i++)
+		new /obj/item/stock_parts/scanning_module(src)
+	new /obj/item/circuitboard/oven(src)
+	new /obj/item/circuitboard/stove(src)
+	new /obj/item/stack/cable_coil(src)
+	new /obj/item/storage/box/kitchen(src)
+	new /obj/item/reagent_containers/spray/cleaner(src)
+	new /obj/item/storage/box/gloves(src)
+	new /obj/item/storage/box/condiment(src)
 
 //A crate that populates itself with randomly selected loot from randomstock.dm
 //Can be passed in a rarity value, which is used as a multiplier on the rare/uncommon chance

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -1373,7 +1373,7 @@
 	icon = 'icons/atmos/tank_scc.dmi'
 
 /obj/machinery/atmospherics/pipe/tank/air/scc_shuttle/airlock
-	start_pressure = 303.975
+	start_pressure = 607.95
 
 /obj/machinery/atmospherics/pipe/tank/oxygen
 	name = "Pressure Tank (Oxygen)"

--- a/html/changelogs/hazelmouse-intrepidremap.yml
+++ b/html/changelogs/hazelmouse-intrepidremap.yml
@@ -56,3 +56,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscadd: "Remapped the SCCV Intrepid to be more compatible with Odyssey expeditions, and to be smoother and easier for larger expeditions generally. The new Intrepid is designed to be able to take on a large bulker of passengers and equipment without as many issues."
+  - balance: "Adjusted pressure of SCC-specific airlock tanks from 300 to 600kpa, to be consistent with the canister airlock variant."

--- a/html/changelogs/hazelmouse-intrepidremap.yml
+++ b/html/changelogs/hazelmouse-intrepidremap.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Remapped the SCCV Intrepid to be more compatible with Odyssey expeditions, and to be smoother and easier for larger expeditions generally. The new Intrepid is designed to be able to take on a large bulker of passengers and equipment without as many issues."

--- a/maps/sccv_horizon/code/sccv_horizon_areas.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_areas.dm
@@ -319,23 +319,23 @@
 	icon_state = "intrepid"
 	requires_power = TRUE
 
-/area/shuttle/intrepid/crew_compartment
-	name = "Intrepid Crew Compartment"
+/area/shuttle/intrepid/main_compartment
+	name = "Intrepid Main Compartment"
 
 /area/shuttle/intrepid/cargo_bay
 	name = "Intrepid Cargo Bay"
 
-/area/shuttle/intrepid/engine_compartment
-	name = "Engine Compartment"
+/area/shuttle/intrepid/medical
+	name = "Intrepid Medical Compartment"
 
-/area/shuttle/intrepid/atmos_compartment
-	name = "Atmos Compartment"
+/area/shuttle/intrepid/engineering
+	name = "Intrepid Engineering Compartment"
+
+/area/shuttle/intrepid/port_storage
+	name = "Intrepid Port Nacelle"
 
 /area/shuttle/intrepid/cockpit
-	name = "Cockpit"
-
-/area/shuttle/intrepid/quarters
-	name = "Intrepid Crew Quarters"
+	name = "Intrepid Cockpit"
 
 /area/shuttle/canary
 	name = "Canary"

--- a/maps/sccv_horizon/code/sccv_horizon_overmap.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_overmap.dm
@@ -89,14 +89,13 @@
 	skybox_image.pixel_y = rand(128,256)
 	return skybox_image
 
-/obj/machinery/computer/shuttle_control/explore/intrepid
+/obj/machinery/computer/shuttle_control/explore/terminal/intrepid
 	name = "\improper Intrepid control console"
 	shuttle_tag = "Intrepid"
 	req_access = list(ACCESS_INTREPID)
 	density = 0
-	icon = 'icons/obj/cockpit_console.dmi'
-	icon_state = "right"
-	icon_screen = "blue"
+	icon_state = "computer"
+	icon_screen = "helm"
 	icon_keyboard = null
 	circuit = null
 

--- a/maps/sccv_horizon/code/sccv_horizon_overmap.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_overmap.dm
@@ -79,7 +79,7 @@
 	vessel_size = SHIP_SIZE_SMALL
 	scanimage = "intrepid.png"
 	designer = "Hephaestus Industries"
-	volume = "21 meters length, 16 meters beam/width, 6 meters vertical height"
+	volume = "26 meters length, 15 meters beam/width, 6 meters vertical height"
 	sizeclass = "Pathfinder Exploration Shuttle"
 	shiptype = "Field expeditions and private research uses"
 

--- a/maps/sccv_horizon/code/sccv_horizon_overmap.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_overmap.dm
@@ -93,7 +93,6 @@
 	name = "\improper Intrepid control console"
 	shuttle_tag = "Intrepid"
 	req_access = list(ACCESS_INTREPID)
-	density = 0
 	icon_state = "computer"
 	icon_screen = "helm"
 	icon_keyboard = null

--- a/maps/sccv_horizon/code/sccv_horizon_shuttles.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_shuttles.dm
@@ -106,7 +106,7 @@
 /datum/shuttle/autodock/overmap/intrepid
 	name = "Intrepid"
 	move_time = 20
-	shuttle_area = list(/area/shuttle/intrepid/crew_compartment, /area/shuttle/intrepid/cargo_bay, /area/shuttle/intrepid/engine_compartment, /area/shuttle/intrepid/atmos_compartment, /area/shuttle/intrepid/cockpit, /area/shuttle/intrepid/quarters)
+	shuttle_area = list(/area/shuttle/intrepid/main_compartment, /area/shuttle/intrepid/cargo_bay, /area/shuttle/intrepid/medical, /area/shuttle/intrepid/engineering, /area/shuttle/intrepid/port_storage, /area/shuttle/intrepid/cockpit)
 	dock_target = "airlock_shuttle_intrepid"
 	current_location = "nav_hangar_intrepid"
 	landmark_transition = "nav_transit_intrepid"


### PR DESCRIPTION
**This is up for review**. The theory behind the redesign can be reviewed in the  [feedback thread](https://forums.aurorastation.org/topic/21474-sccv-intrepid-remap-feedback-thread/), but for quicknotes:

- Designed to be able to carry more people and more stuff more smoothly.
- Maintains access for xenoarchs, should still be very usable for their purposes.
- Should avoid chokepoints.
- Adjusts scc air tank airlock variant's pressure, airlock shouldn't go dry.
- Airlock is 3x3, 9 turfs total. 5/9 regular vent coverage, 3/9 out vent coverage. Cycles out in roughly 12 ticks in my testing, it seems like the size isn't slowing it down much.
- Field kitchen crate variant added so you can set up a miniature kitchen inside the cargo bay. Should cover essentially everything you need.
- Nixed the RTG parts - I want to keep the storage space as open as possible and I've never seen them used, the Intrepid practically can never run out of power.
- For similar storage concerns, three emergency softsuits are now in a wall ecloset, instead of two inside suit storage units. It's a little haggard, but it saves two turfs of storage space.
- Atmos is mostly functionally the same as it was. You can no longer feed into fuel or air from outside, but in my experience this functionality of the Intrepid has never seen much use anyway. Only other thing missing is the ability to directly feed air into the main air tank or the main fuel tank off a canister - can be achieved just by swapping a regulator/pump around in both cases.
- Medical should be identical.
- The three tile wide hallway is meant to avoid congestion, people can go in and out of it into the side seating compartments without being forced into any single tile doorways.
- Navigation console was hard to fit in, ideally I think I'd want to make a wall-mounted variation so it can be incorporated more easily.

![image](https://github.com/user-attachments/assets/66ec82c8-334c-4770-b6e4-080863ce8c3e)
