### PR TITLE
Balance - Energy Weapons ammo buff

### DIFF
--- a/code/modules/projectiles/guns/energy/blaster.dm
+++ b/code/modules/projectiles/guns/energy/blaster.dm
@@ -13,7 +13,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	offhand_accuracy = 1
 	projectile_type = /obj/projectile/energy/blaster
-	max_shots = 6
+	max_shots = 12
 
 	burst_delay = 2
 	sel_mode = 1
@@ -41,7 +41,7 @@
 /obj/item/gun/energy/blaster/pilot_special
 	name = "pilot's sidearm"
 	desc = "A robust, low in maintenance blaster pistol. Customized for peak performance and perfect for self-defense purposes."
-	max_shots = 8
+	max_shots = 12
 	accuracy = 2 // Likely to get nothing else, so they gotta know how to make it count.
 	offhand_accuracy = 2
 
@@ -66,7 +66,7 @@
 	icon = 'icons/obj/guns/blaster_carbine.dmi'
 	icon_state = "blaster_carbine"
 	item_state = "blaster_carbine"
-	max_shots = 12
+	max_shots = 16
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	offhand_accuracy = 0
 	projectile_type = /obj/projectile/energy/blaster
@@ -116,7 +116,7 @@
 	icon = 'icons/obj/guns/blaster_ar.dmi'
 	icon_state = "blaster_ar"
 	item_state = "blaster_ar"
-	max_shots = 20
+	max_shots = 24
 	projectile_type = /obj/projectile/energy/blaster/heavy
 	fire_sound = 'sound/weapons/laserstrong.ogg'
 	slot_flags = SLOT_BACK

--- a/code/modules/projectiles/guns/energy/crank.dm
+++ b/code/modules/projectiles/guns/energy/crank.dm
@@ -6,7 +6,7 @@
 	item_state = "icelance"
 	has_item_ratio = FALSE
 	fire_sound = 'sound/weapons/laser1.ogg'
-	max_shots = 5
+	max_shots = 7
 	accuracy = -1
 	accuracy_wielded = 2
 	fire_delay = 10

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -9,7 +9,7 @@
 	slot_flags = SLOT_BELT|SLOT_BACK
 	accuracy = 1
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 15
+	force = 20
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	projectile_type = /obj/projectile/beam/midlaser
@@ -193,7 +193,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 2000)
 	origin_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 2)
 	projectile_type = /obj/projectile/beam/shotgun
-	max_shots = 20
+	max_shots = 28
 	sel_mode = 1
 	is_wieldable = TRUE
 	burst = 4

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -11,7 +11,7 @@
 	fire_sound = 'sound/weapons/Taser.ogg'
 	slot_flags = SLOT_BELT
 	accuracy = 1
-	max_shots = 10
+	max_shots = 15
 	can_turret = 1
 	secondary_projectile_type = /obj/projectile/beam
 	secondary_fire_sound = 'sound/weapons/laser1.ogg'
@@ -133,7 +133,7 @@
 	item_state = "epistolstun100"
 	fire_sound = 'sound/weapons/Taser.ogg'
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
-	max_shots = 7
+	max_shots = 10
 	fire_delay = 4
 	can_turret = 1
 	secondary_projectile_type = /obj/projectile/beam/pistol
@@ -161,7 +161,7 @@
 	has_item_ratio = FALSE
 	fire_sound = 'sound/weapons/Taser.ogg'
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
-	max_shots = 10
+	max_shots = 12
 	fire_delay = 3
 	can_turret = FALSE
 	secondary_projectile_type = /obj/projectile/beam/pistol/hegemony
@@ -187,7 +187,7 @@
 	has_item_ratio = FALSE
 	fire_sound = 'sound/weapons/laser2.ogg'
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
-	max_shots = 10
+	max_shots = 12
 	fire_delay = 3
 	can_turret = FALSE
 	secondary_projectile_type = /obj/projectile/beam/pistol
@@ -214,7 +214,7 @@
 	has_item_ratio = FALSE
 	fire_sound = 'sound/weapons/energy_repeater.ogg'
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
-	max_shots = 20
+	max_shots = 24
 	fire_delay = 3
 
 	offhand_accuracy = 6 // same as firing it in your main hand
@@ -238,7 +238,7 @@
 	has_item_ratio = FALSE
 	fire_sound = 'sound/weapons/Taser.ogg'
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
-	max_shots = 8
+	max_shots = 10
 	fire_delay = 5
 	secondary_projectile_type = /obj/projectile/beam/pistol/scc/weak
 	secondary_fire_sound = 'sound/weapons/energy_repeater.ogg'
@@ -288,7 +288,7 @@
 	icon_state = "particlesmg"
 	item_state = "particlesmg"
 	slot_flags = SLOT_BELT|SLOT_HOLSTER|SLOT_BACK
-	max_shots = 14
+	max_shots = 18
 	force = 16
 	projectile_type = /obj/projectile/beam/stun/skrell
 	secondary_projectile_type = /obj/projectile/beam/pulse/skrell
@@ -340,7 +340,7 @@
 	fire_sound = 'sound/weapons/Taser.ogg'
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	pin = /obj/item/device/firing_pin/psionic
-	max_shots = 8
+	max_shots = 10
 	fire_delay = 4
 	can_turret = FALSE
 	secondary_projectile_type = /obj/projectile/energy/blaster/skrell

--- a/code/modules/projectiles/guns/energy/rifle.dm
+++ b/code/modules/projectiles/guns/energy/rifle.dm
@@ -9,7 +9,7 @@
 	slot_flags = SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
 	force = 15
