### PR TITLE
Odyssey Latejoin Intrepid Spawn

### DIFF
--- a/code/__DEFINES/global.dm
+++ b/code/__DEFINES/global.dm
@@ -68,6 +68,7 @@ GLOBAL_LIST_EMPTY(latejoin)
 GLOBAL_LIST_EMPTY(latejoin_cryo)
 GLOBAL_LIST_EMPTY(latejoin_cyborg)
 GLOBAL_LIST_EMPTY(latejoin_living_quarters_lift)
+GLOBAL_LIST_EMPTY(latejoin_intrepid)
 GLOBAL_LIST_EMPTY(kickoffsloc)
 GLOBAL_LIST_EMPTY(virtual_reality_spawn)
 

--- a/code/controllers/subsystems/initialization/atlas.dm
+++ b/code/controllers/subsystems/initialization/atlas.dm
@@ -291,9 +291,11 @@ SUBSYSTEM_DEF(atlas)
 /datum/controller/subsystem/atlas/proc/setup_spawnpoints()
 	SHOULD_NOT_SLEEP(TRUE)
 
-	for (var/type in current_map.spawn_types)
-		var/datum/spawnpoint/S = new type
-		spawn_locations[S.display_name] = S
+	for (var/type in subtypesof(/datum/spawnpoint))
+		var/datum/spawnpoint/initial_spawnpoint = type
+		if((type in current_map.spawn_types) || initial(initial_spawnpoint.always_load))
+			var/datum/spawnpoint/spawnpoint = new type
+			spawn_locations[spawnpoint.display_name] = spawnpoint
 
 /datum/controller/subsystem/atlas/proc/InitializeSectors()
 	SHOULD_NOT_SLEEP(TRUE)

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -71,6 +71,19 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	GLOB.latejoin_living_quarters_lift += get_turf(src)
 	return INITIALIZE_HINT_QDEL
 
