### PR TITLE
Protection for Ian and Chauncey, moved a fire alarm in the central ring

### DIFF
--- a/html/changelogs/ASmallCuteCat - Safer Ian and Chauncey, Fire Alarm Moved.yml
+++ b/html/changelogs/ASmallCuteCat - Safer Ian and Chauncey, Fire Alarm Moved.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ASmallCuteCat
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "The windows on the Captain's Office are shuttered at game start, protecting Chauncey from getting spawnkilled by carp."
+  - qol: "The Executive Officer's window shutters are now on their own switch. They are closed at round start, protecting Ian from getting spawnkilled by carp."
+  - qol: "Separated the fire alarm from the disposal unit in the bottom-left corner of the central ring. Removed the guest pass terminal and newscaster from that corner, as there's already a newscaster and a guest pass terminal not too far from where they used to be."


### PR DESCRIPTION
A couple of QOL changes on the Horizon - Ian and Chauncey are now less likely to get killed by carp at round start, and that one disposal bin in the central ring no longer sets off a fire alarm when you try to use it.