### PR TITLE
Actor Preparation remap + clothes vendor

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -1886,6 +1886,7 @@
 		/obj/item/device/radio/headset/ship/odyssey = 12,
 		/obj/item/portable_map_reader/odyssey = 12,
 		/obj/item/card/id/syndicate = 12,
+		/obj/item/storage/box/syndie_kit/chameleon = 12,
 	)
 	light_color = COLOR_GUNMETAL
 	random_itemcount = FALSE

--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -1889,3 +1889,115 @@
 	)
 	light_color = COLOR_GUNMETAL
 	random_itemcount = FALSE
+
+/*
+Generic clothing vendor used in antagonist areas. For now, this almost entirely contains generic items. Prioritises recolourable items.
+Intended to take some pressure off admins asked regularly to spawn in clothing by allowing players to spawn and colour their clothes themselves.
+Only contains very few origin-specific items, as otherwise the list would get so long it'd be entirely incomprehensible.
+If you want to expand this to more than primarily generic items, I recommend designing a UI that supports switching between categories.
+*/
+/obj/machinery/vending/generic_clothing
+	name = "Generic Clothing Vendor"
+	desc = "Contains a large number of generic clothing items. Comes with hand-held dyers to dye its contents however the user wishes."
+	vend_id = "generic_clothing"
+	icon_state = "robotics"
+	icon_vend = "robotics-vend"
+	light_mask = "robotics-light-mask"
+	light_color = COLOR_GREEN
+	random_itemcount = FALSE
+	products = list (
+		// This item allows players to change the colour of recolourable items from this vendor without needing admin intervention.
+		/obj/item/device/clothes_dyer = 6,
+
+		// Generic suits.
+		/obj/item/clothing/suit/storage/toggle/labcoat = 6,
+		/obj/item/clothing/suit/storage/hazardvest/colorable = 6,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/colorable = 6,
+		/obj/item/clothing/suit/storage/hooded/wintercoat/hoodie = 6,
+		/obj/item/clothing/suit/storage/surgical_gown = 6,
+		/obj/item/clothing/suit/storage/toggle/suitjacket = 6,
+		/obj/item/clothing/suit/storage/toggle/trench/colorable = 6,
+		/obj/item/clothing/suit/storage/toggle/bomber = 6,
+		/obj/item/clothing/suit/storage/toggle/cardigan = 6,
+		/obj/item/clothing/suit/storage/toggle/dominia/bomber = 6,
+		/obj/item/clothing/suit/storage/toggle/greatcoat/brown = 6,
+
+		// Generic shirts.
+		/obj/item/clothing/under/dressshirt/alt = 6,
+		/obj/item/clothing/under/dressshirt/polo = 6,
+		/obj/item/clothing/under/dressshirt/silversun= 6,
+		/obj/item/clothing/under/dressshirt/tanktop = 6,
+		/obj/item/clothing/under/dressshirt/puffyblouse = 6,
+
+		// Generic pants & skirts.
+		/obj/item/clothing/pants/shorts/colourable = 6,
+		/obj/item/clothing/pants/mustang/colourable = 6,
+		/obj/item/clothing/pants/dress = 6,
+		/obj/item/clothing/pants/skirt = 6,
+		/obj/item/clothing/pants/skirt/high = 6,
+		/obj/item/clothing/pants/skirt/pencil = 6,
+
+		// Generic uniforms.
+		/obj/item/clothing/under/color/colorable = 6,
+		/obj/item/clothing/under/syndicate = 6,
+		/obj/item/clothing/under/syndicate/tracksuit = 6,
+		/obj/item/clothing/under/dress/colorable/longsleeve = 6,
+		/obj/item/clothing/under/dress/colorable/sleeveless = 6,
+		/obj/item/clothing/under/librarian = 6,
+		/obj/item/clothing/under/rank/medical/generic = 6,
+		/obj/item/clothing/under/dominia/imperial_suit = 6,
+		/obj/item/clothing/under/suit_jacket = 6,
+		/obj/item/clothing/under/tajaran = 6,
+
+		// Generic hats.
+		/obj/item/clothing/head/bandana/colorable = 6,
+		/obj/item/clothing/head/beanie = 6,
+		/obj/item/clothing/head/beret/colorable = 6,
+		/obj/item/clothing/head/bucket/boonie = 6,
+		/obj/item/clothing/head/cowboy/wide = 6,
+		/obj/item/clothing/head/cowboy = 6,
+		/obj/item/clothing/head/fedora = 6,
+		/obj/item/clothing/head/flatcap/colourable = 6,
+		/obj/item/clothing/head/wool = 6,
+		/obj/item/clothing/head/sidecap = 6,
+		/obj/item/clothing/head/plain_hood = 6,
+
+		// Generic gloves.
+		/obj/item/clothing/gloves/black_leather/colour = 6,
+		/obj/item/clothing/gloves/fingerless/colour = 6,
+		/obj/item/clothing/gloves/evening = 6,
+
+		// Generic accessories.
+		/obj/item/clothing/accessory/wcoat_rec = 6,
+		/obj/item/clothing/accessory/bandanna/colorable = 6,
+		/obj/item/clothing/accessory/apron = 6,
+		/obj/item/clothing/accessory/tie/colourable = 6,
+		/obj/item/clothing/accessory/tie/ribbon/neck = 6,
+		/obj/item/clothing/accessory/poncho/colorable/gradient = 6,
+		/obj/item/clothing/accessory/poncho/dominia_cape = 6,
+		/obj/item/clothing/accessory/scarf = 6,
+
+		// Bags.
+		/obj/item/storage/backpack/duffel/eng = 6,
+		/obj/item/storage/backpack/industrial = 6,
+		/obj/item/storage/backpack/messenger = 6,
+		/obj/item/storage/backpack/satchel = 6,
+		/obj/item/storage/backpack/satchel/leather/recolorable = 6,
+		/obj/item/storage/backpack/satchel/leather = 6,
+
+		// Sunglasses and other eyewear.
+		/obj/item/clothing/glasses/regular = 6,
+		/obj/item/clothing/glasses/sunglasses = 6,
+		/obj/item/clothing/glasses/sunglasses/blindfold = 6,
+		/obj/item/clothing/glasses/monocle = 6,
+		/obj/item/clothing/glasses/eyepatch = 6,
+
+		// Shoes and boots.
+		/obj/item/clothing/shoes/jackboots = 6,
+		/obj/item/clothing/shoes/jackboots/cavalry = 6,
+		/obj/item/clothing/shoes/jackboots/toeless = 6,
+		/obj/item/clothing/shoes/sneakers/black = 6,
+		/obj/item/clothing/shoes/laceup/colourable = 6,
+		/obj/item/clothing/shoes/heels = 6,
+		/obj/item/clothing/shoes/winter = 6,
+	)

