### PR TITLE
No Orepit diplomatic aides

### DIFF
--- a/code/modules/background/citizenship/ipc.dm
+++ b/code/modules/background/citizenship/ipc.dm
@@ -66,5 +66,5 @@
 
 	job_species_blacklist = list(
 		"Consular Officer" = ALL_SPECIES,
-		"Diplomatic Aide" = ALL_SPECIES
+		"Diplomatic Aide" = ALL_SPECIES,
 	)

--- a/code/modules/background/citizenship/ipc.dm
+++ b/code/modules/background/citizenship/ipc.dm
@@ -65,5 +65,6 @@
 	allowing its populace to work, study, and travel abroad in the Coalition and beyond, primarily in the All-Xanu Republic, utilizing Xanan documents."
 
 	job_species_blacklist = list(
-		"Consular Officer" = ALL_SPECIES
+		"Consular Officer" = ALL_SPECIES,
+		"Diplomatic Aide" = ALL_SPECIES
 	)

--- a/html/changelogs/SimpleMaroon-noorepitdiplos.yml
+++ b/html/changelogs/SimpleMaroon-noorepitdiplos.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: SimpleMaroon
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Characters with Orepit citizenship can no longer join as Diplomatic Aides."


### PR DESCRIPTION
Title. Characters with Orepit citizenship aren't meant to be either Consular Officers or Diplomatic Aides, but the latter was showing up as an option in the join menu so this should rectify that. Orepitters might still able to be Diplomatic Aides for the Coalition depending on how lore feels, but this doesn't touch that. Should count as a bugfix unless maintainers decide it isn't.