### PR TITLE
Fix default admin_ranks.json

### DIFF
--- a/config/example/admin_ranks.json
+++ b/config/example/admin_ranks.json
@@ -11,7 +11,7 @@
         "name": "Primary Administrator",
         "auths": [
             "R_BUILDMODE", "R_ADMIN", "R_BAN", "R_FUN", "R_STEALTH", "R_SERVER",
-            "R_REJUVENATE", "R_VAREDIT", "R_SOUND", "R_SPAWN", "R_PERMISSIONS",
+            "R_VAREDIT", "R_SOUND", "R_SPAWN", "R_PERMISSIONS",
             "R_MODERATOR", "R_DEVELOPER", "R_CCIAA", "R_DEBUG"
         ]
     },
@@ -20,7 +20,7 @@
         "name": "Secondary Administrator",
         "auths": [
             "R_BUILDMODE", "R_ADMIN", "R_BAN", "R_FUN", "R_STEALTH", "R_SERVER",
-            "R_REJUVENATE", "R_VAREDIT", "R_SOUND", "R_SPAWN", "R_MODERATOR",
+            "R_VAREDIT", "R_SOUND", "R_SPAWN", "R_MODERATOR",
             "R_DEVELOPER", "R_CCIAA"
         ]
     },
@@ -28,7 +28,7 @@
         "role_id": 6,
         "name": "Moderator",
         "auths": [
-            "R_MODERATOR", "R_BAN", "R_SPAWN", "R_REJUVENATE"
+            "R_MODERATOR", "R_BAN", "R_SPAWN"
         ]
     },
     {

--- a/html/changelogs/arrow768-default-config.yml
+++ b/html/changelogs/arrow768-default-config.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Removes a old permissions from the default admin ranks config."


### PR DESCRIPTION
The default admin_ranks.json refers to the R_REJUVENATE permission, which no longer exists, leading to a crash on startup.

