### PR TITLE
Corporate and Diplomatic Bodyguards

### DIFF
--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -288,6 +288,7 @@
 	supervisors = "the Consular Officer"
 	selection_color = "#6186cf"
 	economic_modifier = 5
+	alt_titles = list("Diplomatic Bodyguard")
 
 	minimum_character_age = list(
 		SPECIES_HUMAN = 18,
@@ -334,6 +335,7 @@
 	supervisors = "the Corporate Representative"
 	selection_color = "#6186cf"
 	economic_modifier = 5
+	alt_titles = list("Corporate Bodyguard")
 
 	minimum_character_age = list(
 		SPECIES_HUMAN = 18,

--- a/html/changelogs/greenjoe12345 - bodyguards.yml
+++ b/html/changelogs/greenjoe12345 - bodyguards.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Greenjoe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds bodyguard alt-titles for corporate and diplomatic aides."


### PR DESCRIPTION
Adds a bodyguard alt-title for Corporate and Diplomatic aides. Having seen on the wiki that the aides are able to be bodyguards, I thought this could be a way someone can show that their character may be a bodyguard.