### PR TITLE
Adds missing XGM gas definition for Nitrogen Dioxide

### DIFF
--- a/code/defines/gases.dm
+++ b/code/defines/gases.dm
@@ -128,5 +128,3 @@
 	name = "Nitrogen Dioxide"
 	specific_heat = 33	// J/(mol*K)
 	molar_mass = 0.046	// kg/mol
-
-	flags = XGM_GAS_OXIDIZER | XGM_GAS_FUSION_FUEL

--- a/code/defines/gases.dm
+++ b/code/defines/gases.dm
@@ -122,3 +122,11 @@
 	specific_heat = 11
 	molar_mass = 0.011
 	flags = XGM_GAS_FUSION_FUEL
+
+/singleton/xgm_gas/nitrogendioxide
+	id = GAS_NO2
+	name = "Nitrogen Dioxide"
+	specific_heat = 33	// J/(mol*K)
+	molar_mass = 0.046	// kg/mol
+
+	flags = XGM_GAS_OXIDIZER | XGM_GAS_FUSION_FUEL

--- a/html/changelogs/Batrachophreno-NO2DefinitionXGM.yml
+++ b/html/changelogs/Batrachophreno-NO2DefinitionXGM.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Batrachophreno
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Adding missing XGM gas definition for Nitrogen Dioxide so it resolves and behaves correctly in atmospheric scanner results."


### PR DESCRIPTION
Adds a missing entry for Nitrogen Dioxide to the XGM gas singletons. Discovered on Burzsia ghost role that NO2 didn't display correctly in the atmospheric scanner results. This definition should make gas mixtures containing NO2 both report their contents correctly and behave consistently vis a vis molar mass and specific heat.

Have not played with XGM before and not particularly eager to now, but this one looked like a minor oversight issue alone.