### PR TITLE
Increased maximum IPC tag size to 20 characters. Auto-generated tags remain at 12.

### DIFF
--- a/SQL/migrate-2023/V012__increase_tag_size.sql
+++ b/SQL/migrate-2023/V012__increase_tag_size.sql
@@ -2,4 +2,4 @@
 -- Increases IPC tag size to 20
 --
 
-ALTER TABLE `ss13_characters_ipc_tags` ALTER COLUMN `machine_serial_number` VARCHAR(20)
+ALTER TABLE `ss13_characters_ipc_tags` ALTER COLUMN `machine_serial_number` VARCHAR(20);

--- a/SQL/migrate-2023/V012__increase_tag_size.sql
+++ b/SQL/migrate-2023/V012__increase_tag_size.sql
@@ -1,0 +1,5 @@
+--
+-- Increases IPC tag size to 20
+--
+
+ALTER TABLE `ss13_characters_ipc_tags` ALTER COLUMN `machine_serial_number` VARCHAR(20)

--- a/SQL/migrate-2023/V012__increase_tag_size.sql
+++ b/SQL/migrate-2023/V012__increase_tag_size.sql
@@ -2,5 +2,4 @@
 -- Increases IPC tag size to 20
 --
 
-ALTER TABLE `ss13_characters_ipc_tags` 
-MODIFY COLUMN `serial_number` VARCHAR(20);
+ALTER TABLE `ss13_characters_ipc_tags` MODIFY COLUMN `serial_number` VARCHAR(20);

--- a/SQL/migrate-2023/V012__increase_tag_size.sql
+++ b/SQL/migrate-2023/V012__increase_tag_size.sql
@@ -2,4 +2,5 @@
 -- Increases IPC tag size to 20
 --
 
-ALTER TABLE `ss13_characters_ipc_tags` ALTER COLUMN `machine_serial_number` VARCHAR(20);
+ALTER TABLE `ss13_characters_ipc_tags` 
+ALTER COLUMN `machine_serial_number` VARCHAR(20);

--- a/SQL/migrate-2023/V012__increase_tag_size.sql
+++ b/SQL/migrate-2023/V012__increase_tag_size.sql
@@ -3,4 +3,4 @@
 --
 
 ALTER TABLE `ss13_characters_ipc_tags` 
-MODIFY COLUMN `machine_serial_number` VARCHAR(20);
+MODIFY COLUMN `serial_number` VARCHAR(20);

--- a/SQL/migrate-2023/V012__increase_tag_size.sql
+++ b/SQL/migrate-2023/V012__increase_tag_size.sql
@@ -3,4 +3,4 @@
 --
 
 ALTER TABLE `ss13_characters_ipc_tags` 
-ALTER COLUMN `machine_serial_number` VARCHAR(20);
+MODIFY COLUMN `machine_serial_number` VARCHAR(20);

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -333,7 +333,7 @@
 			to_chat(usr, SPAN_WARNING("You are unable to edit your IPC tag due to a timelock restriction. If you got here, it is either a hack or a bug."))
 			return
 		var/new_serial_number = sanitize(input(user, "Enter what you want to set your serial number to.", "IPC Serial Number", pref.machine_serial_number) as message|null)
-		new_serial_number = uppertext(dd_limittext(new_serial_number, 12))
+		new_serial_number = uppertext(dd_limittext(new_serial_number, 20))
 		if(new_serial_number && CanUseTopic(user))
 			pref.machine_serial_number = sanitize(new_serial_number)
 			return TOPIC_REFRESH

--- a/html/changelogs/flaminglily-tagup.yml
+++ b/html/changelogs/flaminglily-tagup.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FlamingLily
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Increased maximum IPC tag size to 20 characters. Hazels rejoice. Auto-generated tags remain at 12."


### PR DESCRIPTION
Title, as per request of NM
Does not change the randomly generated tag size.

Please merge before #20713 (SQL stuff)