### PR TITLE
Adds an *alarm audible emote (with sound) for IPCs

### DIFF
--- a/code/modules/emotes/definitions/_mob.dm
+++ b/code/modules/emotes/definitions/_mob.dm
@@ -85,6 +85,7 @@
 		/singleton/emote/audible/synth/buzz,
 		/singleton/emote/audible/synth/confirm,
 		/singleton/emote/audible/synth/deny,
+		/singleton/emote/audible/synth/alarm,
 		/singleton/emote/visible/nod,
 		/singleton/emote/visible/shake,
 		/singleton/emote/visible/shiver,

--- a/code/modules/emotes/definitions/synthetics.dm
+++ b/code/modules/emotes/definitions/synthetics.dm
@@ -28,3 +28,8 @@
 	key = "deny"
 	emote_message_3p = "USER emits a negative blip."
 	emote_sound = 'sound/machines/synth_no.ogg'
+
+/singleton/emote/audible/synth/alarm
+	key = "alarm"
+	emote_message_3p = "USER sounds an alarm!"
+	emote_sound = 'sound/machines/warning-buzzer.ogg'

--- a/html/changelogs/flaminglily-alarmist.yml
+++ b/html/changelogs/flaminglily-alarmist.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FlamingLily
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added an *alarm emote for IPCs"


### PR DESCRIPTION
Does exactly what the title says. The specific sound used is the warning buzzer sound that plays when a delivery chute or disposal unit is about to release an object.

Full disclosure, I did this because I specifically wanted this. I wanted to be able to do this.
But, here's my retroactive justification for why it's *needed*:

IPCs do not have a sound emote to express _distress_. Sure, *buzz exists, but that's more an expression of frustration or anger (the sound is even called "buzz sigh"). Distress, though? Being caught in a corner as the mercs with a dominian-army gimmick start blazing gunfire down the corridor? Sure, you could use *scream, but that's very _human_. Sounding an alarm? Now that's exactly what a soulless machine would do.