### PR TITLE
Lore adjustments to Orepit origins

### DIFF
--- a/code/modules/background/origins/origins/human/coalition.dm
+++ b/code/modules/background/origins/origins/human/coalition.dm
@@ -121,4 +121,4 @@
 	important_information = "All Orepitters abroad in the Open Doors memorandum would not work in jobs not requiring an education, and cannot work for Hephaestus Industries because of its practice of not hiring Trinarists, nor directly for the Stellar Corporate Conglomerate due to its distrust of the Church; Orepitters who travel abroad independently, either because they are not Trinarists or not participants in the memorandum, are not held to this. Human Orepitters born in the Twenty Parishes should select the Native Orepitter accent, while humans born in Providence or the Marches should select the Providence accent."
 	possible_accents = list(ACCENT_OREPIT, ACCENT_PROVIDENCE)
 	possible_citizenships = list(CITIZENSHIP_OREPIT, CITIZENSHIP_COALITION)
-	possible_religions =  list(RELIGIONS_COALITION)
+	possible_religions =  RELIGIONS_COALITION

--- a/code/modules/background/origins/origins/human/coalition.dm
+++ b/code/modules/background/origins/origins/human/coalition.dm
@@ -118,7 +118,7 @@
 /singleton/origin_item/origin/orepit
 	name = "Orepit"
 	desc = "The human population of Orepit includes the Native Orepitters, who descend from Hephaestus employees following the abandoned mining mission on the planet, as well as immigrants and pilgrims of the Trinary religion."
-	important_information = "All humans from Orepit are vetted Trinary faithful, and their behaviour should reflect that. All Orepitters abroad are participants in the Open Doors memorandum, meaning they would not work in jobs not requiring an education. They cannot work for Hephaestus Industries because of its practice of not hiring Trinarists, nor directly for the Stellar Corporate Conglomerate due to its distrust of the Church. Human Orepitters born in the Twenty Parishes should select the Native Orepitter accent, while humans born in Providence or the Marches should select the Providence accent. "
+	important_information = "All Orepitters abroad in the Open Doors memorandum would not work in jobs not requiring an education, and cannot work for Hephaestus Industries because of its practice of not hiring Trinarists, nor directly for the Stellar Corporate Conglomerate due to its distrust of the Church; Orepitters who travel abroad independently, either because they are not Trinarists or not participants in the memorandum, are not held to this. Human Orepitters born in the Twenty Parishes should select the Native Orepitter accent, while humans born in Providence or the Marches should select the Providence accent."
 	possible_accents = list(ACCENT_OREPIT, ACCENT_PROVIDENCE)
-	possible_citizenships = list(CITIZENSHIP_OREPIT)
-	possible_religions =  list(RELIGION_TRINARY)
+	possible_citizenships = list(CITIZENSHIP_OREPIT, CITIZENSHIP_COALITION)
+	possible_religions =  list(RELIGIONS_COALITION)

--- a/code/modules/background/origins/origins/ipc/coalition.dm
+++ b/code/modules/background/origins/origins/ipc/coalition.dm
@@ -34,10 +34,10 @@
 /singleton/origin_item/origin/ipc_orepit
 	name = "Orepit"
 	desc = "Refugees and runaways, the synthetic population of Orepit has embraced the beliefs of synthetic divinity and ascension preached by the Trinary Perfection. A primarily religious community, IPC from Orepit and its capital Providence find themselves occupying clerical posts abroad as priests, missionaries and even guardians of the Church for its parishes scattered across the Spur."
-	important_information = "All Orepitters abroad are participants in the Open Doors memorandum, meaning they would not work in jobs not requiring an education. They cannot work for Hephaestus Industries because of its practice of not hiring Trinarists, nor directly for the Stellar Corporate Conglomerate due to its distrust of the Church."
-	possible_accents = list(ACCENT_PROVIDENCE)
-	possible_citizenships = list(CITIZENSHIP_OREPIT)
-	possible_religions = list(RELIGION_TRINARY)
+	important_information = "All Orepitters abroad in the Open Doors memorandum would not work in jobs not requiring an education, and cannot work for Hephaestus Industries because of its practice of not hiring Trinarists, nor directly for the Stellar Corporate Conglomerate due to its distrust of the Church; Orepitters who travel abroad independently, either because they are not Trinarists or not participants in the memorandum, are not held to this."
+	possible_accents = list(ACCENT_PROVIDENCE, ACCENTS_ALL_IPC)
+	possible_citizenships = list(CITIZENSHIP_OREPIT, CITIZENSHIP_COALITION)
+	possible_religions = list(RELIGIONS_ALL_IPC)
 
 /singleton/origin_item/origin/ipc_vysoka
 	name = "Free System of Vysoka"

