### PR TITLE
Various offship QoL changes

### DIFF
--- a/html/changelogs/hazelmouse-offshiptweaks.yml
+++ b/html/changelogs/hazelmouse-offshiptweaks.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Implemented various QoL improvements to the Golden Deep, SPLF, Freebooter, and House Volvalaad offship ghostroles."
+  - qol: "The Freebooter ship now spawns with three guaranteed gun spawns and two guaranteed armored voidsuit spawns, replacing the same number of randomised spawners. This should help bring the ship up to par with other similar ships in boarding actions."

--- a/html/changelogs/hazelmouse-offshiptweaks.yml
+++ b/html/changelogs/hazelmouse-offshiptweaks.yml
@@ -56,4 +56,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - qol: "Implemented various QoL improvements to the Golden Deep, SPLF, Freebooter, and House Volvalaad offship ghostroles."
-  - qol: "The Freebooter ship now spawns with three guaranteed gun spawns and two guaranteed armored voidsuit spawns, replacing the same number of randomised spawners. This should help bring the ship up to par with other similar ships in boarding actions."
+  - balance: "The Freebooter ship now spawns with three guaranteed guns and two guaranteed armored voidsuits, replacing the same number of randomised spawners. This should help bring the ship up to par with other similar ships in boarding actions."

--- a/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel.dmm
+++ b/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel.dmm
@@ -8,7 +8,9 @@
 "aaJ" = (
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	spawn_firedoor = 1;
-	spawn_grille = 1
+	spawn_grille = 1;
+	frame_color = "#ffffff";
+	color = "#ffffff"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
@@ -178,7 +180,9 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	spawn_firedoor = 1;
-	spawn_grille = 1
+	spawn_grille = 1;
+	frame_color = "#ffffff";
+	color = "#ffffff"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_science_shuttle)
@@ -597,7 +601,9 @@
 "brM" = (
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	spawn_firedoor = 1;
-	spawn_grille = 1
+	spawn_grille = 1;
+	frame_color = "#ffffff";
+	color = "#ffffff"
 	},
 /obj/effect/landmark/entry_point/port{
 	name = "port, bridge"
@@ -631,7 +637,9 @@
 "bxu" = (
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	spawn_firedoor = 1;
-	spawn_grille = 1
+	spawn_grille = 1;
+	frame_color = "#ffffff";
+	color = "#ffffff"
 	},
 /obj/effect/landmark/entry_point/port{
 	dir = 4;
@@ -730,7 +738,9 @@
 "bTa" = (
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	spawn_firedoor = 1;
-	spawn_grille = 1
+	spawn_grille = 1;
+	frame_color = "#ffffff";
+	color = "#ffffff"
 	},
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, bridge"
@@ -857,7 +867,9 @@
 "cuJ" = (
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	spawn_firedoor = 1;
-	spawn_grille = 1
+	spawn_grille = 1;
+	frame_color = "#ffffff";
+	color = "#ffffff"
 	},
 /obj/machinery/door/blast/regular/open{
 	name = "Bridge Lockdown";
@@ -3903,7 +3915,9 @@
 "lqn" = (
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	spawn_firedoor = 1;
-	spawn_grille = 1
+	spawn_grille = 1;
+	frame_color = "#ffffff";
+	color = "#ffffff"
 	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/officer)
@@ -4158,7 +4172,9 @@
 "mqx" = (
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	spawn_firedoor = 1;
-	spawn_grille = 1
+	spawn_grille = 1;
+	frame_color = "#ffffff";
+	color = "#ffffff"
 	},
 /obj/machinery/door/blast/regular/open{
 	name = "Bridge Lockdown";
@@ -6195,7 +6211,9 @@
 "sOb" = (
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	spawn_firedoor = 1;
-	spawn_grille = 1
+	spawn_grille = 1;
+	frame_color = "#ffffff";
+	color = "#ffffff"
 	},
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, bridge"

--- a/maps/away/ships/freebooter/freebooter_ship_.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship_.dmm
@@ -66,12 +66,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/ammo)
 "ajb" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light/small/emergency{
 	dir = 4
@@ -124,7 +119,7 @@
 	dir = 4
 	},
 /obj/structure/railing/mapped,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/engineering)
@@ -202,7 +197,11 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, main gun"
 	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary{
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/gunnery)
 "aEa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -214,13 +213,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/door/airlock/engineering{
 	name = "Generator Compartment";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/engineering)
@@ -438,7 +439,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "bhA" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/sign/vacuum{
 	pixel_y = 30
 	},
@@ -502,7 +503,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
 "bsf" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -560,7 +561,6 @@
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
 "buV" = (
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -571,6 +571,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -646,12 +649,7 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
 "bCW" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -664,12 +662,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/freebooter_shuttle)
 "bFv" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 8
 	},
@@ -688,18 +681,17 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "bJj" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
 	},
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/northright,
-/turf/simulated/floor,
-/area/ship/freebooter_ship/engineering)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/void/freelancer,
+/obj/item/clothing/head/helmet/space/void/freelancer,
+/obj/item/tank/jetpack/carbondioxide,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/foyer)
 "bPw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -737,12 +729,7 @@
 "bTz" = (
 /obj/structure/target_stake,
 /obj/item/target/syndicate,
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/ammo)
 "bWt" = (
@@ -818,12 +805,7 @@
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
 "cnH" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/forehallwayport)
@@ -844,7 +826,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
 "cCu" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 28;
 	pixel_x = 6
@@ -873,12 +855,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
 "cEX" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -1074,7 +1051,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -1138,12 +1115,7 @@
 "dZH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1352,7 +1324,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "eDX" = (
@@ -1379,7 +1352,7 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/thruster1)
 "fdD" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/cable{
@@ -1432,12 +1405,7 @@
 "fjD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
@@ -1447,10 +1415,6 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/freebooter_shuttle)
-"fnE" = (
-/obj/structure/viewport/unathi,
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/gunnery)
 "foU" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -1469,12 +1433,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
@@ -1495,7 +1454,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/door/airlock/atmos{
 	name = "Propellant Management";
 	dir = 4
@@ -1503,10 +1461,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/engineering)
 "fGM" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -1558,7 +1519,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -1584,7 +1545,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1794,7 +1755,7 @@
 	dir = 8
 	},
 /obj/structure/railing/mapped,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
