### PR TITLE
Gives Geras Dionae melee armour

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
@@ -64,6 +64,10 @@
 	pain_messages = list("We're in pain", "We hurt so much", "We can't stand the pain")
 	pain_item_drop_cry = list("creaks loudly and ", "rustles erratically and ", "twitches for a moment and ")
 
+	natural_armor = list(
+		MELEE = ARMOR_MELEE_MEDIUM
+	)
+
 	pain_mod = 0.5
 	grab_mod = 0.6 // Viney Tentacles and shit to cling onto
 	resist_mod = 1.5 // Reasonably stronk, not moreso than an Unathi or robot.

--- a/code/modules/mob/living/carbon/human/species/station/diona/diona_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona_subspecies.dm
@@ -13,6 +13,9 @@
 	towards more experienced gestalts as a hand to help guide them. As a result of being more formative and idealistic, Coeus tend to be more pacifistic and less prone towards any kind of \
 	violence, including against more simple-minded creatures such as monkeys."
 
+	// An empty list, so they do not inherit the melee armour of their parent.
+	natural_armor = list()
+
 	slowdown = 0
 	siemens_coefficient = 0.7
 	pain_mod = 2

--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -420,6 +420,7 @@
 /datum/unit_test/mob_damage/diona/brute
 	name = "MOB: Diona Brute Damage Check"
 	damagetype = DAMAGE_BRUTE
+	expected_vulnerability = ARMORED
 
 /datum/unit_test/mob_damage/diona/fire
 	name = "MOB: Diona Fire Damage Check"

--- a/html/changelogs/hazelmouse-shroomofdoom.yml
+++ b/html/changelogs/hazelmouse-shroomofdoom.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Geras Dionae now possess innate melee armour, intended to give them more leeway fighting simplemobs and other melee-based threats."


### PR DESCRIPTION
As title, requested by Diona lore with the intention of making Geras more viable fighting simplemobs - particularly if you want to play one as a miner. 

This is the same rank of armour as a Vaurca Bulwark, though missing their substantive brute modifier. This has been implemented as melee armour instead of a brute modifier so they aren't any less susceptible to projectiles.

Doesn't apply to Coeus Dionae.
