### PR TITLE
Code style guidelines - text vars - allow "wasted" lines

### DIFF
--- a/.github/guides/STYLE.md
+++ b/.github/guides/STYLE.md
@@ -409,7 +409,7 @@ could not use `::` as the provided types are not static.
 Unless absolutely unavoidable, use the compile-time operator `.` to access vars instead of the runtime operator `:`.
 
 ### Text variables
-Do not leave empty lines just to isolate the text, the text should start right after the `"` and end right before the `"`.
+Line breaks should be consistent.
 
 Any newline should be preceded by the space in a phrase, and phrases should only be broken in a newline after complete words
 
@@ -419,12 +419,14 @@ Any newline should be preceded by the space in a phrase, and phrases should only
 	var/text_var = "This is a test variable \
 					that spans multiple lines"
 
-// Bad, wasted lines
+// Good
 /obj/item/mything
 	var/text_var = "\
-					This is a test variable \
-					that spans multiple lines\
-					"
+		This is a very long test variable \
+		that spans multiple lines. \
+		It could be a very long description \
+		or some other kind of long message.\
+		"
 
 // Bad, breaks incorrectly
 /obj/item/mything

--- a/.github/guides/STYLE.md
+++ b/.github/guides/STYLE.md
@@ -411,8 +411,6 @@ Unless absolutely unavoidable, use the compile-time operator `.` to access vars 
 ### Text variables
 Line breaks should be consistent.
 
-Any newline should be preceded by the space in a phrase, and phrases should only be broken in a newline after complete words
-
 ```dm
 // Good
 /obj/item/mything


### PR DESCRIPTION
Hard disagree with disallowing "wasted" lines.

Current code style guide says to do this (A):
![image](https://github.com/user-attachments/assets/c43a289c-cbb4-46d1-9a84-fd02f9544964)

And disallows this (B):
![image](https://github.com/user-attachments/assets/0e170637-7276-4483-b29b-e538f0f9e12f)

But my opinion is that B is much more readable than A, and is easier for copy-pasting or rearranging lines, as they all start with with a tab and end with a newline - it's nice and consistent.

I see no reason to ban either code style. A is better for short text vars, B is better for long text vars.
