### PR TITLE
Adds Reunification Day, on July 17, to the list of holidays

### DIFF
--- a/code/game/gamemodes/events/holidays/holidays.dm
+++ b/code/game/gamemodes/events/holidays/holidays.dm
@@ -97,6 +97,7 @@ var/global/Holiday = null
 					if(prob(50))				Holiday = "DPRA Liberation Day"
 				if(7)							Holiday = "Dominian Founding Day"
 				if(16)							Holiday = "Lunarian Apollo Day"
+				if(17)							Holiday = "Solarian Reunification Day"
 				if(29)							Holiday = "Dominian Victory Day"
 
 

--- a/html/changelogs/tag103-risingsun.yml
+++ b/html/changelogs/tag103-risingsun.yml
@@ -1,0 +1,6 @@
+author: Tag103
+
+delete-after: True
+
+changes:
+  - rscadd: "Added the Day of Reunification, celebrated across the Solarian Alliance on July 17, to the holiday system."

--- a/html/changelogs/tag103-risingsun.yml
+++ b/html/changelogs/tag103-risingsun.yml
@@ -3,4 +3,4 @@ author: Tag103
 delete-after: True
 
 changes:
-  - rscadd: "Added the Day of Reunification, celebrated across the Solarian Alliance on July 17, to the holiday system."
+  - rscadd: "Added Reunification Day, celebrated across the Solarian Alliance on July 17, to the holiday system."

--- a/html/changelogs/tag103-risingsun.yml
+++ b/html/changelogs/tag103-risingsun.yml
@@ -3,4 +3,4 @@ author: Tag103
 delete-after: True
 
 changes:
-  - rscadd: "Added Reunification Day, celebrated across the Solarian Alliance on July 17, to the holiday system."
+  - rscadd: "Added Reunification Day, celebrated on July 17, to the holiday system."


### PR DESCRIPTION
To the list of holidays, adds the Day of Reunification, commemorating the end of the second bloodiest civil war in all of human history and honoring the millions who gave their lives to save the free world and once again deliver mankind from its worst enemy.