### PR TITLE
Fix devices shocking players repeatedly 

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -32,10 +32,6 @@
 	if(!..())
 		return FALSE
 	var/obj/machinery/door/airlock/A = holder
-	if(!istype(user, /mob/living/silicon))
-		if(A.isElectrified())
-			if(A.shock(user, 100))
-				return FALSE
 	if(!A.p_open)
 		return FALSE
 	return TRUE

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -133,7 +133,7 @@
 			A.update_icon()
 
 
-/datum/wires/airlock/on_pulse(wire)
+/datum/wires/airlock/on_pulse(wire, user)
 
 	var/obj/machinery/door/airlock/A = holder
 	switch(wire)
@@ -166,7 +166,9 @@
 
 		if(WIRE_SHOCK)
 			//one wire for electrifying the door. Sending a pulse through this electrifies the door for 30 seconds.
-			A.shock(usr, 50)
+			if(ismob(user))
+				var/mob/living/U = user
+				A.shock(U, 100)
 			A.electrify(30)
 
 		if(WIRE_OPEN)

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -167,8 +167,7 @@
 		if(WIRE_SHOCK)
 			//one wire for electrifying the door. Sending a pulse through this electrifies the door for 30 seconds.
 			if(ismob(user))
-				var/mob/living/U = user
-				A.shock(U, 100)
+				A.shock(user, 100)
 			A.electrify(30)
 
 		if(WIRE_OPEN)

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -166,6 +166,7 @@
 
 		if(WIRE_SHOCK)
 			//one wire for electrifying the door. Sending a pulse through this electrifies the door for 30 seconds.
+			A.shock(usr, 100)
 			A.electrify(30)
 
 		if(WIRE_OPEN)

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -166,7 +166,7 @@
 
 		if(WIRE_SHOCK)
 			//one wire for electrifying the door. Sending a pulse through this electrifies the door for 30 seconds.
-			A.shock(usr, 100)
+			A.shock(usr, 50)
 			A.electrify(30)
 
 		if(WIRE_OPEN)

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -33,13 +33,15 @@
 	. += "The cyan light is [S.cooling ? "on" : "off"]."
 	. += "The blue light is [S.heating ? "on" : "off"]."
 
-/datum/wires/smartfridge/on_pulse(wire)
+/datum/wires/smartfridge/on_pulse(wire, user)
 	var/obj/machinery/smartfridge/S = holder
 	switch(wire)
 		if(WIRE_THROW)
 			S.shoot_inventory = !S.shoot_inventory
 		if(WIRE_SHOCK)
-			S.shock(usr, 50)
+			if(ismob(user))
+				var/mob/living/U = user
+				S.shock(U, 50)
 			S.seconds_electrified = 30
 		if(WIRE_IDSCAN)
 			S.scan_id = !S.scan_id

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -39,6 +39,7 @@
 		if(WIRE_THROW)
 			S.shoot_inventory = !S.shoot_inventory
 		if(WIRE_SHOCK)
+			S.shock(usr, 100)
 			S.seconds_electrified = 30
 		if(WIRE_IDSCAN)
 			S.scan_id = !S.scan_id

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -40,7 +40,7 @@
 			S.shoot_inventory = !S.shoot_inventory
 		if(WIRE_SHOCK)
 			if(ismob(user))
-				S.shock(user, 50)
+				S.shock(user, 100)
 			S.seconds_electrified = 30
 		if(WIRE_IDSCAN)
 			S.scan_id = !S.scan_id

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -40,8 +40,7 @@
 			S.shoot_inventory = !S.shoot_inventory
 		if(WIRE_SHOCK)
 			if(ismob(user))
-				var/mob/living/U = user
-				S.shock(U, 50)
+				S.shock(user, 50)
 			S.seconds_electrified = 30
 		if(WIRE_IDSCAN)
 			S.scan_id = !S.scan_id

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -20,10 +20,6 @@
 	if(!..())
 		return FALSE
 	var/obj/machinery/smartfridge/S = holder
-	if(!istype(user, /mob/living/silicon))
-		if(S.seconds_electrified)
-			if(S.shock(user, 100))
-				return FALSE
 	if(S.panel_open)
 		return TRUE
 	return FALSE

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -39,7 +39,7 @@
 		if(WIRE_THROW)
 			S.shoot_inventory = !S.shoot_inventory
 		if(WIRE_SHOCK)
-			S.shock(usr, 100)
+			S.shock(usr, 50)
 			S.seconds_electrified = 30
 		if(WIRE_IDSCAN)
 			S.scan_id = !S.scan_id

--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -15,10 +15,6 @@
 	if(!..())
 		return FALSE
 	var/obj/machinery/suit_cycler/S = holder
-	if(!istype(user, /mob/living/silicon))
-		if(S.electrified)
-			if(S.shock(user, 100))
-				return FALSE
 	if(S.panel_open)
 		return TRUE
 	return FALSE

