### PR TITLE
SCCV Quark Minor Tweaks

### DIFF
--- a/html/changelogs/furrycactus - quark tweaks.yml
+++ b/html/changelogs/furrycactus - quark tweaks.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added Research staff access to the air alarms on the Quark."
+  - rscadd: "Added a recharger, shortwave radio, basic first-aid kit, two pneumalin autoinhalers, and an expedition tent the Quark."
+  - rscadd: "Added purple Research coloured shortwave radios to the Research expedition prep area."


### PR DESCRIPTION
The Quark is beyond amazing, but I noticed a few tiny things that seemed like they were missing. If any of this was left out for a reason lmk.

  - rscadd: "Added Research staff access to the air alarms on the Quark."
  - rscadd: "Added a recharger, shortwave radio, basic first-aid kit, two pneumalin autoinhalers, and an expedition tent the Quark." (same standard as the SCCV Spark)
  - rscadd: "Added purple Research coloured shortwave radios to the Research expedition prep area."