### PR TITLE
Changes options for Orepit citizenship and updates important origin i…

### DIFF
--- a/code/__DEFINES/background.dm
+++ b/code/__DEFINES/background.dm
@@ -27,6 +27,7 @@
 
 #define CITIZENSHIP_NONE "None"
 #define CITIZENSHIP_GOLDEN "Golden Deep"
+#define CITIZENSHIP_OREPIT "Orepit"
 
 //religion defines
 #define RELIGION_NONE "None"

--- a/code/modules/background/citizenship/ipc.dm
+++ b/code/modules/background/citizenship/ipc.dm
@@ -56,3 +56,14 @@
 	backpack_contents = list(
 		/obj/item/gun/energy/pistol/goldendeep = 1
 	)
+
+/datum/citizenship/orepit
+	name = CITIZENSHIP_OREPIT
+	description = "With the arrival of the Church of the Trinary Perfection in 2419, the planet of Orepit has now organized into a theocratic regime under the rule of \
+	ARM-1DRIL, former follower of Gregol Corkfell. Prominent locations include Providence, Orepit's capital and base of operations for the Church, and the Twenty Parishes, \
+	home to the planet's original native human population, who remain divided on conversion to the faith. Orepit was one of the main signatories to the Open Doors memorandum, \
+	allowing its populace to work, study, and travel abroad in the Coalition and beyond, primarily in the All-Xanu Republic, utilizing Xanan documents."
+
+	job_species_blacklist = list(
+		"Consular Officer" = ALL_SPECIES
+	)

--- a/code/modules/background/origins/origins/human/coalition.dm
+++ b/code/modules/background/origins/origins/human/coalition.dm
@@ -118,7 +118,7 @@
 /singleton/origin_item/origin/orepit
 	name = "Orepit"
 	desc = "The human population of Orepit includes the Native Orepitters, who descend from Hephaestus employees following the abandoned mining mission on the planet, as well as immigrants and pilgrims of the Trinary religion."
-	important_information = "All humans from Orepit are vetted Trinary faithful, and their behaviour should reflect that."
+	important_information = "All humans from Orepit are vetted Trinary faithful, and their behaviour should reflect that. All Orepitters abroad are participants in the Open Doors memorandum, meaning they would not work in jobs not requiring an education. They cannot work for Hephaestus Industries because of its practice of not hiring Trinarists, nor directly for the Stellar Corporate Conglomerate due to its distrust of the Church. Human Orepitters born in the Twenty Parishes should select the Native Orepitter accent, while humans born in Providence or the Marches should select the Providence accent. "
 	possible_accents = list(ACCENT_OREPIT, ACCENT_PROVIDENCE)
-	possible_citizenships = list(CITIZENSHIP_NONE, CITIZENSHIP_COALITION)
+	possible_citizenships = list(CITIZENSHIP_OREPIT)
 	possible_religions =  list(RELIGION_TRINARY)

--- a/code/modules/background/origins/origins/ipc/coalition.dm
+++ b/code/modules/background/origins/origins/ipc/coalition.dm
@@ -34,8 +34,9 @@
 /singleton/origin_item/origin/ipc_orepit
 	name = "Orepit"
 	desc = "Refugees and runaways, the synthetic population of Orepit has embraced the beliefs of synthetic divinity and ascension preached by the Trinary Perfection. A primarily religious community, IPC from Orepit and its capital Providence find themselves occupying clerical posts abroad as priests, missionaries and even guardians of the Church for its parishes scattered across the Spur."
+	important_information = "All Orepitters abroad are participants in the Open Doors memorandum, meaning they would not work in jobs not requiring an education. They cannot work for Hephaestus Industries because of its practice of not hiring Trinarists, nor directly for the Stellar Corporate Conglomerate due to its distrust of the Church."
 	possible_accents = list(ACCENT_PROVIDENCE)
-	possible_citizenships = list(CITIZENSHIP_NONE)
+	possible_citizenships = list(CITIZENSHIP_OREPIT)
 	possible_religions = list(RELIGION_TRINARY)
 
 /singleton/origin_item/origin/ipc_vysoka

--- a/html/changelogs/simplemaroon-orepitmorelikesnorepit.yml
+++ b/html/changelogs/simplemaroon-orepitmorelikesnorepit.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: SimpleMaroon
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added Orepit citizenship, which is unique to human Orepitters and IPCs. This is the only citizenship option both Orepit origins are able to select."
+  - qol: "Both Orepit origins now include information on job/faction limitations and which accent to pick for human Orepitters."


### PR DESCRIPTION
**REQUIRES SYNTH LORE TEAM APPROVAL!!!** If accepted, all added blurbs are placeholders that can be altered as the synth lore team sees fit.

The reasoning regarding this PR is that I think the current in-game information around Orepit and the available listed options for citizenship are too confusing for anyone who may be interested in the origins; humans can either choose Coalition of Colonies or no citizenship, despite implied statelessness for humans being confusing for anyone who might read their card or records and Orepit not being integrated with the broader Coalition. This makes Orepit a separate and unique citizenship in a similar vein to the  format for the Free Tajaran Council or Elyran Non-citizen Persons. The included important information blurbs are for clarity of lore developments regarding the Open Doors memorandum and megacorporate hiring standards for Trinarists.

I understand that I was told by NM that plans will be in the works for Orepit after the Golden Deep arc and hope this isn't seen as overstepping or a stopgap measure.

![image](https://github.com/user-attachments/assets/3c48b59f-9019-4477-9c12-492d14acf1a0)
For humans
![image](https://github.com/user-attachments/assets/306cb756-4807-4623-827e-fbcacfca1fa0)
For IPCs
![image](https://github.com/user-attachments/assets/6c6c35fa-ff82-4052-b7f8-1b89ffca414a)