@@ -1825,12 +1786,7 @@
 	pixel_x = -32
 	},
 /obj/item/paper/crumpled,
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "hhA" = (
@@ -1891,7 +1847,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
@@ -1949,7 +1905,7 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/thruster1)
 "hQd" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/map_effect/marker/airlock{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
@@ -2055,7 +2011,7 @@
 "idP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -2086,12 +2042,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
 "igB" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -2111,7 +2062,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -2194,7 +2145,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -2484,14 +2435,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/forehallway)
 "koD" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -2564,12 +2515,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "kAt" = (
@@ -2621,7 +2567,7 @@
 /obj/machinery/alarm/north{
 	req_one_access = null
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -2683,7 +2629,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -2754,7 +2700,7 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "lck" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -2867,7 +2813,7 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/foyer)
 "lvN" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -2891,10 +2837,12 @@
 "lwO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack,
-/obj/random/voidsuit/freebooter,
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/void/freelancer,
+/obj/item/clothing/head/helmet/space/void/freelancer,
 /obj/item/tank/jetpack/carbondioxide,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
@@ -2992,7 +2940,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -3038,12 +2986,7 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "mbg" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "mbN" = (
@@ -3147,12 +3090,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "msI" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/structure/barricade/wooden{
 	dir = 8
 	},
@@ -3205,7 +3143,7 @@
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/thruster2)
 "mGn" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -3219,7 +3157,9 @@
 /area/ship/freebooter_ship/foyer)
 "mJt" = (
 /obj/structure/table/steel,
-/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = 6
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/ammo)
 "mLD" = (
@@ -3242,12 +3182,7 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/thruster2)
 "mON" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/item/gamehelm/black,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/lockers)
@@ -3282,7 +3217,7 @@
 	target_pressure = 250
 	},
 /obj/structure/railing/mapped,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/engineering)
@@ -3463,7 +3398,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -3742,7 +3677,7 @@
 /area/ship/freebooter_ship/engineering)
 "oHt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