--- a/code/game/turfs/unsimulated/floor.dm
+++ b/code/game/turfs/unsimulated/floor.dm
@@ -3,6 +3,9 @@
 	icon = 'icons/turf/flooring/tiles.dmi'
 	icon_state = "tiled_preview"
 
+/turf/unsimulated/floor/monotile
+	icon_state = "monotile_preview"
+
 /turf/unsimulated/floor/elevatorshaft
 	name = "elevator machinery"
 	icon_state = "elevatorshaft"
@@ -27,6 +30,50 @@
 	name = "mask"
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "rockvault"
+
+/turf/unsimulated/floor/carpet
+	name = "carpet"
+	icon_state = "carpet"
+
+/turf/unsimulated/floor/rubber_carpet
+	name = "rubber carpet"
+	icon = 'icons/turf/flooring/carpet.dmi'
+	icon_state = "rub_carpet"
+
+/turf/unsimulated/floor/dark
+	color = "#4c535b"
+	icon_state = "dark"
+
+/turf/unsimulated/floor/dark_monotile
+	color = "#4c535b"
+	icon_state = "monotile_dark"
+
+/turf/unsimulated/floor/linoleum
+	icon = 'icons/turf/flooring/linoleum.dmi'
+	icon_state = "lino_diamond_preview"
+
+/turf/unsimulated/floor/grass
+	name = "grass"
+	icon = 'icons/turf/flooring/grass.dmi'
+	icon_state = "grass0"
+
+/turf/unsimulated/floor/wood
+	name = "wooden floor"
+	color = "#8f5847"
+	icon_state = "wood"
+
+/turf/unsimulated/floor/freezer
+	icon_state = "freezer"
+
+/turf/unsimulated/floor/marble
+	icon_state = "textured"
+
+/turf/unsimulated/floor/stairs
+	icon_state = "ramptop"
+
+/turf/unsimulated/floor/blue_circuit
+	icon = 'icons/turf/flooring/circuit.dmi'
+	icon_state = "bcircuit"
 
 /turf/unsimulated/mask/ChangeTurf(path, tell_universe = TRUE, force_lighting_update = FALSE, ignore_override = FALSE, mapload = FALSE)
 	if(!path)

