### PR TITLE
Spore packets no longer have a seed packet under their overlay

### DIFF
--- a/code/modules/hydroponics/seed_packets.dm
+++ b/code/modules/hydroponics/seed_packets.dm
@@ -4,7 +4,7 @@ GLOBAL_LIST_EMPTY(plant_seed_sprites)
 /obj/item/seeds
 	name = "packet of seeds"
 	icon = 'icons/obj/seeds.dmi'
-	icon_state = "random"
+	icon_state = "blank"
 	w_class = WEIGHT_CLASS_SMALL
 
 	storage_slot_sort_by_name = TRUE

--- a/html/changelogs/hazelmouse-plaaaants.yml
+++ b/html/changelogs/hazelmouse-plaaaants.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Spores, eggs, and other hydroponics seeds that should not appear in seed packets no longer have a seed packet underneath their overlays."


### PR DESCRIPTION
Resolves an issue causing the 'random' icon in seeds.dmi to appear underneath overlays, causing them to seem to be underneath spores and eggs.

![image](https://github.com/user-attachments/assets/c88a17e3-f7f5-4c8d-9d9d-b570822c1ef4)

There's probably a better way to do this, but from what I've been able to determine there's no way for a seed to generate without having overlays to make up for the naturally blank icon state.