### PR TITLE
Improve usefulness of Custodial Supplies Locator app

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -21,18 +21,15 @@
 	var/cleantime = 25
 	var/last_clean
 	var/clean_msg = FALSE
-	// If it's Horizon janitorial supplies, track it for the app.
-	var/tracked_supply = 0
 
 /obj/item/mop/Initialize()
 	. = ..()
 	create_reagents(30)
 	if(is_station_turf(get_turf(src)))
-		tracked_supply = 1
 		GLOB.janitorial_supplies |= src
 
 /obj/item/mop/Destroy()
-	if(tracked_supply)
+	if(src in GLOB.janitorial_supplies)
 		GLOB.janitorial_supplies -= src
 	return ..()
 

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -21,14 +21,19 @@
 	var/cleantime = 25
 	var/last_clean
 	var/clean_msg = FALSE
+	// If it's Horizon janitorial supplies, track it for the app.
+	var/tracked_supply = 0
 
 /obj/item/mop/Initialize()
 	. = ..()
 	create_reagents(30)
-	GLOB.janitorial_supplies |= src
+	if(is_station_turf(get_turf(src)))
+		tracked_supply = 1
+		GLOB.janitorial_supplies |= src
 
 /obj/item/mop/Destroy()
-	GLOB.janitorial_supplies -= src
+	if(tracked_supply)
+		GLOB.janitorial_supplies -= src
 	return ..()
 
 /obj/item/mop/afterattack(atom/A, mob/user, proximity)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -24,6 +24,8 @@
 	var/has_items = FALSE //This is set true whenever the cart has anything loaded/mounted on it
 	var/driving
 	var/mob/living/pulling
+	// If it's Horizon janitorial supplies, track it for the app.
+	var/tracked_supply = 0
 
 // Regular Variant
 // No trashbag and no light replacer, this is inside the custodian's locker.
@@ -74,10 +76,13 @@
 
 /obj/structure/janitorialcart/New()
 	..()
-	GLOB.janitorial_supplies |= src
+	if(is_station_turf(get_turf(src)))
+		tracked_supply = 1
+		GLOB.janitorial_supplies |= src
 
 /obj/structure/janitorialcart/Destroy()
-	GLOB.janitorial_supplies -= src
+	if(tracked_supply)
+		GLOB.janitorial_supplies -= src
 	QDEL_NULL(mybag)
 	QDEL_NULL(mymop)
 	QDEL_NULL(myspray)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -24,8 +24,6 @@
 	var/has_items = FALSE //This is set true whenever the cart has anything loaded/mounted on it
 	var/driving
 	var/mob/living/pulling
-	// If it's Horizon janitorial supplies, track it for the app.
-	var/tracked_supply = 0
 
 // Regular Variant
 // No trashbag and no light replacer, this is inside the custodian's locker.
@@ -77,11 +75,10 @@
 /obj/structure/janitorialcart/New()
 	..()
 	if(is_station_turf(get_turf(src)))
-		tracked_supply = 1
 		GLOB.janitorial_supplies |= src
 
 /obj/structure/janitorialcart/Destroy()
-	if(tracked_supply)
+	if(src in GLOB.janitorial_supplies)
 		GLOB.janitorial_supplies -= src
 	QDEL_NULL(mybag)
 	QDEL_NULL(mymop)

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -8,14 +8,20 @@
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	var/amount_per_transfer_from_this = 5	//shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 	var/bucketsize = 600 //about 2x the size relative to a regular bucket.
+	// If it's Horizon janitorial supplies, track it for the app.
+	var/tracked_supply = 0
 
 /obj/structure/mopbucket/Initialize()
 	. = ..()
 	create_reagents(bucketsize)
-	GLOB.janitorial_supplies |= src
+
+	if(is_station_turf(get_turf(src)))
+		tracked_supply = 1
+		GLOB.janitorial_supplies |= src
 
 /obj/structure/mopbucket/Destroy()
-	GLOB.janitorial_supplies -= src
+	if(tracked_supply)
+		GLOB.janitorial_supplies -= src
 	return ..()
 
 /obj/structure/mopbucket/get_examine_text(mob/user, distance, is_adjacent, infix, suffix)

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -8,19 +8,16 @@
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	var/amount_per_transfer_from_this = 5	//shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 	var/bucketsize = 600 //about 2x the size relative to a regular bucket.
-	// If it's Horizon janitorial supplies, track it for the app.
-	var/tracked_supply = 0
 
 /obj/structure/mopbucket/Initialize()
 	. = ..()
 	create_reagents(bucketsize)
 
 	if(is_station_turf(get_turf(src)))
-		tracked_supply = 1
 		GLOB.janitorial_supplies |= src
 
 /obj/structure/mopbucket/Destroy()
