### PR TITLE
Allows commune and emotional suggestion through mindshields

### DIFF
--- a/code/modules/psionics/abilities/commune.dm
+++ b/code/modules/psionics/abilities/commune.dm
@@ -36,9 +36,11 @@
 		to_chat(user, SPAN_WARNING("Not even a psion of your level can speak to the dead."))
 		return
 
-	var/psi_blocked = target.is_psi_blocked()
-	if(psi_blocked)
-		to_chat(user, psi_blocked)
+	// We're checking for compatibility since it doesn't check for mindshields.
+	// This ability is intended to not be blocked by mindshields.
+	var/psi_incompatible = target.is_psi_compatible()
+	if(psi_incompatible)
+		to_chat(user, psi_incompatible)
 		return
 
 	user.visible_message(SPAN_NOTICE("<i>[user] blinks, their eyes briefly developing an unnatural shine.</i>"))
@@ -62,10 +64,16 @@
 		else if(M.stat == DEAD && M.client.prefs.toggles & CHAT_GHOSTEARS)
 			to_chat(M, "<span class='notice'>[user] psionically says to [target]:</span> [text]")
 
+	var/psi_blocked = target.is_psi_blocked()
 	var/mob/living/carbon/human/H = target
-	if(H.has_psionics())
+
+	if(H.has_psionics() && psi_blocked)
+		to_chat(H, SPAN_CULT("<b>You instinctively sense [user] passing a thought into your mind, although it seems faint and muffled:</b> [text]"))
+	else if(H.has_psionics())
 		to_chat(H, SPAN_CULT("<b>You instinctively sense [user] passing a thought into your mind:</b> [text]"))
 	else if(target.has_psi_aug())
 		to_chat(H, SPAN_CULT("<b>You sense [user]'s psyche link with your psi-receiver, a thought sliding into your mind:</b> [text]"))
+	else if(psi_blocked)
+		to_chat(H, SPAN_ALIEN("<b>A thought from outside your consciousness rings faintly and distantly in your mind:</b> [text]"))
 	else
 		to_chat(H, SPAN_ALIEN("<b>A thought from outside your consciousness slips into your mind:</b> [text]"))

--- a/code/modules/psionics/abilities/emotional_suggestion.dm
+++ b/code/modules/psionics/abilities/emotional_suggestion.dm
@@ -35,9 +35,11 @@
 		to_chat(user, SPAN_WARNING("Not even a psion of your level can suggest to the dead."))
 		return
 
-	var/psi_blocked = target.is_psi_blocked()
-	if(psi_blocked)
-		to_chat(user, psi_blocked)
+	// We're checking for compatibility since it doesn't check for mindshields.
+	// This ability is intended to not be blocked by mindshields.
+	var/psi_incompatible = target.is_psi_compatible()
+	if(psi_incompatible)
+		to_chat(user, psi_incompatible)
 		return
 
 	user.visible_message(SPAN_NOTICE("<i>[user] blinks, their eyes briefly developing an unnatural shine.</i>"))
@@ -61,10 +63,16 @@
 		else if(M.stat == DEAD && (M.client.prefs.toggles & CHAT_GHOSTEARS))
 			to_chat(M, "<span class='notice'>[user] psionically suggests an emotion to [target]:</span> [text]")
 
+	var/psi_blocked = target.is_psi_blocked()
 	var/mob/living/carbon/human/H = target
-	if(H.has_psionics())
+
+	if(H.has_psionics() && psi_blocked)
+		to_chat(H, SPAN_NOTICE("You feel an emotion of <b>[text]</b> washing faintly and distantly through your mind."))
+	else if(H.has_psionics())
 		to_chat(H, SPAN_NOTICE("You feel an emotion of <b>[text]</b> washing through your mind."))
 	else if(target.has_psi_aug())
 		to_chat(H, SPAN_NOTICE("You sense [user]'s psyche link with your psi-receiver, and an emotion envelops your mind: <b>[text]</b>."))
+	else if(psi_blocked)
+		to_chat(H, SPAN_NOTICE("An emotion from outside your consciousness slips faintly and distantly into your mind: <b>[text]</b>."))
 	else
 		to_chat(H, SPAN_NOTICE("An emotion from outside your consciousness slips into your mind: <b>[text]</b>."))

--- a/code/modules/psionics/mob/mob_helpers.dm
+++ b/code/modules/psionics/mob/mob_helpers.dm
@@ -5,15 +5,28 @@
 	var/obj/item/organ/internal/augment/psi/psiaug = internal_organs_by_name[BP_AUG_PSI]
 	return psiaug && !psiaug.is_broken()
 
+/// For simplemobs.
 /mob/living/proc/is_psi_blocked()
 	return !has_psionics()
 
+/// Checks if the target is psionically deaf, if they have a receiver, and also for mindshields.
 /mob/living/carbon/is_psi_blocked()
 	if(HAS_TRAIT(src, TRAIT_PSIONICALLY_DEAF) && !has_psi_aug())
 		return SPAN_WARNING("[src]'s mind is inaccessible, like hitting a brick wall.")
 	for (var/obj/item/implant/mindshield/I in src)
 		if (I.implanted)
 			return SPAN_WARNING("[src]'s mind is inaccessible, like hitting a brick wall.")
+	return FALSE
+
+/// For simplemobs.
+/mob/living/proc/is_psi_compatible()
+	return !has_psionics()
+
+/** Only checks if the target is psionically deaf and if they have a receiver.
+Used for abilities which shouldn't check for a mindshield. */
+/mob/living/carbon/is_psi_compatible()
+	if(HAS_TRAIT(src, TRAIT_PSIONICALLY_DEAF) && !has_psi_aug())
+		return SPAN_WARNING("[src]'s mind is inaccessible, like hitting a brick wall.")
 	return FALSE
 
 /mob/living/proc/has_zona_bovinae()

--- a/html/changelogs/hazelmouse-psionics.yml
+++ b/html/changelogs/hazelmouse-psionics.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Mindshield augments, such as those provided to the Head of Security and Captain, now allow the commune and emotional suggestion psionic abilities through. Higher psionic abilities remain blocked."


### PR DESCRIPTION
Allows the commune and emotional suggestion psionic abilities through mindshields, so Skrell Captains and Heads of Security can still receive them. Mindshields still block higher abilities, including the read mind psionic ability and a bunch of antagonist stuff.

Implements a new proc that only checks for whether the recipient is psionically deaf or doesn't have a receiver for commune and emotional suggestion, so IPCs without receivers and whatever else still can't receive these at all.