### PR TITLE
Tweaks a few ghost spawns in Burzsia.

### DIFF
--- a/code/__DEFINES/space_sectors.dm
+++ b/code/__DEFINES/space_sectors.dm
@@ -42,7 +42,7 @@
 #define ALL_CORPORATE_SECTORS	list(ALL_TAU_CETI_SECTORS, SECTOR_SRANDMARR, SECTOR_UUEOAESA, ALL_COALITION_SECTORS, ALL_GENERIC_SECTORS, SECTOR_NRRAHRAHUL, SECTOR_BADLANDS)//Currently excludes Elyran sectors and Light's Edge
 
 //For highly dangerous sectors with high piracy. Civilian and leisure ships should be less common or not found here.
-#define ALL_DANGEROUS_SECTORS	list(SECTOR_BADLANDS, ALL_VOID_SECTORS)
+#define ALL_DANGEROUS_SECTORS	list(SECTOR_BADLANDS, ALL_VOID_SECTORS, SECTOR_BURZSIA) //Burszia is considered dangerous for the duration of the Trouble in Paradise arc
 
 /// all non-generic, named and specific sectors, where generic planets or the like should not spawn
 #define ALL_SPECIFIC_SECTORS	list(SECTOR_TAU_CETI, SECTOR_SRANDMARR, SECTOR_HANEUNIM, SECTOR_BURZSIA, SECTOR_UUEOAESA, SECTOR_TABITI, SECTOR_AEMAQ, SECTOR_NRRAHRAHUL, SECTOR_GAKAL)

--- a/html/changelogs/GeneralCamo - Burszia Tweaks.yml
+++ b/html/changelogs/GeneralCamo - Burszia Tweaks.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: GeneralCamo
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/GeneralCamo - Burszia Tweaks.yml
+++ b/html/changelogs/GeneralCamo - Burszia Tweaks.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "For the duration of the current arc, Burszia is now considered a dangerous sector, and will not spawn civilian craft."
+  - rscadd: "The Frontier Rangers can now spawn in Burszia."
+  - balance: "Reduced the weight of the Xanan Frigate in Burszia from 1.0 to 0.5 (matching that of Konyang's equivalent response)."

--- a/maps/away/ships/coc/coc_ranger/coc_ship.dm
+++ b/maps/away/ships/coc/coc_ranger/coc_ship.dm
@@ -7,7 +7,7 @@
 
 	sectors = list(SECTOR_BADLANDS, ALL_COALITION_SECTORS)
 	spawn_weight_sector_dependent = list(ALL_BADLAND_SECTORS = 0.3)
-	sectors_blacklist = list(SECTOR_HANEUNIM, SECTOR_BURZSIA)
+	sectors_blacklist = list(SECTOR_HANEUNIM)
 	spawn_weight = 1
 	ship_cost = 1
 	id = "ranger_corvette"

--- a/maps/away/ships/xanu/xanu_frigate.dm
+++ b/maps/away/ships/xanu/xanu_frigate.dm
@@ -8,7 +8,7 @@
 	suffix = "xanu_frigate.dmm"
 
 	sectors = list(ALL_COALITION_SECTORS)
-	spawn_weight_sector_dependent = list(SECTOR_LIBERTYS_CRADLE = 3)
+	spawn_weight_sector_dependent = list(SECTOR_LIBERTYS_CRADLE = 3, SECTOR_BURZSIA = 0.5)
 	spawn_weight = 1
 	ship_cost = 1
 	id = "xanu_frigate"


### PR DESCRIPTION
Few things this does:

- For the duration of the current arc, Burzsia is considered a "dangerous sector", and will not spawn certain civilian ships (such as the luxury cruise ship). Being that there was an attack and at this time the perpetrators are not caught, there is no reason for these to be spawning here.
- The Frontier Rangers now contribute to the emergency response in the area.
- The Xanan Frigate's spawn weight has been reduced to half that, matching Konyang's ship.