### PR TITLE
Fix CE_TOXINs causing direct damage

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1174,9 +1174,9 @@
 			vomit_score += I.damage
 		else if(should_have_organ(tag))
 			vomit_score += 45
-	if(chem_effects[CE_TOXIN] || radiation)
+	if(chem_effects[CE_TOXIN])
 		vomit_score += 0.5 * getToxLoss()
-	if(chem_effect[CE_ALCOHOL])
+	if(chem_effects[CE_ALCOHOL])
 		vomit_score += 10
 	if(stat != DEAD && vomit_score > 25 && prob(10))
 		vomit(vomit_score, vomit_score/25)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -599,9 +599,6 @@
 		if(CE_PAINKILLER in chem_effects)
 			analgesic = chem_effects[CE_PAINKILLER]
 
-		if(CE_TOXIN in chem_effects)
-			adjustToxLoss(chem_effects[CE_TOXIN])
-
 		if(CE_EMETIC in chem_effects)
 			if(prob(chem_effects[CE_EMETIC]))
 				delayed_vomit()
@@ -1169,12 +1166,20 @@
 		return
 
 	// Puke if toxloss is too high
-	if(!stat)
-		if (getToxLoss() >= 45 && !lastpuke)
-			if (prob(3))
-				delayed_vomit()
-			else if (prob(1))
-				vomit()
+	var/vomit_score = 0
+
+	for(var/tag in list(BP_LIVER,BP_KIDNEYS))
+		var/obj/item/organ/internal/I = internal_organs_by_name[tag]
+		if(I)
+			vomit_score += I.damage
+		else if(should_have_organ(tag))
+			vomit_score += 45
+	if(chem_effects[CE_TOXIN] || radiation)
+		vomit_score += 0.5 * getToxLoss()
+	if(chem_effect[CE_ALCOHOL])
+		vomit_score += 10
+	if(stat != DEAD && vomit_score > 25 && prob(10))
+		vomit(vomit_score, vomit_score/25)
 
 	//0.1% chance of playing a scary sound to someone who's in complete darkness
 	if(isturf(loc) && rand(1,1000) == 1)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -17,6 +17,7 @@
 
 /singleton/reagent/toxin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(strength && alien != IS_DIONA)
+		M.add_chemical_effect(CE_TOXIN, strength)
 		var/dam = (strength * removed)
 		if(HAS_TRAIT(M, TRAIT_ORIGIN_TOX_RESISTANCE))
 			dam = max(dam - 1, 1)
@@ -40,7 +41,6 @@
 					C.take_damage(removed * 2)
 		if(dam)
 			M.adjustToxLoss(target_organ ? (dam * 0.5) : dam)
-			M.add_chemical_effect(CE_TOXIN, removed * strength)
 
 /singleton/reagent/toxin/plasticide
 	name = "Plasticide"

--- a/html/changelogs/GeneralCamo - Toxin Fix.yml
+++ b/html/changelogs/GeneralCamo - Toxin Fix.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Toxins no longer cause double damage."
+  - balance: "Rewrote vomiting code to react better to toxins."


### PR DESCRIPTION
Per title.

CE_TOXIN both in our codebase and other codebases applies indirect negative effects, where it suppresses liver healing and organ healing. This was the assumption for, among other things, the toxin chemical.

In our codebase however, CE_TOXIN _also_ applies direct damage to organs. This means toxins are causing far more damage than intended, creating balance issues and removing the ability to independently balance toxin effects and direct damage. This has been removed for parity with Nebula and Baystation.

While digging here, I noticed our random event code was not updated to consider the toxin chemical effect. I ported over the changes made to it over the years from Bay, allowing a correct reaction to toxins in your body.