### PR TITLE
Potentially fixes issues with stat panel with offline authentication

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -41,9 +41,8 @@
  * Use /mob/proc/LateLogin() instead.
  */
 /mob/Login()
+	SHOULD_CALL_PARENT(FALSE)
 	SHOULD_NOT_OVERRIDE(TRUE)
-
-	..()
 
 	if (client.is_initialized)
 		LateLogin()
@@ -70,6 +69,8 @@
 	if(hud_used)
 		qdel(hud_used)		//remove the hud objects
 	hud_used = new /datum/hud(src)
+
+	client.statobj = src
 
 	disconnect_time = null
 	next_move = 1

--- a/html/changelogs/GeneralCamo - Offline Auth Fix.yml
+++ b/html/changelogs/GeneralCamo - Offline Auth Fix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - code_imp: "Removed call to BYOND's Login() proc, as it may be causing issues with offline authentication. Replaced relevant functionality in LateLogin()."


### PR DESCRIPTION
I am not set up to test this, unfortunately. However, this is a best guess on what's going on.

The client's statobj var handles showing the stat panel to the mob. However, the client does not yet have a ckey set when logging in. This may be causing issues when logging in from offline. This var is set from byond's Login() proc, which does not yet assume a CKey exists.

This potentially resolves this issue by setting it in LateLogin() instead, and removing the parent call in Login(). The only other thing this does is try to set the mob's position to (1, 1, 1), which is done in a very brute force manner which is probably undesirable for this setting.