### PR TITLE
Message server fix

### DIFF
--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -67,7 +67,7 @@
 				priority = "Undetermined"
 
 /obj/machinery/telecomms/message_server
-	icon_state = "server"
+	icon_state = "message_server"
 	name = "messaging server"
 	desc = "A machine that processes and routes request console messages."
 	telecomms_type = /obj/machinery/telecomms/message_server
@@ -163,14 +163,6 @@
 		to_chat(user, "You install additional memory and processors into message server. Its filtering capabilities been enhanced.")
 	else
 		..()
-
-/obj/machinery/telecomms/message_server/update_icon()
-	icon_state = initial(icon_state)
-	ClearOverlays()
-	if(panel_open)
-		icon_state += "_o"
-	if(!operable())
-		icon_state += "_off"
 
 /datum/signal/subspace/pda
 	frequency = PUB_FREQ

--- a/html/changelogs/hazelmouse-serverfix.yml
+++ b/html/changelogs/hazelmouse-serverfix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "The message server in telecommunictions is no longer invisible."


### PR DESCRIPTION
Makes message servers not invisible.

Removes what seems to be a redundant update_icon() definition, functionally identical to the parent except for the ClearOverlays call. Unsure if that call does anything here.