@@ -3853,7 +3788,10 @@
 /area/ship/freebooter_ship/exterior)
 "oUu" = (
 /obj/structure/table/steel,
-/obj/item/clothing/ears/earmuffs/earphones/headphones,
+/obj/item/clothing/ears/earmuffs/earphones/headphones{
+	pixel_x = -4;
+	pixel_y = 3
+	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/ammo)
@@ -3998,7 +3936,7 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/engineering)
 "ptN" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/cable{
@@ -4128,12 +4066,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
 "qej" = (
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/door/airlock/external{
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/mapmanip/submap/edge{
 	dir = 8
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
@@ -4229,7 +4169,7 @@
 "qvJ" = (
 /obj/machinery/atmospherics/binary/pump,
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
 	dir = 4
@@ -4327,7 +4267,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -4397,7 +4337,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -4587,12 +4527,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "rAU" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
@@ -4641,12 +4576,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunneryentrance)
 "rEr" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "rFB" = (
@@ -4941,7 +4871,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "sIh" = (
@@ -5163,12 +5093,7 @@
 	dir = 1;
 	pixel_y = 22
 	},
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -5213,12 +5138,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
 "tMA" = (
@@ -5293,12 +5213,7 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
 "tYf" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -5572,12 +5487,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -5605,7 +5515,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -5736,7 +5646,7 @@
 /turf/simulated/floor/greengrid,
 /area/ship/freebooter_ship/thruster2)
 "vDD" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/map_effect/marker/airlock{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
@@ -5849,11 +5759,13 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/dorms)
 "vUh" = (
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/door/airlock/external{
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/mapmanip/submap/edge{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -5964,7 +5876,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -6067,14 +5979,9 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/northleft,
-/turf/simulated/floor,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/engineering)
 "wLI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6092,7 +5999,7 @@
 /obj/machinery/shower{
 	pixel_y = 17
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/head)
 "wMd" = (
@@ -6141,7 +6048,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/thruster2)
 "wUy" = (
@@ -6237,12 +6144,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "xfg" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
@@ -6313,7 +6215,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/closet)
 "xvT" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
@@ -6347,7 +6249,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -6399,7 +6301,7 @@
 /area/ship/freebooter_ship/gunnery)
 "xKt" = (
 /obj/structure/railing/mapped,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/light/small/emergency{
 	dir = 8
@@ -6423,7 +6325,7 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/thruster1)
 "xQS" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/map_effect/marker/airlock{
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
@@ -35734,7 +35636,7 @@ nwH
 wLI
 wGc
 wGc
-fnE
+kBd
 xRX
 xRX
 xRX
@@ -39036,7 +38938,7 @@ bdI
 lHL
 rnp
 mvP
-pfg
+bJj
 lwO
 lfB
 gIY
@@ -39535,7 +39437,7 @@ qvJ
 aRA
 bBW
 pkY
-bJj
+wJR
 jhL
 xRX
 vZW
@@ -41904,7 +41806,7 @@ lzb
 lzb
 vTz
 vTz
-xRX
+vTz
 xRX
 xRX
 xRX
@@ -42932,7 +42834,7 @@ rbz
 rbz
 rbz
 rbz
-xRX
+rbz
 xRX
 xRX
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship_submaps.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship_submaps.dmm
@@ -46,7 +46,9 @@
 /obj/structure/bed/stool/chair/office/dark{
 	dir = 4
 	},
-/obj/item/paper/crumpled,
+/obj/item/paper/crumpled{
+	pixel_y = -2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "akg" = (
@@ -150,6 +152,7 @@
 	pixel_y = 23;
 	density = 0
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "aHv" = (
@@ -214,12 +217,30 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack,
-/obj/item/ship_ammunition/francisca/frag,
-/obj/item/ship_ammunition/francisca/frag,
-/obj/item/ship_ammunition/francisca/frag,
-/obj/item/ship_ammunition/francisca/frag,
-/obj/item/ship_ammunition/francisca/frag,
-/obj/item/ship_ammunition/francisca/frag,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_x = -4;
+	pixel_y = 7
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "aSK" = (
@@ -242,13 +263,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "aTX" = (
-/obj/effect/floor_decal/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -259,7 +273,10 @@
 	name = "Lavatory";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod1)
 "aZw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -301,11 +318,15 @@
 	},
 /obj/structure/table/wood,
 /obj/item/ammo_magazine/mc9mm{
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 3
 	},
-/obj/item/gun/projectile/pistol/adhomai,
+/obj/item/gun/projectile/pistol/adhomai{
+	pixel_x = -1;
+	pixel_y = 2
+	},
 /obj/item/clothing/head/tajaran/orbital_captain{
-	pixel_y = 8
+	pixel_y = 10
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
@@ -342,12 +363,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod2)
 "bpG" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -408,33 +424,27 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
 "buK" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod2)
 "buM" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/reagent_containers/food/drinks/bottle/gin{
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = 7
 	},
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/vodka{
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 10
 	},
-/obj/item/reagent_containers/food/drinks/bottle/whitewine,
+/obj/item/reagent_containers/food/drinks/bottle/whitewine{
+	pixel_y = 6
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "bxf" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/structure/closet/cabinet,
 /obj/item/paper/fluff/freeboter_ship/captain_note,
 /turf/simulated/floor,
@@ -449,12 +459,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod8)
@@ -513,12 +518,7 @@
 /turf/simulated/wall,
 /area/ship/freebooter_ship/pod8)
 "cmI" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -539,12 +539,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod1)
 "cFm" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/tastybread{
 	pixel_y = 3;
@@ -669,7 +664,6 @@
 	},
 /area/ship/freebooter_ship/pod2)
 "dFi" = (
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -683,6 +677,9 @@
 	name = "Cargo Storage Module";
 	dir = 4
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "dHA" = (
@@ -691,23 +688,24 @@
 /obj/structure/sign/flag/biesel{
 	pixel_x = -32
 	},
-/obj/item/clothing/suit/storage/legion,
+/obj/item/clothing/suit/storage/legion{
+	pixel_x = 6;
+	pixel_y = -2
+	},
 /obj/item/clothing/head/beret/legion/sentinel{
 	pixel_y = 10
 	},
-/obj/item/gun/energy/blaster,
+/obj/item/gun/energy/blaster{
+	pixel_x = -3;
+	pixel_y = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "dHO" = (
 /obj/structure/bed/stool/chair/padded/brown{
 	dir = 8
 	},
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -740,7 +738,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "dXK" = (
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -754,15 +751,13 @@
 	name = "Custom Module";
 	dir = 4
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod4)
 "eaO" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -921,17 +916,9 @@
 	pixel_x = 5;
 	pixel_y = 18
 	},
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "wooden lattice";
-	color = "#CE9175"
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "flG" = (
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -940,6 +927,9 @@
 	},
 /obj/machinery/door/airlock/service{
 	name = "Cabin #2";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -989,7 +979,10 @@
 	pixel_x = 7
 	},
 /obj/machinery/firealarm/east,
-/obj/item/rig/eva,
+/obj/item/rig/eva{
+	pixel_x = -2;
+	pixel_y = 11
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "fJo" = (
@@ -1039,14 +1032,38 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca{
+	pixel_x = -4;
+	pixel_y = 7
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "fRD" = (
@@ -1060,7 +1077,6 @@
 /obj/effect/floor_decal/corner/red/full,
 /obj/item/primer/low,
 /obj/structure/table/rack,
-/obj/item/grenade/frag,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "fTG" = (
@@ -1076,13 +1092,6 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod1)
 "fTT" = (
-/obj/effect/floor_decal/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -1093,7 +1102,10 @@
 	name = "Lavatory";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod1)
 "fUN" = (
 /obj/effect/floor_decal/corner/red{
@@ -1147,8 +1159,8 @@
 /area/ship/freebooter_ship/pod1)
 "glJ" = (
 /obj/machinery/reagentgrinder{
-	pixel_x = 1;
-	pixel_y = 7
+	pixel_x = 3;
+	pixel_y = 16
 	},
 /obj/effect/floor_decal/industrial/outline/service,
 /obj/effect/decal/cleanable/dirt,
@@ -1200,6 +1212,7 @@
 /obj/item/clothing/suit/armor/material/makeshift/trenchcoat,
 /obj/item/clothing/head/hardhat,
 /obj/item/clothing/head/helmet/bucket,
+/obj/random/civgun,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod4)
 "gGE" = (
@@ -1211,11 +1224,13 @@
 /obj/item/clothing/accessory/holster/utility/machete,
 /obj/item/clothing/accessory/holster/utility/machete,
 /obj/item/material/hatchet/machete/steel,
-/obj/item/material/hatchet/machete/steel,
+/obj/item/material/hatchet/machete/steel{
+	pixel_x = 6;
+	pixel_y = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "gSo" = (
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -1227,6 +1242,9 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Habitation Module";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -1337,12 +1355,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "hIE" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/structure/bed/padded,
 /obj/item/bedsheet/brown,
 /obj/effect/ghostspawpoint{
@@ -1361,25 +1374,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
-"hQA" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "wooden lattice";
-	color = "#CE9175"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/pod7)
 "hWE" = (
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 8
@@ -1406,9 +1400,9 @@
 	id_tag = "freebooter_brig"
 	},
 /obj/machinery/door/firedoor/noid{
-	dir = 8
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod8)
 "iaK" = (
 /obj/effect/floor_decal/corner/beige,
@@ -1551,7 +1545,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "jjA" = (
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -1563,6 +1556,9 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Secure NanoTrasen Module";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -1654,18 +1650,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod1)
 "kaR" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "wooden lattice";
-	color = "#CE9175"
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/south{
 	req_access = null
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "kbC" = (
 /obj/effect/floor_decal/corner/dark_green/full{
@@ -1690,12 +1679,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod1)
 "kev" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1758,7 +1742,10 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "krH" = (
-/obj/item/paper/crumpled/bloody,
+/obj/item/paper/crumpled/bloody{
+	pixel_x = -5;
+	pixel_y = 9
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
@@ -1770,6 +1757,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod5)
 "kuG" = (
+/obj/structure/lattice/catwalk,
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "kuV" = (
@@ -1850,11 +1838,13 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
 "kBP" = (
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -2055,7 +2045,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "mbX" = (
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -2067,6 +2056,9 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Refinery Module";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -2100,14 +2092,18 @@
 	},
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/random/civgun,
-/obj/random/civgun/rifle,
 /obj/random/civgun/rifle,
 /obj/item/material/knife/bayonet,
 /obj/item/material/knife/bayonet,
 /obj/item/material/knife/butterfly/switchblade,
 /obj/item/clothing/suit/armor/carrier/generic,
 /obj/item/clothing/head/helmet/security/generic,
+/obj/item/gun/projectile/automatic/rifle/carbine,
+/obj/item/ammo_magazine/a556/carbine,
+/obj/item/ammo_magazine/a556/carbine,
+/obj/item/gun/projectile/automatic/mini_uzi,
+/obj/item/ammo_magazine/c45uzi,
+/obj/item/ammo_magazine/c45uzi,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod4)
 "mCb" = (
@@ -2185,12 +2181,7 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
 "mSI" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/structure/bed/padded,
 /obj/item/bedsheet/syndie{
 	desc = "It has a syndicate emblem and it has an aura of anti-corporatism."
@@ -2248,7 +2239,6 @@
 /turf/simulated/floor/carpet/art,
 /area/ship/freebooter_ship/pod1)
 "ngc" = (
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2257,6 +2247,9 @@
 	},
 /obj/machinery/door/airlock/service{
 	name = "Cabin #1";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -2273,12 +2266,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "nqC" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod4)
@@ -2422,6 +2410,7 @@
 /obj/structure/bed/stool/chair/office/bridge{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "ogz" = (
@@ -2481,9 +2470,13 @@
 	req_access = null
 	},
 /obj/random/civgun/rifle,
-/obj/random/civgun/rifle,
 /obj/item/grenade/frag,
 /obj/item/device/flashlight/maglight,
+/obj/item/gun/projectile/shotgun/pump/rifle,
+/obj/item/ammo_magazine/boltaction,
+/obj/item/ammo_magazine/boltaction,
+/obj/item/ammo_magazine/boltaction,
+/obj/item/ammo_magazine/boltaction,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod4)
 "oyT" = (
@@ -2650,12 +2643,7 @@
 /turf/template_noop,
 /area/template_noop)
 "pup" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/structure/coatrack,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2707,19 +2695,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
 "pBl" = (
-/obj/item/paper/crumpled,
+/obj/item/paper/crumpled{
+	pixel_x = 4;
+	pixel_y = 3
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "pDZ" = (
-/obj/effect/floor_decal/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2730,7 +2714,10 @@
 	name = "Lavatory";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod6)
 "pEW" = (
 /obj/effect/decal/cleanable/blood,
@@ -2790,6 +2777,14 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 21;
+	pixel_x = 4
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 31;
+	pixel_x = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "pXP" = (
@@ -2808,14 +2803,14 @@
 	pixel_y = 6
 	},
 /obj/item/stack/material/gold{
-	pixel_x = 8;
-	pixel_y = -3
+	pixel_x = 1
 	},
 /obj/item/stack/material/gold{
 	pixel_x = 5
 	},
 /obj/item/stack/material/gold{
-	pixel_x = 8
+	pixel_x = 3;
+	pixel_y = 2
 	},
 /obj/item/cell/super{
 	pixel_y = 11
@@ -2846,13 +2841,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "pZO" = (
-/obj/effect/floor_decal/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2863,7 +2851,10 @@
 	name = "Lavatory";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod6)
 "qeD" = (
 /obj/effect/floor_decal/corner/red/full,
@@ -2915,7 +2906,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod1)
 "qst" = (
-/obj/machinery/door/firedoor/noid,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
@@ -2927,6 +2917,9 @@
 	},
 /obj/machinery/door/airlock/service{
 	name = "Cabin #1";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -2961,12 +2954,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "qAl" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod4)
 "qCi" = (
@@ -2975,14 +2963,38 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack,
-/obj/item/ship_ammunition/francisca/ap,
-/obj/item/ship_ammunition/francisca/ap,
-/obj/item/ship_ammunition/francisca/ap,
-/obj/item/ship_ammunition/francisca/ap,
-/obj/item/ship_ammunition/francisca/ap,
-/obj/item/ship_ammunition/francisca/ap,
-/obj/item/ship_ammunition/francisca/ap,
-/obj/item/ship_ammunition/francisca/ap,
+/obj/item/ship_ammunition/francisca/ap{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca/ap{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca/ap{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca/ap{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca/ap{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca/ap{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca/ap{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/ship_ammunition/francisca/ap{
+	pixel_x = -4;
+	pixel_y = 7
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "qDn" = (
@@ -2994,18 +3006,12 @@
 /area/ship/freebooter_ship/pod4)
 "qDs" = (
 /obj/structure/closet/cabinet,
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/item/paper/fluff/freeboter_ship/captain_note,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod1)
 "qEc" = (
-/obj/machinery/door/firedoor/noid,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3020,15 +3026,13 @@
 	name = "Hydroponics Module";
 	dir = 4
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod5)
 "qNb" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -3061,8 +3065,14 @@
 	dir = 1
 	},
 /obj/structure/table/glass,
-/obj/item/folder/yellow,
-/obj/item/paper/crumpled,
+/obj/item/folder/yellow{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/item/paper/crumpled{
+	pixel_x = -7;
+	pixel_y = -6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "rtf" = (
@@ -3104,11 +3114,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/noid,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod4)
 "rKU" = (
 /obj/effect/decal/cleanable/blood,
@@ -3162,12 +3174,7 @@
 /turf/simulated/wall/shuttle/space_ship,
 /area/ship/freebooter_ship/pod7)
 "sck" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -3263,9 +3270,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/phoron{
-	start_pressure = 332
-	},
+/obj/machinery/portable_atmospherics/canister/phoron_scarce,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "sUa" = (
@@ -3297,15 +3302,12 @@
 /turf/simulated/floor/reinforced/airless,
 /area/ship/freebooter_ship/exterior)
 "sUZ" = (
-/obj/machinery/biogenerator{
-	icon_state = "biogen-empty"
-	},
 /obj/effect/floor_decal/industrial/outline/service,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/biogenerator,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod5)
 "sVs" = (
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -3317,6 +3319,9 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Two Person Cabin Module";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -3373,9 +3378,7 @@
 /obj/effect/floor_decal/corner{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/phoron{
-	start_pressure = 165
-	},
+/obj/machinery/portable_atmospherics/canister/phoron_scarce,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "tth" = (
@@ -3489,9 +3492,10 @@
 	},
 /area/ship/freebooter_ship/pod8)
 "uxz" = (
-/obj/machinery/door/firedoor/noid,
-/obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod7)
 "uCl" = (
 /obj/structure/lattice/catwalk,
@@ -3610,7 +3614,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "vgl" = (
-/obj/machinery/door/firedoor/noid,
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
 	},
@@ -3622,6 +3625,9 @@
 	},
 /obj/machinery/door/airlock/service{
 	name = "Cabin #2";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -3794,7 +3800,10 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack,
 /obj/item/rig/light/offworlder,
-/obj/item/clothing/accessory/badge/passcard/scarab,
+/obj/item/clothing/accessory/badge/passcard/scarab{
+	pixel_x = -2;
+	pixel_y = -2
+	},
 /obj/item/clothing/mask/offworlder{
 	color = "#495681";
 	pixel_y = 8;
@@ -3818,8 +3827,13 @@
 /area/ship/freebooter_ship/pod3)
 "wnq" = (
 /obj/structure/table/steel,
-/obj/item/gun/projectile/automatic/improvised,
+/obj/item/gun/projectile/automatic/improvised{
+	pixel_y = 12
+	},
 /obj/effect/floor_decal/corner/red/full,
+/obj/item/grenade/frag{
+	pixel_y = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "wuO" = (
@@ -3863,7 +3877,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "wRc" = (
-/obj/machinery/door/firedoor/noid,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -3911,16 +3927,23 @@
 "wYs" = (
 /obj/structure/table/steel,
 /obj/item/storage/toolbox/lunchbox/swimstars_axic/filled{
-	pixel_x = -5
+	pixel_x = 3
 	},
 /obj/item/laser_components/modifier/grip{
-	pixel_y = 8
+	pixel_y = 12;
+	pixel_x = 5
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 1
 	},
-/obj/item/material/twohanded/baseballbat/metal,
-/obj/item/material/twohanded/baseballbat/metal,
+/obj/item/material/twohanded/baseballbat/metal{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/material/twohanded/baseballbat/metal{
+	pixel_x = -12;
+	pixel_y = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "wYH" = (
@@ -3968,15 +3991,21 @@
 /area/ship/freebooter_ship/pod2)
 "xLr" = (
 /obj/structure/table/steel,
-/obj/item/receivergun,
+/obj/item/receivergun{
+	pixel_x = 3
+	},
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
-/obj/item/material/kitchen/utensil/knife/boot,
+/obj/item/material/kitchen/utensil/knife/boot{
+	pixel_x = -4;
+	pixel_y = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "xOG" = (
 /obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "xPX" = (
@@ -4000,37 +4029,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "ygM" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod6)
-"yjk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "wooden lattice";
-	color = "#CE9175"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/pod7)
 
 (1,1,1) = {"
 poF
@@ -4163,7 +4168,7 @@ poF
 xRX
 poF
 poF
-poF
+uCl
 uCl
 kuG
 uCl
@@ -5499,7 +5504,7 @@ xRX
 pRO
 fNZ
 kpR
-hQA
+ija
 wLs
 wLs
 pRO
@@ -5552,7 +5557,7 @@ xRX
 pRO
 bPE
 kpR
-yjk
+ija
 epB
 liN
 pRO

--- a/maps/away/ships/golden_deep/golden_deep.dmm
+++ b/maps/away/ships/golden_deep/golden_deep.dmm
@@ -5536,6 +5536,17 @@
 /obj/structure/table/wood/gamblingtable,
 /turf/simulated/floor/wood,
 /area/golden_deep/lounge)
+"xf" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/structure/table/wood/gamblingtable,
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/shot{
+	pixel_y = 4;
+	pixel_x = 7
+	},
+/turf/simulated/floor/wood,
+/area/golden_deep/lounge)
 "xg" = (
 /obj/machinery/alarm/south{
 	req_one_access = list(229, 217)
@@ -8143,7 +8154,9 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
 	},
-/obj/machinery/computer/slot_machine,
+/obj/machinery/media/jukebox{
+	anchored = 1
+	},
 /turf/simulated/floor/wood,
 /area/golden_deep/lounge)
 "HE" = (
@@ -10991,7 +11004,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
 	},
-/obj/machinery/computer/slot_machine,
+/obj/random/pottedplant,
 /turf/simulated/floor/wood,
 /area/golden_deep/lounge)
 "SU" = (
@@ -112586,7 +112599,7 @@ Iz
 yK
 GO
 mS
-xa
+xf
 rL
 EP
 Bc

--- a/maps/away/ships/golden_deep/golden_deep.dmm
+++ b/maps/away/ships/golden_deep/golden_deep.dmm
@@ -1322,13 +1322,10 @@
 "fv" = (
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/structure/table/reinforced/steel,
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 32;
-	pixel_x = 3
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 21;
-	pixel_x = 3
+/obj/item/device/radio/intercom/hailing/north,
+/obj/item/device/radio/hailing{
+	pixel_x = 5;
+	pixel_y = 6
 	},
 /turf/simulated/floor/marble/dark,
 /area/shuttle/golden_deep/cockpit)
@@ -2153,6 +2150,14 @@
 	dir = 8;
 	must_start_working = 1
 	},
+/obj/machinery/recharger/wallcharger{
+	pixel_y = -26;
+	pixel_x = 3
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_y = -36;
+	pixel_x = 3
+	},
 /turf/simulated/floor/marble/dark,
 /area/shuttle/golden_deep/cockpit)
 "jk" = (
@@ -2385,6 +2390,11 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/dirt_75,
+/obj/machinery/button/ignition{
+	dir = 8;
+	pixel_x = 23;
+	id = "gd_igniter_port"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/golden_deep/portprop)
 "kd" = (
@@ -2654,6 +2664,12 @@
 /obj/machinery/atm{
 	dir = 1;
 	pixel_y = 28
+	},
+/turf/simulated/floor/wood,
+/area/golden_deep/lounge)
+"li" = (
+/obj/structure/bed/stool/bar/padded/brown{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/golden_deep/lounge)
@@ -3392,6 +3408,9 @@
 /turf/simulated/floor/plating,
 /area/golden_deep/starboardprop)
 "ow" = (
+/obj/structure/bed/stool/bar/padded/brown{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/golden_deep/lounge)
 "ox" = (
@@ -6806,6 +6825,10 @@
 /obj/machinery/atmospherics/unary/vent_pump/siphon/atmos{
 	dir = 8
 	},
+/obj/machinery/sparker{
+	id = "gd_igniter_port";
+	pixel_x = -10
+	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/golden_deep/portprop)
 "CI" = (
@@ -8307,6 +8330,11 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/dirt_75,
+/obj/machinery/button/ignition{
+	dir = 4;
+	pixel_x = -23;
+	id = "gd_igniter_starboard"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/golden_deep/starboardprop)
 "Io" = (
@@ -10867,6 +10895,13 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/golden_deep/bridge_foyer)
+"SA" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/obj/machinery/computer/slot_machine,
+/turf/simulated/floor/wood,
+/area/golden_deep/lounge)
 "SC" = (
 /turf/simulated/wall/shuttle/dark/cardinal/closet_gold,
 /area/golden_deep/central_hallway)
@@ -10956,7 +10991,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
 	},
-/obj/random/pottedplant,
+/obj/machinery/computer/slot_machine,
 /turf/simulated/floor/wood,
 /area/golden_deep/lounge)
 "SU" = (
@@ -11058,6 +11093,13 @@
 	},
 /turf/simulated/floor/carpet/magenta,
 /area/golden_deep/merchant)
+"Tp" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/machinery/computer/slot_machine,
+/turf/simulated/floor/wood,
+/area/golden_deep/lounge)
 "Tq" = (
 /obj/effect/floor_decal/corner_wide/dark_blue{
 	dir = 10
@@ -12112,10 +12154,10 @@
 /obj/item/storage/toolbox/electrical{
 	pixel_y = 11
 	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 2
-	},
 /obj/random/dirt_75,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/golden_deep/workshop)
 "XM" = (
@@ -12435,6 +12477,10 @@
 /area/golden_deep/starboardprop)
 "Zc" = (
 /obj/effect/map_effect/perma_light,
+/obj/machinery/sparker{
+	id = "gd_igniter_starboard";
+	pixel_x = -10
+	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/golden_deep/starboardprop)
 "Zd" = (
@@ -109708,8 +109754,8 @@ iG
 iG
 iG
 yD
-tw
-tw
+SA
+SA
 jn
 AP
 vd
@@ -112021,8 +112067,8 @@ lI
 lI
 lI
 lh
-Zj
-Zj
+Tp
+Tp
 Uc
 vM
 WD
@@ -112278,8 +112324,8 @@ uw
 ft
 lI
 Rc
-ow
-ow
+li
+li
 cK
 zB
 mS

--- a/maps/away/ships/sol/sol_splf/splf_raider.dm
+++ b/maps/away/ships/sol/sol_splf/splf_raider.dm
@@ -54,7 +54,7 @@
 	invisible_until_ghostrole_spawn = TRUE
 
 /obj/effect/overmap/visitable/ship/splf_raider/New()
-	designation = "[pick("Not A Fan Of The Government", "National Liberation", "Free Spirit", "Not Wanted Here", "Tight-knit", "Silat", "Sejarah Melayu", "As They Were Before", "Hand of Cabanas", "Justice for Mictlan", "Not One Step More", "Fraternity", "Culpability", "Magistrate", "Equity", " Sic Semper Tyrannis")]"
+	designation = "[pick("Not A Fan Of The Government", "National Liberation", "Free Spirit", "Not Wanted Here", "Tight-knit", "Silat", "Sejarah Melayu", "As They Were Before", "Hand of Cabanas", "Justice for Mictlan", "Not One Step More", "Fraternity", "Culpability", "Magistrate", "Equity", "Sic Semper Tyrannis")]"
 	..()
 
 // Using the freighter sprite.

--- a/maps/away/ships/sol/sol_splf/splf_raider.dmm
+++ b/maps/away/ships/sol/sol_splf/splf_raider.dmm
@@ -31,10 +31,12 @@
 /obj/structure/table/rack,
 /obj/random/dirt_75,
 /obj/item/storage/bag/inflatable,
+/obj/item/storage/bag/inflatable,
 /obj/item/storage/backpack/duffel/eng{
 	pixel_y = 6;
 	pixel_x = -1
 	},
+/obj/item/clothing/gloves/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/starboard_hall)
 "ap" = (
@@ -100,6 +102,7 @@
 	dir = 6
 	},
 /obj/structure/lattice,
+/obj/effect/map_effect/perma_light/starlight/wide,
 /turf/space/dynamic,
 /area/space)
 "aQ" = (
@@ -529,6 +532,7 @@
 /area/shuttle/splf)
 "do" = (
 /obj/effect/floor_decal/corner/paleblue/full,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/central)
 "dp" = (
@@ -559,6 +563,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/docking)
 "dw" = (
@@ -895,6 +900,7 @@
 	pixel_x = -9;
 	pixel_y = -9
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/lounge)
 "eV" = (
@@ -1265,6 +1271,10 @@
 /obj/item/material/scythe/sickle,
 /obj/item/wirecutters/clippers,
 /obj/item/material/hatchet,
+/obj/item/reagent_containers/glass/fertilizer/ez,
+/obj/item/reagent_containers/glass/fertilizer/ez,
+/obj/item/reagent_containers/glass/fertilizer/ez,
+/obj/item/reagent_containers/glass/fertilizer/ez,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/docking)
 "hu" = (
@@ -1372,6 +1382,11 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
+/obj/item/material/shard{
+	icon_state = "small";
+	pixel_x = 9;
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/gunnery)
 "in" = (
@@ -1515,6 +1530,7 @@
 	pixel_x = 33;
 	pixel_y = -8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/splf_raider/ready)
 "jh" = (
@@ -1995,6 +2011,14 @@
 /obj/structure/ship_weapon_dummy,
 /turf/simulated/floor/airless,
 /area/space)
+"lO" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/obj/structure/lattice,
+/obj/effect/map_effect/perma_light/starlight/wide,
+/turf/space/dynamic,
+/area/space)
 "lP" = (
 /obj/effect/floor_decal/industrial/hatch_door/red,
 /obj/machinery/door/airlock/external{
@@ -2322,6 +2346,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
+/obj/machinery/door/blast/regular/open{
+	id = "splf_windows"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/engine)
 "oc" = (
@@ -2468,12 +2495,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/alarm/east,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/splf_raider/engine)
 "oF" = (
 /obj/effect/floor_decal/corner_wide/brown/full{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/portside_slot)
 "oG" = (
@@ -2965,6 +2994,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/item/paper/crumpled{
+	pixel_x = 9;
+	pixel_y = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/splf_raider/starboard_hall)
 "rm" = (
@@ -3021,6 +3054,7 @@
 	pixel_x = 3;
 	pixel_y = 7
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/lounge)
 "rs" = (
@@ -3106,6 +3140,22 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/gunnery)
+"rR" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/gridded,
+/area/splf_raider/central)
 "rT" = (
 /obj/structure/table/steel,
 /obj/machinery/reagentgrinder{
@@ -3391,6 +3441,11 @@
 	},
 /turf/simulated/floor,
 /area/splf_raider/gunnery)
+"tg" = (
+/obj/structure/ship_weapon_dummy,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/dark/full,
+/area/splf_raider/gunnery)
 "th" = (
 /turf/simulated/wall/shuttle/raider,
 /area/splf_raider/office)
@@ -3631,6 +3686,17 @@
 	},
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/central)
+"vi" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/gridded,
+/area/splf_raider/central)
 "vk" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -3785,6 +3851,7 @@
 	dir = 10
 	},
 /obj/structure/lattice,
+/obj/effect/map_effect/perma_light/starlight/wide,
 /turf/space/dynamic,
 /area/space)
 "ws" = (
@@ -3945,6 +4012,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/splf_raider/engine)
 "xr" = (
@@ -4059,6 +4127,7 @@
 "yd" = (
 /obj/effect/floor_decal/corner_wide/brown,
 /obj/structure/platform,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/gunmetal,
 /area/splf_raider/gunnery)
 "ye" = (
@@ -4223,6 +4292,16 @@
 	},
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/lounge)
+"zj" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/machinery/light/colored/decayed{
+	dir = 4
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/gridded,
+/area/splf_raider/central)
 "zl" = (
 /obj/effect/landmark{
 	name = "carpspawn"
@@ -4238,6 +4317,16 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/splf)
+"zq" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/gridded,
+/area/splf_raider/central)
 "zs" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
@@ -4484,8 +4573,8 @@
 /obj/item/grenade/stinger,
 /obj/item/grenade/smokebomb,
 /obj/item/grenade/frag,
-/obj/item/plastique/seismic,
-/obj/item/plastique/seismic,
+/obj/item/plastique,
+/obj/item/plastique,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/ready)
@@ -4582,6 +4671,7 @@
 /obj/machinery/light/colored/decayed{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/splf_raider/engine)
 "Bc" = (
@@ -4827,6 +4917,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/central)
 "Ck" = (
@@ -4878,6 +4969,22 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/docking)
+"CA" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/gridded,
+/area/splf_raider/central)
 "CF" = (
 /obj/effect/map_effect/window_spawner/full/shuttle/raider,
 /obj/machinery/door/blast/regular/open{
@@ -4934,6 +5041,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor,
 /area/splf_raider/propulsion)
+"Dn" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/lattice,
+/obj/effect/map_effect/perma_light/starlight/wide,
+/turf/space/dynamic,
+/area/space)
 "Dt" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -5086,6 +5199,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/random/dirt_75,
 /turf/simulated/floor,
 /area/splf_raider/engine)
 "DO" = (
@@ -5188,6 +5302,16 @@
 	},
 /turf/simulated/floor,
 /area/splf_raider/starboard_slot)
+"Ef" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/machinery/light/colored/decayed{
+	dir = 8
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/gridded,
+/area/splf_raider/central)
 "Ek" = (
 /obj/effect/floor_decal/corner_wide/brown/full{
 	dir = 8
@@ -5211,6 +5335,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/random/dirt_75,
+/obj/structure/trash_pile,
 /turf/simulated/floor/tiled/dark,
 /area/splf_raider/propulsion)
 "Et" = (
@@ -5269,6 +5394,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/machinery/meter,
 /turf/simulated/floor,
 /area/splf_raider/portside_hall)
 "ER" = (
@@ -5643,6 +5769,7 @@
 /obj/item/trash/tray{
 	pixel_y = 3
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/lounge)
 "Ha" = (
@@ -5706,6 +5833,7 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/docking)
 "HM" = (
@@ -5910,6 +6038,14 @@
 	},
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/cargo_1)
+"Jc" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/obj/structure/lattice,
+/obj/effect/map_effect/perma_light/starlight/wide,
+/turf/space/dynamic,
+/area/space)
 "Jd" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/clipboard{
@@ -6087,6 +6223,7 @@
 /obj/machinery/light/colored/decayed{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/splf_raider/engine)
 "JY" = (
@@ -6122,6 +6259,7 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
+/obj/structure/trash_pile,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/engine)
 "Ke" = (
@@ -6140,10 +6278,10 @@
 	dir = 8
 	},
 /obj/machinery/alarm/east,
-/obj/structure/bed/stool/chair/office/dark{
+/obj/random/dirt_75,
+/obj/structure/bed/stool/chair/folding{
 	dir = 1
 	},
-/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/splf_raider/starboard_hall)
 "Kk" = (
@@ -6227,6 +6365,7 @@
 	dir = 1;
 	level = 2
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/gunnery)
 "KG" = (
@@ -6608,6 +6747,7 @@
 	dir = 10
 	},
 /obj/structure/platform,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/gunmetal,
 /area/splf_raider/gunnery)
 "MY" = (
@@ -6806,6 +6946,7 @@
 	pixel_y = -3;
 	pixel_x = -4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/lounge)
 "Oo" = (
@@ -6864,6 +7005,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/gunnery)
 "OD" = (
@@ -7058,6 +7200,11 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
+/obj/item/material/shard{
+	icon_state = "medium";
+	pixel_x = -6;
+	pixel_y = 6
+	},
 /turf/simulated/floor,
 /area/splf_raider/engine)
 "PD" = (
@@ -7142,6 +7289,10 @@
 	dir = 4
 	},
 /obj/random/dirt_75,
+/obj/item/stack/rods{
+	pixel_x = 13;
+	pixel_y = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/splf_raider/propulsion)
 "Qe" = (
@@ -7655,6 +7806,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/central)
 "SZ" = (
@@ -7703,6 +7855,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 6
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/docking)
 "Tx" = (
@@ -7784,12 +7937,12 @@
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/lounge)
 "TU" = (
-/obj/machinery/vending/hydroseeds,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/random/dirt_75,
+/obj/machinery/seed_storage/garden,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/docking)
 "Ua" = (
@@ -7913,6 +8066,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/splf_raider/ready)
 "Uz" = (
@@ -7976,6 +8130,7 @@
 	dir = 9
 	},
 /obj/structure/extinguisher_cabinet/west,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/central)
 "US" = (
@@ -8057,6 +8212,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/splf_raider/central)
+"Vn" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/gridded,
+/area/splf_raider/central)
 "Vo" = (
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 8
@@ -8112,6 +8274,13 @@
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor,
 /area/splf_raider/engine)
+"VL" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/gridded,
+/area/splf_raider/central)
 "VS" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 8
@@ -8163,6 +8332,9 @@
 /obj/effect/map_effect/window_spawner/full/shuttle/raider,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "splf_windows"
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/propulsion)
@@ -8270,6 +8442,7 @@
 	pixel_x = 23;
 	dir = 4
 	},
+/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark,
 /area/splf_raider/engine)
 "WY" = (
@@ -8454,6 +8627,7 @@
 /area/splf_raider/central)
 "XK" = (
 /obj/effect/floor_decal/corner/paleblue,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/gridded,
 /area/splf_raider/central)
 "XM" = (
@@ -8468,6 +8642,7 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/splf_raider/ready)
 "XT" = (
@@ -8643,6 +8818,10 @@
 /obj/item/paper/fluff/splf_raider_engine_guide{
 	pixel_x = -18
 	},
+/obj/item/paper/crumpled{
+	pixel_x = 6;
+	pixel_y = 7
+	},
 /turf/simulated/floor/tiled/dark,
 /area/splf_raider/starboard_hall)
 "YY" = (
@@ -8753,6 +8932,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/splf_raider/engine)
 "Zs" = (
@@ -36480,13 +36660,13 @@ UG
 aN
 mb
 JQ
+Dn
 JQ
 JQ
+Dn
 JQ
 JQ
-JQ
-JQ
-Yn
+lO
 UG
 Cq
 Cq
@@ -38043,7 +38223,7 @@ yd
 Yu
 Yi
 KD
-Py
+tg
 Py
 rf
 qZ
@@ -40883,8 +41063,8 @@ Yh
 Jj
 Gp
 Aw
-Gp
-Gp
+Jj
+Jj
 Jj
 KB
 th
@@ -41377,11 +41557,11 @@ GT
 Af
 Jz
 eA
-Jz
+VL
 UN
-Jz
-Jz
-eA
+VL
+VL
+CA
 Af
 MY
 Jz
@@ -41389,8 +41569,8 @@ Jz
 Jz
 wF
 ST
-Af
-Jz
+Ef
+VL
 do
 gl
 re
@@ -41635,7 +41815,7 @@ bx
 EI
 Kv
 EI
-bx
+vi
 EI
 EI
 Kv
@@ -41888,9 +42068,9 @@ AK
 OD
 XK
 nj
-Zt
-Wo
-mr
+zj
+Vn
+rR
 Wo
 Wo
 Wo
@@ -41898,8 +42078,8 @@ Wo
 TH
 Zt
 Ce
-Wo
-Wo
+Vn
+Vn
 Wo
 cG
 mr
@@ -42143,7 +42323,7 @@ bd
 bd
 dr
 rE
-jC
+zq
 No
 No
 Cs
@@ -46760,13 +46940,13 @@ UG
 wr
 mb
 JQ
+Dn
 JQ
 JQ
+Dn
 JQ
 JQ
-JQ
-JQ
-xD
+Jc
 UG
 Cq
 Cq

--- a/maps/away/ships/sol/sol_splf/splf_raider_ghostroles.dm
+++ b/maps/away/ships/sol/sol_splf/splf_raider_ghostroles.dm
@@ -78,6 +78,7 @@
 	back = /obj/item/storage/backpack/satchel/eng
 	belt = /obj/item/storage/belt/utility/full
 	id = /obj/item/card/id/white
+	accessory = /obj/item/clothing/accessory/storage/pouches/brown
 	l_ear = /obj/item/device/radio/headset/ship
 
 	backpack_contents = list(/obj/item/storage/box/survival = 1)


### PR DESCRIPTION
See changelog, mostly a variety of very mundane QoL changes to a few offships - hydroponics had the wrong vendor on the SPLF ship, adjusting misaligned firedoors, accidentally miscoloured windows on the Volvalaad ship, etc.

This replaces the fake object lattices in the freebooter ship with actual lattices. I don't believe it's traditionally possible to overlay lattices on plating ingame, but it resolves a lot of the jank with the fake objects.

The freebooter now spawns with a ballistic carbine, .45 machine pistol, and 7.62 bolt action rifle in the armoury every round, plus one additional random handgun. It also spawns with 2 armored voidsuits every round, the other 3 suits remaining random. 50/50 randomised to static is intended to make the ship a little stronger, so it's impossible you roll poor RNG and end up with 5 non-combat voidsuits and a bunch of pocket rifles in the armory.