### PR TITLE
SFA spawning tweaks

### DIFF
--- a/html/changelogs/hazelmouse-sfaspawnweight.yml
+++ b/html/changelogs/hazelmouse-sfaspawnweight.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "The SFA Patrol Ship ghostrole now spawns with half the regularity."
+  - rscdel: "The SFA Patrol Ship ghostrole no longer spawns in the Corporate Reconstruction Zone."

--- a/html/changelogs/hazelmouse-sfaspawnweight.yml
+++ b/html/changelogs/hazelmouse-sfaspawnweight.yml
@@ -55,5 +55,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscdel: "The SFA Patrol Ship ghostrole now spawns with half the regularity."
-  - rscdel: "The SFA Patrol Ship ghostrole no longer spawns in the Corporate Reconstruction Zone."
+  - balance: "The SFA Patrol Ship ghostrole now spawns with half the regularity."
+  - balance: "The SFA Patrol Ship ghostrole no longer spawns in the Corporate Reconstruction Zone."

--- a/maps/away/ships/sol/sol_pirate/sfa_patrol_ship.dm
+++ b/maps/away/ships/sol/sol_pirate/sfa_patrol_ship.dm
@@ -5,8 +5,8 @@
 	prefix = "ships/sol/sol_pirate/"
 	suffix = "sfa_patrol_ship.dmm"
 
-	sectors = list(SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS)
-	spawn_weight = 1
+	sectors = list(SECTOR_VALLEY_HALE, SECTOR_BADLANDS)
+	spawn_weight = 0.5 // Lowered to represent increasing scarcity of faction.
 	ship_cost = 1
 	id = "sfa_patrol_ship"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/sfa_shuttle)


### PR DESCRIPTION
This removes the SFA ghostrole from the CRZ and reduces its spawn weight in the remaining sectors from 1 to 0.5. The SFA is meant to be a badly waning gaggle of remnants, so they should be spawning less frequently, and the new SPLF ghostrole fills the niche of a piratical Sol ship in the CRZ.

Cleared by Schwann, so this should be fine on the lore side.