### PR TITLE
Diona magboots 2.0

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -182,6 +182,9 @@
 /// This trait makes Check_Shoegrip return TRUE. Used for magboot-like behaviour.
 #define TRAIT_SHOE_GRIP "shoe_grip"
 
+/// Trait is added from a species verb.
+#define TRAIT_SOURCE_SPECIES_VERB "species_verb"
+
 // DISABILITY TRAITS
 
 /// Causes the mob to take twice as long to clot their wounds

--- a/code/modules/mob/living/carbon/human/diona_gestalt.dm
+++ b/code/modules/mob/living/carbon/human/diona_gestalt.dm
@@ -359,6 +359,55 @@
 	visible_message(SPAN_WARNING("\The [src] quivers slightly, then splits apart with a wet slithering noise."))
 	qdel(src)
 
+/**
+Movespeed modifier used in the root_to_ground proc. This determines how much the ability slows you down by.
+ */
+/datum/movespeed_modifier/root_to_ground
+	multiplicative_slowdown = 1.5
+
+/**
+This verb lets the Diona anchor themselves to the ground, giving them magboot properties.
+Slows you down while being used, and cannot be used below 50 nutrition and 20 energy.
+*/
+/mob/living/carbon/human/proc/root_to_ground()
+	set name = "Extend Roots"
+	set desc = "Extend your roots to keep yourself upright in case of pressure changes."
+	set category = "Abilities"
+
+	if(use_check_and_message(src))
+		return
+
+	if(nutrition <= 50)
+		to_chat(src, SPAN_WARNING("You lack nutrition to perform this action!"))
+		return
+
+	if(DS.stored_energy <= 20)
+		to_chat(src, SPAN_WARNING("You lack energy to perform this action!"))
+		return
+
+	if(last_special > world.time)
+		to_chat(src, SPAN_WARNING("You've used an ability too recently! Wait a bit."))
+		return
+
+	if(!has_organ(BP_R_FOOT) && !has_organ(BP_L_FOOT))
+		to_chat(src, SPAN_WARNING("You have no supporting limbs to extend your roots from!"))
+		return
+
+	last_special = world.time + 2 SECONDS
+
+	if(HAS_TRAIT(src, TRAIT_SHOE_GRIP))
+		visible_message(SPAN_NOTICE("[src] retracts the roots growing from their feet back into their body.")
+		, SPAN_NOTICE("You retract your roots back into your body."))
+		REMOVE_TRAIT(src, TRAIT_SHOE_GRIP, TRAIT_SOURCE_SPECIES_VERB)
+		remove_movespeed_modifier(/datum/movespeed_modifier/root_to_ground)
+		playsound(src, 'sound/species/diona/gestalt_split.ogg', 20, extrarange = SILENCED_SOUND_EXTRARANGE)
+	else
+		visible_message(SPAN_NOTICE("[src] extends an array of roots out from their feet, clutching at any available surface!")
+		, SPAN_NOTICE("You extend strong roots from your feet, serving as natural braces to keep your footing secure."))
+		ADD_TRAIT(src, TRAIT_SHOE_GRIP, TRAIT_SOURCE_SPECIES_VERB)
+		add_movespeed_modifier(/datum/movespeed_modifier/root_to_ground)
+		playsound(src, 'sound/species/diona/gestalt_grow.ogg', 30, extrarange = SILENCED_SOUND_EXTRARANGE)
+
 #undef COLD_DAMAGE_LEVEL_1
 #undef COLD_DAMAGE_LEVEL_2
 #undef COLD_DAMAGE_LEVEL_3

--- a/code/modules/mob/living/carbon/human/diona_gestalt.dm
+++ b/code/modules/mob/living/carbon/human/diona_gestalt.dm
@@ -359,9 +359,9 @@
 	visible_message(SPAN_WARNING("\The [src] quivers slightly, then splits apart with a wet slithering noise."))
 	qdel(src)
 
-/**
+/*
 Movespeed modifier used in the root_to_ground proc. This determines how much the ability slows you down by.
- */
+*/
 /datum/movespeed_modifier/root_to_ground
 	multiplicative_slowdown = 1.5
 

--- a/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
@@ -27,7 +27,8 @@
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/consume_nutrition_from_air,
 		/mob/living/carbon/human/proc/create_structure,
-		/mob/living/carbon/proc/sample
+		/mob/living/carbon/human/proc/root_to_ground,
+		/mob/living/carbon/proc/sample,
 	)
 	//primitive_form = "Nymph"
 	slowdown = 4

--- a/html/changelogs/hazelmouse-shroomroots.yml
+++ b/html/changelogs/hazelmouse-shroomroots.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse, MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Dionae now have access to an ability granting them magboot-like functionality."


### PR DESCRIPTION
This is a continuation of https://github.com/Aurorastation/Aurora.3/pull/18875, full credit goes to Matt for the original PR.

This adds an ability allowing Dionae to access the functionality of magboots. As the only spaceborne species in the setting, they should have more abilities allowing them to excel in their natural environment.

A slowdown has been added to using the ability that wasn't in the original PR to establish a downside to using it, hopefully addressing some of the feedback to the original PR, and it can now be toggled while in space - I found that limitation frustrating, since travelling over lattices or on the side of a hull is one of the most frequent times you'll want to disable or enable magboots.