### PR TITLE
Fixed ninja teleporter

### DIFF
--- a/code/modules/modular_computers/file_system/programs/app_presets_antag.dm
+++ b/code/modules/modular_computers/file_system/programs/app_presets_antag.dm
@@ -7,6 +7,7 @@
 
 /datum/modular_computer_app_presets/command/teleporter/ninja/New()
 	. = ..()
+	program_list -= /datum/computer_file/program/teleporter //Remove the default one since ninjas have a special one
 	program_list += /datum/computer_file/program/teleporter/ninja
 
 

--- a/code/modules/modular_computers/file_system/programs/command/teleporter.dm
+++ b/code/modules/modular_computers/file_system/programs/command/teleporter.dm
@@ -153,6 +153,7 @@
 			. = TRUE
 
 /datum/computer_file/program/teleporter/ninja
-	required_access_run = list()
+	filename = "ninjateleporter"
+	filedesc = "Ninja Teleporter Control"
 	requires_ntnet = FALSE
 	requires_access_to_run = FALSE

--- a/html/changelogs/fluffyghost-fixninjateleporter.yml
+++ b/html/changelogs/fluffyghost-fixninjateleporter.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed ninja teleporter requiring access to run."
+  - qol: "Renamed the program to 'ninja teleporter' and removed the standard teleporter from the program list for the preset."


### PR DESCRIPTION
Fixed ninja teleporter requiring access to run.
Renamed the program to 'ninja teleporter' and removed the standard teleporter from the program list for the preset.

Fixes #20237 