### PR TITLE
Konyang planetside POIs alterations

### DIFF
--- a/html/changelogs/greenjoe12345 - konyangmaps.yml
+++ b/html/changelogs/greenjoe12345 - konyangmaps.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: greenjoe12345
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Alters some of the planetside pois for Konyang to make them fit the setting now the rampancy virus has been gone for a while."

--- a/maps/random_ruins/exoplanets/konyang/abandoned/abandoned_outpost.dmm
+++ b/maps/random_ruins/exoplanets/konyang/abandoned/abandoned_outpost.dmm
@@ -63,9 +63,10 @@
 /turf/simulated/floor/wood,
 /area/konyang_telecomms_outpost)
 "dd" = (
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/turf/simulated/floor/exoplanet/dirt_konyang,
+/obj/structure/table/rack/folding_table,
+/obj/item/hammer,
+/obj/item/wrench,
+/turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "dx" = (
 /obj/machinery/button/remote/blast_door{
@@ -100,14 +101,18 @@
 /turf/simulated/floor/exoplanet/dirt_konyang,
 /area/konyang_telecomms_outpost)
 "fh" = (
-/obj/structure/flora/rock/konyang/small,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/turf/simulated/floor/exoplanet/dirt_konyang,
+/obj/structure/table/rack/folding_table,
+/obj/item/stack/material/steel,
+/obj/item/stack/material/steel,
+/turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "fB" = (
-/obj/effect/landmark/corpse/ipc_zombie,
-/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/table/rack/folding_table,
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/obj/item/stack/rods,
 /turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "fN" = (
@@ -161,16 +166,9 @@
 /turf/simulated/floor/exoplanet/lino/diamond,
 /area/konyang_telecomms_outpost)
 "ja" = (
-/obj/structure/table/wood,
-/obj/effect/decal/fake_object{
-	desc = "An expensive flatscreen holo-television. This one's connection to the extranet seems to be severed.";
-	dir = 4;
-	icon = 'icons/effects/city.dmi';
-	icon_state = "flatscreen";
-	name = "expensive flatscreen holovision";
-	pixel_y = 15
-	},
-/turf/simulated/floor/exoplanet/wood,
+/obj/structure/flora/bush/konyang_reeds,
+/obj/structure/automobile/poplar_boxvan_blue,
+/turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "jH" = (
 /turf/simulated/floor/bluegrid/cooled,
@@ -185,6 +183,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/table/rack/folding_table,
+/obj/item/screwdriver,
 /turf/simulated/floor/exoplanet/dirt_konyang,
 /area/konyang_telecomms_outpost)
 "jX" = (
@@ -208,7 +208,8 @@
 /turf/simulated/floor/asphalt,
 /area/konyang_telecomms_outpost)
 "ks" = (
-/obj/item/stack/rods,
+/obj/structure/table/rack/folding_table,
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "kA" = (
@@ -263,11 +264,6 @@
 	},
 /turf/simulated/floor/exoplanet/tiled,
 /area/konyang_telecomms_outpost)
-"ni" = (
-/obj/structure/flora/bush/konyang_reeds,
-/obj/item/ammo_casing/a556/spent,
-/turf/simulated/floor/exoplanet/konyang,
-/area/konyang_telecomms_outpost)
 "nj" = (
 /obj/structure/table/stone/marble,
 /obj/machinery/chemical_dispenser/coffeemaster/full{
@@ -314,13 +310,6 @@
 	},
 /turf/simulated/floor/exoplanet/tiled,
 /area/konyang_telecomms_outpost)
-"oJ" = (
-/obj/structure/flora/bush/konyang_reeds,
-/obj/effect/landmark/corpse/ipc_zombie,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/item/stack/rods,
-/turf/simulated/floor/exoplanet/konyang,
-/area/konyang_telecomms_outpost)
 "pc" = (
 /turf/simulated/floor/exoplanet/wood,
 /area/konyang_telecomms_outpost)
@@ -338,11 +327,12 @@
 /turf/simulated/floor/exoplanet/wood,
 /area/konyang_telecomms_outpost)
 "pT" = (
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/turf/simulated/floor/exoplanet/dirt_konyang,
+/obj/structure/table/rack/folding_table,
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "qS" = (
 /obj/structure/chainlink_fence{
@@ -363,11 +353,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/asphalt,
-/area/konyang_telecomms_outpost)
-"rI" = (
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "sg" = (
 /obj/structure/flora/bush/konyang_reeds,
@@ -449,10 +434,6 @@
 	},
 /turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
-"uU" = (
-/obj/item/stack/material/wood,
-/turf/simulated/floor/wood,
-/area/konyang_telecomms_outpost)
 "vc" = (
 /obj/structure/filingcabinet/filingcabinet{
 	pixel_x = 10;
@@ -461,14 +442,17 @@
 /turf/simulated/floor/exoplanet/tiled,
 /area/konyang_telecomms_outpost)
 "vq" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/item/stack/rods,
-/turf/simulated/floor/exoplanet/konyang,
+/obj/structure/table/rack/folding_table,
+/obj/item/stack/material/steel,
+/obj/item/stack/material/steel,
+/obj/item/stack/material/steel,
+/obj/item/stack/material/steel,
+/obj/item/stack/material/steel,
+/turf/simulated/floor/exoplanet/dirt_konyang,
 /area/konyang_telecomms_outpost)
 "vC" = (
-/obj/item/stack/material/steel,
-/obj/structure/girder,
-/turf/simulated/floor/plating,
+/obj/structure/table/rack/folding_table,
+/turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "vF" = (
 /obj/structure/bed/stool/chair/office/dark{
@@ -525,12 +509,6 @@
 	},
 /turf/simulated/floor/exoplanet/dirt_konyang,
 /area/konyang_telecomms_outpost)
-"ym" = (
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/turf/simulated/floor/exoplanet/konyang,
-/area/konyang_telecomms_outpost)
 "yr" = (
 /obj/effect/decal/road_marking/thin,
 /obj/machinery/mech_recharger/automobile,
@@ -579,12 +557,6 @@
 	},
 /turf/simulated/floor/exoplanet/tiled,
 /area/konyang_telecomms_outpost)
-"zO" = (
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/turf/simulated/floor/exoplanet/dirt_konyang,
-/area/konyang_telecomms_outpost)
 "Ac" = (
 /obj/machinery/light{
 	dir = 8
@@ -592,10 +564,10 @@
 /turf/simulated/floor/asphalt,
 /area/konyang_telecomms_outpost)
 "Aq" = (
-/obj/structure/flora/bush/konyang_reeds,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/item/stack/rods,
-/obj/effect/landmark/corpse/ipc_zombie,
+/obj/structure/table/rack/folding_table,
+/obj/item/stack/material/wood,
+/obj/item/stack/material/wood,
+/obj/item/stack/material/wood,
 /turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "AH" = (
@@ -691,14 +663,6 @@
 /obj/machinery/door/airlock/highsecurity,
 /turf/simulated/floor/exoplanet/tiled,
 /area/konyang_telecomms_outpost)
-"Fo" = (
-/obj/effect/landmark/corpse/ipc_zombie,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/exoplanet/dirt_konyang,
-/area/konyang_telecomms_outpost)
 "FA" = (
 /turf/simulated/floor/exoplanet/dirt_konyang,
 /area/konyang_telecomms_outpost)
@@ -734,9 +698,8 @@
 /turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "Gq" = (
-/obj/item/stack/material/steel,
-/obj/item/flag/konyang/l,
-/turf/simulated/floor/plating,
+/obj/structure/automobile/poplar_boxvan_green/weathered,
+/turf/simulated/floor/exoplanet/dirt_konyang,
 /area/konyang_telecomms_outpost)
 "Gr" = (
 /obj/effect/decal/fake_object{
@@ -788,26 +751,16 @@
 	},
 /turf/simulated/floor/exoplanet/tiled,
 /area/konyang_telecomms_outpost)
-"Hv" = (
-/obj/structure/flora/bush/konyang_reeds,
-/obj/item/stack/rods,
-/turf/simulated/floor/exoplanet/konyang,
-/area/konyang_telecomms_outpost)
-"HN" = (
-/obj/effect/landmark/corpse/ipc_zombie,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/exoplanet/dirt_konyang,
-/area/konyang_telecomms_outpost)
 "If" = (
 /obj/structure/flora/bush/konyang_reeds,
 /obj/structure/flora/bush/konyang_reeds,
 /turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "Il" = (
-/obj/item/stack/material/steel,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/landmark/corpse/ipc_zombie,
-/turf/simulated/floor/exoplanet/dirt_konyang,
+/obj/structure/table/rack/folding_table,
+/obj/item/screwdriver,
+/obj/item/wrench,
+/turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "IK" = (
 /obj/structure/window/reinforced{
@@ -849,6 +802,9 @@
 /obj/machinery/light{
 	icon_state = "tube_empty"
 	},
+/obj/item/material/knife{
+	pixel_x = -4
+	},
 /turf/simulated/floor/exoplanet/lino/diamond,
 /area/konyang_telecomms_outpost)
 "JS" = (
@@ -886,15 +842,6 @@
 "Lu" = (
 /turf/simulated/floor/asphalt,
 /area/konyang_telecomms_outpost)
-"Lx" = (
-/obj/effect/landmark/corpse/ipc_zombie,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/exoplanet/konyang,
-/area/konyang_telecomms_outpost)
 "MM" = (
 /obj/effect/decal/fake_object{
 	icon_state = "hub";
@@ -905,11 +852,6 @@
 /area/konyang_telecomms_outpost)
 "Ns" = (
 /turf/simulated/wall/concrete,
-/area/konyang_telecomms_outpost)
-"NO" = (
-/obj/structure/flora/bush/konyang_reeds,
-/obj/effect/landmark/corpse/ipc_zombie,
-/turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "NR" = (
 /obj/structure/sink{
@@ -928,8 +870,10 @@
 /turf/simulated/floor/exoplanet/wood,
 /area/konyang_telecomms_outpost)
 "OC" = (
-/obj/effect/landmark/corpse/ipc_zombie,
-/turf/simulated/floor/plating,
+/obj/structure/table/rack/folding_table,
+/obj/item/hammer,
+/obj/item/screwdriver,
+/turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "Pz" = (
 /obj/effect/decal/road_marking/thin,
@@ -945,10 +889,6 @@
 	name = "Garage"
 	},
 /turf/simulated/floor/asphalt,
-/area/konyang_telecomms_outpost)
-"Qc" = (
-/obj/item/ammo_casing/a556/spent,
-/turf/simulated/floor/exoplanet/dirt_konyang,
 /area/konyang_telecomms_outpost)
 "QM" = (
 /obj/structure/flora/bush/konyang_reeds,
@@ -1020,14 +960,6 @@
 /obj/structure/automobile,
 /turf/simulated/floor/asphalt,
 /area/konyang_telecomms_outpost)
-"Sm" = (
-/obj/item/material/shard,
-/obj/item/material/shard,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/turf/simulated/floor/exoplanet/dirt_konyang,
-/area/konyang_telecomms_outpost)
 "St" = (
 /obj/structure/chainlink_fence{
 	dir = 4
@@ -1046,6 +978,7 @@
 	pixel_y = 10;
 	pixel_x = -10
 	},
+/obj/item/flag/konyang/l,
 /turf/simulated/floor/exoplanet/tiled,
 /area/konyang_telecomms_outpost)
 "UC" = (
@@ -1076,14 +1009,6 @@
 /obj/effect/landmark/corpse/ipc_zombie,
 /turf/simulated/floor/exoplanet/water/shallow/konyang,
 /area/konyang_telecomms_outpost)
-"WD" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/item/material/knife{
-	pixel_x = -4
-	},
-/obj/effect/landmark/corpse/ipc_zombie,
-/turf/simulated/floor/exoplanet/lino/diamond,
-/area/konyang_telecomms_outpost)
 "WQ" = (
 /obj/structure/table/stone/marble,
 /obj/item/reagent_containers/food/condiment/enzyme{
@@ -1092,20 +1017,6 @@
 	},
 /obj/item/material/kitchen/rollingpin,
 /turf/simulated/floor/exoplanet/lino/diamond,
-/area/konyang_telecomms_outpost)
-"Yx" = (
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/obj/item/ammo_casing/a556/spent,
-/turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "YF" = (
 /obj/machinery/button/remote/blast_door{
@@ -1117,9 +1028,10 @@
 /turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "Ze" = (
-/obj/structure/flora/bush/konyang_reeds,
-/obj/effect/landmark/corpse/ipc_zombie,
-/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/table/rack/folding_table,
+/obj/item/stack/material/steel,
+/obj/item/stack/material/steel,
+/obj/item/stack/material/steel,
 /turf/simulated/floor/exoplanet/konyang,
 /area/konyang_telecomms_outpost)
 "Zj" = (
@@ -1130,12 +1042,6 @@
 "Zo" = (
 /obj/effect/decal/road_marking/thin,
 /turf/simulated/floor/asphalt,
-/area/konyang_telecomms_outpost)
-"ZQ" = (
-/obj/effect/landmark/corpse/ipc_zombie,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/item/stack/rods,
-/turf/simulated/floor/exoplanet/dirt_konyang,
 /area/konyang_telecomms_outpost)
 "ZV" = (
 /obj/machinery/hologram/holopad/long_range,
@@ -1613,7 +1519,7 @@ CY
 bM
 sg
 sg
-rI
+bM
 sg
 sg
 sg
@@ -1623,7 +1529,7 @@ sg
 sg
 sg
 bM
-NO
+sg
 FA
 FA
 sg
@@ -1650,7 +1556,7 @@ bM
 sg
 sg
 sg
-bM
+pT
 CY
 bM
 sg
@@ -1692,14 +1598,14 @@ bM
 sg
 sg
 sg
-bM
+ks
 uR
 bM
 sg
-Ze
 sg
 sg
-rI
+sg
+bM
 bM
 sg
 sg
@@ -1735,7 +1641,7 @@ bM
 sg
 sg
 bM
-oJ
+sg
 sg
 sg
 sg
@@ -1745,7 +1651,7 @@ sg
 sg
 bM
 sg
-Ze
+sg
 sg
 sg
 sg
@@ -1778,21 +1684,21 @@ sg
 sg
 bM
 bM
-ks
 bM
 bM
-ym
 bM
-sg
-sg
-sg
 bM
 bM
 sg
+sg
+sg
+bM
+bM
+sg
 bM
 bM
 bM
-pT
+FA
 FA
 bM
 sg
@@ -1820,7 +1726,7 @@ sg
 sg
 bM
 FA
-ZQ
+FA
 FA
 FA
 bM
@@ -1878,7 +1784,7 @@ sg
 bM
 FA
 FA
-Lx
+bM
 sg
 Dz
 sg
@@ -1901,11 +1807,11 @@ bM
 (19,1,1) = {"
 sg
 bM
-HN
+FA
 FA
 yg
 jI
-FA
+vq
 JS
 FA
 bM
@@ -1924,8 +1830,8 @@ bM
 bM
 bM
 bM
-ni
-Yx
+sg
+bM
 Ns
 Tw
 dN
@@ -1942,32 +1848,32 @@ bM
 "}
 (20,1,1) = {"
 FA
-HN
 FA
 FA
-Il
+FA
+FA
 FA
 FA
 JS
 FA
-fh
-FA
-FA
-FA
-pT
+UO
 FA
 FA
 FA
 FA
 FA
-dd
 FA
 FA
 FA
-Fo
 FA
-Qc
-zO
+FA
+FA
+FA
+FA
+FA
+FA
+FA
+FA
 un
 lD
 lD
@@ -1989,14 +1895,13 @@ FA
 FA
 ar
 FA
-dd
+FA
 JS
 FA
 FA
 FA
 FA
 FA
-zO
 FA
 FA
 FA
@@ -2004,12 +1909,13 @@ FA
 FA
 FA
 FA
-dd
 FA
 FA
 FA
 FA
-dd
+FA
+FA
+FA
 lp
 lD
 lD
@@ -2028,12 +1934,11 @@ bM
 FA
 FA
 FA
-FA
+Gq
 yg
-Qc
-Sm
+FA
+FA
 JS
-ym
 bM
 bM
 bM
@@ -2045,8 +1950,9 @@ bM
 bM
 bM
 bM
-fB
-HN
+bM
+bM
+FA
 FA
 sg
 sg
@@ -2069,7 +1975,7 @@ bM
 (23,1,1) = {"
 bM
 FA
-HN
+FA
 kc
 Ns
 uw
@@ -2094,7 +2000,7 @@ bM
 sg
 sg
 bM
-Gq
+tE
 vF
 ZV
 yU
@@ -2135,7 +2041,7 @@ FA
 sg
 sg
 sg
-bM
+dd
 Ns
 vc
 pf
@@ -2154,7 +2060,7 @@ bM
 sg
 sg
 bM
-bM
+vC
 Ns
 lD
 lD
@@ -2162,7 +2068,7 @@ Ns
 bM
 sE
 bM
-fB
+bM
 sg
 sg
 sg
@@ -2177,7 +2083,7 @@ FA
 sg
 sg
 sg
-bM
+Ze
 Ns
 Ns
 Ns
@@ -2196,8 +2102,8 @@ bM
 sg
 bM
 bM
-bM
-vC
+fh
+hH
 lD
 lD
 AH
@@ -2239,7 +2145,7 @@ sg
 sg
 sg
 bM
-OC
+tE
 tE
 Ns
 Ns
@@ -2375,7 +2281,7 @@ fW
 Gu
 iT
 iT
-WD
+iT
 JR
 fW
 bM
@@ -2420,7 +2326,7 @@ iT
 iT
 iT
 fW
-bM
+OC
 bM
 sg
 bM
@@ -2462,7 +2368,7 @@ pc
 pc
 pc
 fW
-bM
+Aq
 bM
 sg
 bM
@@ -2503,7 +2409,7 @@ Dv
 Zj
 UC
 pc
-uU
+BP
 FA
 FA
 FA
@@ -2589,7 +2495,7 @@ pc
 gw
 fW
 bM
-sg
+ja
 sg
 bM
 bM
@@ -2627,7 +2533,7 @@ cB
 pc
 pc
 pc
-ja
+Dv
 Jh
 fW
 bM
@@ -2716,8 +2622,8 @@ fW
 fW
 sg
 sg
-sg
-sg
+fB
+Il
 sg
 sg
 sg
@@ -2760,9 +2666,9 @@ St
 St
 St
 St
-vq
-Hv
-Aq
+bM
+sg
+sg
 sg
 Vm
 Vm

--- a/maps/random_ruins/exoplanets/konyang/abandoned/abandoned_village.dmm
+++ b/maps/random_ruins/exoplanets/konyang/abandoned/abandoned_village.dmm
@@ -8,9 +8,10 @@
 /turf/simulated/floor/exoplanet/wood/bamboo,
 /area/konyang_village)
 "ag" = (
-/obj/item/material/shard,
-/obj/structure/window_frame/wood,
-/turf/simulated/floor/exoplanet/tiled/full,
+/obj/structure/flora/rock/konyang/small,
+/obj/random/dirt_75,
+/obj/structure/automobile/poplar_boxvan_blue/weathered,
+/turf/simulated/floor/exoplanet/dirt_konyang,
 /area/konyang_village)
 "aE" = (
 /obj/random/junk{
@@ -58,14 +59,6 @@
 /obj/structure/trash_pile,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/sidewalk,
-/area/konyang_village)
-"cC" = (
-/obj/item/material/shard,
-/obj/item/material/shard,
-/obj/item/material/shard,
-/obj/item/material/shard,
-/obj/structure/window_frame/wood,
-/turf/simulated/floor/exoplanet/tiled/full,
 /area/konyang_village)
 "cK" = (
 /obj/structure/sink/kitchen{
@@ -154,11 +147,6 @@
 "gv" = (
 /turf/simulated/floor/exoplanet/sidewalk,
 /area/konyang_village)
-"gz" = (
-/obj/structure/window_frame/wood,
-/obj/item/material/shard,
-/turf/simulated/floor/exoplanet/tiled/full,
-/area/konyang_village)
 "gE" = (
 /obj/structure/chainlink_fence{
 	dir = 1
@@ -207,8 +195,6 @@
 "hM" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/effect/landmark/corpse/ipc_zombie,
-/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/exoplanet/sidewalk,
 /area/konyang_village)
 "hP" = (
@@ -322,8 +308,6 @@
 /turf/simulated/floor/exoplanet/wood,
 /area/konyang_village)
 "mb" = (
-/obj/item/material/shard,
-/obj/item/material/shard,
 /obj/structure/window_frame/wood,
 /turf/simulated/floor/exoplanet/tiled/full,
 /area/konyang_village)
@@ -364,7 +348,6 @@
 /obj/effect/decal/exterior_stairs/half/center{
 	dir = 8
 	},
-/obj/item/stack/material/wood,
 /turf/simulated/floor/exoplanet/wood,
 /area/konyang_village)
 "nx" = (
@@ -375,10 +358,6 @@
 /area/konyang_village)
 "nR" = (
 /obj/machinery/door/urban,
-/turf/simulated/floor/exoplanet/wood,
-/area/konyang_village)
-"of" = (
-/obj/structure/television,
 /turf/simulated/floor/exoplanet/wood,
 /area/konyang_village)
 "ou" = (
@@ -414,12 +393,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/teacup{
 	pixel_x = 6;
 	pixel_y = 1
-	},
-/turf/simulated/floor/exoplanet/wood,
-/area/konyang_village)
-"pd" = (
-/obj/structure/barricade/wooden{
-	dir = 4
 	},
 /turf/simulated/floor/exoplanet/wood,
 /area/konyang_village)
@@ -487,9 +460,6 @@
 /area/konyang_village)
 "qH" = (
 /obj/structure/table/wood,
-/obj/structure/barricade/wooden{
-	dir = 4
-	},
 /turf/simulated/floor/exoplanet/wood,
 /area/konyang_village)
 "qN" = (
@@ -602,7 +572,6 @@
 /obj/item/material/kitchen/utensil/fork/chopsticks,
 /obj/item/material/kitchen/utensil/fork/chopsticks,
 /obj/machinery/light,
-/obj/item/material/shard,
 /turf/simulated/floor/exoplanet/lino/diamond,
 /area/konyang_village)
 "vc" = (
@@ -648,8 +617,11 @@
 /turf/simulated/floor/exoplanet/dirt_konyang,
 /area/konyang_village)
 "vY" = (
+/obj/random/dirt_75,
+/obj/structure/table/rack/folding_table,
 /obj/item/stack/material/wood,
-/turf/simulated/floor/exoplanet/wood,
+/obj/item/stack/material/wood,
+/turf/simulated/floor/exoplanet/sidewalk/blocks,
 /area/konyang_village)
 "wp" = (
 /obj/random/dirt_75,
@@ -805,10 +777,9 @@
 /turf/simulated/floor/exoplanet/lino/diamond,
 /area/konyang_village)
 "yM" = (
-/obj/item/material/hatchet/butch,
-/obj/effect/landmark/corpse/ipc_zombie,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/exoplanet/wood,
+/obj/structure/table/rack/folding_table,
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/exoplanet/konyang,
 /area/konyang_village)
 "yQ" = (
 /obj/structure/flora/tree/konyang/fall,
@@ -828,7 +799,6 @@
 /area/konyang_village)
 "zz" = (
 /obj/structure/table/wood,
-/obj/item/material/shard,
 /turf/simulated/floor/exoplanet/lino/diamond,
 /area/konyang_village)
 "zK" = (
@@ -848,10 +818,6 @@
 /obj/structure/table/wood,
 /obj/structure/window/reinforced{
 	dir = 8
-	},
-/obj/machinery/chemical_dispenser/coffeemaster/full{
-	pixel_y = 18;
-	pixel_x = 1
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/lino/diamond,
@@ -984,7 +950,6 @@
 /obj/structure/bed/stool/chair/office/dark{
 	dir = 8
 	},
-/obj/item/material/shard,
 /turf/simulated/floor/exoplanet/lino/diamond,
 /area/konyang_village)
 "CD" = (
@@ -1027,11 +992,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/dirt_konyang,
 /area/konyang_village)
-"DI" = (
-/obj/random/dirt_75,
-/obj/item/material/shard,
-/turf/simulated/floor/exoplanet/sidewalk/blocks,
-/area/konyang_village)
 "DL" = (
 /obj/structure/chainlink_fence{
 	dir = 1
@@ -1052,9 +1012,7 @@
 /area/konyang_village)
 "Eu" = (
 /obj/effect/decal/exterior_stairs/half/center,
-/obj/structure/barricade/wooden{
-	dir = 1
-	},
+/obj/machinery/door/urban,
 /turf/simulated/floor/exoplanet/wood,
 /area/konyang_village)
 "EH" = (
@@ -1079,15 +1037,9 @@
 /area/konyang_village)
 "GG" = (
 /obj/effect/decal/exterior_stairs/half/center,
-/obj/item/stack/material/wood,
 /turf/simulated/floor/exoplanet/lino/diamond,
 /area/konyang_village)
 "GM" = (
-/turf/simulated/floor/exoplanet/wood,
-/area/konyang_village)
-"GX" = (
-/obj/effect/landmark/corpse/ipc_zombie,
-/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/exoplanet/wood,
 /area/konyang_village)
 "Hb" = (
@@ -1305,8 +1257,9 @@
 /turf/simulated/floor/exoplanet/wood,
 /area/konyang_village)
 "MA" = (
-/obj/item/material/shard,
-/turf/simulated/floor/exoplanet/wood,
+/obj/structure/table/rack/folding_table,
+/obj/item/stack/material/glass,
+/turf/simulated/floor/exoplanet/konyang,
 /area/konyang_village)
 "MH" = (
 /obj/structure/flora/bush/konyang_reeds,
@@ -1450,11 +1403,6 @@
 	},
 /turf/simulated/floor/exoplanet/tiled/white,
 /area/konyang_village)
-"OZ" = (
-/obj/structure/lattice/catwalk/indoor/planks,
-/obj/structure/bed/stool/bamboo,
-/turf/simulated/floor/exoplanet/dirt_konyang,
-/area/konyang_village)
 "Pc" = (
 /obj/structure/flora/rock/konyang,
 /obj/effect/decal/exterior_stairs/half/center{
@@ -1474,10 +1422,11 @@
 /turf/simulated/floor/exoplanet/wood,
 /area/konyang_village)
 "PH" = (
-/obj/structure/window_frame/wood,
-/obj/item/material/shard,
-/obj/item/material/shard,
-/turf/simulated/floor/exoplanet/tiled/full,
+/obj/random/dirt_75,
+/obj/structure/table/rack/folding_table,
+/obj/item/hammer,
+/obj/item/screwdriver,
+/turf/simulated/floor/exoplanet/sidewalk,
 /area/konyang_village)
 "PQ" = (
 /obj/structure/railing/fence{
@@ -1569,8 +1518,6 @@
 /area/konyang_village)
 "SZ" = (
 /obj/effect/floor_decal/spline/plain/full,
-/obj/effect/landmark/corpse/ipc_zombie,
-/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/exoplanet/dirt_konyang,
 /area/konyang_village)
 "To" = (
@@ -1599,9 +1546,8 @@
 /turf/simulated/floor/exoplanet/tiled/white,
 /area/konyang_village)
 "TO" = (
-/obj/effect/decal/exterior_stairs/half/center,
-/obj/item/stack/material/wood,
-/turf/simulated/floor/exoplanet/wood,
+/obj/structure/table/rack/folding_table,
+/turf/simulated/floor/exoplanet/konyang,
 /area/konyang_village)
 "TP" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
@@ -1624,9 +1570,6 @@
 /area/konyang_village)
 "Vi" = (
 /obj/structure/table/wood,
-/obj/item/modular_computer/laptop/preset{
-	pixel_y = 11
-	},
 /obj/item/pen/black{
 	pixel_y = -2;
 	pixel_x = -6
@@ -1640,16 +1583,12 @@
 	},
 /turf/simulated/floor/exoplanet/konyang,
 /area/konyang_village)
-"VY" = (
-/obj/item/material/shard,
-/obj/item/material/shard,
-/turf/simulated/floor/exoplanet/wood,
-/area/konyang_village)
 "Wd" = (
 /obj/structure/lattice/catwalk/indoor/planks,
-/obj/structure/bed/stool/bamboo{
-	dir = 1
-	},
+/obj/structure/table/rack/folding_table,
+/obj/item/stack/material/glass,
+/obj/item/stack/material/glass,
+/obj/item/stack/material/glass,
 /turf/simulated/floor/exoplanet/konyang,
 /area/konyang_village)
 "Wj" = (
@@ -1740,10 +1679,8 @@
 /area/konyang_village)
 "Xy" = (
 /obj/structure/lattice/catwalk/indoor/planks,
-/obj/structure/table/rack/cafe_table,
-/obj/item/reagent_containers/food/drinks/greentea{
-	pixel_x = 7
-	},
+/obj/structure/table/rack/folding_table,
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/exoplanet/konyang,
 /area/konyang_village)
 "XH" = (
@@ -1875,8 +1812,11 @@
 /turf/simulated/floor/exoplanet/lino/diamond,
 /area/konyang_village)
 "ZE" = (
-/obj/item/material/shard,
-/turf/simulated/floor/exoplanet/lino/diamond,
+/obj/structure/table/rack/folding_table,
+/obj/item/stack/material/glass,
+/obj/item/stack/material/glass,
+/obj/item/stack/material/glass,
+/turf/simulated/floor/exoplanet/konyang,
 /area/konyang_village)
 "ZO" = (
 /obj/effect/floor_decal/spline/plain{
@@ -2494,7 +2434,7 @@ oF
 qf
 tT
 hj
-GX
+GM
 GM
 Kf
 OA
@@ -2504,9 +2444,9 @@ rG
 OB
 cK
 GM
-GX
 GM
-of
+GM
+GM
 tT
 aP
 oF
@@ -2543,7 +2483,7 @@ OA
 tD
 St
 CY
-TO
+Eu
 tT
 GM
 GM
@@ -2584,8 +2524,8 @@ oF
 OA
 oR
 St
-DI
-cC
+CY
+oF
 tT
 tT
 Tr
@@ -2619,8 +2559,8 @@ Bu
 OB
 Zh
 Cu
-MA
-VY
+GM
+GM
 CH
 OB
 OA
@@ -2661,8 +2601,8 @@ CY
 OB
 OB
 OB
-PH
-PH
+mb
+mb
 oF
 OB
 CY
@@ -2672,7 +2612,7 @@ OA
 OB
 oF
 mb
-ag
+mb
 OB
 Vi
 JT
@@ -2703,7 +2643,7 @@ OA
 dx
 jO
 xv
-OZ
+Hw
 Xy
 Wd
 IK
@@ -2711,8 +2651,8 @@ CY
 tD
 oR
 OA
-Av
-Av
+ZE
+MA
 Av
 dx
 OB
@@ -2962,7 +2902,7 @@ yx
 OB
 Av
 HH
-OA
+PH
 St
 oR
 CY
@@ -2998,13 +2938,13 @@ oF
 ou
 yw
 yw
-yM
+GM
 GM
 oT
 OB
 OB
 OB
-CY
+vY
 Dt
 St
 CY
@@ -3075,7 +3015,7 @@ jO
 xH
 Av
 OA
-Av
+TO
 OB
 OB
 OB
@@ -3117,7 +3057,7 @@ NX
 Bc
 Av
 gv
-Av
+yM
 OB
 RZ
 OB
@@ -3125,12 +3065,12 @@ OB
 OB
 OB
 OB
-vY
+GM
 OB
 OB
 ca
 OB
-ic
+ag
 oR
 St
 CY
@@ -3162,7 +3102,7 @@ oM
 oM
 GG
 tT
-ZE
+tT
 NQ
 OB
 Ix
@@ -3202,7 +3142,7 @@ Bc
 Av
 Av
 Av
-gz
+oF
 zz
 tT
 sd
@@ -3244,7 +3184,7 @@ Bc
 Av
 Qs
 jO
-gz
+oF
 dT
 GM
 GM
@@ -3304,7 +3244,7 @@ St
 NX
 hP
 qH
-pd
+GM
 BM
 OB
 Av

--- a/maps/random_ruins/exoplanets/konyang/abandoned/house_small.dmm
+++ b/maps/random_ruins/exoplanets/konyang/abandoned/house_small.dmm
@@ -1,8 +1,12 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aO" = (
-/obj/random/junk,
-/turf/simulated/floor/exoplanet/asphalt,
-/area/exoplanet/grass/konyang)
+/obj/structure/lattice/catwalk/indoor/tatami{
+	dir = 4
+	},
+/obj/structure/table/rack/folding_table,
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/exoplanet/tiled/white,
+/area/konyang/house_small)
 "bi" = (
 /obj/structure/table/stone/marble,
 /turf/simulated/floor/exoplanet/tiled/white,
@@ -12,10 +16,11 @@
 /turf/simulated/floor/exoplanet/sidewalk/paved,
 /area/exoplanet/grass/konyang)
 "bY" = (
-/obj/random/junk,
-/obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/foundation,
-/area/konyang/house_small)
+/obj/structure/table/rack/folding_table,
+/obj/item/hammer,
+/obj/item/screwdriver,
+/turf/simulated/floor/exoplanet/sidewalk/blocks,
+/area/exoplanet/grass/konyang)
 "cq" = (
 /obj/structure/window/urban{
 	dir = 4
@@ -281,11 +286,6 @@
 "nP" = (
 /turf/simulated/floor/exoplanet/foundation,
 /area/konyang/house_small)
-"oF" = (
-/obj/structure/table/glass,
-/obj/item/device/toner,
-/turf/simulated/floor/exoplanet/wood/bamboo,
-/area/konyang/house_small)
 "oG" = (
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/tiled/white,
@@ -319,10 +319,6 @@
 /obj/structure/bed/stool/chair/wood{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/wood/bamboo,
-/area/konyang/house_small)
-"rh" = (
-/obj/random/junk,
 /turf/simulated/floor/exoplanet/wood/bamboo,
 /area/konyang/house_small)
 "rl" = (
@@ -363,8 +359,11 @@
 /turf/simulated/floor/exoplanet/sidewalk/dark,
 /area/konyang/house_small)
 "uk" = (
-/obj/structure/table,
-/obj/item/material/shard,
+/obj/structure/table/rack/folding_table,
+/obj/item/stack/tile/wood/bamboo,
+/obj/item/stack/tile/wood/bamboo,
+/obj/item/stack/tile/wood/bamboo,
+/obj/item/stack/tile/wood/bamboo,
 /turf/simulated/floor/exoplanet/wood/bamboo,
 /area/konyang/house_small)
 "um" = (
@@ -501,11 +500,6 @@
 /obj/machinery/appliance/cooker/stove,
 /turf/simulated/floor/exoplanet/foundation,
 /area/konyang/house_small)
-"Aj" = (
-/obj/random/junk,
-/obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/wood/bamboo,
-/area/konyang/house_small)
 "AB" = (
 /obj/structure/curtain/open/privacy,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -579,13 +573,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/tiled/white,
 /area/konyang/house_small)
-"HA" = (
-/obj/structure/table,
-/obj/item/material/shard,
-/obj/item/stack/rods,
-/obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/tiled/white,
-/area/konyang/house_small)
 "HB" = (
 /turf/simulated/floor/exoplanet/konyang,
 /area/exoplanet/grass/konyang)
@@ -609,9 +596,15 @@
 /turf/simulated/floor/exoplanet/wood/bamboo,
 /area/konyang/house_small)
 "HZ" = (
-/obj/item/reagent_containers/food/snacks/ricetub,
-/turf/simulated/floor/exoplanet/foundation,
-/area/konyang/house_small)
+/obj/structure/table/rack/folding_table,
+/obj/item/stack/material/wood,
+/obj/item/stack/material/wood,
+/obj/item/stack/material/wood,
+/obj/item/stack/material/wood,
+/obj/item/stack/material/wood,
+/obj/item/stack/material/wood,
+/turf/simulated/floor/exoplanet/sidewalk/blocks,
+/area/exoplanet/grass/konyang)
 "Im" = (
 /obj/structure/flora/rock/konyang/small,
 /obj/effect/decal/curb{
@@ -621,7 +614,6 @@
 /turf/simulated/floor/exoplanet/sidewalk/paved,
 /area/exoplanet/grass/konyang)
 "Iv" = (
-/obj/item/stack/rods,
 /obj/structure/filingcabinet,
 /turf/simulated/floor/exoplanet/wood/bamboo,
 /area/konyang/house_small)
@@ -660,12 +652,6 @@
 	},
 /turf/simulated/floor/exoplanet/sidewalk/paved,
 /area/exoplanet/grass/konyang)
-"JS" = (
-/obj/structure/television{
-	pixel_y = -8
-	},
-/turf/simulated/floor/exoplanet/foundation,
-/area/konyang/house_small)
 "JX" = (
 /obj/effect/decal/curb{
 	dir = 4
@@ -854,11 +840,6 @@
 	},
 /turf/simulated/floor/exoplanet/sidewalk/blocks,
 /area/exoplanet/grass/konyang)
-"UL" = (
-/obj/random/junk,
-/obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/sidewalk/dark,
-/area/konyang/house_small)
 "Vq" = (
 /obj/structure/lattice/catwalk/indoor/tatami{
 	dir = 8
@@ -1055,15 +1036,15 @@ PB
 oG
 oG
 gZ
-JS
+nP
 OY
-HZ
+nP
 MU
 xY
 vd
 lo
 vo
-aO
+vo
 vo
 vQ
 vQ
@@ -1080,10 +1061,10 @@ zC
 PB
 PB
 Vq
-HA
+oG
 sY
 OT
-bY
+gZ
 gZ
 lN
 xY
@@ -1108,8 +1089,8 @@ nP
 nP
 nh
 Nc
-nh
-OT
+aO
+uk
 gZ
 gZ
 HE
@@ -1212,7 +1193,7 @@ HB
 jm
 xY
 kZ
-UL
+ZG
 XI
 xY
 Qk
@@ -1318,7 +1299,7 @@ mb
 mb
 Jv
 Lb
-oF
+OT
 Iv
 OT
 OT
@@ -1345,7 +1326,7 @@ vQ
 mb
 Jv
 nP
-uk
+OT
 qB
 HE
 OT
@@ -1370,11 +1351,11 @@ vQ
 vQ
 vQ
 Jv
-mb
+HZ
 xY
 Ob
 Ui
-Aj
+HE
 OT
 xY
 dj
@@ -1397,7 +1378,7 @@ vQ
 vQ
 mb
 Jv
-mb
+bY
 Lb
 OT
 OT
@@ -1486,7 +1467,7 @@ xY
 OT
 HE
 OT
-rh
+OT
 HE
 HE
 xY
@@ -1541,7 +1522,7 @@ cB
 if
 xY
 pH
-rh
+OT
 OT
 Po
 xY

--- a/maps/random_ruins/exoplanets/konyang/abandoned/rural_clinic.dmm
+++ b/maps/random_ruins/exoplanets/konyang/abandoned/rural_clinic.dmm
@@ -49,8 +49,6 @@
 /turf/simulated/floor/tiled/white,
 /area/konyang/rural_clinic)
 "jy" = (
-/obj/item/material/shard,
-/obj/item/material/shard,
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/white,
 /area/konyang/rural_clinic)
@@ -63,16 +61,6 @@
 /obj/effect/decal/cleanable/generic/beet_tree_petals,
 /turf/simulated/floor/exoplanet/konyang,
 /area/exoplanet/grass/konyang)
-"md" = (
-/obj/effect/floor_decal/corner/green/diagonal{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/green/diagonal{
-	dir = 4
-	},
-/obj/item/stack/rods,
-/turf/simulated/floor/tiled/white,
-/area/konyang/rural_clinic)
 "mu" = (
 /obj/effect/floor_decal/konyang_flowers,
 /obj/effect/decal/cleanable/generic/beet_tree_petals,
@@ -159,7 +147,12 @@
 /turf/simulated/floor/exoplanet/konyang,
 /area/exoplanet/grass/konyang)
 "rP" = (
-/obj/effect/landmark/corpse/ipc_zombie,
+/obj/structure/table/rack/folding_table,
+/obj/item/stack/material/glass,
+/obj/item/stack/material/glass,
+/obj/item/stack/material/glass,
+/obj/item/stack/material/glass,
+/obj/item/stack/material/glass,
 /turf/simulated/floor/exoplanet/konyang,
 /area/exoplanet/grass/konyang)
 "te" = (
@@ -223,20 +216,8 @@
 /obj/effect/map_effect/window_spawner/full/wood,
 /turf/simulated/floor/tiled/white,
 /area/konyang/rural_clinic)
-"xB" = (
-/obj/item/stack/rods,
-/turf/simulated/floor/tiled/white,
-/area/konyang/rural_clinic)
-"yv" = (
-/obj/effect/floor_decal/corner/green/diagonal{
-	dir = 4
-	},
-/obj/item/stack/medical/splint/full,
-/turf/simulated/floor/tiled/white,
-/area/konyang/rural_clinic)
 "yZ" = (
 /obj/structure/window_frame/wood,
-/obj/item/material/shard,
 /turf/simulated/floor/tiled/white,
 /area/konyang/rural_clinic)
 "zu" = (
@@ -257,15 +238,6 @@
 /obj/effect/decal/cleanable/generic/beet_tree_petals,
 /turf/simulated/floor/exoplanet/konyang/pink,
 /area/exoplanet/grass/konyang)
-"Cc" = (
-/obj/effect/floor_decal/corner/green/diagonal{
-	dir = 4
-	},
-/obj/item/stack/medical/bruise_pack/full{
-	pixel_y = -2
-	},
-/turf/simulated/floor/tiled/white,
-/area/konyang/rural_clinic)
 "DB" = (
 /obj/machinery/door/urban{
 	dir = 1
@@ -275,22 +247,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/konyang/rural_clinic)
-"DO" = (
-/obj/item/material/shard,
-/turf/simulated/floor/tiled/white,
-/area/konyang/rural_clinic)
 "Er" = (
 /obj/structure/flora/bush/konyang_reeds/water,
 /turf/simulated/floor/exoplanet/konyang/wilting,
 /area/exoplanet/grass/konyang)
-"Gg" = (
-/obj/effect/floor_decal/corner/green/diagonal{
-	dir = 4
-	},
-/obj/item/material/shard,
-/obj/machinery/iv_drip,
-/turf/simulated/floor/tiled/white,
-/area/konyang/rural_clinic)
 "GS" = (
 /turf/simulated/wall/wood,
 /area/konyang/rural_clinic)
@@ -364,20 +324,10 @@
 /turf/simulated/floor/tiled/white,
 /area/konyang/rural_clinic)
 "Oz" = (
-/obj/effect/floor_decal/corner/green/diagonal{
-	dir = 4
-	},
-/obj/item/material/shard,
-/obj/item/stack/rods,
-/turf/simulated/floor/tiled/white,
-/area/konyang/rural_clinic)
-"Sg" = (
-/obj/effect/floor_decal/corner/green/diagonal{
-	dir = 4
-	},
-/obj/item/reagent_containers/hypospray,
-/turf/simulated/floor/tiled/white,
-/area/konyang/rural_clinic)
+/obj/structure/table/rack/folding_table,
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/exoplanet/konyang,
+/area/exoplanet/grass/konyang)
 "SG" = (
 /obj/structure/table/rack/retail_shelf,
 /obj/item/stack/medical/ointment/full{
@@ -420,23 +370,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/konyang/rural_clinic)
-"Xb" = (
-/obj/effect/floor_decal/corner/green/diagonal{
-	dir = 4
-	},
-/obj/item/stack/rods,
-/turf/simulated/floor/tiled/white,
-/area/konyang/rural_clinic)
 "Xe" = (
 /turf/simulated/floor/exoplanet/konyang,
 /area/exoplanet/grass/konyang)
-"XG" = (
-/obj/effect/floor_decal/corner/green/diagonal{
-	dir = 4
-	},
-/obj/item/material/shard,
-/turf/simulated/floor/tiled/white,
-/area/konyang/rural_clinic)
 "XO" = (
 /obj/structure/flora/bush/konyang_reeds/water,
 /obj/structure/flora/bush/konyang_reeds/water,
@@ -804,11 +740,11 @@ Xe
 Xe
 Xe
 Xe
+Xe
 rP
-rP
-rP
-rP
-rP
+Oz
+Xe
+Xe
 Xe
 Xe
 Xe
@@ -902,7 +838,7 @@ cd
 zu
 DB
 cd
-Oz
+zu
 zu
 xw
 Vq
@@ -934,7 +870,7 @@ zu
 qH
 GS
 pl
-DO
+Vq
 Vq
 iW
 Vq
@@ -998,11 +934,11 @@ et
 pV
 GS
 pl
-xB
+Vq
 Vq
 zu
 Vq
-XG
+zu
 Vq
 GS
 Xe
@@ -1032,10 +968,10 @@ DB
 cd
 zu
 zu
-md
-Gg
 cd
-Xb
+GT
+cd
+zu
 yZ
 Xe
 Xe
@@ -1161,7 +1097,7 @@ qz
 NZ
 wJ
 SG
-Cc
+zu
 GS
 Xe
 Xe
@@ -1190,9 +1126,9 @@ Xe
 GS
 gs
 zu
-Sg
 zu
-Cc
+zu
+zu
 te
 GS
 Xe
@@ -1220,7 +1156,7 @@ Xe
 Xe
 Xe
 GS
-yv
+zu
 JK
 wc
 pq

--- a/maps/random_ruins/exoplanets/konyang/hivebot_burrows_1.dmm
+++ b/maps/random_ruins/exoplanets/konyang/hivebot_burrows_1.dmm
@@ -49,7 +49,6 @@
 	dries = 0;
 	basecolor = "#400000"
 	},
-/mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/exoplanet/dirt_konyang/cave,
 /area/hivebot_burrows_1)
 "aw" = (
@@ -76,7 +75,6 @@
 "bi" = (
 /obj/structure/pit,
 /obj/random/dirt_75,
-/mob/living/simple_animal/hostile/hivebot/range,
 /turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_1)
 "bn" = (
@@ -262,7 +260,6 @@
 	pixel_x = -4;
 	pixel_y = -13
 	},
-/obj/effect/decal/cleanable/blood/drip,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_1)
@@ -602,7 +599,6 @@
 "lw" = (
 /obj/random/dirt_75,
 /obj/structure/pit,
-/mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_1)
 "lA" = (
@@ -651,15 +647,6 @@
 	pixel_y = 5;
 	name = "crumpled note"
 	},
-/obj/effect/decal/cleanable/blood/no_dry{
-	name = "dried blood";
-	basecolor = "#400000"
-	},
-/obj/effect/decal/cleanable/blood/no_dry{
-	name = "dried blood";
-	basecolor = "#400000"
-	},
-/obj/effect/landmark/corpse/miner/hivebot_burrows,
 /turf/simulated/floor/exoplanet/dirt_konyang,
 /area/space)
 "my" = (
@@ -693,7 +680,6 @@
 "mV" = (
 /obj/random/dirt_75,
 /obj/structure/pit,
-/mob/living/simple_animal/hostile/hivebot/range,
 /turf/simulated/floor/exoplanet/dirt_konyang/cave,
 /area/hivebot_burrows_1)
 "no" = (
@@ -804,12 +790,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren/cave,
 /area/hivebot_burrows_1)
-"qs" = (
-/obj/random/dirt_75,
-/obj/item/stack/rods,
-/mob/living/simple_animal/hostile/hivebot/guardian,
-/turf/simulated/floor/exoplanet/basalt/cave,
-/area/hivebot_burrows_1)
 "qt" = (
 /obj/random/dirt_75,
 /obj/structure/girder,
@@ -833,7 +813,6 @@
 /obj/structure/flora/rock/konyang/small,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/mob/living/simple_animal/hostile/hivebot/guardian,
 /obj/effect/decal/cleanable/blood/drip{
 	name = "dried drips of blood";
 	dries = 0;
@@ -974,12 +953,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_1)
-"ts" = (
-/obj/random/dirt_75,
-/mob/living/simple_animal/hostile/hivebot/bomber,
-/obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/basalt/cave,
-/area/hivebot_burrows_1)
 "ty" = (
 /obj/structure/track,
 /turf/simulated/floor/exoplanet/basalt/cave,
@@ -1053,15 +1026,8 @@
 /obj/structure/ore_box,
 /turf/simulated/floor/exoplanet/barren/cave,
 /area/hivebot_burrows_1)
-"vW" = (
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/mob/living/simple_animal/hostile/hivebot/guardian,
-/turf/simulated/floor/exoplanet/basalt/cave,
-/area/hivebot_burrows_1)
 "wb" = (
 /obj/item/gun/projectile/shotgun/doublebarrel/pellet,
-/obj/effect/decal/cleanable/blood/drip,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/basalt/cave,
@@ -1076,11 +1042,6 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/blood/splatter{
-	basecolor = "#400000";
-	dries = 0;
-	name = "dried blood"
-	},
 /turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_1)
 "ww" = (
@@ -1208,22 +1169,6 @@
 /area/hivebot_burrows_1)
 "yl" = (
 /obj/item/arrow/rod,
-/turf/simulated/floor/exoplanet/basalt/cave,
-/area/hivebot_burrows_1)
-"yr" = (
-/obj/structure/lattice/catwalk/indoor/planks{
-	name = "duckboard"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpse/miner/hivebot_burrows,
-/obj/effect/decal/cleanable/blood/no_dry{
-	name = "dried blood";
-	basecolor = "#400000"
-	},
-/obj/effect/decal/cleanable/blood/no_dry{
-	name = "dried blood";
-	basecolor = "#400000"
-	},
 /turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_1)
 "yw" = (
@@ -1395,11 +1340,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/exoplanet/barren,
 /area/space)
-"BH" = (
-/mob/living/simple_animal/hostile/hivebot/range,
-/obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/basalt/cave,
-/area/hivebot_burrows_1)
 "BL" = (
 /obj/structure/flora/rock/konyang{
 	density = 0
@@ -1554,11 +1494,6 @@
 	pixel_x = 6
 	},
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/blood/drip{
-	name = "dried drips of blood";
-	dries = 0;
-	basecolor = "#400000"
-	},
 /turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_1)
 "ED" = (
@@ -1627,26 +1562,6 @@
 "Gc" = (
 /obj/random/dirt_75,
 /obj/structure/track,
-/turf/simulated/floor/exoplanet/basalt/cave,
-/area/hivebot_burrows_1)
-"Gh" = (
-/obj/random/dirt_75,
-/mob/living/simple_animal/hostile/hivebot,
-/obj/effect/decal/cleanable/blood/drip{
-	name = "dried drips of blood";
-	dries = 0;
-	basecolor = "#400000"
-	},
-/obj/effect/decal/cleanable/blood/drip{
-	name = "dried drips of blood";
-	dries = 0;
-	basecolor = "#400000"
-	},
-/obj/effect/decal/cleanable/blood/drip{
-	name = "dried drips of blood";
-	dries = 0;
-	basecolor = "#400000"
-	},
 /turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_1)
 "Gl" = (
@@ -1745,17 +1660,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren/cave,
 /area/hivebot_burrows_1)
-"Hj" = (
-/obj/structure/flora/rock/konyang{
-	density = 0
-	},
-/obj/effect/decal/cleanable/blood/splatter{
-	basecolor = "#400000";
-	dries = 0;
-	name = "dried blood"
-	},
-/turf/simulated/floor/exoplanet/basalt/cave,
-/area/hivebot_burrows_1)
 "HB" = (
 /obj/structure/flora/rock/pile,
 /turf/simulated/floor/exoplanet/dirt_konyang,
@@ -1824,7 +1728,6 @@
 /area/hivebot_burrows_1)
 "Jw" = (
 /obj/structure/pit,
-/mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_1)
 "JK" = (
@@ -1863,12 +1766,6 @@
 	},
 /obj/machinery/door/urban,
 /turf/simulated/floor/exoplanet/barren/cave,
-/area/hivebot_burrows_1)
-"KC" = (
-/mob/living/simple_animal/hostile/hivebot/range,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_1)
 "KD" = (
 /obj/random/dirt_75,
@@ -2126,7 +2023,6 @@
 /obj/random/dirt_75,
 /obj/structure/flora/rock/konyang/small,
 /obj/structure/pit,
-/mob/living/simple_animal/hostile/hivebot/range,
 /turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_1)
 "OZ" = (
@@ -2231,11 +2127,6 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/exoplanet/dirt_konyang/cave,
 /area/hivebot_burrows_1)
-"QO" = (
-/mob/living/simple_animal/hostile/hivebot,
-/obj/structure/track,
-/turf/simulated/floor/exoplanet/basalt/cave,
-/area/hivebot_burrows_1)
 "RL" = (
 /obj/random/dirt_75,
 /obj/structure/rope_post{
@@ -2265,12 +2156,6 @@
 /obj/random/dirt_75,
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/exoplanet/barren/cave,
-/area/hivebot_burrows_1)
-"SB" = (
-/obj/random/dirt_75,
-/obj/structure/pit,
-/mob/living/simple_animal/hostile/hivebot/range,
-/turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_1)
 "SE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2373,13 +2258,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/exoplanet/barren/cave,
-/area/hivebot_burrows_1)
-"UC" = (
-/mob/living/simple_animal/hostile/hivebot,
-/obj/structure/track,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_1)
 "UU" = (
 /obj/random/dirt_75,
@@ -3240,7 +3118,7 @@ ve
 tf
 Ah
 YM
-qs
+cT
 xf
 xf
 xf
@@ -3451,7 +3329,7 @@ xf
 tr
 Ad
 VG
-BH
+JK
 hZ
 Gc
 De
@@ -3613,7 +3491,7 @@ xf
 xf
 xf
 xf
-QO
+ty
 ty
 xf
 xf
@@ -3773,7 +3651,7 @@ xf
 xf
 xf
 IQ
-TD
+JK
 Ew
 hZ
 xf
@@ -3825,8 +3703,8 @@ mV
 xf
 xf
 Jd
-Hj
-Yp
+oH
+JK
 wb
 NB
 xf
@@ -3869,7 +3747,7 @@ ib
 WX
 xi
 jt
-ts
+Wd
 Wd
 Wd
 Sl
@@ -3879,7 +3757,7 @@ xf
 hZ
 eV
 wj
-Gh
+JK
 no
 xf
 xf
@@ -3923,7 +3801,7 @@ Go
 tr
 xf
 xf
-vW
+Wd
 bZ
 xf
 xf
@@ -3931,7 +3809,7 @@ xf
 xs
 Ad
 sN
-yr
+RN
 NI
 xf
 xf
@@ -4089,7 +3967,7 @@ tr
 xf
 xf
 xf
-SB
+lw
 JK
 xf
 xf
@@ -4172,7 +4050,7 @@ Wd
 Wd
 Wd
 Lm
-UC
+Vx
 Vx
 Vx
 xf
@@ -4230,7 +4108,7 @@ Vx
 Vx
 tr
 JK
-KC
+Wd
 Fv
 Ad
 xf

--- a/maps/random_ruins/exoplanets/konyang/hivebot_burrows_2.dmm
+++ b/maps/random_ruins/exoplanets/konyang/hivebot_burrows_2.dmm
@@ -12,7 +12,6 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/exoplanet/asphalt,
 /area/hivebot_burrows_2)
 "aL" = (
@@ -178,7 +177,6 @@
 "cR" = (
 /obj/random/dirt_75,
 /obj/structure/pit,
-/mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_2)
 "cW" = (
@@ -464,7 +462,6 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/effect/landmark/corpse/scientist/hivebot_burrows,
 /obj/effect/decal/cleanable/blood/no_dry{
 	name = "dried blood";
 	basecolor = "#400000"
@@ -896,12 +893,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/dirt_konyang/cave,
 /area/hivebot_burrows_2)
-"my" = (
-/obj/structure/pit,
-/obj/random/dirt_75,
-/mob/living/simple_animal/hostile/hivebot/range,
-/turf/simulated/floor/exoplanet/basalt/cave,
-/area/hivebot_burrows_2)
 "mA" = (
 /obj/item/stack/material/steel{
 	pixel_y = 9;
@@ -1011,7 +1002,6 @@
 /area/hivebot_burrows_2)
 "ob" = (
 /obj/structure/pit,
-/mob/living/simple_animal/hostile/hivebot,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/basalt/cave,
@@ -1066,11 +1056,6 @@
 	pixel_x = 3
 	},
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/blood/drip{
-	name = "dried drips of blood";
-	dries = 0;
-	basecolor = "#400000"
-	},
 /turf/simulated/floor/exoplanet/plating,
 /area/hivebot_burrows_2)
 "oI" = (
@@ -1201,15 +1186,6 @@
 	dir = 10
 	},
 /obj/random/dirt_75,
-/obj/effect/landmark/corpse/scientist/hivebot_burrows,
-/obj/effect/decal/cleanable/blood/no_dry{
-	name = "dried blood";
-	basecolor = "#400000"
-	},
-/obj/effect/decal/cleanable/blood/no_dry{
-	name = "dried blood";
-	basecolor = "#400000"
-	},
 /turf/simulated/floor/exoplanet/tiled/dark,
 /area/hivebot_burrows_2)
 "qJ" = (
@@ -1229,12 +1205,6 @@
 	pixel_x = 6
 	},
 /turf/simulated/floor/exoplanet/plating,
-/area/hivebot_burrows_2)
-"qQ" = (
-/obj/random/dirt_75,
-/mob/living/simple_animal/hostile/hivebot/bomber,
-/obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_2)
 "qR" = (
 /obj/random/dirt_75,
@@ -1400,10 +1370,6 @@
 	},
 /obj/random/dirt_75,
 /obj/random/junk,
-/obj/effect/decal/cleanable/blood/no_dry{
-	name = "dried blood";
-	basecolor = "#400000"
-	},
 /turf/simulated/floor/exoplanet/tiled/dark,
 /area/hivebot_burrows_2)
 "tj" = (
@@ -1868,11 +1834,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/blood/drip{
-	name = "dried drips of blood";
-	dries = 0;
-	basecolor = "#400000"
-	},
 /turf/simulated/floor/exoplanet/tiled/dark,
 /area/hivebot_burrows_2)
 "zH" = (
@@ -2084,11 +2045,6 @@
 	pixel_y = -4;
 	pixel_x = 5
 	},
-/obj/effect/decal/cleanable/blood/splatter{
-	basecolor = "#400000";
-	dries = 0;
-	name = "dried blood"
-	},
 /turf/simulated/floor/exoplanet/tiled/white,
 /area/hivebot_burrows_2)
 "Cr" = (
@@ -2155,7 +2111,6 @@
 /area/hivebot_burrows_2)
 "DA" = (
 /obj/structure/pit,
-/mob/living/simple_animal/hostile/hivebot,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_2)
@@ -2165,12 +2120,6 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/mob/living/simple_animal/hostile/hivebot,
-/obj/effect/decal/cleanable/blood/splatter{
-	basecolor = "#400000";
-	dries = 0;
-	name = "dried blood"
-	},
 /turf/simulated/floor/exoplanet/tiled/dark,
 /area/hivebot_burrows_2)
 "DI" = (
@@ -2303,7 +2252,6 @@
 "Fs" = (
 /obj/random/dirt_75,
 /obj/structure/pit,
-/mob/living/simple_animal/hostile/hivebot/range,
 /obj/item/pickaxe/hand{
 	pixel_x = 12;
 	pixel_y = 8
@@ -2628,7 +2576,6 @@
 /obj/effect/floor_decal/corner_wide/mauve/diagonal,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/exoplanet/tiled/dark,
 /area/hivebot_burrows_2)
 "Le" = (
@@ -2943,7 +2890,6 @@
 /area/hivebot_burrows_2)
 "PL" = (
 /obj/structure/pit,
-/mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_2)
 "PR" = (
@@ -3288,17 +3234,6 @@
 	},
 /turf/simulated/floor/exoplanet/basalt/cave,
 /area/hivebot_burrows_2)
-"Ts" = (
-/obj/structure/flora/rock/konyang/small,
-/obj/random/dirt_75,
-/obj/effect/decal/cleanable/blood/drip{
-	name = "dried drips of blood";
-	dries = 0;
-	basecolor = "#400000"
-	},
-/mob/living/simple_animal/hostile/hivebot/guardian,
-/turf/simulated/floor/exoplanet/basalt/cave,
-/area/hivebot_burrows_2)
 "Ty" = (
 /obj/effect/floor_decal/konyang_flowers,
 /obj/effect/decal/fake_object/light_source/invisible{
@@ -3347,16 +3282,6 @@
 	dir = 5
 	},
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/blood/drip{
-	name = "dried drips of blood";
-	dries = 0;
-	basecolor = "#400000"
-	},
-/obj/effect/decal/cleanable/blood/drip{
-	name = "dried drips of blood";
-	dries = 0;
-	basecolor = "#400000"
-	},
 /turf/simulated/floor/exoplanet/tiled/dark,
 /area/hivebot_burrows_2)
 "Us" = (
@@ -3512,11 +3437,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/hivebot_burrows_2)
-"VR" = (
-/obj/random/dirt_75,
-/mob/living/simple_animal/hostile/hivebot/guardian,
-/turf/simulated/floor/exoplanet/barren/cave,
-/area/hivebot_burrows_2)
 "Wf" = (
 /obj/structure/flora/rock/konyang{
 	density = 0
@@ -3547,7 +3467,6 @@
 	pixel_y = 6;
 	pixel_x = 6
 	},
-/mob/living/simple_animal/hostile/hivebot/guardian,
 /turf/simulated/floor/exoplanet/dirt_konyang/cave,
 /area/hivebot_burrows_2)
 "Wz" = (
@@ -3556,16 +3475,6 @@
 	pixel_x = 3
 	},
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/blood/drip{
-	name = "dried drips of blood";
-	dries = 0;
-	basecolor = "#400000"
-	},
-/obj/effect/decal/cleanable/blood/drip{
-	name = "dried drips of blood";
-	dries = 0;
-	basecolor = "#400000"
-	},
 /turf/simulated/floor/exoplanet/plating,
 /area/hivebot_burrows_2)
 "WD" = (
@@ -3576,11 +3485,6 @@
 /obj/item/pickaxe/hand{
 	pixel_x = -12;
 	pixel_y = 12
-	},
-/obj/effect/decal/cleanable/blood/splatter{
-	basecolor = "#400000";
-	dries = 0;
-	name = "dried blood"
 	},
 /turf/simulated/floor/exoplanet/tiled/dark,
 /area/hivebot_burrows_2)
@@ -4484,7 +4388,7 @@ NY
 XQ
 XQ
 XQ
-my
+DA
 if
 XQ
 XQ
@@ -4646,7 +4550,7 @@ XQ
 tP
 ud
 ud
-qQ
+ud
 WK
 ud
 ud
@@ -5056,7 +4960,7 @@ XQ
 XQ
 Pf
 oq
-VR
+AA
 fb
 AA
 JI
@@ -5365,7 +5269,7 @@ Gg
 Hh
 JG
 XQ
-my
+DA
 XQ
 XQ
 ww
@@ -5482,7 +5386,7 @@ NR
 Hl
 LV
 RL
-Ts
+zU
 lK
 pU
 dU


### PR DESCRIPTION
This alters some of the planetside POIs for Konyang. It removes the dead IPCs from them, as well as makes it look like repair is underway on some of the damaged buildings. It also removes the hivebots from two maps that had those, since the military would likely have cleared those out by now.