### PR TITLE
Removed arm guards protecting the hands, leg guards protecting the feet.

### DIFF
--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -1,7 +1,7 @@
 //Leg guards.
 /obj/item/clothing/accessory/leg_guard
 	name = "corporate leg guards"
-	desc = "These will protect your legs and feet."
+	desc = "These will protect your legs."
 	desc_info = "These items must be hooked onto plate carriers for them to work!"
 	icon = 'icons/clothing/kit/modular_armor.dmi'
 	icon_state = "legguards_sec"
@@ -17,7 +17,7 @@
 		ENERGY = ARMOR_ENERGY_SMALL,
 		BOMB = ARMOR_BOMB_PADDED
 	)
-	body_parts_covered = LEGS|FEET
+	body_parts_covered = LEGS
 	drop_sound = 'sound/items/drop/boots.ogg'
 	pickup_sound = 'sound/items/pickup/boots.ogg'
 
@@ -41,7 +41,7 @@
 
 /obj/item/clothing/accessory/leg_guard/ablative
 	name = "ablative leg guards"
-	desc = "These will protect your legs and feet from energy weapons."
+	desc = "These will protect your legs from energy weapons."
 	icon_state = "legguards_ablative"
 	item_state = "legguards_ablative"
 	armor = list(
@@ -55,7 +55,7 @@
 
 /obj/item/clothing/accessory/leg_guard/ballistic
 	name = "ballistic leg guards"
-	desc = "These will protect your legs and feet from ballistic weapons."
+	desc = "These will protect your legs from ballistic weapons."
 	icon_state = "legguards_ballistic"
 	item_state = "legguards_ballistic"
 	armor = list(
@@ -69,7 +69,7 @@
 
 /obj/item/clothing/accessory/leg_guard/riot
 	name = "riot leg guards"
-	desc = "These will protect your legs and feet from close combat weapons."
+	desc = "These will protect your legs from close combat weapons."
 	icon_state = "legguards_riot"
 	item_state = "legguards_riot"
 	armor = list(
@@ -83,7 +83,7 @@
 
 /obj/item/clothing/accessory/leg_guard/military
 	name = "sol army leg guards"
-	desc = "These will protect your legs and feet from most things."
+	desc = "These will protect your legs from most things."
 	icon_state = "legguards_military"
 	item_state = "legguards_military"
 	armor = list(
@@ -97,7 +97,7 @@
 
 /obj/item/clothing/accessory/leg_guard/heavy
 	name = "heavy leg guards"
-	desc = "These leg guards will protect your legs and feet from most things."
+	desc = "These leg guards will protect your legs from most things."
 	icon_state = "legguards_heavy"
 	item_state = "legguards_heavy"
 	armor = list(
@@ -186,14 +186,14 @@
 //Arm guards.
 /obj/item/clothing/accessory/arm_guard
 	name = "corporate arm guards"
-	desc = "These arm guards will protect your hands and arms."
+	desc = "A pair of arm pads reinforced with armor plating. Attaches to a plate carrier."
 	icon = 'icons/clothing/kit/modular_armor.dmi'
 	icon_state = "armguards_sec"
 	item_state = "armguards_sec"
 	contained_sprite = TRUE
 	slot = ACCESSORY_SLOT_ARM_GUARDS
 	accessory_layer = ACCESSORY_LAYER_LOWER
-	body_parts_covered = HANDS|ARMS
+	body_parts_covered = ARMS
 	armor = list(
 		MELEE = ARMOR_MELEE_KEVLAR,
 		BULLET = ARMOR_BALLISTIC_MEDIUM,
@@ -225,7 +225,7 @@
 
 /obj/item/clothing/accessory/arm_guard/ablative
 	name = "ablative arm guards"
-	desc = "These arm guards will protect your hands and arms from energy weapons."
+	desc = "A pair of armored arm pads with advanced shielding to protect against energy weapons. Attaches to a plate carrier."
 	icon_state = "armguards_ablative"
 	item_state = "armguards_ablative"
 	armor = list(
@@ -239,7 +239,7 @@
 
 /obj/item/clothing/accessory/arm_guard/ballistic
 	name = "ballistic arm guards"
-	desc = "These arm guards will protect your hands and arms from ballistic weapons."
+	desc = "A pair of armored arm pads with heavy plates to protect against ballistic projectiles. Attaches to a plate carrier."
 	icon_state = "armguards_ballistic"
 	item_state = "armguards_ballistic"
 	armor = list(
@@ -253,7 +253,7 @@
 
 /obj/item/clothing/accessory/arm_guard/riot
 	name = "riot arm guards"
-	desc = "These arm guards will protect your hands and arms from close combat weapons."
+	desc = "A pair of armored arm and hand pads with heavy padding to protect against melee attacks."
 	icon_state = "armguards_riot"
 	item_state = "armguards_riot"
 	armor = list(
@@ -264,10 +264,11 @@
 		BOMB = ARMOR_BOMB_PADDED
 	)
 	slowdown = 0.3
+	body_parts_covered = ARMS|HANDS
 
 /obj/item/clothing/accessory/arm_guard/military
 	name = "sol army arm guards"
-	desc = "These arm guards will protect your hands and arms from most things."
+	desc = "A pair of green arm and hands pads reinforced with armor plating. Attaches to a plate carrier."
 	icon_state = "armguards_military"
 	item_state = "armguards_military"
 	armor = list(
@@ -278,10 +279,11 @@
 		BOMB = ARMOR_BOMB_PADDED,
 	)
 	slowdown = 0.3
+	body_parts_covered = ARMS|HANDS
 
 /obj/item/clothing/accessory/arm_guard/heavy
 	name = "heavy arm guards"
-	desc = "These arm guards will protect your hands and arms from most things."
+	desc = "A pair of armored arm pads reinforced with heavy armor plating. Attaches to a plate carrier."
 	icon_state = "armguards_heavy"
 	item_state = "armguards_heavy"
 	armor = list(
@@ -295,9 +297,11 @@
 
 /obj/item/clothing/accessory/arm_guard/heavy/scc
 	name = "heavy SCC arm guards"
+	desc = "A pair of armored arm and hand pads reinforced with heavy armor plating. Attaches to a plate carrier."
 	icon_state = "armguards_blue"
 	item_state = "armguards_blue"
 	slowdown = 0.3
+	body_parts_covered = ARMS|HANDS
 
 /obj/item/clothing/accessory/arm_guard/heavy/sec
 	name = "heavy corporate arm guards"
@@ -314,7 +318,7 @@
 
 /obj/item/clothing/accessory/arm_guard/kala
 	name = "kala arm guards"
-	desc = "These arm guards are made out of an advanced lightweight alloy."
+	desc = "These arm guards are made out of an advanced lightweight alloy. Attaches to a plate carrier."
 	icon_state = "armguards_sec_heavy"
 	item_state = "armguards_sec_heavy"
 	armor = list(
@@ -327,7 +331,7 @@
 
 /obj/item/clothing/accessory/arm_guard/tcaf
 	name = "\improper TCAF carapace arm guards"
-	desc = "Blue carapace armguards to protect you in the modern battlefield of 2465."
+	desc = "Blue carapace armguards to protect you in the modern battlefield of 2465. Attaches to a plate carrier."
 	icon = 'icons/clothing/kit/modular_armor.dmi'
 	icon_state = "tcaf_armguards"
 	item_state = "tcaf_armguards"
@@ -340,6 +344,7 @@
 		BOMB = ARMOR_BOMB_PADDED,
 	)
 	slowdown = 0.3
+	body_parts_covered = ARMS|HANDS
 
 /obj/item/clothing/accessory/arm_guard/tcaf/tcaf_stripe
 	name = "striped TCAF carapace arm guards"

--- a/html/changelogs/GeneralCamo - Arm and Leg Guard.yml
+++ b/html/changelogs/GeneralCamo - Arm and Leg Guard.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Arm guards (with the exception of riot variants and a few older variants) no longer protect the hands."
+  - rscdel: "Leg guards no longer protect the feet."


### PR DESCRIPTION
A companion to #20795 

During discussion on this PR, it has come to my attention that no one realized these also protect your hands and feet. And why would they, considering their sprites do not cover said areas?

This is poor for player feedback, so these have been corrected to only protect areas actually covered on the sprite itself.