### PR TITLE
Mechanical Eye-Emotion Coupling

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -190,6 +190,9 @@
 /// Causes the mob to never clot their wounds
 #define TRAIT_DISABILITY_HEMOPHILIA_MAJOR "disability_hemophilia_major"
 
+/// Causes the mob's mechanical eyes to change colour when their intents change
+#define TRAIT_DISABILITY_INTENT_EYES "disability_intent_eyes"
+
 /// hnnnnnnnggggg..... you're pretty good....
 #define TRAIT_NICE_SHOT "nice_shot"
 /// Mobs with this trait cannot be hit by projectiles, meaning the projectiles will just go through.

--- a/code/modules/mob/abstract/new_player/character_traits.dm
+++ b/code/modules/mob/abstract/new_player/character_traits.dm
@@ -79,3 +79,10 @@
 	name = "Major Hemophilia"
 	desc = "Your blood lacks ALL clotting factors, causing wounds to never stop bleeding."
 	trait_type = TRAIT_DISABILITY_HEMOPHILIA_MAJOR
+
+/datum/character_disabilities/intent_eyes
+	name = "Mechanical Eye-Emotion Coupling"
+	desc = "Your mechanical eyes change colour based on your selected intent."
+
+/datum/character_disabilities/intent_eyes/apply_self(var/mob/living/carbon/human/H)
+	ADD_TRAIT(H, TRAIT_DISABILITY_INTENT_EYES, DISABILITY_TRAIT)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -45,7 +45,26 @@
 	if(is_pacified() && set_intent == I_HURT && !is_berserk())
 		to_chat(src, SPAN_WARNING("You don't want to harm other beings!"))
 		return
-	..()
+
+	. = ..()
+
+	// has the trait that lets mechanical eyes change their colour
+	if(HAS_TRAIT(src, TRAIT_DISABILITY_INTENT_EYES))
+		var/obj/item/organ/internal/eyes/eyes = get_eyes()
+		if(eyes && (eyes.status & ORGAN_ROBOT))
+			var/intent_colors = list(
+				I_HELP = COLOR_BRIGHT_GREEN,
+				I_GRAB = COLOR_YELLOW,
+				I_DISARM = COLOR_BLUE_LIGHT,
+				I_HURT = COLOR_RED_LIGHT
+			)
+			var/new_color = intent_colors[a_intent]
+			if(new_color)
+				var/r_eyes = hex2num(copytext(new_color, 2, 4))
+				var/g_eyes = hex2num(copytext(new_color, 4, 6))
+				var/b_eyes = hex2num(copytext(new_color, 6, 8))
+				change_eye_color(r_eyes, g_eyes, b_eyes)
+
 
 /mob/living/carbon/human/proc/update_equipment_vision(var/machine_grants_equipment_vision = FALSE)
 	flash_protection = 0

--- a/html/changelogs/geeves-intent_eye_switching.yml
+++ b/html/changelogs/geeves-intent_eye_switching.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Added the 'Mechanical Eye-Emotion Coupling' disability, which makes your character's eyes change colour based on their intent, so long as they're mechanical."


### PR DESCRIPTION
* Added the 'Mechanical Eye-Emotion Coupling' disability, which makes your character's eyes change colour based on their intent, so long as they're mechanical.

https://github.com/user-attachments/assets/74c98c24-c4da-419b-b4b0-8fd79de67442

