### PR TITLE
Horizon Scattershot Changes 4 - yeag

### DIFF
--- a/html/changelogs/courierbravo - scattershothorizonchanges4.yml
+++ b/html/changelogs/courierbravo - scattershothorizonchanges4.yml
@@ -1,0 +1,66 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: CourierBravo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added airtight flaps to the xenobotany maintenance doors."
+  - rscadd: "Slightly changed the doctors smoking lounge to be more comfy looking."
+  - rscadd: "Changed the look of the area outside the gym a little, moving floor decals around."
+  - rscadd: "Changed the outline decals around the ports for the hot/cold loop on the supermatter. The hot side is now red, the cold side is now blue."
+  - rscdel: "Removed a civilian sign in the lifts."
+  - bugfix: "Fixed APC rotation in the corporate representative office"
+  - bugfix: "Added shutters to the library desk, so the button actually serves a purpose."
+  - bugfix: "Placed medical floor outlines under first aid lockers with a solid floor under them."
+  - bugfix: "Fixes some weird area stuff around the horizon's sensors outside of command."


### PR DESCRIPTION
- adds airtight flaps to the maints doors in xenobio
- made the medical smoking lounge look a little more comfy
- moved around some of the decals outside of the gym
- changed the floor decals in the supermatter room for the hot/cold loop pumps.
- removed a civilian sign in the lifts that just points to the reclamation terminal 
- fixed an apc in the corporate reps office being the wrong way
- added shutters to the library desk, also made the shutters button require the librarians access.
- placed medical outlines under some first aid lockers that didn't have them. did not do this for the one next to the INDRA, since theres a grate under it and it just makes it look weird.
- fixed the weird area stuff happening around the horizons sensors. it looks like the sensors got moved at some point but the areas were never changed to match it.
