### PR TITLE
Turns Off-worlder RMT pills into an optional loadout item

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/xeno/human.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/human.dm
@@ -99,3 +99,9 @@
 	sort_category = "Xenowear - Human"
 	flags = GEAR_HAS_DESC_SELECTION
 	origin_restriction = list(/singleton/origin_item/origin/coa_spacer)
+
+/datum/gear/drugs_meds/rmt_bottle
+	display_name = "RMT pill bottle"
+	path = /obj/item/storage/pill_bottle/rmt
+	whitelisted = list(SPECIES_HUMAN_OFFWORLD)
+	sort_category = "Xenowear - Human"

--- a/code/modules/mob/living/carbon/human/species/station/human/human_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/human/human_subspecies.dm
@@ -25,12 +25,6 @@
 
 	examine_color = "#C2AE95"
 
-/datum/species/human/offworlder/equip_later_gear(var/mob/living/carbon/human/H)
-	if(istype(H.get_equipped_item(slot_back), /obj/item/storage/backpack) && H.equip_to_slot_or_del(new /obj/item/storage/pill_bottle/rmt(H.back), slot_in_backpack))
-		return
-	var/obj/item/storage/pill_bottle/rmt/PB = new /obj/item/storage/pill_bottle/rmt(get_turf(H))
-	H.put_in_hands(PB)
-
 /datum/species/human/offworlder/get_species_tally(var/mob/living/carbon/human/H)
 
 	if(istype(H.back, /obj/item/rig/light/offworlder))

--- a/html/changelogs/SimpleMaroon-offworlderslop.yml
+++ b/html/changelogs/SimpleMaroon-offworlderslop.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: SimpleMaroon
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "RMT pill bottles are now an optional selection that can be taken from the loadout under Xenowear - Human, rather than an item that all offworlders spawn with."


### PR DESCRIPTION
Title. WIP while I figure out how to make it so off-ship off-worlders still spawn with them.

As funny as it's always been to spawn in as my off-worlder character and throw away the pill bottle every single round, I think this makes more sense in the long run.