### PR TITLE
Removes androids

### DIFF
--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -45,7 +45,7 @@
 	supervisors = "your laws and the AI"	//Nodrak
 	selection_color = "#6c5b73"
 	minimal_player_age = 1
-	alt_titles = list("Android", "Robot")
+	alt_titles = list("Robot")
 	account_allowed = 0
 	economic_modifier = 0
 

--- a/code/modules/ghostroles/spawner/atom/posibrain.dm
+++ b/code/modules/ghostroles/spawner/atom/posibrain.dm
@@ -1,7 +1,7 @@
 /datum/ghostspawner/posibrain
 	short_name = "posibrain"
 	name = "Positronic Brain"
-	desc = "Enter a synthetic brain, capable of piloting a spiderbrain, operating an android, becoming an AI, or being a pocketbuddy."
+	desc = "Enter a synthetic brain, capable of piloting a spiderbrain, becoming an IPC, becoming an AI, or being a pocketbuddy."
 	show_on_job_select = FALSE
 	tags = list("Stationbound")
 

--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -351,7 +351,7 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 	if (SSticker.current_state == GAME_STATE_PLAYING)
 		if(character.mind.role_alt_title)
 			rank = character.mind.role_alt_title
-		// can't use their name here, since cyborg namepicking is done post-spawn, so we'll just say "A new Cyborg has arrived"/"A new Android has arrived"/etc.
+		// can't use their name here, since cyborg namepicking is done post-spawn, so we'll just say "A new Cyborg has arrived"/"A new Robot has arrived"/etc.
 		GLOB.global_announcer.autosay("A new[rank ? " [rank]" : " visitor" ] [join_message ? join_message : "has arrived on the [SSatlas.current_map.station_type]"].", "Arrivals Announcer")
 
 /mob/abstract/new_player/proc/LateChoices()

--- a/code/modules/mob/living/silicon/robot/combat_robot.dm
+++ b/code/modules/mob/living/silicon/robot/combat_robot.dm
@@ -21,7 +21,7 @@
 	icon_state = "syndie_bloodhound"
 	spawn_sound = 'sound/mecha/nominalsyndi.ogg'
 	pitch_toggle = FALSE
-	braintype = "Android" // Posibrain.
+	braintype = "Robot"
 
 	// ID and Access
 	req_access = list(ACCESS_SYNDICATE)

--- a/code/modules/mob/living/silicon/robot/items/robot_parts.dm
+++ b/code/modules/mob/living/silicon/robot/items/robot_parts.dm
@@ -279,6 +279,11 @@
 					to_chat(user, SPAN_WARNING("\The [attacking_item] does not seem to fit. (The player has been banned from playing this role)"))
 					return
 
+				// So you cannot make a cyborg with a positronic in it.
+				if(istype(M, /obj/item/device/mmi/digital/posibrain))
+					to_chat(user, SPAN_WARNING("Positronic brains are not compatible with this kind of chassis."))
+					return
+
 				var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(src), TRUE)
 				if(!O)
 					return
@@ -306,7 +311,7 @@
 				callHook("borgify", list(O))
 				O.Namepick()
 				qdel(src)
-		else
+		else if(!istype(O.mmi, /obj/item/device/mmi/digital/posibrain))
 			to_chat(user, SPAN_WARNING("\The [attacking_item] can only be inserted after everything else is installed."))
 		return
 

--- a/code/modules/mob/living/silicon/robot/presets.dm
+++ b/code/modules/mob/living/silicon/robot/presets.dm
@@ -3,7 +3,7 @@
 	mod_type = "Military"
 	spawn_module = /obj/item/robot_module/military
 	cell_type = /obj/item/cell/super
-	braintype = "Android" // Posibrain.
+	braintype = "Robot" // Posibrain.
 
 /mob/living/silicon/robot/military/ert
 	scrambled_codes = TRUE
@@ -106,7 +106,7 @@
 	law_update = FALSE
 	overclocked = TRUE
 	has_jetpack = TRUE
-	braintype = "Android"
+	braintype = "Robot"
 
 /mob/living/silicon/robot/purpose/Initialize()
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -369,9 +369,7 @@
 	if(prefix)
 		mod_type = prefix
 
-	if(istype(mmi, /obj/item/device/mmi/digital/posibrain))
-		braintype = "Android"
-	else if(istype(mmi, /obj/item/device/mmi/digital/robot))
+	if(istype(mmi, /obj/item/device/mmi/digital/robot))
 		braintype = "Robot"
 	else
 		braintype = "Cyborg"

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -191,9 +191,7 @@
 	O.forceMove(loc)
 	O.job = "Cyborg"
 	if(O.mind.assigned_role == "Cyborg")
-		if(O.mind.role_alt_title == "Android")
-			O.mmi = new /obj/item/device/mmi/digital/posibrain(O)
-		else if(O.mind.role_alt_title == "Robot")
+		if(O.mind.role_alt_title == "Robot")
 			O.mmi = new /obj/item/device/mmi/digital/robot(O)
 		else
 			O.mmi = new /obj/item/device/mmi(O)

--- a/html/changelogs/hazelmouse-androids1984.yml
+++ b/html/changelogs/hazelmouse-androids1984.yml
@@ -56,3 +56,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscdel: "You can no longer play as an android, or otherwise install a positronic brain into a shipbound chassis. You can still play as a cyborg or robot, which are mechanically identical except for lacking a positronic brain."
+  - rscdel: "Removes the two positronic brains from the workshop."

--- a/html/changelogs/hazelmouse-androids1984.yml
+++ b/html/changelogs/hazelmouse-androids1984.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "You can no longer play as an android, or otherwise install a positronic brain into a shipbound chassis. You can still play as a cyborg or robot, which are mechanically identical except for lacking a positronic brain."


### PR DESCRIPTION
Per request of synthlore - you can no longer select the android job title to spawn in with a positronic brain in a shipbound chassis, and neither can you manufacture one. 