### PR TITLE
Exoplanet turf adjustments

### DIFF
--- a/code/modules/overmap/exoplanets/decor/_turfs.dm
+++ b/code/modules/overmap/exoplanets/decor/_turfs.dm
@@ -109,12 +109,14 @@
 
 /turf/simulated/floor/exoplanet/water/shallow
 	name = "shallow water"
+	desc = "Some water shallow enough to wade through."
 	icon = 'icons/misc/beach.dmi'
 	icon_state = "seashallow"
 	footstep_sound = /singleton/sound_category/water_footstep
 
 /turf/simulated/floor/exoplanet/permafrost
 	name = "permafrost"
+	desc = "The ground here is frozen solid by the cold."
 	icon = 'icons/turf/flooring/snow.dmi'
 	icon_state = "permafrost"
 	footstep_sound = /singleton/sound_category/asteroid_footstep

--- a/code/modules/overmap/exoplanets/decor/turfs/asphalt.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/asphalt.dm
@@ -1,5 +1,6 @@
 /turf/simulated/floor/exoplanet/asphalt
 	name = "asphalt"
+	gender = PLURAL
 	desc = "Once-hot asphalt."
 	icon = 'icons/turf/flooring/urban_turfs.dmi'
 	icon_state = "asphalt0"

--- a/code/modules/overmap/exoplanets/decor/turfs/barren.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/barren.dm
@@ -1,8 +1,9 @@
 /turf/simulated/floor/exoplanet/barren
 	name = "ground"
+	gender = PLURAL
+	desc = "A patch of dirt."
 	icon = 'icons/turf/flooring/asteroid.dmi'
 	icon_state = "asteroid"
-	does_footprint = TRUE
 
 /turf/simulated/floor/exoplanet/barren/update_icon()
 	overlays.Cut()
@@ -23,6 +24,8 @@
 	update_icon(1)
 
 /turf/simulated/floor/exoplanet/barren/raskara
+	desc = "Dark, dark regolith."
+	does_footprint = TRUE
 	color = "#373737"
 
 /turf/simulated/floor/exoplanet/barren/raskara/update_icon()

--- a/code/modules/overmap/exoplanets/decor/turfs/concrete.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/concrete.dm
@@ -1,5 +1,6 @@
 /turf/simulated/floor/exoplanet/concrete
 	name = "concrete"
+	gender = PLURAL
 	desc = "Stone-like artificial material."
 	icon = 'icons/turf/flooring/concrete.dmi'
 	icon_state = "concrete0"

--- a/code/modules/overmap/exoplanets/decor/turfs/crystal.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/crystal.dm
@@ -1,5 +1,6 @@
 /turf/simulated/floor/exoplanet/crystal
 	name = "quartz"
+	gender = PLURAL
 	desc = "A tough, compacted mineral surface, polished to a mirror sheen."
 	icon = 'icons/turf/crystal.dmi'
 	icon_state = "crystal"

--- a/code/modules/overmap/exoplanets/decor/turfs/diona.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/diona.dm
@@ -1,5 +1,6 @@
 /turf/simulated/floor/exoplanet/diona
 	name = "biomass flooring"
+	gender = PLURAL
 	icon = 'icons/turf/flooring/diona.dmi'
 	icon_state = "diona0"
 	footstep_sound = /singleton/sound_category/grass_footstep

--- a/code/modules/overmap/exoplanets/decor/turfs/grass.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/grass.dm
@@ -1,5 +1,7 @@
 /turf/simulated/floor/exoplanet/grass
 	name = "grass"
+	gender = PLURAL
+	desc = "Some lush grass."
 	icon = 'icons/turf/jungle.dmi'
 	icon_state = "greygrass"
 	color = "#799c4b"
@@ -19,6 +21,7 @@
 		resources[ORE_DIAMOND] = 1
 
 /turf/simulated/floor/exoplanet/grass/grove
+	desc = "Short grass is growing here."
 	icon_state = "grove_grass1"
 	color = null
 	has_edge_icon = FALSE
