### PR TITLE
Minor Horizon shuttle tweaks

### DIFF
--- a/html/changelogs/hazelmouse-intrepidtweaks.yml
+++ b/html/changelogs/hazelmouse-intrepidtweaks.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Made some minor tweaks in layout to the SCCV Intrepid, introduced new tables to cargo areas, made location of bluespace beacon visible through grate."
+  - rscadd: "Added a bluespace beacon to the SCCV Quark."

--- a/html/changelogs/hazelmouse-intrepidtweaks.yml
+++ b/html/changelogs/hazelmouse-intrepidtweaks.yml
@@ -58,3 +58,4 @@ changes:
   - rscadd: "Made some minor tweaks in layout to the SCCV Intrepid, introduced new tables to cargo areas, made location of bluespace beacon visible through grate."
   - rscadd: "Added a bluespace beacon to the SCCV Quark."
   - rscadd: "The bluespace beacon's exact location is now visible on the SCCV Quark, Spark, Canary, and Intrepid."
+  - bugfix: "All Intrepid cameras should now be fully accessible from camera consoles."

--- a/html/changelogs/hazelmouse-intrepidtweaks.yml
+++ b/html/changelogs/hazelmouse-intrepidtweaks.yml
@@ -57,3 +57,4 @@ delete-after: True
 changes:
   - rscadd: "Made some minor tweaks in layout to the SCCV Intrepid, introduced new tables to cargo areas, made location of bluespace beacon visible through grate."
   - rscadd: "Added a bluespace beacon to the SCCV Quark."
+  - rscadd: "The bluespace beacon's exact location is now visible on the SCCV Quark, Spark, Canary, and Intrepid."


### PR DESCRIPTION
Adds a bluespace beacon to the Quark so it can be teleported to, makes some minor tweaks to the Intrepid (including making the layout ever so slightly less box-like), adds grates to the locations of each Horizon shuttle's teleporting beacon so the bluespace beacon sprite is visible. Fixes Intrepid cameras, I missed the c_tag var in the initial PR.