### PR TITLE
Overmap Manoeuvrability Tweak

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -287,7 +287,7 @@
 			var/ndir = text2num(params["turn"])
 			if(connected.can_turn())
 				connected.turn_ship(ndir)
-				addtimer(CALLBACK(src, PROC_REF(updateUsrDialog)), min(connected.vessel_mass / 10, 1) SECONDS + 1)
+				addtimer(CALLBACK(src, PROC_REF(updateUsrDialog)), 0.1 SECONDS + 1)
 
 		if (action == "combat_turn")
 			var/ndir = text2num(params["combat_turn"])

--- a/code/modules/overmap/ships/landable.dm
+++ b/code/modules/overmap/ships/landable.dm
@@ -12,6 +12,7 @@
 	icon_state = "shuttle"
 	moving_state = "shuttle_moving"
 	layer = OVERMAP_SHUTTLE_LAYER
+	burn_delay = 0.5 SECONDS // landable shuttles are more manoeuvrable
 
 /obj/effect/overmap/visitable/ship/landable/Destroy()
 	GLOB.shuttle_moved_event.unregister(SSshuttle.shuttles[shuttle], src)

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -253,11 +253,12 @@ var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 	for(var/datum/ship_engine/E in engines)
 		. += E.get_thrust()
 
-/obj/effect/overmap/visitable/ship/proc/can_burn()
+/// Determines whether the ship can initiate a burn, when ignore_burn_delay is set to true, the ship's burn delay isn't factored in
+/obj/effect/overmap/visitable/ship/proc/can_burn(var/ignore_burn_delay = FALSE)
 	if(halted)
-		return 0
-	if (world.time < last_burn + burn_delay)
-		return 0
+		return FALSE
+	if(!ignore_burn_delay && world.time < last_burn + burn_delay)
+		return FALSE
 	for(var/datum/ship_engine/E in engines)
 		. |= E.can_burn()
 
@@ -313,13 +314,13 @@ var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 		return TRUE
 	return FALSE
 
+/// Whether the ship can turn itself to face 45 degrees left or right
 /obj/effect/overmap/visitable/ship/proc/can_turn()
-	if(!can_burn())
+	if(!can_burn(TRUE)) // ignores the burn delay, just checks that it actually /can/ burn
 		return FALSE
-	var/cooldown = min(vessel_mass / 10, 1) SECONDS //max 1s for horizon
-	if(world.time >= (last_turn + cooldown))
-		return TRUE
-	return FALSE
+	if(world.time < (last_turn + 0.1 SECONDS))
+		return FALSE
+	return TRUE
 
 /obj/effect/overmap/visitable/ship/proc/turn_ship(var/new_dir)
 	burn(0.25)

--- a/html/changelogs/geeves-need_for_speed.yml
+++ b/html/changelogs/geeves-need_for_speed.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - balance: "Standardized and reduced burn delays for ships and shuttles. Ships now have a 1 second burn delay, down from 2. Shuttles now have a 0.5 second burn delay, down from 1. The only exception are the racer shuttles, which have a 0.25 burn second delay."
+  - balance: "Standardized all ships and shuttles to have a 0.1 second turn delay."

--- a/maps/away/away_site/cult_base/cult_base_.dm
+++ b/maps/away/away_site/cult_base/cult_base_.dm
@@ -70,7 +70,6 @@
 	moving_state = "cetus_moving"
 	colors = list("#d3d155", "#bea03b")
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/away_site/pirate_base/pirate_base.dm
+++ b/maps/away/away_site/pirate_base/pirate_base.dm
@@ -51,7 +51,6 @@
 	volume = "27 meters length, 19 meters beam/width, 14 meters vertical height"
 	colors = list("#CD4A4C")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_SMALL

--- a/maps/away/away_site/racers/racers.dm
+++ b/maps/away/away_site/racers/racers.dm
@@ -52,7 +52,7 @@
 	moving_state = "shuttle_moving"
 	color = "#d21410"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 1 SECONDS
+	burn_delay = 0.25 SECONDS
 	vessel_mass = 500 //Tiny shuttle designed to be VERY fast and maneuverable
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY
@@ -79,7 +79,7 @@
 	moving_state = "shuttle_moving"
 	color = "#0fc4f1"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 1 SECONDS
