### PR TITLE
Civilian Yacht Reflavour: Any Affluent Origin

### DIFF
--- a/html/changelogs/kermit-civyacht-generalisation.yml
+++ b/html/changelogs/kermit-civyacht-generalisation.yml
@@ -1,0 +1,7 @@
+author: kermit
+
+delete-after: True
+
+changes:
+  - rscadd: "The Civilian Yacht has been reflavoured to include affluent individuals from places besides the Sol Alliance."
+  - rscadd: "The Civilian Yacht Crew ghostrole allows you to select Skrell and Synthetics, in addition to Human."

--- a/maps/away/ships/yacht_civ/yacht_civ_.dm
+++ b/maps/away/ships/yacht_civ/yacht_civ_.dm
@@ -23,7 +23,7 @@
 	name = "Civilian Yacht"
 	class = "ICV"
 	desc = "\
-		Diamond-class Yacht, commonly seen in Sol and usually used for short-range flights between Solarian planets, moons, and other nearby sectors, \
+		Diamond-class Yacht, commonly seen in more affluent systems and usually used for short-range flights between civilised planets, moons, and other nearby sectors, \
 		shuttling the rich between work, home, and recreation. Certainly not a cheap platform, sparing no expenses in its internal systems, \
 		it is a quick and capable ship, being designed by Einstein Engines and produced by Hephaestus Industries.\
 		"
@@ -60,16 +60,12 @@
 	)
 
 /obj/effect/overmap/visitable/ship/yacht_civ/New()
-	var/planetary_body = pick(
-		"Jupiter", "Saturn", "Uranus", "Neptune", "Venus", "Mars", "Ganymede", "Titan",
-		"Mercury", "Callisto", "Io", "Europa", "Triton", "Pluto", "Eris", "Haumea",
-		"Titania", "Rhea", "Oberon", "Iapetus", "Makemake", "Charon", "Umbriel", "Ariel",
-		"Dione", "Quaoar", "Tethys", "Sedna", "Ceres", "Orcus", "Salacia", "Vesta",
-		"Pallas", "Enceladus", "Mimas", "Nereid", "Europa", "Hyperion", "Juno", "Mnemosyne",
-	)
-	var/prefix  = pick("", "", "", pick("Wondrous ", "Little ", "Tiny ", "Dreamy ", "Fine ", "Orbiter of ", "Greetings from "))
-	var/postfix = pick("", "", "", pick(", the Adventurer", " among Stars", ", Explorer", " of Sol", " from Sol", " and Moons"))
-	designation = "[prefix][planetary_body][postfix]"
+	var/pretentious_reference = pick(
+		"Ulysses", "Priam", "Helen", "Aeneas", "Virgil", "Dante", "Palamon", "Arcita", "Nimue", "Morgana", "Gawain", //IRL
+		"Xavier", "Madhar", "Orillian", "Saeli", "Roxanne") //Aurora-specific
+	var/prefix  = pick("", "", "", pick("Wondrous ", "Little ", "Tiny ", "Dreamy ", "Fine ", "Greetings from "))
+	var/suffix = pick("", "", "", pick(", the Adventurer", " among Stars", ", Explorer"))
+	designation = "[prefix][pretentious_reference][suffix]"
 	..()
 
 // shuttle

--- a/maps/away/ships/yacht_civ/yacht_civ_ghostroles.dm
+++ b/maps/away/ships/yacht_civ/yacht_civ_ghostroles.dm
@@ -1,11 +1,10 @@
 /datum/ghostspawner/human/yacht_civ
 	short_name = "yacht_civ_crew"
 	name = "Civilian Yacht Crew"
-	desc = "Crew and owner of a private civilian yacht, shared with three other people, all coming from Sol. Be rich, seek adventure, see sights, explore stars."
+	desc = "An affluent owner of a private civilian yacht, shared with three other people. Be rich, seek adventure, see sights, explore stars."
 	welcome_message = "\
 		You are a member of crew on a private civilian yacht, owned by, and shared with three other people. \
 		Perhaps you are friends or family, invested in some risky stocks or inherited all your assets, and want to to explore the stars together. \
-		You are Solarian, but most of your life you have lived on some planet or moon - you are not a 'spacer', and life in space is mostly a new thing for you. \
 		You are rich enough to afford a small yacht, to maintain it, and live in relative luxury, \
 		and you are free to do anything you like, this is your vacation after all.\
 		"
@@ -15,7 +14,7 @@
 	max_count = 4
 
 	outfit = /obj/outfit/admin/yacht_civ
-	possible_species = list(SPECIES_HUMAN)
+	possible_species = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL)
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 
 	assigned_role = "Civilian Yacht Crew"
@@ -29,4 +28,3 @@
 	wrist = list(/obj/item/clothing/wrists/watch/silver, /obj/item/clothing/wrists/watch/gold)
 	l_ear = /obj/item/device/radio/headset/ship
 	l_pocket = /obj/item/storage/wallet/rich
-	r_pocket = /obj/item/clothing/accessory/badge/passport/sol


### PR DESCRIPTION
```
changes:
  - rscadd: "The Civilian Yacht has been reflavoured to include affluent individuals from places besides the Sol Alliance."
  - rscadd: "The Civilian Yacht Crew ghostrole allows you to select Skrell and Synthetics, in addition to Human."
```

There exist affluent explorers from the Republic of Biesel and Coalition of Colonies too, not just the Sol Alliance.
This allows for more off-ship gimmicks (and easier ones, when we're so far from the Alliance, usually).

No map files touched.