### PR TITLE
Allows Chemistry Bags To Hold Inhaler Cartridges

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -331,6 +331,4 @@
 		/obj/item/reagent_containers/pill,
 		/obj/item/reagent_containers/glass/beaker,
 		/obj/item/reagent_containers/glass/bottle,
-		/obj/item/reagent_containers/personal_inhaler_cartridge,
-		/obj/item/personal_inhaler,
-		/obj/item/reagent_containers/inhaler)
+		/obj/item/reagent_containers/personal_inhaler_cartridge)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -327,4 +327,10 @@
 	max_storage_space = 200
 	w_class = WEIGHT_CLASS_BULKY
 	slowdown = 1
-	can_hold = list(/obj/item/reagent_containers/pill,/obj/item/reagent_containers/glass/beaker,/obj/item/reagent_containers/glass/bottle)
+	can_hold = list(
+		/obj/item/reagent_containers/pill,
+		/obj/item/reagent_containers/glass/beaker,
+		/obj/item/reagent_containers/glass/bottle,
+		/obj/item/reagent_containers/personal_inhaler_cartridge,
+		/obj/item/personal_inhaler,
+		/obj/item/reagent_containers/inhaler)

--- a/code/modules/reagents/reagent_containers/inhaler_advanced.dm
+++ b/code/modules/reagents/reagent_containers/inhaler_advanced.dm
@@ -18,6 +18,7 @@
 	origin_tech = list(TECH_BIO = 2, TECH_MATERIAL = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 250)
 	center_of_mass = null
+	storage_slot_sort_by_name = TRUE
 
 /obj/item/reagent_containers/personal_inhaler_cartridge/on_reagent_change()
 	update_icon()

--- a/html/changelogs/Acetrea-bagmedatinhalerbaby.yml
+++ b/html/changelogs/Acetrea-bagmedatinhalerbaby.yml
@@ -55,4 +55,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Allows pharmacy bags to hold inhalers and autoinhalers."
+  - rscadd: "Allows pharmacy bags to hold inhaler cartridges."

--- a/html/changelogs/Acetrea-bagmedatinhalerbaby.yml
+++ b/html/changelogs/Acetrea-bagmedatinhalerbaby.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Acetrea
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Allows pharmacy bags to hold inhalers and autoinhalers."


### PR DESCRIPTION
Given that the pharmacist is given inhalers and autoinhalers to fill every round with pneumalin, pulmo, dexalin, and whatever, I figured this might've been an oversight.

Super helpful for Odyssey rounds when all the crew are going down and medical wants to bring the entire fridge (8 autoinhalers + 2 inhalers + 4-6 small inhaler cartridges AND the bottles)

EDIT: Changed to only inhaler cartridges, not autoinhalers nor inhaler bases.