### PR TITLE
Workflow - Fix Megalinter Permisions

### DIFF
--- a/.github/workflows/byond.yml
+++ b/.github/workflows/byond.yml
@@ -79,6 +79,10 @@ jobs:
     name: Validate EditorConfig Compliance
     runs-on: ubuntu-24.04
     if: ${{ !(contains(github.event.head_commit.message, '[ci skip]')) }}
+    
+    permissions:
+      issues: write
+      pull-requests: write
 
     concurrency:
       group: megalinter-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Adapt the megalinter permissions, so it can properly output the errors to the PRs