+/**
+ * # Latejoin intrepid marker
+ *
+ * Used to spawn players in when they latejoin in an Odyssey round and select the "Intrepid" spawn they get prompted with
+ */
+/obj/effect/landmark/latejoin_intrepid
+	invisibility = INVISIBILITY_ABSTRACT
+	movable_flags = MOVABLE_FLAG_EFFECTMOVE // so it gets brought along with the shuttle
+
+// does NOT get deleted, we need this landmark to be transported along with the intrepid
+/obj/effect/landmark/latejoin_intrepid/Initialize()
+	..()
+	GLOB.latejoin_intrepid += src // note, we're adding the landmark to the list, NOT the turf. this is because the intrepid moves. we'll spawn in the hangar otherwise
 
 
 /**

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -295,8 +295,10 @@
 
 	else if(href_list["spawnpoint"])
 		var/list/spawnkeys = list()
-		for(var/S in SSatlas.spawn_locations)
-			spawnkeys += S
+		for(var/spawn_location in SSatlas.spawn_locations)
+			var/datum/spawnpoint/spawnpoint = SSatlas.spawn_locations[spawn_location]
+			if(spawnpoint.add_to_preferences)
+				spawnkeys += spawn_location
 		var/choice = input(user, "Where would you like to spawn when late-joining?") as null|anything in spawnkeys
 		if(!choice || !SSatlas.spawn_locations[choice] || !CanUseTopic(user))	return TOPIC_NOACTION
 		pref.spawnpoint = choice

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -1,10 +1,30 @@
 /datum/spawnpoint
-	var/msg          //Message to display on the arrivals computer.
-	var/list/turfs   //List of turfs to spawn on.
-	var/display_name //Name used in preference setup.
+	/// Message to display on the arrivals computer.
+	var/msg
+
+	/// List of atoms to spawn on.
+	var/list/spawn_locations
+
+	/// Name used in preference setup.
+	var/display_name
+
+	/// Only allows people with a job in this list to spawn at this spawnpoint
 	var/list/restrict_job = null
+
+	/// Prevents people with a job in this list to spawn at this spawnpoint
 	var/list/disallow_job = null
 
+	/// Whether this spawnpoint should be loaded regardless of whether the map has it set as a selectable spawnpoint
+	var/always_load = FALSE
+
+	/// Whether people can select this spawnpoint in their character preferences
+	var/add_to_preferences = TRUE
+
+/// Handles spawning the mob onto its spawn location, will effectively always just be a forceMove
+/datum/spawnpoint/proc/handle_spawn(var/mob/spawning_mob)
+	spawning_mob.forceMove(get_turf(pick(spawn_locations)))
+
+/// Checks whether the player's job is within the restricted or disallowed list, returning TRUE if everything's valid
 /datum/spawnpoint/proc/check_job_spawning(job)
 	if(restrict_job && !(job in restrict_job))
 		return FALSE
@@ -14,6 +34,7 @@
 
 	return TRUE
 
+/// Called after the mob is spawned in
 /datum/spawnpoint/proc/after_join(mob/victim)
 	return
 
@@ -25,7 +46,7 @@
 /datum/spawnpoint/arrivals/New()
 	..()
 	msg = "is inbound from the [SSatlas.current_map.dock_name]"
-	turfs = GLOB.latejoin
+	spawn_locations = GLOB.latejoin
 
 /datum/spawnpoint/cryo
 	display_name = "Cryogenic Storage"
@@ -34,7 +55,7 @@
 
 /datum/spawnpoint/cryo/New()
 	..()
-	turfs = GLOB.latejoin_cryo
+	spawn_locations = GLOB.latejoin_cryo
 
 /datum/spawnpoint/cryo/after_join(mob/victim)
 	if(!istype(victim))
@@ -54,7 +75,7 @@
 
 /datum/spawnpoint/cyborg/New()
 	..()
-	turfs = GLOB.latejoin_cyborg
+	spawn_locations = GLOB.latejoin_cyborg
 
 /datum/spawnpoint/living_quarters_lift
 	display_name = "Living Quarters Lift"
@@ -63,7 +84,7 @@
 
 /datum/spawnpoint/living_quarters_lift/New()
 	..()
-	turfs = GLOB.latejoin_living_quarters_lift
+	spawn_locations = GLOB.latejoin_living_quarters_lift
 
 /datum/spawnpoint/living_quarters_lift/after_join(mob/victim)
 	if(!istype(victim))
@@ -73,4 +94,26 @@
 		if(!C.occupant)
 			C.set_occupant(victim, 1)
 			to_chat(victim, SPAN_NOTICE("You have arrived from the living quarters aboard the [SSatlas.current_map.full_name]."))
+			return
+
+/datum/spawnpoint/intrepid_cryo
+	display_name = "Intrepid"
+	msg = "has completed cryogenic revival aboard the Intrepid"
+	disallow_job = list("Cyborg", "Merchant")
+	always_load = TRUE
+	add_to_preferences = FALSE
+
+/datum/spawnpoint/intrepid_cryo/New()
+	..()
+	spawn_locations = GLOB.latejoin_intrepid
+
+/datum/spawnpoint/intrepid_cryo/after_join(mob/victim)
+	if(!istype(victim))
+		return
+	var/area/spawn_area = get_area(victim)
+	for(var/obj/machinery/cryopod/C in spawn_area)
+		if(!C.occupant)
+			C.set_occupant(victim, 1)
+			victim.Sleeping(3)
+			to_chat(victim, SPAN_NOTICE("You are slowly waking up from the cryostasis aboard the Intrepid. It might take a few seconds."))
 			return

--- a/html/changelogs/geeves-odyssey_spawning.yml
+++ b/html/changelogs/geeves-odyssey_spawning.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "When latejoining, if it's an Odyssey round and the Intrepid is not in its hangar, the latejoiner is given the option of spawning directly onto the Intrepid."


### PR DESCRIPTION
* When latejoining, if it's an Odyssey round and the Intrepid is not in its hangar, the latejoiner is given the option of spawning directly onto the Intrepid.

![image](https://github.com/user-attachments/assets/83a7f40f-e7bc-464c-b29b-fcdd9cd07987)
