### PR TITLE
Adds some INDRA kinetic harvester recipes

### DIFF
--- a/code/defines/gases.dm
+++ b/code/defines/gases.dm
@@ -11,12 +11,14 @@
 	name = "Nitrogen"
 	specific_heat = 20	// J/(mol*K)
 	molar_mass = 0.028	// kg/mol
+	flags = XGM_GAS_FUSION_FUEL
 
 /singleton/xgm_gas/carbon_dioxide
 	id = GAS_CO2
 	name = "Carbon Dioxide"
 	specific_heat = 30	// J/(mol*K)
 	molar_mass = 0.044	// kg/mol
+	flags = XGM_GAS_FUSION_FUEL
 
 /singleton/xgm_gas/phoron
 	id = GAS_PHORON
@@ -50,6 +52,7 @@
 	tile_overlay = "sleeping_agent"
 	overlay_limit = 1
 	flags = XGM_GAS_OXIDIZER
+	flags = XGM_GAS_FUSION_FUEL
 
 /singleton/xgm_gas/hydrogen/deuterium
 	id = GAS_DEUTERIUM
@@ -104,6 +107,7 @@
 
 	specific_heat = 30	// J/(mol*K)
 	molar_mass = 0.044	// kg/mol
+	flags = XGM_GAS_FUSION_FUEL
 
 /singleton/xgm_gas/chlorine
 	id = GAS_CHLORINE
@@ -112,7 +116,7 @@
 	overlay_limit = 0.5
 	specific_heat = 5	// J/(mol*K)
 	molar_mass = 0.017	// kg/mol
-	flags = XGM_GAS_CONTAMINANT
+	flags = XGM_GAS_CONTAMINANT|XGM_GAS_FUSION_FUEL
 
 /singleton/xgm_gas/boron
 	id = GAS_BORON

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -291,6 +291,7 @@
 	stack_origin_tech = list(TECH_MATERIAL = 5)
 	door_icon_base = "stone"
 	golem = SPECIES_GOLEM_URANIUM
+	is_fusion_fuel = TRUE
 
 /material/diamond
 	name = MATERIAL_DIAMOND
@@ -310,6 +311,7 @@
 	golem = SPECIES_GOLEM_DIAMOND
 	drop_sound = 'sound/items/drop/glass.ogg'
 	pickup_sound = 'sound/items/pickup/glass.ogg'
+	is_fusion_fuel = TRUE
 
 /material/gold
 	name = MATERIAL_GOLD
@@ -323,6 +325,7 @@
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
 	golem = SPECIES_GOLEM_GOLD
+	is_fusion_fuel = TRUE
 
 /material/bronze
 	name = MATERIAL_BRONZE
@@ -334,6 +337,7 @@
 	icon_colour = "#EDD12F"
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	golem = SPECIES_GOLEM_BRONZE
+	is_fusion_fuel = TRUE
 
 /material/osmium
 	name = MATERIAL_OSMIUM
@@ -356,6 +360,7 @@
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
 	golem = SPECIES_GOLEM_SILVER
+	is_fusion_fuel = TRUE
 
 /material/phoron
 	name = MATERIAL_PHORON
@@ -419,6 +424,7 @@
 	golem = SPECIES_GOLEM_MARBLE
 	drop_sound = 'sound/items/drop/boots.ogg'
 	pickup_sound = 'sound/items/pickup/boots.ogg'
+	is_fusion_fuel = TRUE
 
 /material/concrete
 	name = MATERIAL_CONCRETE
@@ -443,6 +449,7 @@
 	golem = SPECIES_GOLEM_STEEL
 	hitsound = 'sound/weapons/smash.ogg'
 	weapon_hitsound = 'sound/weapons/metalhit.ogg'
+	is_fusion_fuel = TRUE
 
 
 /material/diona
@@ -494,6 +501,7 @@
 	golem = SPECIES_GOLEM_PLASTEEL
 	hitsound = 'sound/weapons/smash.ogg'
 	weapon_hitsound = 'sound/weapons/metalhit.ogg'
+	is_fusion_fuel = TRUE
 
 /material/plasteel/titanium
 	name = MATERIAL_TITANIUM
@@ -508,6 +516,7 @@
 	door_icon_base = "metal"
 	icon_colour = "#D1E6E3"
 	golem = SPECIES_GOLEM_TITANIUM
+	is_fusion_fuel = TRUE
 
 /material/glass
 	name = MATERIAL_GLASS
@@ -533,6 +542,7 @@
 	golem = SPECIES_GOLEM_GLASS
 	drop_sound = 'sound/items/drop/glass.ogg'
 	pickup_sound = 'sound/items/pickup/glass.ogg'
+	is_fusion_fuel = TRUE
 
 /material/glass/build_windows(var/mob/living/user, var/obj/item/stack/used_stack)
 
@@ -684,6 +694,7 @@
 	golem = SPECIES_GOLEM_PLASTIC
 	drop_sound = 'sound/items/drop/card.ogg'
 	pickup_sound = 'sound/items/pickup/card.ogg'
+	is_fusion_fuel = TRUE
 
 /material/plastic/holographic
 	name = MATERIAL_PLASTIC_HOLO
@@ -720,6 +731,7 @@
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
+	is_fusion_fuel = TRUE
 
 /material/iron
 	name = MATERIAL_IRON
@@ -733,6 +745,7 @@
 	golem = SPECIES_GOLEM_IRON
 	hitsound = 'sound/weapons/smash.ogg'
 	weapon_hitsound = 'sound/weapons/metalhit.ogg'
