### PR TITLE
Announcements now actually only show up for ghosts if they are on the same z-level OR if it's a Horizon announcement.

### DIFF
--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -48,7 +48,7 @@
 			continue
 
 		// Due to spam, only print announcements if the ghost is in the matching z-level, OR if it's a Horizon message.
-		if((isghost(M) && (zlevels == SSatlas.current_map.contact_levels || GET_Z(M) in zlevels)) || (!isdeaf(M) && (GET_Z(M) in zlevels))
+		if((isghost(M) && ((zlevels == SSatlas.current_map.contact_levels) || GET_Z(M) in zlevels)) || (!isdeaf(M) && (GET_Z(M) in zlevels)))
 			var/turf/T = get_turf(M)
 			if(T)
 				to_chat(M, msg)

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -48,7 +48,7 @@
 			continue
 
 		// Due to spam, only print announcements if the ghost is in the matching z-level, OR if it's a Horizon message.
-		if((isghost(M) && ((zlevels == SSatlas.current_map.contact_levels) || GET_Z(M) in zlevels)) || (!isdeaf(M) && (GET_Z(M) in zlevels)))
+		if((isghost(M) && ((zlevels == SSatlas.current_map.contact_levels) || (GET_Z(M) in zlevels))) || (!isdeaf(M) && (GET_Z(M) in zlevels)))
 			var/turf/T = get_turf(M)
 			if(T)
 				to_chat(M, msg)

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -48,7 +48,7 @@
 			continue
 
 		// Due to spam, only print announcements if the ghost is in the matching z-level, OR if it's a Horizon message.
-		if(isghost(M) || (!isdeaf(M) && ((GET_Z(M) in zlevels) || zlevels == SSatlas.current_map.contact_levels)))
+		if((isghost(M) && (zlevels == SSatlas.current_map.contact_levels || GET_Z(M) in zlevels)) || (!isdeaf(M) && (GET_Z(M) in zlevels))
 			var/turf/T = get_turf(M)
 			if(T)
 				to_chat(M, msg)

--- a/html/changelogs/mattatlas-announcefix.yml
+++ b/html/changelogs/mattatlas-announcefix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Announcements now actually only show up for ghosts if they are on the same z-level OR if it's a Horizon announcement."


### PR DESCRIPTION
messed up the order