### PR TITLE
BAPI - build_bapi CI update

### DIFF
--- a/.github/workflows/build_bapi.yml
+++ b/.github/workflows/build_bapi.yml
@@ -64,7 +64,7 @@ jobs:
           rustup target add i686-pc-windows-gnu
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt-get install zlib1g-dev:i386 lib32gcc-11-dev mingw-w64 mingw-w64-i686-dev
+          sudo apt-get install zlib1g-dev:i386 lib32gcc-11-dev gcc-11-multilib mingw-w64 mingw-w64-i686-dev
 
           # Build it.
           cargo build --release --target i686-unknown-linux-gnu


### PR DESCRIPTION
sudo apt-get install zlib1g-dev:i386 lib32gcc-11-dev **<ins>gcc-11-multilib</ins>** mingw-w64 mingw-w64-i686-dev