### PR TITLE
Some is_outside fixes

### DIFF
--- a/html/changelogs/hazelmouse-bugfix.yml
+++ b/html/changelogs/hazelmouse-bugfix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Prevents weather, such as rain, from rendering inside several indoors areas."

--- a/maps/away/away_site/konyang/point_verdant/point_verdant_areas.dm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant_areas.dm
@@ -6,7 +6,7 @@
 	base_turf = /turf/simulated/floor/exoplanet/dirt_konyang
 	ambience = AMBIENCE_KONYANG_TRAFFIC
 	sound_environment = SOUND_ENVIRONMENT_CITY
-	is_outside = TRUE
+	is_outside = OUTSIDE_YES
 	var/lighting = FALSE //Is this area automatically lit?
 
 /area/point_verdant/Initialize()
@@ -43,7 +43,7 @@
 	name = "Point Verdant - Indoors"
 	sound_environment = SOUND_AREA_LARGE_SOFTFLOOR
 	ambience = AMBIENCE_KONYANG_RAIN_MUFFLED
-	is_outside = FALSE
+	is_outside = OUTSIDE_NO
 
 //Main city buildings
 /area/point_verdant/interior/laundromat

--- a/maps/helpers/event_shuttles/eventshuttles_areas_readme.dm
+++ b/maps/helpers/event_shuttles/eventshuttles_areas_readme.dm
@@ -32,4 +32,4 @@
 	dynamic_lighting = TRUE
 	no_light_control = FALSE
 	area_flags = AREA_FLAG_RAD_SHIELDED
-	is_outside = FALSE
+	is_outside = OUTSIDE_NO

--- a/maps/random_ruins/exoplanets/adhomai/adhomai_silo.dm
+++ b/maps/random_ruins/exoplanets/adhomai/adhomai_silo.dm
@@ -27,7 +27,7 @@
 /area/adhomai_silo/cabin
 	name = "Adhomian Missile Silo Cabin"
 	icon_state = "security"
-	is_outside = FALSE
+	is_outside = OUTSIDE_NO
 
 //ghost roles
 

--- a/maps/random_ruins/exoplanets/asteroid/abandoned_prison/abandoned_prison.dm
+++ b/maps/random_ruins/exoplanets/asteroid/abandoned_prison/abandoned_prison.dm
@@ -20,6 +20,7 @@
 	requires_power = TRUE
 	dynamic_lighting = TRUE
 	no_light_control = TRUE
+	is_outside = OUTSIDE_NO
 
 /area/abandoned_prison/eva_prep
 	name = "EVA Preparation Room"
@@ -60,3 +61,4 @@
 /area/abandoned_prison/exterior
 	name = "Exterior"
 	icon_state = "space"
+	is_outside = OUTSIDE_YES

--- a/maps/random_ruins/exoplanets/asteroid/coalition_base/coalition_base.dm
+++ b/maps/random_ruins/exoplanets/asteroid/coalition_base/coalition_base.dm
@@ -19,6 +19,7 @@
 	requires_power = TRUE
 	dynamic_lighting = TRUE
 	no_light_control = TRUE
+	is_outside = OUTSIDE_NO
 
 /area/coalition_base/eva_prep
 	name = "EVA Preparation Room"

--- a/maps/random_ruins/exoplanets/asteroid/listening_post/listening_post_unique.dm
+++ b/maps/random_ruins/exoplanets/asteroid/listening_post/listening_post_unique.dm
@@ -21,6 +21,7 @@
 	requires_power = TRUE
 	dynamic_lighting = TRUE
 	no_light_control = TRUE
+	is_outside = OUTSIDE_NO
 
 /area/listening_post/entrance
 	name = "Listening Post Installation - Entrance"

--- a/maps/random_ruins/exoplanets/asteroid/mystery_ship/mystery_ship_areas.dm
+++ b/maps/random_ruins/exoplanets/asteroid/mystery_ship/mystery_ship_areas.dm
@@ -1,27 +1,40 @@
 /area/ship/mystery_ship
 	no_light_control = 1
 	requires_power = TRUE
+	is_outside = OUTSIDE_NO
+
 /area/ship/mystery_ship/cockpit
 	name = "Cockpit"
+
 /area/ship/mystery_ship/crew_seating
 	name = "Seating Area"
+
 /area/ship/mystery_ship/port_airlock
 	name = "Port Airlock"
+
 /area/ship/mystery_ship/starboard_airlock
 	name = "Starboard Airlock"
+
 /area/ship/mystery_ship/equipment
 	name = "Equipment"
+
 /area/ship/mystery_ship/resting_area
 	name = "Resting Area"
+
 /area/ship/mystery_ship/armoury
 	name = "Ready Room"
+
 /area/ship/mystery_ship/atmospherics
 	name = "Atmospherics"
+
 /area/ship/mystery_ship/power
 	name = "Power"
+
 /area/ship/mystery_ship/medical
 	name = "Medical"
+
 /area/ship/mystery_ship/auxillary_storage
 	name = "Auxillary Storage"
+
 /area/ship/mystery_ship/research
 	name = "Research"

--- a/maps/random_ruins/exoplanets/burzsia/burzsia_mining.dm
+++ b/maps/random_ruins/exoplanets/burzsia/burzsia_mining.dm
@@ -21,6 +21,7 @@
 	no_light_control = FALSE
 	base_turf = /turf/simulated/floor/exoplanet/barren
 	area_flags = AREA_FLAG_RAD_SHIELDED
+	is_outside = OUTSIDE_NO
 
 /area/burzsia_mining/mess_hall
 	name = "Hephaestus Burzsia Mining Outpost Mess Hall"

--- a/maps/random_ruins/exoplanets/konyang/landing_zone.dm
+++ b/maps/random_ruins/exoplanets/konyang/landing_zone.dm
@@ -23,6 +23,7 @@
 /area/konyang_landing_zone/command_center
 	name = "SCC Expedition Command Center"
 	requires_power = TRUE
+	is_outside = OUTSIDE_NO
 
 /area/konyang_landing_zone/command_center/reactor
 	name = "SCC Expedition Command Center Reactor"
@@ -38,6 +39,7 @@
 
 /area/konyang_landing_zone/command_center/landing_pads
 	name = "SCC Expedition Command Center Landing Pads"
+	is_outside = OUTSIDE_YES
 
 /obj/effect/shuttle_landmark/konyang_landing_zone_intrepid
 	name = "SCC Expedition Command Center - Intrepid"


### PR DESCRIPTION
Defines the is_outside variable of a few areas to make weather effects stop rendering indoors. This doesn't touch any maps directly, bringing lore planets into compatibility with this will be particularly time-consuming considering most of their ruins don't currently have areas.