### PR TITLE
Changeling armblade menu fix

### DIFF
--- a/code/game/gamemodes/changeling/helpers/_framework.dm
+++ b/code/game/gamemodes/changeling/helpers/_framework.dm
@@ -137,14 +137,18 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 		changeling = mind.antag_datums[MODE_CHANGELING]
 	if(!changeling)
 		return
+
 	for(var/datum/power/changeling/P in changeling.purchasedpowers)
 		if(P.isVerb && !reset_powers)
 			remove_verb(src, P.verbpath)
 		else if(reset_powers && (P.genomecost != 0))
 			if(P.isVerb)
 				remove_verb(src, P.verbpath)
+
+			// Instead of deleting, return the power to the available list
 			changeling.purchasedpowers -= P
-			qdel(P)
+			if(!(P in powerinstances)) // Ensure it's not duplicated
+				powerinstances += P
 	if(!reset_powers)
 		remove_language(LANGUAGE_CHANGELING)
 

--- a/html/changelogs/QuestioningMark_Changeling-Armblade-Menu-Fix.yml
+++ b/html/changelogs/QuestioningMark_Changeling-Armblade-Menu-Fix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: QuestioningMark
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Did a little edit to how the menus handle the removal of the armblade power so it actually can be re-purchased a second time after re-evolution as a changeling"


### PR DESCRIPTION
Did a little edit to how the menus handle the removal of the armblade power so it actually can be re-purchased a second time after re-evolution as a changeling.