+	burn_delay = 0.25 SECONDS
 	vessel_mass = 500 //Tiny shuttle designed to be VERY fast and maneuverable
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/away_site/tajara/mining_jack/mining_jack.dm
+++ b/maps/away/away_site/tajara/mining_jack/mining_jack.dm
@@ -68,7 +68,6 @@
 	sizeclass = "Multi-purpose Civilian Skipjack"
 	shiptype = "Short-term industrial prospecting, raw goods transport"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/away_site/tajara/peoples_station/peoples_station.dm
+++ b/maps/away/away_site/tajara/peoples_station/peoples_station.dm
@@ -84,7 +84,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#8C8A81")
 	max_speed = 1/(1 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 3000
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY
@@ -123,7 +122,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#8C8A81")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/away_site/tajara/saniorios_outpost/saniorios_outpost.dm
+++ b/maps/away/away_site/tajara/saniorios_outpost/saniorios_outpost.dm
@@ -66,7 +66,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#CD4A4C")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/away_site/tajara/scrapper/scrapper.dm
+++ b/maps/away/away_site/tajara/scrapper/scrapper.dm
@@ -63,7 +63,6 @@
 	moving_state = "skipjack_moving"
 	colors = list("#DAA06D")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/away_site/tajara/taj_safehouse/tajara_safehouse.dm
+++ b/maps/away/away_site/tajara/taj_safehouse/tajara_safehouse.dm
@@ -57,7 +57,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#CD4A4C")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/away_site/uueoaesa/reclamation/ihss_reclamation.dm
+++ b/maps/away/away_site/uueoaesa/reclamation/ihss_reclamation.dm
@@ -96,7 +96,6 @@
 	weapons = "Single fore-mounted ballistic weapon."
 	colors = list("#e38222", "#f0ba3e")
 	max_speed = 1/(1 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 3000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/away_site/uueoaesa/tret/tret_industrial_complex_.dm
+++ b/maps/away/away_site/uueoaesa/tret/tret_industrial_complex_.dm
@@ -84,7 +84,6 @@
 	sizeclass = "Short-range crew transport and mineral extraction pod"
 	shiptype = "Short-term industrial prospecting, raw goods transport"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/biesel/tcaf_corvette/tcaf_corvette.dm
+++ b/maps/away/ships/biesel/tcaf_corvette/tcaf_corvette.dm
@@ -33,7 +33,6 @@
 	moving_state = "tcaf_moving"
 	colors = list("#5d68c8", "#70a2e7")
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -84,7 +83,6 @@
 	sizeclass = "Reaver-class gunship"
 	colors = list("#5d68c8", "#70a2e7")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 2500 // Same as the SCCV Canary. Lower than usual to compensate for only having two thrusters.
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/biesel/tcfl_patrol/tcfl_peacekeeper_ship.dm
+++ b/maps/away/ships/biesel/tcfl_patrol/tcfl_peacekeeper_ship.dm
@@ -36,7 +36,6 @@
 	moving_state = "cetus_moving"
 	colors = list("#263aeb", "#3d8cfa")
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -96,7 +95,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#263aeb", "#3d8cfa")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/casino/casino.dm
+++ b/maps/away/ships/casino/casino.dm
@@ -30,7 +30,6 @@
 	shiptype = "Long-distance freight and leisure transit"
 	vessel_mass = 15000
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECOND
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_SMALL
 	initial_generic_waypoints = list(
@@ -88,7 +87,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#c3c7eb", "#a0a8ec")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 3000 //Hard to move
 	fore_dir = WEST
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/coc/coc_ranger/coc_ship.dm
+++ b/maps/away/ships/coc/coc_ranger/coc_ship.dm
@@ -99,7 +99,6 @@
 	sizeclass = "Xansan-class Gunboat"
 	shiptype = "Military patrol and combat utility"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -185,7 +184,6 @@
 	moving_state = "pod_moving"
 	colors = list("#8492fd", "#4d61fc")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/coc/coc_scarab/coc_scarab.dm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab.dm
@@ -37,7 +37,6 @@
 	sizeclass = "Modified Burrow-class Transport."
 	shiptype = "Salvage, fuel extraction and mineral exploitation."
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -137,7 +136,6 @@
 	shuttle = "Scarab Shuttle"
 	colors = list("#a400c1", "#4d61fc")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/coc/coc_surveyor/coc_surveyor.dm
+++ b/maps/away/ships/coc/coc_surveyor/coc_surveyor.dm
@@ -33,7 +33,6 @@
 	sizeclass = "Galga-class Surveyor"
 	shiptype = "Exploration, mineral and artifact recovery"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -92,7 +91,6 @@
 	shuttle = "COC Survey Shuttle"
 	colors = list("#8492fd", "#4d61fc")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = WEST
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/coc/gadpathur_patrol/gadpathur_patrol.dm
+++ b/maps/away/ships/coc/gadpathur_patrol/gadpathur_patrol.dm
@@ -33,7 +33,6 @@
 	sizeclass = "Skanda-class Patrol"
 	shiptype = "Military patrol and combat utility"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 6000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -88,7 +87,6 @@
 	colors = list("#474800")
 	shuttle = "Gadpathurian Corvette Shuttle"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/dominia/dominian_corvette/dominian_corvette.dm
+++ b/maps/away/ships/dominia/dominian_corvette/dominian_corvette.dm
@@ -128,7 +128,6 @@
 	sizeclass = "Lammergeier-class Corvette"
 	shiptype = "Military patrol and combat utility"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -211,7 +210,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#df1032", "#d4296b")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_SMALL

--- a/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel.dm
+++ b/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel.dm
@@ -33,7 +33,6 @@
 	sizeclass = "Explorer-class Science Vessel"
 	shiptype = "Survey and scientific research"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -112,7 +111,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#df1032", "#d4296b")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/dominia/dominian_unathi_privateer/dominian_unathi_privateer.dm
+++ b/maps/away/ships/dominia/dominian_unathi_privateer/dominian_unathi_privateer.dm
@@ -30,7 +30,6 @@
 	drive = "Low-Speed Warp Acceleration FTL Drive"
 	weapons = "Port wingtip-mounted extruding medium-caliber ballistic armament, starboard obscured flight craft bay"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -85,7 +84,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#e67f09", "#fcf9f5")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/dpra/hailstorm/hailstorm_ship.dm
+++ b/maps/away/ships/dpra/hailstorm/hailstorm_ship.dm
@@ -87,7 +87,6 @@
 	designation = "Yve'kha"
 	shuttle = "Spacer Militia Shuttle"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/einstein/ee_spy_ship.dm
+++ b/maps/away/ships/einstein/ee_spy_ship.dm
@@ -35,7 +35,6 @@
 	moving_state = "light_cruiser_moving"
 	colors = list("#18e9b5", "#6aa9dd")
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -82,7 +81,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#18e9b5", "#6aa9dd")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/elyra/elyra_corvette/elyra_corvette.dm
+++ b/maps/away/ships/elyra/elyra_corvette/elyra_corvette.dm
@@ -32,7 +32,6 @@
 	sizeclass = "Sahin-class Corvette"
 	shiptype = "Military patrol and combat utility"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -111,7 +110,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#ffae17", "#ffcd70")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/freebooter/freebooter_ship_.dm
+++ b/maps/away/ships/freebooter/freebooter_ship_.dm
@@ -51,7 +51,6 @@
 	sizeclass = "Ox-class Modular Freighter"
 	shiptype = "Multi-purpose freight"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -88,7 +87,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#9dc04c", "#52c24c")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/golden_deep/golden_deep.dm
+++ b/maps/away/ships/golden_deep/golden_deep.dm
@@ -31,7 +31,6 @@
 	moving_state = "tramp_moving"
 	color = "#efd10fe4"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -72,7 +71,6 @@
 	designation = "Cybele"
 	shuttle = "Golden Deep Shuttle"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = EAST
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/hegemony/fishing_trawler/fishing_league_trawler.dm
+++ b/maps/away/ships/hegemony/fishing_trawler/fishing_league_trawler.dm
@@ -34,7 +34,6 @@
 	shiptype = "Long-term shipping utilities"
 	scanimage = "unathi_freighter2.png"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1
 	vessel_mass = 5000
 	vessel_size = SHIP_SIZE_SMALL
 	fore_dir = SOUTH
@@ -71,7 +70,6 @@
 	colors = list("#F06553")
 	designation = "Shrieker"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000
 	fore_dir = WEST
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dm
+++ b/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dm
@@ -33,7 +33,6 @@
 	sizeclass = "Foundation-class corvette"
 	shiptype = "Military patrol and anti-pirate operation."
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -99,7 +98,6 @@
 	shuttle = "Hegemony Shuttle"
 	colors = list("#e38222", "#f0ba3e")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/hegemony/merchants_guild/merchant_freighter.dm
+++ b/maps/away/ships/hegemony/merchants_guild/merchant_freighter.dm
@@ -26,7 +26,6 @@
 	moving_state = "tramp_moving"
 	colors = list("5a189a")
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -89,7 +88,6 @@
 	designation = "Gilded Claw"
 	shuttle = "Merchants' Guild Shuttle"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = EAST
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/hegemony/miners_guild/miners_guild_station.dm
+++ b/maps/away/ships/hegemony/miners_guild/miners_guild_station.dm
@@ -97,7 +97,6 @@
 	sizeclass = "Short-range crew transport and mineral extraction pod"
 	shiptype = "Short-term industrial prospecting, raw goods transport"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/heph/cyclops/cyclops_mining_ship.dm
+++ b/maps/away/ships/heph/cyclops/cyclops_mining_ship.dm
@@ -30,7 +30,6 @@
 	drive = "Low-Speed Warp Acceleration FTL Drive"
 	sizeclass = "Cyclops Mining Freighter"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -131,7 +130,6 @@
 	moving_state = "pod_moving"
 	colors = list("#c3c7eb", "#a0a8ec")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/heph/heph_security/heph_security.dm
+++ b/maps/away/ships/heph/heph_security/heph_security.dm
@@ -29,7 +29,6 @@
 	drive = "Low-Speed Warp Acceleration FTL Drive"
 	sizeclass = "Eumenides-class security transport"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -84,7 +83,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#BAB86C", "#8B4000")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/iac/iac_rescue_ship.dm
+++ b/maps/away/ships/iac/iac_rescue_ship.dm
@@ -111,7 +111,6 @@
 	sizeclass = "Sanctuary-class Rescue Ship"
 	shiptype = "Emergency medical logistics relief and distress response"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -225,7 +224,6 @@
 	moving_state = "pod_moving"
 	colors = list("#ace8fa", "#71abf7")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/idris/idris_cruiser.dm
+++ b/maps/away/ships/idris/idris_cruiser.dm
@@ -34,7 +34,6 @@
 	sizeclass = "Argentum-class Cruise Yacht"
 	shiptype = "Luxury cruise yacht"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	vessel_size = SHIP_SIZE_SMALL
 	fore_dir = SOUTH
@@ -70,7 +69,6 @@
 	moving_state = "pod_moving"
 	colors = "#5acfc0"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 1000
 	fore_dir = EAST
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/kataphracts/kataphract_ship.dm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dm
@@ -108,7 +108,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#e38222", "#f0ba3e")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 6000 //Ship has a lot of thrusters, so if its too low the shuttle goes too fast. Also, imagine a hard egg flying towards you.
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/konyang/air_konyang/air_konyang.dm
+++ b/maps/away/ships/konyang/air_konyang/air_konyang.dm
@@ -29,7 +29,6 @@
 	sizeclass = "Peregrine-class civilian transport"
 	shiptype = "Civilian passenger transport."
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL

--- a/maps/away/ships/konyang/einstein_shuttle/einstein_shuttle.dm
+++ b/maps/away/ships/konyang/einstein_shuttle/einstein_shuttle.dm
@@ -76,7 +76,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#18e9b5", "#6aa9dd")
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000
 	vessel_size = SHIP_SIZE_SMALL
 	fore_dir = SOUTH

--- a/maps/away/ships/konyang/ipc_refugee/ipc_refugee_ship.dm
+++ b/maps/away/ships/konyang/ipc_refugee/ipc_refugee_ship.dm
@@ -31,7 +31,6 @@
 	sizeclass = "Akers-class Freighter"
 	shiptype = "Light Cargo Freighter"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -127,7 +126,6 @@
 	moving_state = "pod_moving"
 	colors = list("#c3c7eb", "#a0a8ec")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/konyang/kasf_ship/kasf_ship.dm
+++ b/maps/away/ships/konyang/kasf_ship/kasf_ship.dm
@@ -34,7 +34,6 @@
 	sizeclass = "Sai-class Corvette"
 	shiptype = "Military patrol and combat utility"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -132,7 +131,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#8492fd", "#4d61fc")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/konyang/konyang_wreck/konyang_wreck.dm
+++ b/maps/away/ships/konyang/konyang_wreck/konyang_wreck.dm
@@ -25,7 +25,6 @@
 	shiptype = "Long-range cargo transport"
 	vessel_mass = 5000
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_size = SHIP_SIZE_SMALL
 	initial_generic_waypoints = list(
 		"konyang_wreck_nav1",

--- a/maps/away/ships/konyang/water_barge/water_barge.dm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dm
@@ -30,7 +30,6 @@
 	sizeclass = "Shelfer-class cargo transport"
 	shiptype = "Long-distance cargo hauling"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 8000 //big boy
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -91,7 +90,6 @@
 	icon_state = "shuttle"
 	moving_state = "shuttle_moving"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/lone_spacer/lone_spacer.dm
+++ b/maps/away/ships/lone_spacer/lone_spacer.dm
@@ -27,7 +27,6 @@
 	moving_state = "spacer_moving"
 	colors = list("#70a170")
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 7500
 	vessel_size = SHIP_SIZE_SMALL
 	fore_dir = SOUTH

--- a/maps/away/ships/nka/nka_merchant/nka_merchant.dm
+++ b/maps/away/ships/nka/nka_merchant/nka_merchant.dm
@@ -89,7 +89,6 @@
 	designation = "Tajani"
 	shuttle = "Her Majesty's Mercantile Flotilla Shuttle"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/orion/orion_express_ship.dm
+++ b/maps/away/ships/orion/orion_express_ship.dm
@@ -135,7 +135,6 @@
 	shiptype = "Refuel, resupply and commercial logistics services"
 	drive = "Medium-Speed Warp Acceleration FTL Drive"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	vessel_size = SHIP_SIZE_SMALL
 	fore_dir = SOUTH
@@ -261,7 +260,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#a1a8e2", "#818be0")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/pra/database_freighter/database_freighter.dm
+++ b/maps/away/ships/pra/database_freighter/database_freighter.dm
@@ -93,7 +93,6 @@
 	designation = "Yve'kha"
 	shuttle = "Database Freighter Shuttle"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dm
@@ -108,7 +108,6 @@
 	designation = "Yve'kha"
 	shuttle = "Orbital Fleet Shuttle"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/sadar_scout/sadar_scout.dm
+++ b/maps/away/ships/sadar_scout/sadar_scout.dm
@@ -33,7 +33,6 @@
 	sizeclass = "Boreas-class Expeditionary Vessel"
 	shiptype = "Long-term expeditionary utility"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -146,7 +145,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#8a0f8a", "#a201a2")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/scc/scc_scout_ship.dm
+++ b/maps/away/ships/scc/scc_scout_ship.dm
@@ -33,7 +33,6 @@
 	sizeclass = "Serendipity-class Scout Ship"
 	shiptype = "Multi-purpose scout"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	vessel_size = SHIP_SIZE_SMALL
 	fore_dir = SOUTH
@@ -71,7 +70,6 @@
 	moving_state = "intrepid_moving"
 	colors = list("#cfd4ff", "#78adf8")
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 3000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/sol/sol_merc/fsf_patrol_ship.dm
+++ b/maps/away/ships/sol/sol_merc/fsf_patrol_ship.dm
@@ -34,7 +34,6 @@
 	sizeclass = "Montevideo-class Corvette"
 	shiptype = "Military patrol and combat utility"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -116,7 +115,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#9dc04c", "#52c24c")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/sol/sol_pirate/sfa_patrol_ship.dm
+++ b/maps/away/ships/sol/sol_pirate/sfa_patrol_ship.dm
@@ -104,7 +104,6 @@
 	weapons = "Dual extruding fore and starboard-mounted medium caliber ballistic armament, fore obscured flight craft bay"
 	sizeclass = "Unidentified-type Retrofitted Montevideo-class Corvette"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -179,7 +178,6 @@
 	moving_state = "pod_moving"
 	colors = list("#9dc04c", "#52c24c")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/sol/sol_splf/splf_raider.dm
+++ b/maps/away/ships/sol/sol_splf/splf_raider.dm
@@ -25,7 +25,6 @@
 	moving_state = "freighter_moving"
 	colors = list("#5a644e", "#6a7e53")
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL

--- a/maps/away/ships/sol/sol_splf/splf_raider_shuttle.dm
+++ b/maps/away/ships/sol/sol_splf/splf_raider_shuttle.dm
@@ -11,7 +11,6 @@
 	shiptype = "Short-distance passenger transportation"
 	colors = list("#aaafd4", "#78adf8")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/sol/sol_ssmd/ssmd_ship.dm
+++ b/maps/away/ships/sol/sol_ssmd/ssmd_ship.dm
@@ -106,7 +106,6 @@
 	sizeclass = "Uhlan-class Corvette"
 	shiptype = "Military reconnaissance and extended-duration combat utility"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -159,7 +158,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#9dc04c", "#52c24c")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/tajara/circus/adhomian_circus.dm
+++ b/maps/away/ships/tajara/circus/adhomian_circus.dm
@@ -37,7 +37,6 @@
 
 	colors = list(COLOR_CYAN, COLOR_WARM_YELLOW, COLOR_PALE_BTL_GREEN, COLOR_HOT_PINK)
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -86,7 +85,6 @@
 	class = "ACV"
 	designation = "Rafama"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	icon_state = "pod"
 	moving_state = "pod_moving"

--- a/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dm
+++ b/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dm
@@ -35,7 +35,6 @@
 	sizeclass = "Zhsram Freighter"
 	shiptype = "Long-term shipping utilities"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -83,7 +82,6 @@
 	moving_state = "pod_moving"
 	colors = list("#c3c7eb", "#a0a8ec")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY
@@ -122,7 +120,6 @@
 	icon_state = "pod"
 	moving_state = "pod_moving"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/tirakqi_smuggler/tirakqi_smuggler.dm
+++ b/maps/away/ships/tirakqi_smuggler/tirakqi_smuggler.dm
@@ -34,7 +34,6 @@
 	shiptype = "Luxupi Freighter"
 	class = "ISV"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -112,7 +111,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#27e4ee", "#4febbf")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/tramp_freighter/tramp_freighter.dm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter.dm
@@ -27,7 +27,6 @@
 	moving_state = "tramp_moving"
 	colors = list("#c3c7eb", "#a0a8ec")
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -79,7 +78,6 @@
 	moving_state = "pod_moving"
 	colors = list("#c3c7eb", "#a0a8ec")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = EAST
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/unathi_pirate/hiskyn/unathi_pirate_hiskyn.dm
+++ b/maps/away/ships/unathi_pirate/hiskyn/unathi_pirate_hiskyn.dm
@@ -26,7 +26,6 @@
 	moving_state = "freighter_moving"
 	colors = list("#9c0101")
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -101,7 +100,6 @@
 	shuttle = "Hiskyn Revanchist Shuttle"
 	sizeclass = "Yupmi-class shuttle"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/unathi_pirate/izharshan/unathi_pirate_izharshan.dm
+++ b/maps/away/ships/unathi_pirate/izharshan/unathi_pirate_izharshan.dm
@@ -79,7 +79,6 @@
 	colors = list("#95de9c")
 	scanimage = "unathi_freighter1.png"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 7500 //This truck is too damn big
 	vessel_size = SHIP_SIZE_SMALL
 	fore_dir = SOUTH

--- a/maps/away/ships/unathi_pirate/tarwa/unathi_pirate_tarwa.dm
+++ b/maps/away/ships/unathi_pirate/tarwa/unathi_pirate_tarwa.dm
@@ -26,7 +26,6 @@
 	colors = list("#c2c1ac", "#1b7325")
 	scanimage = "unathi_diona_freighter.png"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -89,7 +88,6 @@
 	colors = list("#1b4720")
 	shuttle = "Tarwa Conglomerate Shuttle"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = EAST
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/wildlands_militia/militia_ship.dm
+++ b/maps/away/ships/wildlands_militia/militia_ship.dm
@@ -35,7 +35,6 @@
 	moving_state = "generic_moving"
 	colors = list("#c3c7eb", "#a0a8ec")
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -82,7 +81,6 @@
 	moving_state = "pod_moving"
 	colors = list("#c3c7eb", "#a0a8ec")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/xanu/xanu_frigate.dm
+++ b/maps/away/ships/xanu/xanu_frigate.dm
@@ -41,7 +41,6 @@
 	sizeclass = "Shrike-class Frigate"
 	shiptype = "Naval frigate"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 6000
 	vessel_size = SHIP_SIZE_LARGE
 	fore_dir = SOUTH
@@ -84,7 +83,6 @@
 	moving_state = "canary_moving"
 	colors = COLOR_COALITION
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 0.5 SECONDS
 	vessel_mass = 800
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY
@@ -126,7 +124,6 @@
 	moving_state = "intrepid_moving"
 	colors = COLOR_COALITION
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 0.5 SECONDS
 	vessel_mass = 1500
 	fore_dir = EAST
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/away/ships/yacht_civ/yacht_civ_.dm
+++ b/maps/away/ships/yacht_civ/yacht_civ_.dm
@@ -38,7 +38,6 @@
 	sizeclass = "Diamond-class Yacht"
 	shiptype = "Leisure yacht"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 3000
 	vessel_size = SHIP_SIZE_SMALL
 	fore_dir = SOUTH
@@ -86,7 +85,6 @@
 	moving_state = "pod_moving"
 	colors = list("#c3c7eb", "#a0a8ec")
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 1000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/random_ruins/exoplanets/haneunim/haneunim_crash.dm
+++ b/maps/random_ruins/exoplanets/haneunim/haneunim_crash.dm
@@ -30,7 +30,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#ad3d3d", "#d0d1d0")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 3000 //Hard to move
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/random_ruins/exoplanets/konyang/pirate_outpost.dm
+++ b/maps/random_ruins/exoplanets/konyang/pirate_outpost.dm
@@ -40,7 +40,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#9dc04c", "#52c24c")
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 3000 //Hard to move
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/random_ruins/exoplanets/uueoaesa/kazhkz_crash.dm
+++ b/maps/random_ruins/exoplanets/uueoaesa/kazhkz_crash.dm
@@ -28,7 +28,6 @@
 	moving_state = "shuttle_moving"
 	colors = list("#d65e1e", "#1f731f") //Kazhkz and Han'san colors
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 3000 //Hard to move
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/runtime/runtime_overmap.dm
+++ b/maps/runtime/runtime_overmap.dm
@@ -8,7 +8,6 @@
 	moving_state = "runtime_penal_colony"
 	colors = list("#f147cd", "#f79aea")
 	vessel_mass = 100000
-	burn_delay = 2 SECONDS
 	base = TRUE
 
 /obj/effect/overmap/visitable/ship/landable/runtime
@@ -18,7 +17,6 @@
 	desc = "A RUN-T1M3 long range shuttle."
 	shuttle = "WhileTrue"
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = WEST
 	vessel_size = SHIP_SIZE_SMALL

--- a/maps/sccv_horizon/code/sccv_horizon_overmap.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_overmap.dm
@@ -12,7 +12,6 @@
 	colors = list("#cfd4ff", "#78adf8")
 	fore_dir = SOUTH
 	vessel_mass = 70000
-	burn_delay = 2 SECONDS
 	base = TRUE
 
 	scanimage = "horizon.png"
@@ -73,7 +72,6 @@
 	moving_state = "intrepid_moving"
 	colors = list("#cfd4ff", "#78adf8")
 	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 5000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
@@ -119,7 +117,6 @@
 	sizeclass = "Pickaxe-Class Mining Shuttle"
 	shiptype = "Field survey and specialized prospecting"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY
@@ -161,7 +158,6 @@
 	sizeclass = "Jester-type Scout Skiff"
 	shiptype = "Exploratory survey and scouting, high-speed target interception"
 	max_speed = 2/(1 SECONDS)
-	burn_delay = 1 SECONDS
 	vessel_mass = 2500
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY
@@ -217,7 +213,6 @@
 	sizeclass = "Celeste-type Exploration Shuttlecraft"
 	shiptype = "Exploratory survey and scouting"
 	max_speed = 1/(3 SECONDS)
-	burn_delay = 2 SECONDS
 	vessel_mass = 3000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY


### PR DESCRIPTION
* Standardized and reduced burn delays for ships and shuttles. Ships now have a 1 second burn delay, down from 2. Shuttles now have a 0.5 second burn delay, down from 1. The only exception are the racer shuttles, which have a 0.25 burn second delay.
* Standardized all ships and shuttles to have a 0.1 second turn delay.


https://github.com/user-attachments/assets/d95fe58c-6160-4e02-a50a-d78441cb5b92

