### PR TITLE
Platforms Fixes and Hopping down them from the upper side.

### DIFF
--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -423,6 +423,7 @@
 	atom_flags = ATOM_FLAG_CHECKS_BORDER|ATOM_FLAG_ALWAYS_ALLOW_PICKUP
 	climbable = TRUE
 	color = COLOR_TILED
+	pass_flags_self = LETPASSTHROW
 
 /obj/structure/platform/dark
 	icon_state = "platform_dark"
@@ -435,8 +436,6 @@
 	if(istype(mover, /obj/projectile))
 		return TRUE
 	if(!istype(mover) || mover.pass_flags & PASSRAILING)
-		return TRUE
-	if(mover.throwing)
 		return TRUE
 	if(get_dir(mover, target) == REVERSE_DIR(dir))
 		return FALSE
@@ -462,10 +461,14 @@
 			var/climb_text = same_turf ? "over" : "down"
 			LAZYADD(climbers, user)
 			user.visible_message(SPAN_NOTICE("[user] starts climbing [climb_text] \the [src]..."), SPAN_NOTICE("You start climbing [climb_text] \the [src]..."))
-			if(do_after(user, 1 SECOND) && can_climb(user, TRUE))
-				user.visible_message(SPAN_NOTICE("[user] climbs [climb_text] \the [src]."), SPAN_NOTICE("You climb [climb_text] \the [src]."))
-				user.forceMove(next_turf)
-				LAZYREMOVE(climbers, user)
+
+			if(!do_after(user, 1 SECOND) || !can_climb(user, TRUE))
+				LAZYREMOVE(climbers, user) // Prevents early-cancellation not clearing the climber off the list
+				return
+
+			user.visible_message(SPAN_NOTICE("[user] climbs [climb_text] \the [src]."), SPAN_NOTICE("You climb [climb_text] \the [src]."))
+			user.forceMove(next_turf)
+			LAZYREMOVE(climbers, user)
 
 /obj/structure/platform/ledge
 	icon_state = "ledge"

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -423,7 +423,7 @@
 	atom_flags = ATOM_FLAG_CHECKS_BORDER|ATOM_FLAG_ALWAYS_ALLOW_PICKUP
 	climbable = TRUE
 	color = COLOR_TILED
-	pass_flags_self = LETPASSTHROW
+	pass_flags_self = LETPASSTHROW|PASSSTRUCTURE|PASSRAILING
 
 /obj/structure/platform/dark
 	icon_state = "platform_dark"
@@ -469,6 +469,16 @@
 			user.visible_message(SPAN_NOTICE("[user] climbs [climb_text] \the [src]."), SPAN_NOTICE("You climb [climb_text] \the [src]."))
 			user.forceMove(next_turf)
 			LAZYREMOVE(climbers, user)
+
+/obj/structure/platform/CollidedWith(atom/bumped_atom)
+	. = ..()
+	if(get_dir(src, bumped_atom) == REVERSE_DIR(dir))
+		var/atom/movable/bumped_movable = bumped_atom
+		if(ismob(bumped_movable))
+			visible_message(SPAN_NOTICE("[bumped_movable] hops down the platform."))
+		else
+			visible_message(SPAN_NOTICE("[bumped_movable] goes over the platform."))
+		bumped_movable.forceMove(src.loc)
 
 /obj/structure/platform/ledge
 	icon_state = "ledge"

--- a/html/changelogs/flaminglily-platforms.yml
+++ b/html/changelogs/flaminglily-platforms.yml
@@ -57,3 +57,4 @@ delete-after: True
 changes:
   - bugfix: "Fixed throwing and maneuvering over platforms."
   - bugfix: "Fixed a bug where early aborting a climb over platforms would render that platform permanently not-climable."
+  - qol: "Made it possible to go down a platform by walking. This also allows mechs, vehicles, etc. to go down a platform."

--- a/html/changelogs/flaminglily-platforms.yml
+++ b/html/changelogs/flaminglily-platforms.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FlamingLily
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed throwing and maneuvering over platforms."
+  - bugfix: "Fixed a bug where early aborting a climb over platforms would render that platform permanently not-climable."


### PR DESCRIPTION
Fixes:
* Platforms blocking thrown items from moving. I believe this also fixes maneuvering over platforms, et cetera.
* Fixed a bug that would cause platforms to become un-climbable if climbing them was aborted early.
* Made it so that you can "climb down" a platform just by walking over them. Climbing "Up" a platform still requires a climb action and will block things that cannot climb, but now you can have vehicles, such as mechs, go over a platform without needing to climb. This allows you to piledriver someone with a mech from deck three to deck one. If you want.