### PR TITLE
Unmaps the Hivebot Transmitter from Xenoarchaeology

### DIFF
--- a/html/changelogs/kermit-unmaps-hivebot-transmitter.yml
+++ b/html/changelogs/kermit-unmaps-hivebot-transmitter.yml
@@ -1,0 +1,6 @@
+author: kermit
+
+delete-after: True
+
+changes:
+  - rscdel: "Unmaps the Hivebot Transmitter from Xenoarchaeology."


### PR DESCRIPTION
Unmaps the Hivebot Transmitter 'head' from Xenoarchaeology following a minievent that saw its IC return to the Republic of Konyang.

Doesn't remove it from the repo incase a Hivebot Transmitter make a similar reappearance in future arcs.