-	max_shots = 20
+	max_shots = 25
 	fire_delay = 6
 	burst_delay = 3
 	accuracy = -1
@@ -46,7 +46,7 @@
 	item_state = "laserrifle"
 	has_item_ratio = FALSE // the back and suit slots have ratio sprites but the in-hands dont
 	fire_sound = 'sound/weapons/laser1.ogg'
-	max_shots = 15
+	max_shots = 20
 	fire_delay = 6
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	projectile_type = /obj/projectile/beam/midlaser
@@ -75,7 +75,7 @@
 	icon = 'icons/obj/guns/crew_laser.dmi'
 	icon_state = "trilaser"
 	item_state = "trilaser"
-	max_shots = 12
+	max_shots = 15
 	fire_delay = 5
 	burst_delay = 5
 	origin_tech = list(TECH_COMBAT = 8, TECH_MAGNET = 4)
@@ -250,7 +250,7 @@
 	has_item_ratio = FALSE
 	fire_sound = 'sound/weapons/laser1.ogg'
 	slot_flags = SLOT_BELT|SLOT_BACK
-	max_shots = 15
+	max_shots = 18
 	can_turret = TRUE
 	turret_is_lethal = TRUE
 	projectile_type = /obj/projectile/beam/midlaser/hegemony

--- a/html/changelogs/courierbravo - energyweaponsbuff.yml
+++ b/html/changelogs/courierbravo - energyweaponsbuff.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: CourierBravo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance "Increases ammo count for most commonly seen energy weapons. Laser pistols see increases of 2-3 shots, averaging between 10-12, carbines and rifles gain 3-5 more rounds, with some skipped due to high ammo counts or powerful projectiles. And blasters have had increases of 2-6, depending on the model. Anything scoped, recharging, a disruptor, or otherwise unique/odd is kept the same for balance."

--- a/html/changelogs/courierbravo - energyweaponsbuff.yml
+++ b/html/changelogs/courierbravo - energyweaponsbuff.yml
@@ -55,4 +55,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - balance "Increases ammo count for most commonly seen energy weapons. Laser pistols see increases of 2-3 shots, averaging between 10-12, carbines and rifles gain 3-5 more rounds, with some skipped due to high ammo counts or powerful projectiles. And blasters have had increases of 2-6, depending on the model. Anything scoped, recharging, a disruptor, or otherwise unique/odd is kept the same for balance."
+  - balance "Increases ammo count for most commonly seen energy weapons. Laser pistols see increases of 2-3 shots, averaging between 10-12 shots, carbines and rifles gain 3-5 more rounds, with some skipped due to high ammo counts or powerful projectiles. And blasters have had increases of 2-6, depending on the model. Anything scoped, recharging, a disruptor, or otherwise unique/odd is kept the same for balance."

--- a/html/changelogs/courierbravo - energyweaponsbuff.yml
+++ b/html/changelogs/courierbravo - energyweaponsbuff.yml
@@ -55,4 +55,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - balance "Increases ammo count for most commonly seen energy weapons. Laser pistols see increases of 2-3 shots, averaging between 10-12 shots, carbines and rifles gain 3-5 more rounds, with some skipped due to high ammo counts or powerful projectiles. And blasters have had increases of 2-6, depending on the model. Anything scoped, recharging, a disruptor, or otherwise unique/odd is kept the same for balance."
+  - balance: "Increases ammo count for most commonly seen energy weapons. Laser pistols see increases of 2-3 shots, averaging between 10-12 shots, carbines and rifles gain 3-5 more rounds, with some skipped due to high ammo counts or powerful projectiles. And blasters have had increases of 2-6, depending on the model. Anything scoped, recharging, a disruptor, or otherwise unique/odd is kept the same for balance."


### PR DESCRIPTION
Buffs most commonly seen energy weapons by anywhere from 2-6 shots. Laser pistols get closer to 2-3, laser carbines and rifles see buffs of 3-5 more shots, and blasters get the most love at 2-6 more shots, depending on model. Anything with a scope, disruptors, anything that autorecharges, or otherwise unique/odd have been left alone.

These changes are being made to hopefully bring energy weapons more in line with ballistics. I've noticed that energy weapons are very rarely used by anyone but security or someone doing a very specific gimmick. Any time its rev or there otherwise is a crew militia started, I'll order both laser and ballistics, and the ballistics are always taken first. Ballistics overall are very strong, dealing far more enduring damage than energy weapons tend to. And, most ballistics blow energy weapons out of the water for just raw DPS. For example, both the laser rifle and burst rifle have a damage of 30, with an ap of 20 for the laser and 28 for the ballistic. This is fairly comparable, but critically, the burst rifle is a burst rifle. So per trigger pull, you're potentially doing up to 60 damage with ap 28. This of course assumes you're using lethal for both, polymer rounds for the burst rifle do 25 damage at ap 34. Which would be up to 50 damage per trigger pull. I just don't think that the rechargeable plus beams going through windows makes up for it.

Energy weapons also just suffer from critically small ammo counts. Which is fine in a ship environment like the horizon (to a degree), but they tend to perform very poorly in expedition settings. To the point that they're arguably not worth taking for most away sites. This is mostly because the average encounter will spend half or 1/3rd your ammo.

I still want ballistics and energy weapons to have their respective rolls of expendable ammo vs rechargeable, and projectile vs beams (going through windows without having to break them first being a very nice advantage). But, I'd like to see people at least consider energy weapons over ballistic for mechanical reasons rather than just flavor. Like I tend to do with their current stats.