### PR TITLE
Fix Brain Math

### DIFF
--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -109,8 +109,7 @@
 			var/can_heal = (damage && damage < max_damage && (damage % damage_threshold_value || owner.chem_effects[CE_BRAIN_REGEN] || (!past_damage_threshold(3) && owner.chem_effects[CE_STABLE]))) && (!(owner.chem_effects[CE_NEUROTOXIC]) || owner.chem_effects[CE_ANTITOXIN])
 			var/damprob
 			var/brain_regen_amount = owner.chem_effects[CE_BRAIN_REGEN]	* seconds_per_tick
-			var/brain_damage_amount = 10 * seconds_per_tick //under normal server load, this is 1.
-															//TODO: Rework this math to no longer depend on RNG, and be more deterministic.
+			var/brain_damage_amount = seconds_per_tick
 			//Effects of bloodloss
 			switch(blood_volume)
 				if(BLOOD_VOLUME_SAFE to INFINITY)
@@ -120,33 +119,30 @@
 						damage = max(damage - brain_damage_amount, 0)
 				if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)
 					owner.notify_message(SPAN_WARNING("You feel a bit [pick("lightheaded","dizzy","pale")]..."), rand(20 SECONDS, 40 SECONDS), key = "blood_volume_okay")
-					damprob = owner.chem_effects[CE_STABLE] ? 30 : 60
-					if(!past_damage_threshold(2) && prob(damprob))
-						take_internal_damage(brain_damage_amount)
+					dammod = owner.chem_effects[CE_STABLE] ? 0.30 : 0.60
+					if(!past_damage_threshold(2))
+						take_internal_damage(brain_damage_amount * dammod)
 				if(BLOOD_VOLUME_BAD to BLOOD_VOLUME_OKAY)
 					owner.notify_message(SPAN_WARNING("You feel [pick("weak","disoriented","faint","cold")]."), rand(20 SECONDS, 40 SECONDS), key = "blood_volume_bad")
 					owner.eye_blurry = max(owner.eye_blurry,6)
-					damprob = owner.chem_effects[CE_STABLE] ? 40 : 80
-					if(!past_damage_threshold(4) && prob(damprob))
-						take_internal_damage(brain_damage_amount)
+					dammod = owner.chem_effects[CE_STABLE] ? 0.40 : 0.80
+					if(!past_damage_threshold(4))
+						take_internal_damage(brain_damage_amount * dammod)
 					if(!owner.paralysis && prob(10))
 						owner.Paralyse(rand(1,3))
 				if(BLOOD_VOLUME_SURVIVE to BLOOD_VOLUME_BAD)
 					owner.notify_message(SPAN_WARNING("You feel <b>extremely</b> [pick("cold","woozy","faint","weak","confused","tired","lethargic")]."), rand(20 SECONDS, 40 SECONDS), key = "blood_volume_survive")
 					owner.eye_blurry = max(owner.eye_blurry,6)
-					damprob = owner.chem_effects[CE_STABLE] ? 60 : 100
-					if(!past_damage_threshold(6) && prob(damprob))
-						take_internal_damage(brain_damage_amount)
+					dammod = owner.chem_effects[CE_STABLE] ? 0.60 : 1
+					if(!past_damage_threshold(6))
+						take_internal_damage(brain_damage_amount * dammod)
 					if(!owner.paralysis && prob(15))
 						owner.Paralyse(rand(3, 5))
 				if(-(INFINITY) to BLOOD_VOLUME_SURVIVE) // Also see heart.dm, being below this point puts you into cardiac arrest.
 					owner.notify_message(SPAN_DANGER("You feel like death is imminent."), rand(20 SECONDS, 40 SECONDS), key = "blood_volume_dying")
 					owner.eye_blurry = max(owner.eye_blurry,6)
-					damprob = owner.chem_effects[CE_STABLE] ? 80 : 100
-					if(prob(damprob))
-						take_internal_damage(brain_damage_amount)
-					if(prob(damprob))
-						take_internal_damage(brain_damage_amount)
+					dammod = owner.chem_effects[CE_STABLE] ? 0.80 : 1
+					take_internal_damage(2 * brain_damage_amount * dammod)
 	..()
 
 /obj/item/organ/internal/brain/proc/handle_severe_brain_damage()

--- a/html/changelogs/hellfirejag-fixbraindamageinconsistency.yml
+++ b/html/changelogs/hellfirejag-fixbraindamageinconsistency.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hellfirejag
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed brain damage being inconsistent under high or low server load."


### PR DESCRIPTION
This PR fixes an issue where characters were experiencing brain damage at rates that were sometimes inconsistent depending on player population and server performance. To accomplish this, it makes it so that brain damage taken is no longer a random amount per second that fluctuates based on server performance, and is instead an amount of damage per second that scales with the previous conditions, but is "tick invariant", meaning it no longer changes if for instance you have 75 players online causing server lag. 

The benefit of this is particularly noticeable in the extreme ends of lowpop as well as high pop. It'll no longer cause brain-damage at hyperspeed if theres' only 10 people online. 