+	is_fusion_fuel = TRUE
 
 /material/aluminium
 	name = MATERIAL_ALUMINIUM
@@ -742,6 +755,7 @@
 	conductivity = 29.48
 	hitsound = 'sound/weapons/smash.ogg'
 	weapon_hitsound = 'sound/weapons/metalhit.ogg'
+	is_fusion_fuel = TRUE
 
 /material/lead
 	name = MATERIAL_LEAD
@@ -753,6 +767,7 @@
 	sheet_plural_name = "ingots"
 	hitsound = 'sound/weapons/smash.ogg'
 	weapon_hitsound = 'sound/weapons/metalhit.ogg'
+	is_fusion_fuel = TRUE
 
 // Adminspawn only, do not let anyone get this.
 /material/elevatorium
@@ -1192,6 +1207,7 @@
 	sheet_plural_name = "bars"
 	drop_sound = 'sound/items/drop/boots.ogg'
 	pickup_sound = 'sound/items/pickup/boots.ogg'
+	is_fusion_fuel = TRUE
 
 /material/tritium
 	name = MATERIAL_TRITIUM

--- a/code/modules/power/fusion/fuel_assembly/fuel_assembly.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_assembly.dm
@@ -77,3 +77,61 @@
 
 /obj/item/fuel_assembly/hydrogen/New(newloc)
 	..(newloc, MATERIAL_HYDROGEN_METALLIC)
+
+// New fuel rods for messing around. Added by ASCC, all of my additions should go after this
+/obj/item/fuel_assembly/plastic/New(newloc)
+	..(newloc, MATERIAL_PLASTIC)
+
+/obj/item/fuel_assembly/plasteel/New(newloc)
+	..(newloc, MATERIAL_PLASTEEL)
+
+/obj/item/fuel_assembly/steel/New(newloc)
+	..(newloc, MATERIAL_STEEL)
+
+/obj/item/fuel_assembly/glass/New(newloc)
+	..(newloc, MATERIAL_GLASS)
+
+/obj/item/fuel_assembly/gold/New(newloc)
+	..(newloc, MATERIAL_GOLD)
+
+/obj/item/fuel_assembly/silver/New(newloc)
+	..(newloc, MATERIAL_SILVER)
+
+/obj/item/fuel_assembly/diamond/New(newloc)
+	..(newloc, MATERIAL_DIAMOND)
+
+/obj/item/fuel_assembly/uranium/New(newloc)
+	..(newloc, MATERIAL_URANIUM)
+
+/obj/item/fuel_assembly/iron/New(newloc)
+	..(newloc, MATERIAL_IRON)
+
+/obj/item/fuel_assembly/sandstone/New(newloc)
+	..(newloc, MATERIAL_SANDSTONE)
+
+/obj/item/fuel_assembly/platinum/New(newloc)
+	..(newloc, MATERIAL_PLATINUM)
+
+/obj/item/fuel_assembly/bronze/New(newloc)
+	..(newloc, MATERIAL_BRONZE)
+
+/obj/item/fuel_assembly/marble/New(newloc)
+	..(newloc, MATERIAL_MARBLE)
+
+/obj/item/fuel_assembly/titanium/New(newloc)
+	..(newloc, MATERIAL_TITANIUM)
+
+/obj/item/fuel_assembly/sand/New(newloc)
+	..(newloc, MATERIAL_SAND)
+
+/obj/item/fuel_assembly/mhydrogen/New(newloc)
+	..(newloc, MATERIAL_HYDROGEN_METALLIC)
+
+/obj/item/fuel_assembly/graphite/New(newloc)
+	..(newloc, MATERIAL_GRAPHITE)
+
+/obj/item/fuel_assembly/aluminium/New(newloc)
+	..(newloc, MATERIAL_ALUMINIUM)
+
+/obj/item/fuel_assembly/lead/New(newloc)
+	..(newloc, MATERIAL_LEAD)

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -176,3 +176,35 @@ var/global/list/fusion_reactions
 	radiation = 30
 	instability = 5
 	products = list("uranium" = 10, "lead" = 10, "borosilicate glass" = 10) // Psuedoscience but here we are
+
+// More reactions to mess around with, added by ASCC, everything past this is her word salad
+/singleton/fusion_reaction/plastic_CO2
+	p_react = "plastic"
+	s_react = GAS_CO2
+	minimum_energy_level = 10000
+	energy_consumption = 7
+	energy_production = 1
+	radiation = 0
+	instability = 3
+	products = list("plasteel" = 10)
+
+/singleton/fusion_reaction/steel_oxygen
+	p_react = "steel"
+	s_react = GAS_OXYGEN
+	minimum_energy_level = 40000
+	energy_consumption = 5
+	energy_production = 0.6
+	radiation = 2
+	instability = 4
+	products = list("diamond" = 5)
+	//ADJUST THIS VALUE
+
+/singleton/fusion_reaction/plasteel_titanium
+	p_react = "plasteel"
+	s_react = "titanium"
+	minimum_energy_level = 60000
+	energy_consumption = 10
+	energy_production = 1
+	radiation = 5
+	instability = 10
+	products = list("plastitanium alloy" = 5)


### PR DESCRIPTION
WORK IN PROGRESS!!!!

Adds some new recipes for the INDRA's kinetic harvester.
A whole bunch more materials can now be used to create Fuel Rods.
More gases have been flagged as usable for fusion fuel.

Numbers and quantities are subject to change, I don't know what any of them really mean and I imagine the other staff, devs, and admins have a better idea of game balance than I do.