### PR TITLE
Increases the max player requirement of Loner to 15 from 8

### DIFF
--- a/code/game/gamemodes/loner/loner.dm
+++ b/code/game/gamemodes/loner/loner.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/loner
 	name = "loner"
 	config_tag = "loner"
-	max_players = 8
+	max_players = 15
 	required_enemies = 1
 	required_players = 5
 	round_description = "Does anyone else hear a whistling noise...?"

--- a/html/changelogs/4000daniel1-loner-players_.yml
+++ b/html/changelogs/4000daniel1-loner-players_.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: 4000daniel1
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Changed the max player requirement of Loner from 8 to 15, making it the same as Technomancer."


### PR DESCRIPTION
So it turns out the reason Loner is literally never seen is because there HAS to be 5-8 players readied for it to even have a chance of rolling. 

15 is the max player requirement of Technomancer, so I feel it makes sense here as well.