### PR TITLE
Mix Pipe Connection to Bluespace Drive

### DIFF
--- a/html/changelogs/furrycactus - atmos pipe tidying.yml
+++ b/html/changelogs/furrycactus - atmos pipe tidying.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Furrycactus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a pipe connection from the connectors in Atmospherics to a connector in storage behind the Bluespace Drive, to cut out the hardest and most tedious portion of piping a gas mix to the drive."


### PR DESCRIPTION
Adds a pipe connection from Atmospherics to the storage room behind the Bluespace Drive. It's my understanding the intended mode of operating the BSDrive was for Atmos Techs to lay down a pipe all the way to Atmospherics, but it's an extremely time consuming and tedious process to cross such a massive distance (maybe not point-to-point, but in practice there's a great deal of twisting turns and doorways to go through) with a pipeline, especially every single round. It's either a huge timesink nobody wants to do for a "just in case" scenario, or it takes too long to be viable if a jump is urgently needed.

Admittedly, I think a mix chamber in the BSDrive itself would be better, but I don't want to go against the spirit of the intent. 

![StrongDMM_hc2ZQf7iiW](https://github.com/user-attachments/assets/7a820482-69a1-4428-8d1d-1a0c6406a2d8)
![StrongDMM_Z3oLgG32NU](https://github.com/user-attachments/assets/f5bd60e6-148a-44df-8cb6-615efdaa2e90)

Personally I feel this is a nice compromise. It cuts past the hardest and most tedious part of laying pipe (the maintenance area between atmos/custodial/grav generator are extremely congested for pipe traffic), but doesn't do the whole job for you. It lets you fill canisters in the storage room to haul back into the BSDrive, or if you want a direct line-in, it's close enough now that it won't be a 20 minute job.

The Bluespace Drive is awesome, and I'd love to see it used more.