### PR TITLE
Fix missing emissives for high visibility jacket

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -411,7 +411,7 @@
 /obj/item/clothing/suit/storage/toggle/highvis/get_mob_overlay(mob/living/carbon/human/H, mob_icon, mob_state, slot)
 	var/image/I = ..()
 	if(slot == slot_wear_suit_str)
-		var/image/emissive_overlay = emissive_appearance(mob_icon, "[opened ? "jacket_highvis_open_su_emis" : "jacket_highvis_su_emis"]", alpha = src.alpha)
+		var/image/emissive_overlay = emissive_appearance(mob_icon, "[opened ? "jacket_highvis_open_su-emis" : "jacket_highvis_su-emis"]", alpha = src.alpha)
 		I.AddOverlays(emissive_overlay)
 	return I
 

--- a/html/changelogs/fabiank3-bugfix-high-vis-jacket-not-showing-emis.yml
+++ b/html/changelogs/fabiank3-bugfix-high-vis-jacket-not-showing-emis.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Added missing emissives for the regular high visibility jacket."


### PR DESCRIPTION
### Summary

This PR fixes the missing emissives for the high vis jacket.
Pants and all alt-variations seems to be correct in the first place, the main jacket had an invalid icon state in the code when adding the emissives.