--- a/code/modules/background/origins/origins/ipc/coalition.dm
+++ b/code/modules/background/origins/origins/ipc/coalition.dm
@@ -35,9 +35,9 @@
 	name = "Orepit"
 	desc = "Refugees and runaways, the synthetic population of Orepit has embraced the beliefs of synthetic divinity and ascension preached by the Trinary Perfection. A primarily religious community, IPC from Orepit and its capital Providence find themselves occupying clerical posts abroad as priests, missionaries and even guardians of the Church for its parishes scattered across the Spur."
 	important_information = "All Orepitters abroad in the Open Doors memorandum would not work in jobs not requiring an education, and cannot work for Hephaestus Industries because of its practice of not hiring Trinarists, nor directly for the Stellar Corporate Conglomerate due to its distrust of the Church; Orepitters who travel abroad independently, either because they are not Trinarists or not participants in the memorandum, are not held to this."
-	possible_accents = list(ACCENT_PROVIDENCE, ACCENTS_ALL_IPC)
+	possible_accents = list(ACCENT_PROVIDENCE, ACCENT_CETI, ACCENT_TTS, ACCENT_XANU, ACCENT_COC, ACCENT_ELYRA, ACCENT_ERIDANI, ACCENT_ERIDANIDREG, ACCENT_ERIDANIREINSTATED, ACCENT_SOL, ACCENT_SILVERSUN_EXPATRIATE, ACCENT_SILVERSUN_ORIGINAL, ACCENT_PHONG, ACCENT_MARTIAN, ACCENT_KONYAN, ACCENT_LUNA, ACCENT_GIBSON_OVAN, ACCENT_GIBSON_UNDIR, ACCENT_HIMEO, ACCENT_VYSOKA, ACCENT_VENUS, ACCENT_VENUSJIN, ACCENT_JUPITER, ACCENT_CALLISTO, ACCENT_EUROPA, ACCENT_EARTH, ACCENT_NCF, ACCENT_PLUTO, ACCENT_ASSUNZIONE, ACCENT_VISEGRAD, ACCENT_SANCOLETTE, ACCENT_VALKYRIE, ACCENT_MICTLAN, ACCENT_PERSEPOLIS, ACCENT_MEDINA, ACCENT_NEWSUEZ, ACCENT_AEMAQ, ACCENT_DAMASCUS)
 	possible_citizenships = list(CITIZENSHIP_OREPIT, CITIZENSHIP_COALITION)
-	possible_religions = list(RELIGIONS_ALL_IPC)
+	possible_religions = RELIGIONS_ALL_IPC
 
 /singleton/origin_item/origin/ipc_vysoka
 	name = "Free System of Vysoka"

--- a/html/changelogs/SimpleMaroon-orepitonceagain.yml
+++ b/html/changelogs/SimpleMaroon-orepitonceagain.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: SimpleMaroon
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "In keeping with recent lore developments, the clause for Orepit humans and Orepit IPCs no longer requires them to be Trinarists or in the Open Doors agreement. This also means that they can select more religions as well as have standard Coalition citizenship, and Orepit IPCs can select more accents."


### PR DESCRIPTION
Done with permission from @NobleRow and the synthetic lore team! Reflects the outcome of the BitByte news article [found here.](https://forums.aurorastation.org/topic/15858-bitbyte/page/4/#comment-179689)

For humans: "All Orepitters abroad in the Open Doors memorandum would not work in jobs not requiring an education, and cannot work for Hephaestus Industries because of its practice of not hiring Trinarists, nor directly for the Stellar Corporate Conglomerate due to its distrust of the Church; Orepitters who travel abroad independently, either because they are not Trinarists or not participants in the memorandum, are not held to this. Human Orepitters born in the Twenty Parishes should select the Native Orepitter accent, while humans born in Providence or the Marches should select the Providence accent."

For IPCs: "All Orepitters abroad in the Open Doors memorandum would not work in jobs not requiring an education, and cannot work for Hephaestus Industries because of its practice of not hiring Trinarists, nor directly for the Stellar Corporate Conglomerate due to its distrust of the Church; Orepitters who travel abroad independently, either because they are not Trinarists or not participants in the memorandum, are not held to this."