@@ -28,12 +31,16 @@
 	icon_state = "grove_grass[rand(1,2)]"
 
 /turf/simulated/floor/exoplanet/grass/stalk
+	name = "stalky grass"
+	desc = "Odd-looking, stalky grass."
 	icon = 'icons/turf/flooring/grass.dmi'
 	icon_state = "grass_stalk"
 	color = null
 	has_edge_icon = null
 
 /turf/simulated/floor/exoplanet/grass/marsh
+	name = "marshy ground"
+	desc = "Marshy ground, small mushrooms grow here and there."
 	icon = 'icons/turf/fungal_marsh.dmi'
 	icon_state = "marsh"
 	color = null
@@ -45,13 +52,18 @@
 	icon_state = "marsh[rand(1,8)]"
 
 /turf/simulated/floor/exoplanet/grass/moghes
+	name = "alien grass"
+	desc = "Thick, alien grass grows here."
 	icon = 'icons/turf/flooring/exoplanet/moghes.dmi'
 	icon_state = "grass"
 	color = null
 
 /turf/simulated/floor/exoplanet/grass/moghes/dirt
+	name = "dirt"
+	desc = "A patch of dirt."
 	icon_state = "dirt"
 	color = null
 
 /turf/simulated/floor/exoplanet/grass/moghes/dirt/beach
+	desc = "The ground slopes down into some water."
 	icon_state = "beach"

--- a/code/modules/overmap/exoplanets/decor/turfs/ice.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/ice.dm
@@ -1,5 +1,7 @@
 /turf/simulated/floor/exoplanet/ice
 	name = "ice"
+	gender = PLURAL
+	desc = "Water, frozen solid. Careful not to slip."
 	icon = 'icons/turf/flooring/snow.dmi'
 	icon_state = "ice"
 	footprint_color = FALSE

--- a/code/modules/overmap/exoplanets/decor/turfs/konyang.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/konyang.dm
@@ -1,5 +1,7 @@
 /turf/simulated/floor/exoplanet/konyang
 	name = "dense mossy grass"
+	gender = PLURAL
+	desc = "An alien moss covers the ground."
 	icon = 'icons/turf/flooring/exoplanet/konyang.dmi'
 	icon_state = "grass"
 	footstep_sound = /singleton/sound_category/grass_footstep
@@ -31,6 +33,7 @@
 
 /turf/simulated/floor/exoplanet/konyang/wilting//manually mapped. To be surrounded by normal grass
 	name = "wilting mossy grass"
+	desc = "An alien moss covers the ground. This patch doesn't look so healthy..."
 	icon = 'icons/turf/flooring/exoplanet/konyang/moss_transition_1.dmi'
 	icon_state = "unsmooth"
 	smoothing_flags = SMOOTH_MORE | SMOOTH_BORDER | SMOOTH_NO_CLEAR_ICON
@@ -38,12 +41,14 @@
 
 /turf/simulated/floor/exoplanet/konyang/pink//manually mapped. To be surrounded by wilting grass
 	name = "blossoming mossy grass"
+	desc = "The moss here is blooming in a shade of pink."
 	icon = 'icons/turf/flooring/exoplanet/konyang/moss_transition_2.dmi'
 	icon_state = "unsmooth"
 	smoothing_flags = SMOOTH_TRUE
 
 /turf/simulated/floor/exoplanet/dirt_konyang//a different path entirely so it will allow for edges to generate from grass
 	name = "compacted dirt"
+	desc = "A patch of dirt."
 	icon = 'icons/turf/flooring/exoplanet/konyang.dmi'
 	icon_state = "dirt"
 	layer = 1.99//to let the grass edges go over it, which otherwise doesnt happen due to positioning and byond layering
@@ -61,6 +66,7 @@
 
 /turf/simulated/floor/exoplanet/dirt_konyang/sand//same as above
 	name = "fine coastal sand"
+	desc = "Some fine, white sand."
 	icon = 'icons/turf/flooring/exoplanet/konyang/konyang_beach.dmi'
 	icon_state = "sand"
 	footstep_sound = /singleton/sound_category/asteroid_footstep

