### PR TITLE
Antagland Spring Cleaning

### DIFF
--- a/html/changelogs/hazelmouse-antagmaintenance.yml
+++ b/html/changelogs/hazelmouse-antagmaintenance.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Made several QoL changes to make the off-ship antag areas more in-line with the mapping standards of newer maps in the codebase, including primarily cosmetic alterations to the raider, burglar, and mercenary shuttles."

--- a/maps/_common/areas/special.dm
+++ b/maps/_common/areas/special.dm
@@ -144,7 +144,6 @@
 /area/antag/wizard
 	name = "Wizard Mind Palace"
 	icon_state = "wizard"
-	dynamic_lighting = FALSE
 
 /area/antag/actor
 	name = "Actor Preparation"


### PR DESCRIPTION
Does some spring cleaning on the off-ship antagonist area. This is primarily in relation to lighting, decals, and some small changes to the layouts of shuttles - particularly the mercenary shuttle, which has received significant changes to its shape.

This is not a comprehensive remap, it's only to bring the area slightly more in line with the mapping standards of the server.

I suspect that starlight doesn't render against unsimulated turfs, so I've had to use some janky floating starlight fixtures outside of windows to simulate that. It's not ideal, but neither is anything in CC.

![image](https://github.com/user-attachments/assets/d2bec39c-0e59-49eb-a1b2-76990e8f7170)

![image](https://github.com/user-attachments/assets/f7db446f-4bbb-490c-9cbe-b7f0e34606d0)

![image](https://github.com/user-attachments/assets/e196fd98-5840-4254-80e0-798ad135d49b)

![image](https://github.com/user-attachments/assets/0d910c23-5232-43e4-bdae-0f7443ae4402)

![image](https://github.com/user-attachments/assets/432538c5-2692-4636-aaa5-71b282550dfc)

