### PR TITLE
Drill Drop Resource Fix

### DIFF
--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -58,6 +58,7 @@
 	var/list/old_decals = decals
 	var/old_outside = is_outside
 	var/old_is_open = is_open()
+	var/list/old_resources = resources ? resources.Copy() : null
 
 	changing_turf = TRUE
 
@@ -66,6 +67,7 @@
 
 	// So we call destroy.
 	qdel(src)
+
 	//We do this here so anything that doesn't want to persist can clear itself
 	var/list/old_listen_lookup = _listen_lookup?.Copy()
 	var/list/old_signal_procs = _signal_procs?.Copy()
@@ -142,6 +144,8 @@
 	new_turf.post_change(!mapload)
 
 	new_turf.update_weather(force_update_below = new_turf.is_open() != old_is_open)
+
+	new_turf.resources = old_resources
 
 	. = new_turf
 

--- a/html/changelogs/geeves-resource_maintaining.yml
+++ b/html/changelogs/geeves-resource_maintaining.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Dropping a drill directly onto a turf with underground resources will no longer delete the resources."


### PR DESCRIPTION
* Dropping a drill directly onto a turf with underground resources will no longer delete the resources.