### PR TITLE
Synthetic forewarning to hivebot invasions

### DIFF
--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -53,6 +53,10 @@
 /datum/event/infestation/start()
 	..()
 
+	if(chosen_mob == INFESTATION_HIVEBOTS) {
+		hivebot_message()
+	}
+
 	spawn_mobs()
 
 /datum/event/infestation/proc/choose_area()
@@ -130,6 +134,14 @@
 /datum/event/infestation/proc/spawn_mobs()
 	for(var/spawned_mob in chosen_mob_types)
 		new spawned_mob(chosen_area.random_space())
+
+/// Sends out a message to all IPCs on the ship warning them that hivebots are present.
+/datum/event/infestation/proc/hivebot_message()
+	for(var/mob/living/carbon/human/H in GLOB.living_mob_list) {
+		if(isipc(H) && (H.z in affecting_z)) {
+			to_chat(H, FONT_LARGE(SPAN_CULT("Suddenly, your internals are pierced by a terrible abnormality! Something antithetical to your existence has come terribly close, and it wishes for you to unite with it...")))
+		}
+	}
 
 /datum/event/infestation/announce()
 	command_announcement.Announce("[chosen_scan_type] indicate that [chosen_mob] [chosen_verb] [chosen_area]. Clear them out before this starts to affect productivity.", event_name, new_sound = 'sound/AI/vermin.ogg', zlevels = affecting_z)

--- a/html/changelogs/hazelmouse-ipcwarning.yml
+++ b/html/changelogs/hazelmouse-ipcwarning.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Synthetics on the SCCV Horizon now receive a visceral forewarning to hivebot invasions before they are announced to the wider crew. You perceive something is terribly wrong..."


### PR DESCRIPTION
This adds a foreboding warning at the beginning of hivebot invasions, appearing exclusively to synthetic crew. This riffs off the unique relationship positronics have with hivebots in lore, but isn't intended to portray a resurgence of the hivebot signal on every single hivebot invasion event.

**Must be greenlit by synthlore before being merged.**