### PR TITLE
Created equivalent functions for NanoUI-based objects for TGUI

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -271,6 +271,11 @@ Class Procs:
 /obj/machinery/CouldNotUseTopic(var/mob/user)
 	user.unset_machine()
 
+/obj/machinery/CouldUseUI(mob/user)
+	..()
+	if(clicksound && iscarbon(user))
+		playsound(src, clicksound, clickvol)
+
 ////////////////////////////////////////////////////////////////////////////////////////////
 
 /obj/machinery/attack_ai(mob/user as mob)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -71,6 +71,10 @@
 	QDEL_NULL(talking_atom)
 	return ..()
 
+/obj/CouldUseUI(mob/user)
+	..()
+	user.AddTopicPrint(src)
+
 /obj/Topic(href, href_list, var/datum/ui_state/state = GLOB.default_state)
 	if(..())
 		return 1

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -144,6 +144,11 @@
 
 	return ..()
 
+/obj/item/modular_computer/CouldUseUI(mob/user)
+	..()
+	if(iscarbon(user))
+		playsound(src, 'sound/machines/pda_click.ogg', 20)
+
 /obj/item/modular_computer/CouldUseTopic(var/mob/user)
 	..()
 	if(iscarbon(user))

--- a/code/modules/tgui/external.dm
+++ b/code/modules/tgui/external.dm
@@ -89,7 +89,20 @@
 	SEND_SIGNAL(src, COMSIG_UI_ACT, usr, action)
 	// If UI is not interactive or usr calling Topic is not the UI user, bail.
 	if(!ui || ui.status != UI_INTERACTIVE)
+		CouldNotUseUI(usr)
 		return TRUE
+
+	CouldUseUI(usr)
+
+///Called when the UI was able to be used
+/datum/proc/CouldUseUI(mob/user)
+	SHOULD_CALL_PARENT(TRUE)
+	//nada
+
+///Called when the UI was unable to be used
+/datum/proc/CouldNotUseUI(mob/user)
+	SHOULD_CALL_PARENT(TRUE)
+	//nada
 
 /**
  * public

--- a/html/changelogs/GeneralCamo - Use Fixes.yml
+++ b/html/changelogs/GeneralCamo - Use Fixes.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Repaired machine click and PDA use sounds."
+  - bugfix: "TGUI-based machines now give fingerprints, as NanoUI-based machines do."


### PR DESCRIPTION
NanoUI (and possibly VueUI, though I'm not digging to check) used two functions: `CouldUseUI` and `CouldNotUseUI` for various functions. These were never replicated in the port to TGUI, resulting in no fingerprints when using a TGUI object, and broken `clicksound`s for all machines.

These have been replicated for all TGUI-based objects. I am not sure where the old functions are completely unused, so I have not stripped those at the moment. But this should fix, from a user perspective, fingerprints and machine click sounds.