### PR TITLE
Fixes firefighter helmets

### DIFF
--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -63,6 +63,7 @@
 	icon_supported_species_tags = list("una", "taj")
 	contained_sprite = TRUE
 	min_pressure_protection = FIRESUIT_MIN_PRESSURE
+	heat_protection = HEAD
 
 /obj/item/clothing/head/hardhat/paramedic
 	name = "medical helmet"
@@ -91,6 +92,8 @@
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	flash_protection = FLASH_PROTECTION_MODERATE
+	heat_protection = HEAD
+	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/head/hardhat/firefighter/chief
 	name = "chief firefighter helmet"

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
@@ -380,9 +380,6 @@ Bulwarks are much larger and have significantly thicker carapaces than most Vaur
 	heat_level_2 = 400 //Default 400
 	heat_level_3 = 800 //Default 1000
 
-	hazard_high_pressure = 3000
-	warning_high_pressure = 2775
-
 	sprint_speed_factor = 1.0
 	stamina = 50
 	possible_external_organs_modifications = list("Normal", "Amputated") //We don't have any limb modfications for this species, yet

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
@@ -380,6 +380,9 @@ Bulwarks are much larger and have significantly thicker carapaces than most Vaur
 	heat_level_2 = 400 //Default 400
 	heat_level_3 = 800 //Default 1000
 
+	hazard_high_pressure = 3000
+	warning_high_pressure = 2775
+
 	sprint_speed_factor = 1.0
 	stamina = 50
 	possible_external_organs_modifications = list("Normal", "Amputated") //We don't have any limb modfications for this species, yet

--- a/html/changelogs/SimpleMaroon-firewarkbuffs.yml
+++ b/html/changelogs/SimpleMaroon-firewarkbuffs.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: SimpleMaroon
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Firefighter helmets now have proper defense against high heat, meaning that wearing a whole firesuit works again."
+  - qol: "Vaurca Bulwarks now have higher pressure protection, since they can work in Engineering but can't wear voidsuits and have to rely on firesuits."

--- a/html/changelogs/SimpleMaroon-firewarkbuffs.yml
+++ b/html/changelogs/SimpleMaroon-firewarkbuffs.yml
@@ -56,4 +56,3 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - bugfix: "Firefighter helmets now have proper defense against high heat, meaning that wearing a whole firesuit works again."
-  - qol: "Vaurca Bulwarks now have higher pressure protection, since they can work in Engineering but can't wear voidsuits and have to rely on firesuits."


### PR DESCRIPTION
Basically, firefighter helmets didn't have heat protection assigned to the head, nor did non-atmos firefighter helmets have a maximum heat protection value assigned. This meant that

1. Heat would seep through the helmet and burn the mob anyway, making firesuit loadouts essentially functionless
2. Vaurca Bulwarks had no way of protecting against fires because of the above and the fact that they can't wear voidsuits

This rectifies that.

![image](https://github.com/user-attachments/assets/942588de-9d7e-4989-89d7-4bc23c3c1326)
