### PR TITLE
Allows Storytellers to go freely between z-levels

### DIFF
--- a/code/modules/mob/abstract/ghost/storyteller/storyteller.dm
+++ b/code/modules/mob/abstract/ghost/storyteller/storyteller.dm
@@ -134,15 +134,6 @@
 /mob/abstract/ghost/storyteller/can_ztravel(direction)
 	return TRUE
 
-// Allows storytellers to move freely between z-levels.
-/mob/abstract/ghost/storyteller/zMove(direction)
-	var/turf/T = get_turf(src)
-	var/turf/destination = (direction == UP) ? GET_TURF_ABOVE(T) : GET_TURF_BELOW(T)
-	if(destination)
-		forceMove(destination)
-	else
-		to_chat(src, SPAN_NOTICE("There is nothing of interest in this direction."))
-
 /mob/abstract/ghost/storyteller/verb/odyssey_panel()
 	set name = "Odyssey Panel"
 	set category = "Storyteller"

--- a/code/modules/mob/abstract/ghost/storyteller/storyteller.dm
+++ b/code/modules/mob/abstract/ghost/storyteller/storyteller.dm
@@ -134,6 +134,15 @@
 /mob/abstract/ghost/storyteller/can_ztravel(direction)
 	return TRUE
 
+/// Allows storytellers to move freely between z-levels.
+/mob/abstract/ghost/storyteller/zMove(direction)
+	var/turf/T = get_turf(src)
+	var/turf/destination = (direction == UP) ? GET_TURF_ABOVE(T) : GET_TURF_BELOW(T)
+	if(destination)
+		forceMove(destination)
+	else
+		to_chat(src, SPAN_NOTICE("There is nothing of interest in this direction."))
+
 /mob/abstract/ghost/storyteller/verb/odyssey_panel()
 	set name = "Odyssey Panel"
 	set category = "Storyteller"

--- a/code/modules/mob/abstract/ghost/storyteller/storyteller.dm
+++ b/code/modules/mob/abstract/ghost/storyteller/storyteller.dm
@@ -134,7 +134,7 @@
 /mob/abstract/ghost/storyteller/can_ztravel(direction)
 	return TRUE
 
-/// Allows storytellers to move freely between z-levels.
+// Allows storytellers to move freely between z-levels.
 /mob/abstract/ghost/storyteller/zMove(direction)
 	var/turf/T = get_turf(src)
 	var/turf/destination = (direction == UP) ? GET_TURF_ABOVE(T) : GET_TURF_BELOW(T)

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -112,7 +112,8 @@
 	else
 		to_chat(owner, SPAN_NOTICE("There is nothing of interest in this direction."))
 
-/mob/abstract/ghost/observer/zMove(direction)
+// Both observers and storytellers depend on this to be able to move through z-levels freely!
+/mob/abstract/ghost/zMove(direction)
 	var/turf/T = get_turf(src)
 	var/turf/destination = (direction == UP) ? GET_TURF_ABOVE(T) : GET_TURF_BELOW(T)
 	if(destination)

--- a/html/changelogs/hazelmouse-stmovement.yml
+++ b/html/changelogs/hazelmouse-stmovement.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Storytellers can now move freely between z-levels, similarly to an observer."


### PR DESCRIPTION
As title. Previously they were bound to only being able to move up or down in microgravity, like a regular mob. 

This is just using a proc copied straight from ghost/observer, there's probably a more elegant solution - I'm curious if there would be any negative implications to just giving everything under /ghost this behaviour.