### PR TITLE
Spy Bug Fixes

### DIFF
--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -29,7 +29,7 @@
 	. = ..()
 	if(distance <= 0)
 		. += "It's a tiny camera, microphone, and transmission device in a happy union."
-		. += "Needs to be both configured and brought in contact with monitor device to be fully functional."
+		. += "Needs to be both configured and brought in contact with monitor device to be fully functional. A pen can also be used to label the device on a given network."
 
 /obj/item/device/spy_bug/attack_self(mob/user)
 	radio.set_broadcasting(!radio.get_broadcasting())
@@ -48,7 +48,7 @@
 		return ..()
 
 /obj/item/device/spy_bug/hear_talk(mob/M, var/msg, verb, datum/language/speaking)
-	radio.hear_talk(M, msg, speaking)
+	radio.hear_talk(M, msg, verb, speaking)
 
 
 /obj/item/device/spy_monitor
@@ -148,7 +148,7 @@
 /obj/machinery/camera/spy
 	// These cheap toys are accessible from the mercenary camera console as well
 	network = list(NETWORK_MERCENARY)
-	active_power_usage = 0
+	active_power_usage = FALSE
 
 /obj/machinery/camera/spy/Initialize()
 	. = ..()
@@ -157,6 +157,18 @@
 
 /obj/machinery/camera/spy/check_eye(var/mob/user as mob)
 	return 0
+
+/obj/machinery/camera/spy/attackby(obj/item/attacking_item, mob/user)
+	if(!istype(user))
+		return
+
+	if(attacking_item.ispen())
+		var/n_tag = sanitizeSafe( tgui_input_text(user, "What would you like to label the camera?", "Bug Labelling", default = c_tag, max_length = MAX_NAME_LEN), MAX_NAME_LEN )
+		if(Adjacent(user) && user.stat == 0)
+			c_tag = n_tag
+			return TRUE
+	else
+		return ..()
 
 /obj/item/device/radio/spy
 	canhear_range = 7

--- a/html/changelogs/Ben10083 - Fix Spy Bugs.yml
+++ b/html/changelogs/Ben10083 - Fix Spy Bugs.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Spy bug microphones now properly handle different languages."
+  - qol: "Spy bugs can be labeled with pen to allow for an easier time switching between cameras."


### PR DESCRIPTION
- [ ] Spy Bugs do not work across z-levels
- [ ] Spy Bug labeling
- [ ] Spy bugs have radio wierdness

Touchup to Spy Bugs to make them work after changes have negatively impacted them.