### PR TITLE
Arterial bleeding rebalance

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -140,7 +140,7 @@
 	var/artery_name = "artery"
 
 	///Multiplier for bleeding in a limb
-	var/arterial_bleed_severity = 1
+	var/arterial_bleed_severity = 0.7
 
 	///Descriptive string used in amputation
 	var/amputation_point

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -80,7 +80,7 @@
 	limb_flags = ORGAN_CAN_AMPUTATE | ORGAN_CAN_BREAK | ORGAN_CAN_MAIM | ORGAN_HAS_TENDON | ORGAN_CAN_GRASP
 	tendon_name = "palmaris longus tendon"
 	artery_name = "basilic vein"
-	arterial_bleed_severity = 0.75
+	arterial_bleed_severity = 0.5
 	amputation_point = "left shoulder"
 	augment_limit = 2
 
@@ -113,7 +113,7 @@
 	joint = "left knee"
 	tendon_name = "quadriceps tendon"
 	artery_name = "femoral artery"
-	arterial_bleed_severity = 0.75
+	arterial_bleed_severity = 0.5
 	amputation_point = "left hip"
 	limb_flags = ORGAN_CAN_AMPUTATE | ORGAN_CAN_BREAK | ORGAN_CAN_MAIM | ORGAN_HAS_TENDON
 	augment_limit = 2

--- a/html/changelogs/hazelmouse-abbalance.yml
+++ b/html/changelogs/hazelmouse-abbalance.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Arterial bleeding now causes less rapid blood loss."


### PR DESCRIPTION
This reduces the multiplier for arterial bleeding blood a little, making it 0.7 from 1 for the head and upper body, and a uniform 0.5 for all limb organs, from 0.75 for arms and legs.

This is intended to keep arterials enough of a danger that they require immediate medical treatment to resolve, while giving crew a little more leeway with them before they go critical. This is mostly aimed at crew without medical, including when there is no medical at all and also for miners and other roles who leave the ship and need to come back to be treated for arterials.

I have tested these new values, even 0.5 is enough to substantively reduce blood volume over several minutes. The lower threshold for an AB being inconsequential appears to be around 0.25, which is why I haven't lowered any values that far down.