### PR TITLE
Hydroponics layout tweaks

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -20,6 +20,7 @@
 	new /obj/item/wirecutters/clippers(src)
 	new /obj/item/reagent_containers/spray/plantbgone(src)
 	new /obj/item/storage/belt/hydro(src)
+	new /obj/item/watertank(src)
 
 /obj/structure/closet/secure_closet/xenobotany
 	name = "xenobotanist's locker"

--- a/html/changelogs/hazelmouse-hydrotweaks.yml
+++ b/html/changelogs/hazelmouse-hydrotweaks.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Implements several tweaks and minor fixes to hydroponics, particularly affecting the component on the first deck. This includes some rearranged machines, layout tweaks, filling in some missing decals, and correcting some erroneous space turfs."
+  - rscadd: "Hydroponics lockers now naturally spawn with a water tank inside them."


### PR DESCRIPTION
This implements several tweaks to the layout and contents of the recently remapped hydroponics bay to make the space smoother and more intuitive to play in.

The intention of the mapping here is to make D1 hydroponics a non-liminal space to be in, it should have amenities that mean you can spend a long time there comfortably - I believe this was also the intention of the original PR. It contains most of the hydroponics machines. This is also intended to ensure that you can comfortably spend most of your time in D2 if you prefer, which is important as it's the more visible area.

The empty middle row in the D1 hydroponics racks is intended to be an intuitive spot to cultivate bees. There are two chairs at the desk since there are two gardeners, and the vendors have been moved to a more prominent spot on D2 to make it feel less liminal. I've replaced the hatches under the hydroponics trays with outlines, as a green hatch under a plant makes the plant pretty indistinct. Windoors have been removed between the two areas, since they are no longer required to gate chef access.

![image](https://github.com/user-attachments/assets/40d393ec-4201-45b8-b710-9e155f36dfcc)
![image](https://github.com/user-attachments/assets/ca7b8c40-846d-4e10-bef0-1e3d5cfd897a)

