### PR TITLE
Adds some karaoke stage decoration to the Point Verdant bar

### DIFF
--- a/html/changelogs/ASmallCuteCat - Point Verdant Bar Karaoke.yml
+++ b/html/changelogs/ASmallCuteCat - Point Verdant Bar Karaoke.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: ASmallCuteCat
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/ASmallCuteCat - Point Verdant Bar Karaoke.yml
+++ b/html/changelogs/ASmallCuteCat - Point Verdant Bar Karaoke.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a karaoke setup to the Point Verdant bar."
+  - rscdel: "Removed the piano from the Point Verdant Bar to make room for the karaoke setup."

--- a/maps/away/away_site/konyang/point_verdant/point_verdant.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant.dmm
@@ -1653,6 +1653,21 @@
 /obj/item/storage/box/fancy/egg_box,
 /obj/item/storage/box/fancy/egg_box,
 /obj/random/dirt_75,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
 /turf/simulated/floor/tiled/white,
 /area/point_verdant/interior/restaurant)
 "aWE" = (
@@ -4307,10 +4322,11 @@
 /turf/simulated/floor/reinforced,
 /area/point_verdant/interior/robotics)
 "crU" = (
-/obj/structure/ledge/quarter{
-	dir = 1
-	},
 /obj/effect/map_effect/particle_emitter/bar_smoke,
+/obj/structure/ledge/quarter{
+	dir = 5
+	},
+/obj/effect/decal/exterior_stairs/half,
 /turf/simulated/floor/lino,
 /area/point_verdant/interior/bar)
 "csl" = (
@@ -5302,10 +5318,9 @@
 /turf/simulated/floor/lino,
 /area/point_verdant/interior/hotel)
 "cUW" = (
-/obj/structure/ledge/quarter{
-	dir = 1
-	},
-/turf/simulated/floor/lino,
+/obj/structure/table/reinforced/wood,
+/obj/item/device/megaphone/stagemicrophone,
+/turf/simulated/floor/tiled/full,
 /area/point_verdant/interior/bar)
 "cVd" = (
 /obj/effect/decal/road_marking/thin,
@@ -13492,12 +13507,6 @@
 	},
 /turf/simulated/floor/asphalt,
 /area/point_verdant/outdoors)
-"hCW" = (
-/obj/structure/ledge/quarter/corner{
-	dir = 8
-	},
-/turf/simulated/floor/lino,
-/area/point_verdant/interior/bar)
 "hDH" = (
 /obj/effect/decal/road_marking{
 	dir = 8
@@ -13858,10 +13867,11 @@
 /turf/simulated/floor/sidewalk,
 /area/point_verdant/outdoors)
 "hOF" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/green/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/point_verdant/interior/restaurant)
 "hPc" = (
@@ -17091,11 +17101,16 @@
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/arcade)
 "jFh" = (
-/obj/structure/reagent_dispensers/cookingoil,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/table/stone/marble,
+/obj/machinery/chemical_dispenser/bar_soft/full{
+	dir = 8;
+	pixel_x = 7;
+	pixel_y = 5
+	},
 /turf/simulated/floor/tiled/white,
 /area/point_verdant/interior/restaurant)
 "jFE" = (
@@ -19533,9 +19548,6 @@
 /turf/simulated/floor/tiled/white,
 /area/point_verdant/interior/laundromat)
 "kXe" = (
-/obj/structure/bed/stool{
-	dir = 8
-	},
 /obj/machinery/light/colored/blue{
 	dir = 1;
 	pixel_y = 22
@@ -20143,7 +20155,9 @@
 /turf/simulated/floor/exoplanet/konyang/no_edge,
 /area/point_verdant/outdoors)
 "lqn" = (
-/obj/effect/decal/exterior_stairs/half,
+/obj/structure/ledge/quarter{
+	dir = 5
+	},
 /turf/simulated/floor/lino,
 /area/point_verdant/interior/bar)
 "lqo" = (
@@ -21965,7 +21979,7 @@
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/offices)
 "mpm" = (
-/obj/structure/synthesized_instrument/synthesizer/piano,
+/obj/machinery/media/jukebox,
 /turf/simulated/floor/tiled/full,
 /area/point_verdant/interior/bar)
 "mpn" = (
@@ -24536,6 +24550,14 @@
 	},
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/green/diagonal,
+/obj/item/reagent_containers/glass/fertilizer/ez,
+/obj/item/reagent_containers/glass/fertilizer/ez,
+/obj/item/reagent_containers/glass/fertilizer/ez,
+/obj/item/seeds/mossseed,
+/obj/item/seeds/mossseed,
+/obj/item/seeds/mossseed,
+/obj/item/seeds/mossseed,
+/obj/item/seeds/mossseed,
 /turf/simulated/floor/tiled/white,
 /area/point_verdant/interior/restaurant)
 "nOI" = (
@@ -35118,12 +35140,10 @@
 /turf/simulated/floor/roofing_tiles,
 /area/point_verdant/interior/arcade)
 "usD" = (
-/obj/structure/flora/pottedplant/orientaltree,
-/obj/effect/floor_decal/corner_wide/mauve{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/point_verdant/interior/offices)
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/reagent_dispensers/cookingoil,
+/turf/simulated/floor/tiled/white,
+/area/point_verdant/interior/restaurant)
 "usQ" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -68275,7 +68295,7 @@ qjz
 kUu
 aDQ
 eQd
-hCW
+wUq
 wUq
 cYB
 qXz
@@ -68530,9 +68550,9 @@ qWF
 duW
 duW
 vWM
-mpm
 fFf
-cUW
+fFf
+lqn
 wUq
 qjz
 wih
@@ -69044,8 +69064,8 @@ qWF
 qWF
 duW
 vWM
-fFf
-fFf
+cUW
+mpm
 lqn
 wUq
 cqj
@@ -121448,7 +121468,7 @@ vya
 dVi
 fOT
 xcq
-usD
+avA
 vya
 vya
 avA
@@ -137906,7 +137926,7 @@ haT
 haT
 emO
 haT
-wsO
+usD
 kzP
 ciW
 ryF
@@ -138164,7 +138184,7 @@ ksE
 ksE
 haT
 ksE
-ksE
+wsO
 ciW
 cDm
 ryi


### PR DESCRIPTION
Requested by NewOriginalSchwann, this PR removes the piano from the Point Verdant bar and replaces it with a jukebox and a microphone. Doesn't actually mechanically enable karaoke, but now it's easier to pretend.
