### PR TITLE
Adds an exception to "Lost in space" to prevent removing revivable IPC players

### DIFF
--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -52,6 +52,16 @@ GLOBAL_LIST_INIT_TYPED(cached_space, /obj/effect/overmap/visitable/sector/tempor
 	return isnull(client)
 
 /mob/living/carbon/human/lost_in_space()
+	if(!(species && species.flags & IS_MECHANICAL))
+		return isnull(client) && stat == DEAD // Delete any corpses with no clients, if they're not IPC
+	if(!(mind && mind.key))
+		return isnull(client) && stat == DEAD // Delete IPC who have no mind or associated player
+
+	for(var/client/clt in GLOB.clients)
+		if(mind.key == clt.key)
+			return FALSE // If we find a key (from an online client) that once belonged to this dead IPC, don't delete them, as that player can still be revived.
+
+	// If, somehow, we get past all these checks and still haven't returned, just delete the dead ones.
 	return isnull(client) && stat == DEAD
 
 /proc/overmap_spacetravel(var/turf/space/T, var/atom/movable/A)

--- a/html/changelogs/flaminglily-spacedelete.yml
+++ b/html/changelogs/flaminglily-spacedelete.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FlamingLily
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Added an exception to the 'Lost In Space' mechanic that prevents dead IPC being deleted if their player is still online (and therefore can be brought back into the round)."


### PR DESCRIPTION
"Lost in space" occurs whenever a dead human mob reaches a space sector change. If that mob has no client attached, they are deleted. This also occurs when a player ghosts out to spectate. This is done I believe to avoid spawning temporary space sectors for a dead, floating mob.

Normally, this is fine, as that player is dead, and cannot be revived (well, they can be borgified, technically, but they can also do that through ghost spawners and most people don't like being borgified anyway). However, dead IPC can be revived by having their positronics removed. This can occur no matter what, no matter how dead the IPC actually is.

This means there is a case where an IPC may be lost in space and removed from a round despite being revivable and (eg: if they have a GPS) recoverable.

The exception specifically checks the following: 
If the mob is not an IPC, delete it as normal.
If the IPC has no mind or the mind has no key, delete it as normal.
If the key attached to the mind is found in the online clients list, do not delete the IPC.
Otherwise, delete the IPC.

Any similarity between this PR and recent events is purely coincidental.