### PR TITLE
Adds some clipboards to some certain departments

### DIFF
--- a/html/changelogs/kano-dot-clipboardening.yml
+++ b/html/changelogs/kano-dot-clipboardening.yml
@@ -1,0 +1,6 @@
+author: Kano
+
+delete-after: True
+
+changes:
+  - rscadd: "Added a few clipboards to several departments for the masses to enjoy."


### PR DESCRIPTION
## About PR

This PR adds clipboards to following areas:

- Operations: front desk
- Medbay: examination room
- Engineering: lobby
- C-Goliath Bluespace Drive: control room
- Science: conference room
- Security: front desk

Currently only bridge has the entire clipboard spawns, which doesn't make sense for other departments that should be doing paperwork on a daily basis. This PR gives tidy paperwork privileges to the masses.