### PR TITLE
Radios for assistant alt-title jobs

### DIFF
--- a/code/game/jobs/job/ship_crew.dm
+++ b/code/game/jobs/job/ship_crew.dm
@@ -38,7 +38,7 @@
 		if("Technical Assistant")
 			out_list += list(ACCESS_ENGINE)
 		if("Medical Orderly")
-			out_list += list(ACCESS_MEDICAL, ACCESS_MEDICAL_EQUIP, ACCESS_MORGUE)
+			out_list += list(ACCESS_MEDICAL, ACCESS_MORGUE)
 	return out_list
 
 /obj/outfit/job/assistant

--- a/code/game/jobs/job/ship_crew.dm
+++ b/code/game/jobs/job/ship_crew.dm
@@ -38,7 +38,7 @@
 		if("Technical Assistant")
 			out_list += list(ACCESS_ENGINE)
 		if("Medical Orderly")
-			out_list += list(ACCESS_MEDICAL)
+			out_list += list(ACCESS_MEDICAL, ACCESS_MEDICAL_EQUIP, ACCESS_MORGUE)
 	return out_list
 
 /obj/outfit/job/assistant
@@ -58,22 +58,42 @@
 	uniform = /obj/item/clothing/under/color/lightpurple
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat
 	glasses = /obj/item/clothing/glasses/safety/goggles/science
+	headset = /obj/item/device/radio/headset/headset_sci
+	bowman = /obj/item/device/radio/headset/headset_sci/alt
+	double_headset = /obj/item/device/radio/headset/alt/double/sci
+	wrist_radio = /obj/item/device/radio/headset/wrist/sci
+	clipon_radio = /obj/item/device/radio/headset/wrist/clip/sci
 
 /obj/outfit/job/assistant/tech_assistant
 	name = "Technical Assistant"
 	uniform = /obj/item/clothing/under/color/yellowgreen
 	suit = /obj/item/clothing/suit/storage/hazardvest
 	backpack_contents = list(/obj/item/device/debugger = 1)
+	headset = /obj/item/device/radio/headset/headset_eng
+	bowman = /obj/item/device/radio/headset/headset_eng/alt
+	double_headset = /obj/item/device/radio/headset/alt/double/eng
+	wrist_radio = /obj/item/device/radio/headset/wrist/eng
+	clipon_radio = /obj/item/device/radio/headset/wrist/clip/eng
 
 /obj/outfit/job/assistant/med_assistant
 	name = "Medical Orderly"
 	uniform = /obj/item/clothing/under/color/blue
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat
 	backpack_contents = list(/obj/item/reagent_containers/spray/sterilizine = 1)
+	headset = /obj/item/device/radio/headset/headset_med
+	bowman = /obj/item/device/radio/headset/headset_med/alt
+	double_headset = /obj/item/device/radio/headset/alt/double/med
+	wrist_radio = /obj/item/device/radio/headset/wrist/med
+	clipon_radio = /obj/item/device/radio/headset/wrist/clip/med
 
 /obj/outfit/job/assistant/waiter
 	name = "Wait Staff"
 	uniform = /obj/item/clothing/under/waiter
+	headset = /obj/item/device/radio/headset/headset_service
+	bowman = /obj/item/device/radio/headset/headset_service/alt
+	double_headset = /obj/item/device/radio/headset/alt/double/service
+	wrist_radio = /obj/item/device/radio/headset/wrist/service
+	clipon_radio = /obj/item/device/radio/headset/wrist/clip/service
 
 /datum/job/visitor
 	title = "Off-Duty Crew Member"

--- a/html/changelogs/floppa-fix.yml
+++ b/html/changelogs/floppa-fix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Flpfs
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Orderly, Technical and Wait Staff now have respective radios for their departments. Orderly now has mourge and cubicle access."

--- a/html/changelogs/floppa-fix.yml
+++ b/html/changelogs/floppa-fix.yml
@@ -55,4 +55,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - balance: "Orderly, Technical and Wait Staff now have respective radios for their departments. Orderly now has mourge and cubicle access."
+  - balance: "Orderly, Technical and Wait Staff now have respective radios for their departments. Orderly now has mourge access."


### PR DESCRIPTION
Changes:

Medical Orderly, Technical Assistant and Wait Staff now have Medical, Engineering and Service radios.
Medical Orderly gets Medical Equipment and Morgue access.

Why?

If they're meant to be helping roles, they need to be able to be reached by their superiors on the frequency. Having to ask for a radio every round is repetitive and makes no sense at all.

Orderly got morgue added for obvious reasons, and medical equipment has been added so that they can can access the medical cubicle + exam rooms.