--- a/html/changelogs/hazelmouse-actorremap.yml
+++ b/html/changelogs/hazelmouse-actorremap.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Implements a remap of the spawning area for Actors, as part of the Odyssey gamemode, to hopefully be more enjoyable and intuitive."
+  - rscadd: "Adds a generic clothing vendor to CC, available to every off-ship antagonist. This permits players to choose from a variety of generic clothing items, in addition to allowing them to recolour all recolourable items to their preference."

--- a/html/changelogs/hazelmouse-actorremap.yml
+++ b/html/changelogs/hazelmouse-actorremap.yml
@@ -55,5 +55,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Implements a remap of the spawning area for Actors, as part of the Odyssey gamemode, to hopefully be more enjoyable and intuitive."
+  - rscadd: "Implements a remap of the spawning area for Actors, as part of the Odyssey gamemode, to hopefully be more enjoyable and intuitive. Now featuring a big table for everyone to get around on to disagree on the gimmick until the Storyteller tells you off."
   - rscadd: "Adds a generic clothing vendor to CC, available to every off-ship antagonist. This permits players to choose from a variety of generic clothing items, in addition to allowing them to recolour all recolourable items to their preference."

--- a/html/changelogs/hazelmouse-actorremap.yml
+++ b/html/changelogs/hazelmouse-actorremap.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: hazelmouse
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/hazelmouse-actorremap.yml
+++ b/html/changelogs/hazelmouse-actorremap.yml
@@ -57,3 +57,4 @@ delete-after: True
 changes:
   - rscadd: "Implements a remap of the spawning area for Actors, as part of the Odyssey gamemode, to hopefully be more enjoyable and intuitive. Now featuring a big table for everyone to get around on to disagree on the gimmick until the Storyteller tells you off."
   - rscadd: "Adds a generic clothing vendor to CC, available to every off-ship antagonist. This permits players to choose from a variety of generic clothing items, in addition to allowing them to recolour all recolourable items to their preference."
+  - refactor: "Shifts many of the unsimulated floors on the CC z-level, but not all of them, to dedicated subtypes instead of a single varedited type."


### PR DESCRIPTION
Remaps the Actor's area of CC to be a little more inviting to players. There aren't very many tangible changes to the balance, besides that the areas separated from the rest by glass in the original map have been removed, the contents of the medical section moved to an open area, and the number of guns reduced and moved similarly to an open area. 

Food and drinks are added as well, for players that want to pack their lunches, and an incinerator is added so you can incinerate your trash. Or other Actors, if you want to annoy the ST.

This also introduces a generic clothing vendor, populated primarily with non faction-specific recolourable clothing items, bags, and accessories, in addition to the clothes dyer item made for the Golden Deep ship so you can actually recolour all those items. This is added to every off-ship antag area.

Very few origin-specific items have been added because adding them would increase the scope of the vendor so drastically that I feel we would need a much better UI than the standard vendor UI currently being utilised. It's not the best possible implementation of a way to give antagonists access to generic clothes, but a clunky first iteration is better than nothing.

![image](https://github.com/user-attachments/assets/98e77cc5-7b7c-4b37-9122-d578519f68c8)

![image](https://github.com/user-attachments/assets/1d487e77-39ad-42da-a9b0-e29b3d2b8845)