--- a/code/modules/overmap/exoplanets/decor/turfs/linoleum.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/linoleum.dm
@@ -1,5 +1,6 @@
 /turf/simulated/floor/exoplanet/lino
 	name = "linoleum"
+	desc = "It's like the 2390's all over again."
 	icon = 'icons/turf/flooring/linoleum.dmi'
 	icon_state = "lino_preview"
 	initial_flooring = /singleton/flooring/linoleum

--- a/code/modules/overmap/exoplanets/decor/turfs/mineral.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/mineral.dm
@@ -1,11 +1,13 @@
 /turf/simulated/floor/exoplanet/mineral
 	name = "sand"
+	gender = PLURAL
 	desc = "It's coarse and gets everywhere."
 	dirt_color = "#544c31"
 	footstep_sound = /singleton/sound_category/sand_footstep
 
 /turf/simulated/floor/exoplanet/mineral/adhomai
 	name = "icy rock"
+	desc = "Some cold rock."
 	icon = 'icons/turf/flooring/ice_cavern.dmi'
 	icon_state = "icy_rock"
 	temperature = T0C - 5

--- a/code/modules/overmap/exoplanets/decor/turfs/sand.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/sand.dm
@@ -1,5 +1,6 @@
 /turf/simulated/floor/exoplanet/desert
 	name = "sand"
+	gender = PLURAL
 	desc = "It's coarse and gets everywhere."
 	icon = 'icons/turf/desert.dmi'
 	icon_state = "desert"

--- a/code/modules/overmap/exoplanets/decor/turfs/sidewalk.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/sidewalk.dm
@@ -1,5 +1,6 @@
 /turf/simulated/floor/exoplanet/sidewalk
 	name = "weathered tiling"
+	gender = PLURAL
 	desc = "Great for speeding on."
 	icon = 'icons/turf/flooring/urban_turfs.dmi'
 	icon_state = "sidewalk-tile"

--- a/code/modules/overmap/exoplanets/decor/turfs/snow.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/snow.dm
@@ -1,5 +1,7 @@
 /turf/simulated/floor/exoplanet/snow
 	name = "snow"
+	gender = PLURAL
+	desc = "It crunches as you pass over it."
 	icon = 'icons/turf/smooth/snow40.dmi'
 	icon_state = "snow"
 	dirt_color = "#e3e7e8"
@@ -32,6 +34,8 @@
 
 /turf/simulated/floor/exoplanet/permafrost
 	name = "permafrost"
+	gender = PLURAL
+	desc = "Icy, frozen ground."
 	icon = 'icons/turf/flooring/snow.dmi'
 	icon_state = "permafrost"
 	footstep_sound = /singleton/sound_category/asteroid_footstep

--- a/code/modules/overmap/exoplanets/decor/turfs/water.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/water.dm
@@ -1,4 +1,9 @@
 /turf/simulated/floor/exoplanet/water
+	name = "water"
+	gender = PLURAL
+	icon = 'icons/misc/beach.dmi'
+	icon_state = "seadeep"
+	desc = "It is wet."
 	footstep_sound = /singleton/sound_category/water_footstep
 	movement_cost = 4
 	has_resources = FALSE
@@ -109,6 +114,7 @@
 
 /turf/simulated/floor/exoplanet/water/shallow
 	name = "shallow water"
+	desc = "Some water shallow enough to wade through."
 	icon = 'icons/misc/beach.dmi'
 	icon_state = "seashallow"
 	footstep_sound = /singleton/sound_category/water_footstep

--- a/html/changelogs/greenjoe12345 - turfwork.yml
+++ b/html/changelogs/greenjoe12345 - turfwork.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Greenjoe12345
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Makes it so the generic exoplanet dirt ground doesn't leave footprints."
+  - rscadd: "Gives exoplanet turfs descriptions so they don't just say they are the bare hull. Adjusts some names as well."


### PR DESCRIPTION
Adjusts the generic exoplanet dirt turf so it doesn't leave footprints, it's used in maps such as odyssey ones and the footprints get hellish on those.
Also gives many exoplanet turfs descriptions, as well as adjusts the names of some of them.