### PR TITLE
Odyssey Early Announcement Tweak

### DIFF
--- a/code/datums/scenarios/scenario.dm
+++ b/code/datums/scenarios/scenario.dm
@@ -136,7 +136,7 @@
 	/// The title for the messages sent to the Horizon to notify them of the scenarios, both in notify_scenario_early and notify_scenario_late.
 	var/horizon_announcement_title = "Central Command Situation Report"
 	/// The announcement message sent to the Horizon immediately after roundstart (5 minutes or so), telling them to prepare for a yet unknown expedition.
-	var/horizon_early_announcement_message = "SCCV Horizon, your sensors suite has located a site of interest and the coordinates have been marked on your sensors. Please prepare an expedition while we investigate landing conditions."
+	var/horizon_early_announcement_message = "SCCV Horizon, your sensors suite has located a site of interest and the coordinates have been marked on your sensors. Please prepare an expedition while we investigate landing conditions.\n\nAll crew are encouraged to volunteer and should notify their relevant department heads as soon as possible. Volunteers should only be rejected in the most dire circumstances."
 	/// The announcement message sent to the Horizon around 20 minutes in, typically telling them to go investigate the scenario and the reason why.
 	var/horizon_unrestrict_landing_message = "The landing sites have been registered and cleared. An expedition is now authorized to depart."
 

--- a/html/changelogs/geeves-odyssey_announcement_tweak.yml
+++ b/html/changelogs/geeves-odyssey_announcement_tweak.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Added a blurb to the Odyssey early announcement detailing that crew from all departments are encouraged to volunteer, and that they should be accepted in almost all circumstances."


### PR DESCRIPTION
* Added a blurb to the Odyssey early announcement detailing that crew from all departments are encouraged to volunteer, and that they should be accepted in almost all circumstances.

![image](https://github.com/user-attachments/assets/0f866bda-3396-47dc-a100-6de0f962f29c)
