### PR TITLE
Look up/down hotkeys and quality of life.

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -346,8 +346,8 @@
 					if(H.last_special + 50 > world.time)
 						return
 					H.last_special = world.time
-				to_chat(usr, SPAN_NOTICE("You take look around to see if there are any holes in the roof around."))
-				for(var/turf/T in view(usr.client.view + 3, usr)) // slightly extra to account for moving while looking for openness
+				to_chat(H, SPAN_NOTICE("You take look around to see if there are any holes in the roof around."))
+				for(var/turf/T in view(H.client.view + 3, H)) // slightly extra to account for moving while looking for openness
 					if(T.density)
 						continue
 					var/turf/above_turf = GET_TURF_ABOVE(T)
@@ -356,17 +356,17 @@
 					var/image/up_image = image(icon = 'icons/mob/screen/generic.dmi', icon_state = "arrow_up", loc = T)
 					up_image.plane = LIGHTING_LAYER + 1
 					up_image.layer = LIGHTING_LAYER + 1
-					usr << up_image
+					H << up_image
 					QDEL_IN(up_image, 12)
 				return
-			var/turf/T1 = get_turf(usr)
+			var/turf/T1 = get_turf(H)
 			var/turf/T = GET_TURF_ABOVE(T1)
 			if (!T)
-				to_chat(usr, SPAN_NOTICE("There is nothing above you!"))
+				to_chat(H, SPAN_NOTICE("There is nothing above you!"))
 			else if (T.is_hole)
-				to_chat(usr, SPAN_NOTICE("There's no roof above your head! You can see up!"))
+				H.look_up_open_space(T1)
 			else
-				to_chat(usr, SPAN_NOTICE("You see a ceiling staring back at you."))
+				to_chat(H, SPAN_NOTICE("You see a ceiling staring back at you."))
 
 		if("module")
 			if(isrobot(usr))

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -346,8 +346,8 @@
 					if(H.last_special + 50 > world.time)
 						return
 					H.last_special = world.time
-				to_chat(H, SPAN_NOTICE("You take look around to see if there are any holes in the roof around."))
-				for(var/turf/T in view(H.client.view + 3, H)) // slightly extra to account for moving while looking for openness
+				to_chat(usr, SPAN_NOTICE("You take look around to see if there are any holes in the roof around."))
+				for(var/turf/T in view(usr.client.view + 3, usr)) // slightly extra to account for moving while looking for openness
 					if(T.density)
 						continue
 					var/turf/above_turf = GET_TURF_ABOVE(T)
@@ -356,17 +356,21 @@
 					var/image/up_image = image(icon = 'icons/mob/screen/generic.dmi', icon_state = "arrow_up", loc = T)
 					up_image.plane = LIGHTING_LAYER + 1
 					up_image.layer = LIGHTING_LAYER + 1
-					H << up_image
+					usr << up_image
 					QDEL_IN(up_image, 12)
 				return
-			var/turf/T1 = get_turf(H)
+
+			if(!isliving(usr))
+				return
+			var/mob/living/user = usr
+			var/turf/T1 = get_turf(user)
 			var/turf/T = GET_TURF_ABOVE(T1)
 			if (!T)
-				to_chat(H, SPAN_NOTICE("There is nothing above you!"))
+				to_chat(user, SPAN_NOTICE("There is nothing above you!"))
 			else if (T.is_hole)
-				H.look_up_open_space(T1)
+				user.look_up_open_space(T1)
 			else
-				to_chat(H, SPAN_NOTICE("You see a ceiling staring back at you."))
+				to_chat(user, SPAN_NOTICE("You see a ceiling staring back at you."))
 
 		if("module")
 			if(isrobot(usr))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2259,16 +2259,17 @@
 	set desc = "If you want to know what's above."
 	set category = "IC"
 
+	look_up_open_space(get_turf(src))
 
+/mob/living/proc/look_up_open_space(var/turf/T)
 	if(client && !is_physically_disabled())
 		if(z_eye)
 			reset_view(null)
 			QDEL_NULL(z_eye)
 			return
-		var/turf/T = get_turf(src)
 		var/turf/above = GET_TURF_ABOVE(T)
 		if(TURF_IS_MIMICING(above))
-			z_eye = new /atom/movable/z_observer/z_up(src, src)
+			z_eye = new /atom/movable/z_observer/z_up(src, src, T)
 			visible_message(SPAN_NOTICE("[src] looks up."), SPAN_NOTICE("You look up."))
 			reset_view(z_eye)
 			return
@@ -2281,21 +2282,23 @@
 	set desc = "If you want to know what's below."
 	set category = "IC"
 
+	look_down_open_space(get_turf(src))
+
+/mob/living/proc/look_down_open_space(var/turf/T)
 	if(client && !is_physically_disabled())
 		if(z_eye)
 			reset_view(null)
 			QDEL_NULL(z_eye)
 			return
-		var/turf/T = get_turf(src)
 		if(TURF_IS_MIMICING(T) && GET_TURF_BELOW(T))
-			z_eye = new /atom/movable/z_observer/z_down(src, src)
+			z_eye = new /atom/movable/z_observer/z_down(T, src, T)
 			visible_message(SPAN_NOTICE("[src] looks below."), SPAN_NOTICE("You look below."))
 			reset_view(z_eye)
 			return
 		else
 			T = get_step(T, dir)
 			if(TURF_IS_MIMICING(T) && GET_TURF_BELOW(T))
-				z_eye = new /atom/movable/z_observer/z_down(src, src, TRUE)
+				z_eye = new /atom/movable/z_observer/z_down(T, src, T)
 				visible_message(SPAN_NOTICE("[src] leans over to look below."), SPAN_NOTICE("You lean over to look below."))
 				reset_view(z_eye)
 				return

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -371,7 +371,7 @@
 								return M.attackby(W,src)
 
 			var/randn = rand(1, 100)
-			if(z_eye && z_eye.tile_shifted) //They're looking down in front of them.
+			if(z_eye) //They're looking down in front of them.
 				var/turf/T = loc
 				var/obj/structure/railing/problem_railing
 				var/same_loc = FALSE

--- a/code/modules/multiz/turfs/open_space.dm
+++ b/code/modules/multiz/turfs/open_space.dm
@@ -209,6 +209,13 @@
 	for(var/obj/O in src)
 		O.hide(0)
 
+/turf/simulated/open/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
+	. = ..()
+	if(isliving(user))
+		var/mob/living/looker = user
+		if(looker.Adjacent(src) && !looker.incapacitated())
+			looker.look_down_open_space(src)
+
 /turf/simulated/open/get_examine_text(mob/user, distance, is_adjacent, infix, suffix)
 	. = ..()
 	if(distance <= 2)
@@ -259,7 +266,6 @@
 	return
 
 /turf/simulated/open/attack_hand(var/mob/user)
-
 	if(ishuman(user) && user.a_intent == I_GRAB)
 		var/mob/living/carbon/human/H = user
 		var/turf/T = get_turf(H)

--- a/html/changelogs/mattatlas-lookhotkey.yml
+++ b/html/changelogs/mattatlas-lookhotkey.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "You can now look down open spaces by shift clicking/examining them when they're next to you."
+  - rscadd: "You can now look up open spaces by clicking the HUD element at the top right."
+  - bugfix: "Fixed inconsistencies with the camera getting stuck while looking up or down. It should now be much more fluid."


### PR DESCRIPTION
  - You can now look down open spaces by shift clicking/examining them when they're next to you.
  - You can now look up open spaces by clicking the HUD element at the top right.
  - Fixed inconsistencies with the camera getting stuck while looking up or down. It should now be much more fluid.