### PR TITLE
The large Visegrad flag is now in the loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/general.dm
+++ b/code/modules/client/preference_setup/loadout/items/general.dm
@@ -371,8 +371,8 @@
 	flags["flag, Northern Solarian Reconstruction Mandate"] = /obj/item/flag/nsrm/l
 	flags["flag, Provisional Government of Mars"] = /obj/item/flag/mars/l
 	flags["flag, Pluto"] = /obj/item/flag/pluto/l
-	flags["flag, Antique Visegrad"] = /obj/item/flag/old_visegrad
-	flags["flag, Visegrad"] = /obj/item/flag/visegrad
+	flags["flag, Antique Visegrad"] = /obj/item/flag/old_visegrad/l
+	flags["flag, Visegrad"] = /obj/item/flag/visegrad/l
 	flags["flag, HPS Narrows"] = /obj/item/flag/narrows/l
 	gear_tweaks += new /datum/gear_tweak/path(flags)
 

--- a/html/changelogs/elorgrhg-visegrad-flagging.yml
+++ b/html/changelogs/elorgrhg-visegrad-flagging.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: ElorgRHG
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "The large Visegrad flags in the loadout are now actually large."


### PR DESCRIPTION
Fixes the large Visegrad (and antique Visegrad) loadout flag being unobtainable as both the banner and flag loadout options give the small flag, small oversight from https://github.com/Aurorastation/Aurora.3/pull/19972 it seems.

Also the changelog generation here is scary.

That is all.
![image](https://github.com/user-attachments/assets/c31a2174-f010-450c-85d9-ea4a2dd7f948)
