### PR TITLE
Hydroponics chemical additions

### DIFF
--- a/code/modules/hydroponics/seed_datums/mushrooms.dm
+++ b/code/modules/hydroponics/seed_datums/mushrooms.dm
@@ -247,7 +247,7 @@
 	name = "towercap"
 	seed_name = "tower cap"
 	display_name = "tower caps"
-	chems = list(/singleton/reagent/woodpulp = list(10,1))
+	chems = list(/singleton/reagent/woodpulp = list(10,1), /singleton/reagent/acetone = list(3,4))
 	mutants = null
 
 /datum/seed/mushroom/towercap/setup_traits()
@@ -289,7 +289,7 @@
 	seed_name = "plastellium"
 	display_name = "plastellium"
 	mutants = null
-	chems = list(/singleton/reagent/toxin/plasticide = list(1,10))
+	chems = list(/singleton/reagent/toxin/plasticide = list(1,10), /singleton/reagent/carbon = list(4, 6))
 
 /datum/seed/mushroom/plastic/setup_traits()
 	..()

--- a/code/modules/hydroponics/seed_datums/nralakk.dm
+++ b/code/modules/hydroponics/seed_datums/nralakk.dm
@@ -5,7 +5,7 @@
 	seed_name = "dyn"
 	display_name = "dyn bush"
 	mutants = null
-	chems = list(/singleton/reagent/drink/dynjuice = list(2, 2), /singleton/reagent/dylovene = list(0, 1))
+	chems = list(/singleton/reagent/drink/dynjuice = list(2, 2), /singleton/reagent/dylovene = list(2, 3))
 	kitchen_tag = "dyn leaf"
 
 /datum/seed/dyn/setup_traits()
@@ -144,7 +144,7 @@
 	seed_name = "fjylozyn"
 	display_name = "fjylozyn"
 	mutants = null
-	chems = list(/singleton/reagent/nutriment = list(3, 5), /singleton/reagent/toxin = list(2, 3))
+	chems = list(/singleton/reagent/nutriment = list(3, 5), /singleton/reagent/toxin = list(2, 3), /singleton/reagent/ammonia = list(2, 3))
 	kitchen_tag = "fjylozyn"
 
 /datum/seed/fjylozyn/setup_traits()

--- a/code/modules/hydroponics/seed_datums/unathi.dm
+++ b/code/modules/hydroponics/seed_datums/unathi.dm
@@ -124,6 +124,7 @@
 	name = "serkiflower"
 	seed_name = "S'erki flower"
 	display_name = "S'erki flowers"
+	chems = list(/singleton/reagent/nutriment = list(3,5), /singleton/reagent/perconol = list(3,5), /singleton/reagent/soporific = list(3,5))
 
 /datum/seed/flower/serkiflower/setup_traits()
 	..()

--- a/html/changelogs/hazelmouse-plantexpansion.yml
+++ b/html/changelogs/hazelmouse-plantexpansion.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "More chemicals and medicines are now available via hydroponics! S'erki flowers now yield small quantities of perconol and soporific, plastellium mushrooms yield carbon in addition to plasticide, dyn yields a greater quantity of dylovene, fjylozyn yields some ammonia, and tower caps yield some acetone."


### PR DESCRIPTION
This adds a number of new chemicals to what's available to grow in hydroponics. These include:

- Tower caps yield acetone.
- Plastellium yields carbon.
- Dyn yields a greater quantity of dylovene.
- Fjylozyn yields some ammonia.
- S'erki flowers yield some perconol and soporific.

This is intended to give hydroponicists more options if they want to distil basic medicines from what they grow, particularly now there is a prominent front desk for them to sell what they can make.

The inclusion of carbon, acetone, and ammonia is intended to let hydroponicists grow a few of the more frequently exhausted chemicals used by the pharmacist - so a hydroponicist player could make a regular habit of growing some tower caps and plastellium to resupply the pharmacist, that kind of thing.