### PR TITLE
Tea no longer poisons Dionae

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drink/food_drink_coalition.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drink/food_drink_coalition.dm
@@ -32,9 +32,8 @@
 
 /singleton/reagent/drink/tea/hakhma_tea/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder) //milk effects
 	..()
-	if(alien != IS_DIONA)
-		M.heal_organ_damage(0.1 * removed, 0)
-		holder.remove_reagent(/singleton/reagent/capsaicin, 10 * removed)
+	M.heal_organ_damage(0.1 * removed, 0)
+	holder.remove_reagent(/singleton/reagent/capsaicin, 10 * removed)
 
 /singleton/reagent/drink/bochbrew
 	name = "Boch Brew"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drink/food_drink_species_unathi.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drink/food_drink_species_unathi.dm
@@ -258,14 +258,6 @@
 
 	var/last_taste_time = -100
 
-/singleton/reagent/alcohol/butanol/trizkizki_tea/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	if(alien == IS_DIONA)
-		if(last_taste_time + 800 < world.time) // Not to spam message
-			to_chat(M, SPAN_DANGER("Your body withers as you feel slight pain throughout."))
-			last_taste_time = world.time
-		metabolism = REM * 0.33
-		M.adjustToxLoss(1.5 * removed)
-
 /singleton/reagent/alcohol/butanol/pulque
 	name = "Xuizi pulque"
 	description = "A variation of Mictlanian pulque that is safe to consume for Unathi."

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drink/generic_drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drink/generic_drinks.dm
@@ -607,14 +607,6 @@
 
 	var/last_taste_time = -100
 
-/singleton/reagent/drink/tea/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	if(alien == IS_DIONA)
-		if(last_taste_time + 800 < world.time) // Not to spam message
-			to_chat(M, SPAN_DANGER("Your body withers as you feel slight pain throughout."))
-			last_taste_time = world.time
-		metabolism = REM * 0.33
-		M.adjustToxLoss(1.5 * removed)
-
 /singleton/reagent/drink/tea/sencha
 	name = "Sencha"
 	description = "A type of green tea originating from Japan on Earth, sencha is unique in that it is steamed instead of pan-roasted like most teas. \

--- a/html/changelogs/hazelmouse-shroomer.yml
+++ b/html/changelogs/hazelmouse-shroomer.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Tea no longer poisons Dionae."


### PR DESCRIPTION
As in the title. I've been told this was implemented in the first place because tea formerly cleared radiation, and without that mechanic as context it doesn't make much sense. Will require some wiki edits.

I believe this is wanted by Diona lore, but I'll throw it into their discord channel to verify and close it if they'd prefer that.

Resolves https://github.com/Aurorastation/Aurora.3/issues/16887