-	if(tracked_supply)
+	if(src in GLOB.janitorial_supplies)
 		GLOB.janitorial_supplies -= src
 	return ..()
 

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -56,8 +56,6 @@ GLOBAL_LIST_INIT_TYPED(cleanbot_types, /obj/effect/decal/cleanable, typesof(/obj
 
 	///The turf we got the last movement failure on, since doors have to be bumped to be opened
 	var/turf/last_movement_failure_turf
-	// If it's Horizon janitorial supplies, track it for the app.
-	var/tracked_supply = 0
 
 /mob/living/bot/cleanbot/Cross(atom/movable/crossed)
 	if(crossed)
@@ -75,7 +73,6 @@ GLOBAL_LIST_INIT_TYPED(cleanbot_types, /obj/effect/decal/cleanable, typesof(/obj
 	listener.cleanbot = src
 
 	if(is_station_turf(get_turf(src)))
-		tracked_supply = 1
 		GLOB.janitorial_supplies |= src
 
 	SSradio.add_object(listener, beacon_freq, filter = RADIO_NAVBEACONS)
@@ -90,7 +87,7 @@ GLOBAL_LIST_INIT_TYPED(cleanbot_types, /obj/effect/decal/cleanable, typesof(/obj
 	QDEL_NULL(listener)
 	SSradio.remove_object(listener, beacon_freq)
 
-	if(tracked_supply)
+	if(src in GLOB.janitorial_supplies)
 		GLOB.janitorial_supplies -= src
 	return ..()
 

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -56,6 +56,8 @@ GLOBAL_LIST_INIT_TYPED(cleanbot_types, /obj/effect/decal/cleanable, typesof(/obj
 
 	///The turf we got the last movement failure on, since doors have to be bumped to be opened
 	var/turf/last_movement_failure_turf
+	// If it's Horizon janitorial supplies, track it for the app.
+	var/tracked_supply = 0
 
 /mob/living/bot/cleanbot/Cross(atom/movable/crossed)
 	if(crossed)
@@ -72,7 +74,9 @@ GLOBAL_LIST_INIT_TYPED(cleanbot_types, /obj/effect/decal/cleanable, typesof(/obj
 	listener = new /obj/cleanbot_listener(src)
 	listener.cleanbot = src
 
-	GLOB.janitorial_supplies |= src
+	if(is_station_turf(get_turf(src)))
+		tracked_supply = 1
+		GLOB.janitorial_supplies |= src
 
 	SSradio.add_object(listener, beacon_freq, filter = RADIO_NAVBEACONS)
 
@@ -86,7 +90,8 @@ GLOBAL_LIST_INIT_TYPED(cleanbot_types, /obj/effect/decal/cleanable, typesof(/obj
 	QDEL_NULL(listener)
 	SSradio.remove_object(listener, beacon_freq)
 
-	GLOB.janitorial_supplies -= src
+	if(tracked_supply)
+		GLOB.janitorial_supplies -= src
 	return ..()
 
 /mob/living/bot/cleanbot/proc/handle_target()

--- a/code/modules/modular_computers/file_system/programs/civilian/janitor.dm
+++ b/code/modules/modular_computers/file_system/programs/civilian/janitor.dm
@@ -68,6 +68,7 @@
 			"key" = length(supplies),
 			"x" = AT.x,
 			"y" = AT.y,
+			"z" = AT.z,
 			"dir" = dir,
 			"status" = status,
 			"supply_type" = supply_type

--- a/html/changelogs/Batrachophreno-JanitorSuppliesApp.yml
+++ b/html/changelogs/Batrachophreno-JanitorSuppliesApp.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Batrachophreno
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Custodial Supplies Locator app will now only track cleaning supplies on the Horizon (ignoring all offship supplies)."
+  - rscadd: "Custodial Supplies Locator app now shows objects' z-level in addition to x-y coords."
+  - rscdel: "Custodial Supplies Locator app no longer displays user's x-y coords, requiring use of actual GPS unit instead."

--- a/tgui/packages/tgui/interfaces/Janitor.tsx
+++ b/tgui/packages/tgui/interfaces/Janitor.tsx
@@ -7,7 +7,6 @@ export type JanitorData = {
   supplies: Supply[];
   user_x: number;
   user_y: number;
-  user_z: number;
 };
 
 type Supply = {
@@ -60,9 +59,6 @@ export const Janitor = (props, context) => {
                   </Table.Row>
                 )
             )}
-            <Table.Row>
-              User Location: ({data.user_x}, {data.user_y})
-            </Table.Row>
           </Table>
         </Section>
       </NtosWindow.Content>

--- a/tgui/packages/tgui/interfaces/Janitor.tsx
+++ b/tgui/packages/tgui/interfaces/Janitor.tsx
@@ -7,6 +7,7 @@ export type JanitorData = {
   supplies: Supply[];
   user_x: number;
   user_y: number;
+  user_z: number;
 };
 
 type Supply = {
@@ -14,6 +15,7 @@ type Supply = {
   key: number;
   x: number;
   y: number;
+  z: number;
   dir: string;
   status: string;
   supply_type: string;
@@ -51,7 +53,7 @@ export const Janitor = (props, context) => {
                       {supply.name} (#{supply.key})
                     </Table.Cell>
                     <Table.Cell>
-                      ({supply.x}, {supply.y})
+                      ({supply.x}, {supply.y}, {supply.z})
                     </Table.Cell>
                     <Table.Cell>{supply.dir}</Table.Cell>
                     <Table.Cell>{supply.status}</Table.Cell>


### PR DESCRIPTION
Currently, the Custodial Supplies Locator app provided X and Y coords of every single mop, bucket, janicart, and cleanbot on the entire server.

This PR makes it so that these objects will only be registered to the global list of custodial supplies if they are present on the Horizon on init, and it will also provide Z coords so you can tell if they're on a different deck.

The app also has a weird built-in GPS function that tracks the reader's movements instead of the device's. Instead of fixing this to follow the device, I just removed GPS feedback text- a Janitor can grab one of the GPS units that comes in their lockers, and this also allows them to be tracked by other units.