### PR TITLE
Fixes the rolling fog effect

### DIFF
--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -28,6 +28,14 @@
 	anchored = 1
 	layer = OBJ_LAYER
 
+/// Fancy animated effect used for the holodecks.
+/obj/effect/decal/rolling_fog
+	name = "rolling fog"
+	icon = 'icons/effects/props/holodeck/biesel/32x32.dmi'
+	icon_state = "fog_roll"
+	anchored = 1
+	layer = PROJECTILE_LAYER
+
 /obj/effect/decal/fake_object/Initialize(mapload)
 	.=..()
 	appearance_flags &= ~TILE_BOUND

--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -28,13 +28,13 @@
 	anchored = 1
 	layer = OBJ_LAYER
 
-/// Fancy animated effect used for the holodecks.
+// Fancy animated effect used for the holodecks.
 /obj/effect/decal/rolling_fog
 	name = "rolling fog"
 	icon = 'icons/effects/props/holodeck/biesel/32x32.dmi'
 	icon_state = "fog_roll"
 	anchored = 1
-	layer = PROJECTILE_LAYER
+	layer = ABOVE_PROJECTILE_LAYER
 
 /obj/effect/decal/fake_object/Initialize(mapload)
 	.=..()

--- a/html/changelogs/hazelmouse-fogfix.yml
+++ b/html/changelogs/hazelmouse-fogfix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "The Foggy Mendell Skyline and Jupiter Upper Atmosphere holodeck settings now render their rolling fog correctly."


### PR DESCRIPTION
Separates the rolling fog effect into its own type rather than relying on varedits, shifts it up a few layers so it renders ingame. Currently, it doesn't appear at all in the holodeck settings it's used in.