### PR TITLE
Rough desert turf fix

### DIFF
--- a/code/modules/overmap/exoplanets/decor/turfs/sand.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/sand.dm
@@ -11,6 +11,6 @@
 	icon_state = "desert[rand(1,4)]"
 
 // TODO: Need additional desert turf sprites to distinguish the rough subtype, currently goes no higher than desert4.
-// /turf/simulated/floor/exoplanet/desert/rough/Initialize()
-// 	. = ..()
-// 	icon_state = "desert[rand(5,7)]"
+/turf/simulated/floor/exoplanet/desert/rough/Initialize()
+	. = ..()
+	// icon_state = "desert[rand(5,7)]"

--- a/code/modules/overmap/exoplanets/decor/turfs/sand.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/sand.dm
@@ -10,6 +10,7 @@
 	. = ..()
 	icon_state = "desert[rand(1,4)]"
 
-/turf/simulated/floor/exoplanet/desert/rough/Initialize()
-	. = ..()
-	icon_state = "desert[rand(5,7)]"
+// TODO: Need additional desert turf sprites to distinguish the rough subtype, currently goes no higher than desert4.
+// /turf/simulated/floor/exoplanet/desert/rough/Initialize()
+// 	. = ..()
+// 	icon_state = "desert[rand(5,7)]"

--- a/html/changelogs/hazelmouse-deserturfs.yml
+++ b/html/changelogs/hazelmouse-deserturfs.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Rough desert turfs no longer appear with an invalid sprite."


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/879a6421-120f-448d-b4f7-e303049aed9b)

The exoplanet/desert/rough subtype currently references icons that don't exist, so it appears black ingame. This comments out the icon_state definition pending on the rough subtype actually having sprites, so for now it uses the same sprites as the regular desert turfs.