### PR TITLE
Nanopaste balance changes

### DIFF
--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -109,7 +109,7 @@
 				to_chat(user, SPAN_NOTICE("Nothing to fix in here."))
 
 
-// Antagonist-specific nanopaste. Functions similarly to usual nanoapste, except that it also applies a surge protection organ to the target.
+// Antagonist-specific nanopaste. Functions similarly to usual nanopaste, except that it also applies a surge protection organ to the target.
 // This organ protects the target from a specific number of EMPs. Intended to provide antagonist IPCs counterplay to ions.
 /obj/item/stack/nanopaste/surge
 	name = "modified nanopaste"

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -13,6 +13,8 @@
 	amount = 10
 	surgerysound = 'sound/items/surgery/bonegel.ogg'
 
+	desc_extended = "It takes significantly longer to apply nanopaste to yourself than it does to apply it to others. Nanites are best enjoyed with a friend!"
+
 	/// What materials does it take to fabricate nanopaste?
 	var/list/construction_cost = list(DEFAULT_WALL_MATERIAL = 7000, MATERIAL_GLASS = 7000)
 	/// How long does it take to apply nanopaste?

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -1,3 +1,4 @@
+// Repairs robotic limbs and silicon mobs, with a limited number of uses.
 /obj/item/stack/nanopaste
 	name = "nanopaste"
 	singular_name = "nanite swarm"
@@ -108,6 +109,8 @@
 				to_chat(user, SPAN_NOTICE("Nothing to fix in here."))
 
 
+// Antagonist-specific nanopaste. Functions similarly to usual nanoapste, except that it also applies a surge protection organ to the target.
+// This organ protects the target from a specific number of EMPs. Intended to provide antagonist IPCs counterplay to ions.
 /obj/item/stack/nanopaste/surge
 	name = "modified nanopaste"
 	singular_name = "nanite swarm"

--- a/html/changelogs/hazelmouse-nanopastebalancechanges.yml
+++ b/html/changelogs/hazelmouse-nanopastebalancechanges.yml
@@ -55,5 +55,6 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - balance: "Nanopaste now takes around twice as long to apply to other mobs as before, and over ten times as long to apply to yourself. If you want to be repaired quickly, find a buddy to apply it for you!"
+  - balance: "Nanopaste now takes around twice as long to apply to other mobs as before, and five times as long as that to apply to yourself. If you want to be repaired quickly, find a buddy to apply it for you!"
   - balance: "Nanopaste can no longer be applied multiple times simultaneously."
+  - code_imp: "Expanded documentation to nanopaste code."

--- a/html/changelogs/hazelmouse-nanopastebalancechanges.yml
+++ b/html/changelogs/hazelmouse-nanopastebalancechanges.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Nanopaste now takes around twice as long to apply to other mobs as before, and over ten times as long to apply to yourself. If you want to be repaired quickly, find a buddy to apply it for you!"
+  - balance: "Nanopaste can no longer be applied multiple times simultaneously."


### PR DESCRIPTION
This makes nanopaste take about twice as long to apply at a baseline, 2 seconds rather than 0.7, multiplied by five times if the mob you are applying it to is yourself, reckoning out to 10 seconds to apply it once to yourself. This also prevents you from applying nanopaste multiple times at once, so this time limit can't be contravened.

The intention of this is to discourage using nanopaste mid-firefight, which has been very powerful in the past since it took less than a second to apply and could be spammed repeatedly to speed that up even further. I also hope that it'll encourage IPCs to ask for help to apply nanopaste, involving other people in the repair process, or to simply use the workshop now that nanopaste is less instantaneous.