### PR TITLE
Replaces a redundant camera in the Kitchen with a light fixture.

### DIFF
--- a/html/changelogs/ASmallCuteCat - brighter-kitchen.yml
+++ b/html/changelogs/ASmallCuteCat - brighter-kitchen.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ASmallCuteCat
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Removes a redundant camera from the Kitchen, it was nearly adjacent to another camera and covered roughly the same area."
+  - qol: "In place of the redundant camera, added another light fixture that should lessen the darkness issues by the freezer doors."


### PR DESCRIPTION
This PR removes one of the cameras from the Kitchen (it is exactly two tiles away from another camera that points in the same direction and provides coverage of the same area) and puts a light fixture in its place. This should hopefully brighten up the awkwardly dim spot around the oven and freezer doors.

I can't add an image from the pull request function in VSC so I'm going to add an image of the changes in a comment