### PR TITLE
Offline Authentication Fixes (For real this time)

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -383,6 +383,9 @@ GLOBAL_LIST_INIT(localhost_addresses, list(
 	tgui_panel = new(src, "browseroutput")
 	tgui_say = new(src, "tgui_say")
 
+	// Forcibly enable hardware-accelerated graphics, as we need them for the lighting overlays.
+	winset(src, null, "command=\".configure graphics-hwmode on\"")
+
 	if(IsGuestKey(key) && GLOB.config.external_auth)
 		src.authed = FALSE
 		var/mob/abstract/unauthed/m = new()
@@ -395,25 +398,8 @@ GLOBAL_LIST_INIT(localhost_addresses, list(
 		. = ..()
 		src.InitClient()
 		src.InitPrefs()
+		src.InitUI()
 		mob.LateLogin()
-
-	// Initialize stat panel
-	stat_panel.initialize(
-		inline_html = file("html/statbrowser.html"),
-		inline_js = file("html/statbrowser.js"),
-		inline_css = file("html/statbrowser.css"),
-	)
-	addtimer(CALLBACK(src, PROC_REF(check_panel_loaded)), 30 SECONDS)
-
-	INVOKE_ASYNC(src, PROC_REF(acquire_dpi))
-
-	// Initialize tgui panel
-	tgui_panel.initialize()
-
-	tgui_say.initialize()
-
-	// Forcibly enable hardware-accelerated graphics, as we need them for the lighting overlays.
-	winset(src, null, "command=\".configure graphics-hwmode on\"")
 
 	send_resources()
 
@@ -444,6 +430,21 @@ GLOBAL_LIST_INIT(localhost_addresses, list(
 
 	if(prefs.toggles_secondary & CLIENT_PREFERENCE_HIDE_MENU)
 		addtimer(CALLBACK(src, VERB_REF(toggle_menu), 1 SECONDS))
+
+/client/proc/InitUI()
+	INVOKE_ASYNC(src, PROC_REF(acquire_dpi))
+
+	// Initialize tgui panel
+	tgui_panel.initialize()
+	tgui_say.initialize()
+
+	// Initialize stat panel
+	stat_panel.initialize(
+		inline_html = file("html/statbrowser.html"),
+		inline_js = file("html/statbrowser.js"),
+		inline_css = file("html/statbrowser.css"),
+	)
+	addtimer(CALLBACK(src, PROC_REF(check_panel_loaded)), 30 SECONDS)
 
 /client/proc/InitClient()
 	SHOULD_NOT_SLEEP(TRUE)

--- a/code/modules/mob/abstract/unauthed/login.dm
+++ b/code/modules/mob/abstract/unauthed/login.dm
@@ -11,24 +11,33 @@ GLOBAL_LIST_EMPTY(unauthed)
 /mob/abstract/unauthed/LateLogin()
 	SHOULD_CALL_PARENT(FALSE)
 
+	//Don't redo this if they have already been authenticated
+	if(client?.authed)
+		return
+
 	update_Login_details()
-	to_chat(src, SPAN_DANGER("<b>You need to authenticate before you can continue.</b>"))
 	token = md5("[client.ckey][client.computer_id][world.time][rand()]")
 	GLOB.unauthed[token] = src
 	remove_verb(client, typesof(/client/verb))
-	var/uihtml = "<html><head><style>body * {display: block;text-align:center;margin: 14px 0;font-size:24px;text-decoration:none;font-family:Segoe UI,Frutiger,Frutiger Linotype,Dejavu Sans,Helvetica Neue,Arial,sans-serif;}</style></head><body><p>Please select:</p>"
+	var/uihtml = "<html><head><style>body * {display: block;text-align:center;margin: 14px 0;font-size:24px;text-decoration:none;font-family:Segoe UI Variable,Segoe UI,Frutiger,Frutiger Linotype,Dejavu Sans,Helvetica Neue,Arial,sans-serif;}h1{color: #ff0000;font-family:Segoe UI Variable,Segoe UI,Frutiger,Frutiger Linotype,Dejavu Sans,Helvetica Neue,Arial,sans-serif;}</style></head>"
+	uihtml += "<body><h1>You need to authenticate before you can continue.</h1><br/><p>Please select:</p>"
 	if(GLOB.config.guests_allowed)
 		uihtml += "<a href='byond://?src=[REF(src)];authaction=guest'>Login as guest</a>"
 	if(GLOB.config.webint_url && GLOB.config.external_auth)
 		uihtml += "<a href='byond://?src=[REF(src)];authaction=forums'>Login via forums</a>"
 	if(!GLOB.config.guests_allowed && GLOB.config.webint_url && GLOB.config.external_auth)
 		src.OpenForumAuthWindow()
-	show_browser(src, uihtml, "window=externalauth;size=300x300;border=0;can_close=1;can_resize=0;can_minimize=0;titlebar=1")
-	timeout_timer = addtimer(CALLBACK(src, PROC_REF(timeout)), 900, TIMER_STOPPABLE)
+	uihtml += "</body>"
+	show_browser(src, uihtml, "window=mainwindow.guestbrowser")
+	winset(src, "mainwindow.guestbrowser", "is-visible=true")
+	winset(src, "mainwindow.guestbrowser", "is-disabled=false")
+	timeout_timer = addtimer(CALLBACK(src, PROC_REF(timeout)), 90 SECONDS, TIMER_STOPPABLE)
 
 /mob/abstract/unauthed/proc/timeout()
 	if (client)
-		to_chat_immediate(client, "Your login time has expired. Please relog and try again.")
+		var/alert = "<html><head><title>Login Timeout</title><style>body * {display: block;text-align:center;margin: 14px 0;font-size:24px;text-decoration:none;font-family:Segoe UI Variable,Segoe UI,Frutiger,Frutiger Linotype,Dejavu Sans,Helvetica Neue,Arial,sans-serif;}h1{color: #ff0000;font-family:Segoe UI Variable,Segoe UI,Frutiger,Frutiger Linotype,Dejavu Sans,Helvetica Neue,Arial,sans-serif;}</style></head>"
+		alert += "<body><h1>Your login time has expired. Please relog and try again.</h1></body>"
+		show_browser(src, alert, "window=mainwindow.guestbrowser;")
 	qdel(client)
 	qdel(src)
 
@@ -36,10 +45,12 @@ GLOBAL_LIST_EMPTY(unauthed)
 	if(!client)
 		qdel(src)
 	deltimer(timeout_timer)
+	winset(src, "mainwindow.guestbrowser", "is-visible=false")
+	winset(src, "mainwindow.guestbrowser", "is-disabled=true")
 	var/client/c = client // so we don't lose the client in the current mob.
 
-	show_browser(src, null, "window=externalauth")
 	add_verb(c,  typesof(/client/verb)) // Let's return regular client verbs
+
 	c.authed = TRUE // We declare client as authed now
 	c.prefs = null //Null them so we can load them from the db again for the correct ckey
 	// Check for bans
@@ -62,6 +73,7 @@ GLOBAL_LIST_EMPTY(unauthed)
 	// Note that modifying the key variable does not invoke client/New() or client/Login() again.
 	c.InitClient()
 	c.InitPrefs()
+	c.InitUI()
 	c.mob.LateLogin()
 
 	if(istype(c.mob, /mob/abstract/unauthed))

--- a/html/changelogs/GeneralCamo - Offline Login Fix.yml
+++ b/html/changelogs/GeneralCamo - Offline Login Fix.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed offline authentication failing to load UI elements."
+  - qol: "The offline authentication window is now integrated into the main game window."
+  - code_imp: "Fixed up the HTML tags on the offline authentication window."

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -944,6 +944,14 @@ window "mainwindow"
 		anchor2 = -1,-1
 		is-visible = false
 		saved-params = ""
+	elem "guestbrowser"
+		type = BROWSER
+		pos = 0,0
+		size = 640x440
+		anchor1 = 0,0
+		anchor2 = 100,100
+		is-visible = false
+		is-disabled = true
 
 window "mapwindow"
 	elem "mapwindow"


### PR DESCRIPTION
Thanks to harry for pointing me in the right direction here.

The way this worked previously, is that it bypassed the UI initialization. I ended up moving all of that into a seperate proc, which is now also called upon logging in with the offline authenticator (after prefs are loaded).

In addition, I improved the login window. Instead of having a closable pop-up window (which was only made closable due to a bug with it staying open), it is now integrated into the game window itself (and I fixed the bug requiring it to be closable). There was also an unclosed `<body>` tag which I closed, and all the elements previously sent to the (now blocked) chat window, instead appear on the window itself.