### PR TITLE
Odyssey Canonicity Coinflip

### DIFF
--- a/code/controllers/subsystems/processing/odyssey.dm
+++ b/code/controllers/subsystems/processing/odyssey.dm
@@ -92,6 +92,13 @@ SUBSYSTEM_DEF(odyssey)
 	if(scenario)
 		ody_gamemode.required_players = scenario.min_player_amount
 		ody_gamemode.required_enemies = scenario.min_actor_amount
+
+		//Setting the scenario_type variable for use here in UI info and chat notices.
+		if(!length(scenario.possible_scenario_types))
+			scenario.scenario_type = SCENARIO_TYPE_NONCANON
+		else
+			scenario.scenario_type = pick(scenario.possible_scenario_types)
+
 	site_landing_restricted = scenario.site_landing_restricted
 
 /**

--- a/code/datums/scenarios/scenario.dm
+++ b/code/datums/scenarios/scenario.dm
@@ -5,8 +5,10 @@
 	var/desc = "A generic scenario that should not be in the rotation."
 	/// What sectors this scenario can spawn in. An empty list is all sectors.
 	var/list/sector_whitelist = list()
-	/// The type of scenario this is. NOT a boolean or a bitfield.
-	var/scenario_type = SCENARIO_TYPE_NONCANON
+	/// The type of scenario this is. NOT a boolean or a bitfield. This is automatically set on /scenario/Initialise()
+	var/scenario_type
+	/// A list containing the options for type of scenario. An empty list will default to SCENARIO_TYPE_NONCANON.
+	var/list/possible_scenario_types = list()
 	/// Whether or not landing on the Odyssey away site is restricted by default. Has to be either unrestricted by Storytellers manually, or happens forcefully at 40 minutes in.
 	var/site_landing_restricted = TRUE
 

--- a/code/datums/scenarios/scenario.dm
+++ b/code/datums/scenarios/scenario.dm
@@ -5,7 +5,7 @@
 	var/desc = "A generic scenario that should not be in the rotation."
 	/// What sectors this scenario can spawn in. An empty list is all sectors.
 	var/list/sector_whitelist = list()
-	/// The type of scenario this is. NOT a boolean or a bitfield. This is automatically set on /scenario/Initialise()
+	/// The type of scenario this is. NOT a boolean or a bitfield. This is automatically set on /datum/controller/subsystem/odyssey/proc/setup_scenario_variables().
 	var/scenario_type
 	/// A list containing the options for type of scenario. An empty list will default to SCENARIO_TYPE_NONCANON.
 	var/list/possible_scenario_types = list()

--- a/html/changelogs/kermit - odyssey-canonicity-coinflip.yml
+++ b/html/changelogs/kermit - odyssey-canonicity-coinflip.yml
@@ -1,0 +1,7 @@
+author: kermit
+
+delete-after: True
+
+changes:
+  - rscadd: "Allows Odyssey Scenarios to have a list of possible canonicities set per scenario."
+  - rscadd: "The Ruined Propellant Depot now has Non-Canon and Canon as options to pick from."

--- a/maps/away/scenarios/ruined_propellant_depot/ruined_propellant_depot_scenario.dm
+++ b/maps/away/scenarios/ruined_propellant_depot/ruined_propellant_depot_scenario.dm
@@ -4,6 +4,9 @@
 		An independent propellant depot near some asteroid field, that has launched a distress beacon, requesting help. \
 		SCCV Horizon, the closest ship in this sector, was sent by CC to investigate. \
 		"
+
+	possible_scenario_types = list(SCENARIO_TYPE_NONCANON, SCENARIO_TYPE_CANON)
+
 	scenario_site_id = "ruined_propellant_depot"
 
 	min_player_amount = 0


### PR DESCRIPTION
Adds a `possible_scenario_types` list to Odyssey Scenarios containing allowed canonicity types for a scenario.
`odyssey/proc/setup_scenario_variables()` now sets `scenario_type` by picking from the `possible_scenario_types`. 

By default or if the `possible_scenario_types` list is unset, a scenario defaults to Non-Canon.

This allows a scenario to have both Canon and Non-Canon as an option.

Additionally, the Ruined Propellant Depot scenario has been given the option of both Non-Canon and Canon to pick from.
Supercedes https://github.com/Aurorastation/Aurora.3/pull/20264. 