--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -26,13 +26,15 @@
 	. += "The red light is [S.safeties ? "off" : "blinking"]."
 	. += "The yellow light is [S.locked ? "on" : "off"]."
 
-/datum/wires/suit_storage_unit/on_pulse(wire)
+/datum/wires/suit_storage_unit/on_pulse(wire, user)
 	var/obj/machinery/suit_cycler/S = holder
 	switch(wire)
 		if(WIRE_SAFETY)
 			S.safeties = !S.safeties
 		if(WIRE_SHOCK)
-			S.shock(usr, 50)
+			if(ismob(user))
+				var/mob/living/U = user
+				S.shock(U, 50)
 			S.electrified = 30
 		if(WIRE_LOCKDOWN)
 			S.locked = !S.locked

--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -32,6 +32,7 @@
 		if(WIRE_SAFETY)
 			S.safeties = !S.safeties
 		if(WIRE_SHOCK)
+			S.shock(usr, 100)
 			S.electrified = 30
 		if(WIRE_LOCKDOWN)
 			S.locked = !S.locked

--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -33,8 +33,7 @@
 			S.safeties = !S.safeties
 		if(WIRE_SHOCK)
 			if(ismob(user))
-				var/mob/living/U = user
-				S.shock(U, 50)
+				S.shock(user, 50)
 			S.electrified = 30
 		if(WIRE_LOCKDOWN)
 			S.locked = !S.locked

--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -32,7 +32,7 @@
 		if(WIRE_SAFETY)
 			S.safeties = !S.safeties
 		if(WIRE_SHOCK)
-			S.shock(usr, 100)
+			S.shock(usr, 50)
 			S.electrified = 30
 		if(WIRE_LOCKDOWN)
 			S.locked = !S.locked

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -20,10 +20,6 @@
 	if(!..())
 		return FALSE
 	var/obj/machinery/vending/V = holder
-	if(!istype(user, /mob/living/silicon))
-		if(V.seconds_electrified)
-			if(V.shock(user, 100))
-				return FALSE
 	if(V.panel_open)
 		return TRUE
 	return FALSE

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -43,8 +43,7 @@
 			V.categories ^= CAT_HIDDEN
 		if(WIRE_SHOCK)
 			if(ismob(user))
-				var/mob/living/U = user
-				V.shock(U, 50)
+				V.shock(user, 50)
 			V.seconds_electrified = 30
 		if(WIRE_IDSCAN)
 			V.scan_id = !V.scan_id

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -42,6 +42,7 @@
 		if(WIRE_CONTRABAND)
 			V.categories ^= CAT_HIDDEN
 		if(WIRE_SHOCK)
+			V.shock(usr, 100)
 			V.seconds_electrified = 30
 		if(WIRE_IDSCAN)
 			V.scan_id = !V.scan_id

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -42,7 +42,7 @@
 		if(WIRE_CONTRABAND)
 			V.categories ^= CAT_HIDDEN
 		if(WIRE_SHOCK)
-			V.shock(usr, 100)
+			V.shock(usr, 50)
 			V.seconds_electrified = 30
 		if(WIRE_IDSCAN)
 			V.scan_id = !V.scan_id

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -34,7 +34,7 @@
 	. += "The cyan light is [V.temperature_setting == -1 ? "on" : "off"]."
 	. += "The blue light is [V.temperature_setting == 1 ? "on" : "off"]."
 
-/datum/wires/vending/on_pulse(wire)
+/datum/wires/vending/on_pulse(wire, user)
 	var/obj/machinery/vending/V = holder
 	switch(wire)
 		if(WIRE_THROW)
@@ -42,7 +42,9 @@
 		if(WIRE_CONTRABAND)
 			V.categories ^= CAT_HIDDEN
 		if(WIRE_SHOCK)
-			V.shock(usr, 50)
+			if(ismob(user))
+				var/mob/living/U = user
+				V.shock(U, 50)
 			V.seconds_electrified = 30
 		if(WIRE_IDSCAN)
 			V.scan_id = !V.scan_id

--- a/html/changelogs/victorShchagin-PR-20325.yml
+++ b/html/changelogs/victorShchagin-PR-20325.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: victorShchagin
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Airlocks, vendors, and other machinery no longer cause continuous shocks to the user while the TGUI window is open."


### PR DESCRIPTION
A fix for https://github.com/Aurorastation/Aurora.3/issues/18219

Thanks to mattatlas for figuring out the actual cause - `/datum/wires/suit_storage_unit/interactable` proc was called every tick when TGUI window for that element was opened, and it had code that checked for `isElectrified()`, leading to repeated shocks.

Removal should resolve the issue, actual .shock() calls are happening when appropriate - in `/datum/wires/<MACHINE>/on_pulse(wire)` when interacting with wiring, or in `<MACHINE>.dm` itself when processing interactions.
 
Could not do full testing due to a lack of experience with the game and tooling, but no issues were encountered with what was done.
