### PR TITLE
Fixes RMT Exploit

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -3995,8 +3995,8 @@
 	name = "RMT"
 	id = "rmt"
 	result = /singleton/reagent/rmt
-	result_amount = 2
-	required_reagents = list(/singleton/reagent/potassium = 1, /singleton/reagent/inaprovaline = 1)
+	result_amount = 3
+	required_reagents = list(/singleton/reagent/mental/neurostabin = 1, /singleton/reagent/inaprovaline = 2)
 
 /datum/chemical_reaction/gunpowder
 	name = "Gunpowder"

--- a/html/changelogs/wezzy_RMT-tweak.yml
+++ b/html/changelogs/wezzy_RMT-tweak.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Wowzewow (Wezzy)
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Changes RMT recipe to 1u Neurostabin 2u Inaprovaline = 3u RMT."


### PR DESCRIPTION
  - balance: "Changes RMT recipe to 1u Neurostabin 2u Inaprovaline = 3u RMT."
  
I did this change because it was too easy to accidentally make RMT ; Inaprovaline being a far too common treatment medicine and Potassium being naturally produced during kidney failiure chiefly being one of the main causes.

This has led to people exploiting this oversight in the RMT recipe to completely nullify the consequences of kidney failure.

Neurostabin is already a medicine used for muscle weakness - diluted by the relatively cheap inaprovaline, this is still very much accessible for Offworlders.

