### PR TITLE
Flag iron as fusion fuel mat

### DIFF
--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -733,6 +733,7 @@
 	golem = SPECIES_GOLEM_IRON
 	hitsound = 'sound/weapons/smash.ogg'
 	weapon_hitsound = 'sound/weapons/metalhit.ogg'
+	is_fusion_fuel = TRUE
 
 /material/aluminium
 	name = MATERIAL_ALUMINIUM

--- a/html/changelogs/Batrachophreno-IndraIronFuel.yml
+++ b/html/changelogs/Batrachophreno-IndraIronFuel.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: hazelmouse
+author: Batrachophreno
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -55,5 +55,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - qol: "All traps now produce a noise when set up, and punji traps produce a noise when a mob falls into them."
-  - balance: "Punji traps now cause victims to collapse after falling into them."
+  - bugfix: "Iron fuel assemblies for the INDRA can also be created using five iron ingots, not just the iron reagent cartridge."

--- a/html/changelogs/Batrachophreno-IndraIronFuel.yml
+++ b/html/changelogs/Batrachophreno-IndraIronFuel.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "All traps now produce a noise when set up, and punji traps produce a noise when a mob falls into them."
+  - balance: "Punji traps now cause victims to collapse after falling into them."


### PR DESCRIPTION
https://github.com/Aurorastation/Aurora.3/issues/17671

Iron (as a material) was not flagged is_fusion_fuel. This PR corrects that, so both iron liquid reagent cartridges and five iron ingots can be inserted into the fuel compressor to get fuel assemblies. A happy day for miner-supplied fuel assembly edge cases.