### PR TITLE
Fixes Electronic Frame Placements

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -334,6 +334,7 @@ pixel_x = 10;
 		wiresexposed = 1
 
 		update_icon()
+		set_pixel_offsets()
 		return
 
 	first_run()

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -20,10 +20,17 @@
 	///looping sound datum for our fire alarm siren.
 	var/datum/looping_sound/firealarm/soundloop
 
-/obj/machinery/firealarm/Initialize(mapload, ndir = 0, building)
-	. = ..(mapload, ndir)
+/obj/machinery/firealarm/Initialize(mapload, var/dir, var/building = 0)
+	. = ..(mapload)
 
-	update_icon()
+	if(building)
+		if(dir)
+			src.set_dir(dir)
+		buildstage = 0
+		wiresexposed = 1
+
+		update_icon()
+		set_pixel_offsets()
 
 	if(isContactLevel(z))
 		INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(set_security_level), (GLOB.security_level ? get_security_level() : "green"))
@@ -35,6 +42,8 @@
 
 	if(!mapload)
 		set_pixel_offsets()
+
+	update_icon()
 
 /obj/machinery/firealarm/Destroy()
 	QDEL_NULL(soundloop)

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -2,12 +2,11 @@
 	name = "frame"
 	desc = "Used for building machines."
 	icon = 'icons/obj/monitors.dmi'
-	icon_state = "fire_bitem"
+	icon_state = ""
 	obj_flags = OBJ_FLAG_CONDUCTABLE
 	var/build_machine_type
 	var/refund_amt = 2
 	var/refund_type = /obj/item/stack/material/steel
-	var/reverse = 0 //if resulting object faces opposite its dir (like light fixtures)
 
 /obj/item/frame/attackby(obj/item/attacking_item, mob/user)
 	if (attacking_item.iswrench())
@@ -23,13 +22,9 @@
 	if (get_dist(on_wall,usr)>1)
 		return
 
-	var/ndir
-	if(reverse)
-		ndir = get_dir(usr,on_wall)
-	else
-		ndir = get_dir(on_wall,usr)
-
+	var/ndir = get_dir(usr,on_wall)
 	if (!(ndir in GLOB.cardinals))
+		to_chat(user, SPAN_WARNING("You need to stand in front of the wall, directly, to build \the [src]!"))
 		return
 
 	var/turf/loc = get_turf(usr)
@@ -55,8 +50,8 @@
 /obj/item/frame/fire_alarm
 	name = "fire alarm frame"
 	desc = "Used for building fire alarms."
+	icon_state = "firealarm"
 	build_machine_type = /obj/machinery/firealarm
-	reverse = 1
 
 /obj/item/frame/air_alarm
 	name = "air alarm frame"
@@ -70,7 +65,6 @@
 	icon = 'icons/obj/machinery/light.dmi'
 	icon_state = "tube-construct-item"
 	build_machine_type = /obj/machinery/light_construct
-	reverse = 1
 
 /obj/item/frame/light/small
 	name = "small light fixture frame"

--- a/html/changelogs/kano-dot-electronics-frame-fix.yml
+++ b/html/changelogs/kano-dot-electronics-frame-fix.yml
@@ -1,0 +1,6 @@
+author: Kano
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed an issue causing air alarm frames appearing on opposite direction when put on wall. Also fixed a few inconsistencies about frames."


### PR DESCRIPTION
## What Does This PR Do

- Removes a variable from parent frame object that caused reverse placement in some instances.

- Fixes fire alarm frame being invisible. Also fixes fire alarms ending up being completely built without any further steps when its frame put on a wall.

- Also made it so that electronic frames appear in proper offset when placed on walls.
