### PR TITLE
Storyteller admin/mod/fun verb smorgasbord

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1327,21 +1327,19 @@ var/global/enabled_spooking = 0
 
 /proc/toggle_wind_paralysis(var/mob/living/target, var/mob/user)
 	var/msg
-	if(!check_rights(R_ADMIN|R_MOD, user))
-		return
-	
-	if (target.paralysis == 0)
-		msg = "has paralyzed [key_name_admin(target)]."
-		target.visible_message("<font color='#002eb8'><b>OOC Information:</b></font> <span class='warning'>[target] has been winded by a member of staff! Please freeze all roleplay involving their character until the matter is resolved! Adminhelp if you have further questions.</span>", SPAN_WARNING("<b>You have been winded by a member of staff! Please stand by until they contact you!</b>"))
-		target.paralysis = 8000
-	else
-		if (alert(user, "The player is currently winded. Do you want to unwind him?", "Unwind player?", "Yes", "No") == "No")
-			return
-		target.paralysis = 0
-		msg = "has unparalyzed [key_name_admin(target)]."
-		target.visible_message("<font color='#002eb8'><b>OOC Information:</b></font> <font color='green'>[target] has been unwinded by a member of staff!</font>", SPAN_WARNING("<b>You have been unwinded by a member of staff!</b>"))
-	log_and_message_admins(msg, user)
-	feedback_add_details("admin_verb", "WIND")
+	if(check_rights(R_ADMIN|R_MOD, user))
+		if (target.paralysis == 0)
+			msg = "has paralyzed [key_name_admin(target)]."
+			target.visible_message("<font color='#002eb8'><b>OOC Information:</b></font> <span class='warning'>[target] has been winded by a member of staff! Please freeze all roleplay involving their character until the matter is resolved! Adminhelp if you have further questions.</span>", SPAN_WARNING("<b>You have been winded by a member of staff! Please stand by until they contact you!</b>"))
+			target.paralysis = 8000
+		else
+			if (alert(user, "The player is currently winded. Do you want to unwind him?", "Unwind player?", "Yes", "No") == "No")
+				return
+			target.paralysis = 0
+			msg = "has unparalyzed [key_name_admin(target)]."
+			target.visible_message("<font color='#002eb8'><b>OOC Information:</b></font> <font color='green'>[target] has been unwinded by a member of staff!</font>", SPAN_WARNING("<b>You have been unwinded by a member of staff!</b>"))
+		log_and_message_admins(msg, user)
+		feedback_add_details("admin_verb", "WIND")
 
 /datum/admins/proc/toggle_round_spookyness()
 	set category = "Server"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1320,26 +1320,28 @@ var/global/enabled_spooking = 0
 
 /datum/admins/proc/paralyze_mob(mob/living/H as mob)
 	set category = "Admin"
-	set name = "Toggle Wind"
+	set name = "Toggle Windedness/Paralysis"
 	set desc = "Paralyzes a player. Or unparalyses them."
 
 	toggle_wind_paralysis(H, usr)
 
 /proc/toggle_wind_paralysis(var/mob/living/target, var/mob/user)
 	var/msg
-	if(check_rights(R_ADMIN|R_MOD, user))
-		if (target.paralysis == 0)
-			msg = "has paralyzed [key_name_admin(target)]."
-			target.visible_message("<font color='#002eb8'><b>OOC Information:</b></font> <span class='warning'>[target] has been winded by a member of staff! Please freeze all roleplay involving their character until the matter is resolved! Adminhelp if you have further questions.</span>", SPAN_WARNING("<b>You have been winded by a member of staff! Please stand by until they contact you!</b>"))
-			target.paralysis = 8000
-		else
-			if (alert(user, "The player is currently winded. Do you want to unwind him?", "Unwind player?", "Yes", "No") == "No")
-				return
-			target.paralysis = 0
-			msg = "has unparalyzed [key_name_admin(target)]."
-			target.visible_message("<font color='#002eb8'><b>OOC Information:</b></font> <font color='green'>[target] has been unwinded by a member of staff!</font>", SPAN_WARNING("<b>You have been unwinded by a member of staff!</b>"))
-		log_and_message_admins(msg, user)
-		feedback_add_details("admin_verb", "WIND")
+	if(!check_rights(R_ADMIN|R_MOD, user))
+		return
+	
+	if (target.paralysis == 0)
+		msg = "has paralyzed [key_name_admin(target)]."
+		target.visible_message("<font color='#002eb8'><b>OOC Information:</b></font> <span class='warning'>[target] has been winded by a member of staff! Please freeze all roleplay involving their character until the matter is resolved! Adminhelp if you have further questions.</span>", SPAN_WARNING("<b>You have been winded by a member of staff! Please stand by until they contact you!</b>"))
+		target.paralysis = 8000
+	else
+		if (alert(user, "The player is currently winded. Do you want to unwind him?", "Unwind player?", "Yes", "No") == "No")
+			return
+		target.paralysis = 0
+		msg = "has unparalyzed [key_name_admin(target)]."
+		target.visible_message("<font color='#002eb8'><b>OOC Information:</b></font> <font color='green'>[target] has been unwinded by a member of staff!</font>", SPAN_WARNING("<b>You have been unwinded by a member of staff!</b>"))
+	log_and_message_admins(msg, user)
+	feedback_add_details("admin_verb", "WIND")
 
 /datum/admins/proc/toggle_round_spookyness()
 	set category = "Server"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -515,6 +515,29 @@ GLOBAL_LIST_INIT(admin_verbs_cciaa, list(
 	/client/proc/toggle_aooc
 ))
 
+GLOBAL_LIST_INIT(admin_verbs_storyteller, list(
+	/client/proc/toggle_view_range,		/*changes how far we can see*/
+	/client/proc/jumptozlevel,
+	/client/proc/jumptoshuttle,
+	/client/proc/jumptoship,
+	/client/proc/jumptosector,
+	/client/proc/Getmob,				/*teleports a mob to our location*/
+	/client/proc/Jump,
+	/client/proc/jumptomob,				//allows us to jump to a specific mob,
+	/client/proc/jumptoturf,			/*allows us to jump to a specific turf*/
+	/client/proc/check_ai_laws,			//shows AI and borg laws,
+	/client/proc/manage_silicon_laws,
+	/client/proc/odyssey_panel,
+	/client/proc/damage_menu,
+	/client/proc/change_human_appearance_admin,	// Allows an admin to change the basic appearance of human-based mobs ,
+	/client/proc/change_security_level,
+	/datum/admins/proc/create_admin_fax,
+	/client/proc/check_fax_history,
+	/client/proc/clear_toxins,
+	/datum/admins/proc/call_supply_drop,
+	/datum/admins/proc/call_drop_pod,
+))
+
 
 /client/proc/add_admin_verbs()
 	SHOULD_NOT_SLEEP(TRUE)
@@ -556,6 +579,12 @@ GLOBAL_LIST_INIT(admin_verbs_cciaa, list(
 	remove_verb(src, GLOB.admin_verbs_spawn)
 	remove_verb(src, GLOB.debug_verbs)
 	add_aooc_if_necessary()
+
+/client/proc/add_storyteller_verbs()
+	SHOULD_NOT_SLEEP(TRUE)
+
+	if(isstoryteller(src.mob))
+		add_verb(src, GLOB.admin_verbs_storyteller)
 
 /client/proc/hide_most_verbs()//Allows you to keep some functionality while hiding some verbs
 	set name = "Adminverbs - Hide Most"
@@ -852,7 +881,7 @@ GLOBAL_LIST_INIT(admin_verbs_cciaa, list(
 /client/proc/check_ai_laws()
 	set name = "Check AI Laws"
 	set category = "Admin"
-	if(holder)
+	if(holder || isstoryteller(src.mob))
 		src.holder.output_ai_laws()
 
 /client/proc/rename_silicon()
@@ -874,29 +903,27 @@ GLOBAL_LIST_INIT(admin_verbs_cciaa, list(
 	set name = "Manage Silicon Laws"
 	set category = "Admin"
 
-	if(!check_rights(R_ADMIN)) return
+	if(check_rights(R_ADMIN) || isstoryteller(src.mob))
+		var/mob/living/silicon/S = input("Select silicon.", "Manage Silicon Laws") as null|anything in GLOB.silicon_mob_list
+		if(!S) return
 
-	var/mob/living/silicon/S = input("Select silicon.", "Manage Silicon Laws") as null|anything in GLOB.silicon_mob_list
-	if(!S) return
-
-	var/datum/tgui_module/admin/law_manager/L = new(S)
-	L.ui_interact(usr)
-	log_and_message_admins("has opened [S]'s law manager.")
-	feedback_add_details("admin_verb","MSL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		var/datum/tgui_module/admin/law_manager/L = new(S)
+		L.ui_interact(usr)
+		log_and_message_admins("has opened [S]'s law manager.")
+		feedback_add_details("admin_verb","MSL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/change_human_appearance_admin()
 	set name = "Change Mob Appearance - Admin"
 	set desc = "Allows you to change the mob appearance"
 	set category = "Admin"
 
-	if(!check_rights(R_FUN)) return
+	if(check_rights(R_FUN) || isstoryteller(src.mob))
+		var/mob/living/carbon/human/H = tgui_input_list(usr, "Select mob.", "Change Mob Appearance - Self", GLOB.human_mob_list)
+		if(!H) return
 
-	var/mob/living/carbon/human/H = tgui_input_list(usr, "Select mob.", "Change Mob Appearance - Self", GLOB.human_mob_list)
-	if(!H) return
-
-	log_and_message_admins("is altering the appearance of [H].")
-	H.change_appearance(APPEARANCE_ALL, usr, FALSE)
-	feedback_add_details("admin_verb","CHAA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		log_and_message_admins("is altering the appearance of [H].")
+		H.change_appearance(APPEARANCE_ALL, usr, FALSE)
+		feedback_add_details("admin_verb","CHAA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/change_human_appearance_self()
 	set name = "Change Mob Appearance - Self"
@@ -926,13 +953,12 @@ GLOBAL_LIST_INIT(admin_verbs_cciaa, list(
 	set desc = "Sets the station's security level"
 	set category = "Admin"
 
-	if(!check_rights(R_ADMIN))
-		return
-	var/sec_level = tgui_input_list(usr, "It's currently code [get_security_level()].", "Select Security Level", list("green", "blue", "red", "yellow", "delta") - get_security_level())
-	var/msg = tgui_alert(usr, "Switch from code [get_security_level()] to code [sec_level]?", "Security Level", list("Yes","No"))
-	if(msg == "Yes")
-		set_security_level(sec_level)
-		log_admin("[key_name(usr)] changed the security level to code [sec_level].")
+	if(check_rights(R_ADMIN) || isstoryteller(src.mob))
+		var/sec_level = tgui_input_list(usr, "It's currently code [get_security_level()].", "Select Security Level", list("green", "blue", "red", "yellow", "delta") - get_security_level())
+		var/msg = tgui_alert(usr, "Switch from code [get_security_level()] to code [sec_level]?", "Security Level", list("Yes","No"))
+		if(msg == "Yes")
+			set_security_level(sec_level)
+			log_admin("[key_name(usr)] changed the security level to code [sec_level].")
 
 //---- bs12 verbs ----
 
@@ -948,65 +974,64 @@ GLOBAL_LIST_INIT(admin_verbs_cciaa, list(
 	set name = "Edit Appearance"
 	set category = "Fun"
 
-	if(!check_rights(R_FUN))	return
+	if(check_rights(R_FUN) || isstoryteller(src.mob))
+		var/mob/living/carbon/human/selected_human = input("Select mob.", "Edit Appearance") as null|anything in GLOB.human_mob_list
 
-	var/mob/living/carbon/human/selected_human = input("Select mob.", "Edit Appearance") as null|anything in GLOB.human_mob_list
-
-	if(!istype(selected_human, /mob/living/carbon/human))
-		to_chat(usr, SPAN_WARNING("You can only do this to humans!"))
-		return
-	switch(alert("Are you sure you wish to edit this mob's appearance? Skrell, Unathi and Tajaran can result in unintended consequences.",,"Yes","No"))
-		if("No")
+		if(!istype(selected_human, /mob/living/carbon/human))
+			to_chat(usr, SPAN_WARNING("You can only do this to humans!"))
 			return
-	var/new_facial = input("Please select facial hair color.", "Character Generation") as color
-	if(new_facial)
-		selected_human.r_facial = hex2num(copytext(new_facial, 2, 4))
-		selected_human.g_facial = hex2num(copytext(new_facial, 4, 6))
-		selected_human.b_facial = hex2num(copytext(new_facial, 6, 8))
+		switch(alert("Are you sure you wish to edit this mob's appearance? Skrell, Unathi and Tajaran can result in unintended consequences.",,"Yes","No"))
+			if("No")
+				return
+		var/new_facial = input("Please select facial hair color.", "Character Generation") as color
+		if(new_facial)
+			selected_human.r_facial = hex2num(copytext(new_facial, 2, 4))
+			selected_human.g_facial = hex2num(copytext(new_facial, 4, 6))
+			selected_human.b_facial = hex2num(copytext(new_facial, 6, 8))
 
-	var/new_hair = input("Please select hair color.", "Character Generation") as color
-	if(new_facial)
-		selected_human.r_hair = hex2num(copytext(new_hair, 2, 4))
-		selected_human.g_hair = hex2num(copytext(new_hair, 4, 6))
-		selected_human.b_hair = hex2num(copytext(new_hair, 6, 8))
+		var/new_hair = input("Please select hair color.", "Character Generation") as color
+		if(new_facial)
+			selected_human.r_hair = hex2num(copytext(new_hair, 2, 4))
+			selected_human.g_hair = hex2num(copytext(new_hair, 4, 6))
+			selected_human.b_hair = hex2num(copytext(new_hair, 6, 8))
 
-	var/new_eyes = input("Please select eye color.", "Character Generation") as color
-	if(new_eyes)
-		selected_human.r_eyes = hex2num(copytext(new_eyes, 2, 4))
-		selected_human.g_eyes = hex2num(copytext(new_eyes, 4, 6))
-		selected_human.b_eyes = hex2num(copytext(new_eyes, 6, 8))
-		selected_human.update_eyes()
+		var/new_eyes = input("Please select eye color.", "Character Generation") as color
+		if(new_eyes)
+			selected_human.r_eyes = hex2num(copytext(new_eyes, 2, 4))
+			selected_human.g_eyes = hex2num(copytext(new_eyes, 4, 6))
+			selected_human.b_eyes = hex2num(copytext(new_eyes, 6, 8))
+			selected_human.update_eyes()
 
-	var/new_skin = input("Please select body color. This is for Tajaran, Unathi, and Skrell only!", "Character Generation") as color
-	if(new_skin)
-		selected_human.r_skin = hex2num(copytext(new_skin, 2, 4))
-		selected_human.g_skin = hex2num(copytext(new_skin, 4, 6))
-		selected_human.b_skin = hex2num(copytext(new_skin, 6, 8))
+		var/new_skin = input("Please select body color. This is for Tajaran, Unathi, and Skrell only!", "Character Generation") as color
+		if(new_skin)
+			selected_human.r_skin = hex2num(copytext(new_skin, 2, 4))
+			selected_human.g_skin = hex2num(copytext(new_skin, 4, 6))
+			selected_human.b_skin = hex2num(copytext(new_skin, 6, 8))
 
-	var/new_tone = input("Please select skin tone level: (Light [selected_human.species.lower_skin_tone_bound] - [selected_human.species.upper_skin_tone_bound] Dark). Higher is darker.", "Character Generation")  as text
+		var/new_tone = input("Please select skin tone level: (Light [selected_human.species.lower_skin_tone_bound] - [selected_human.species.upper_skin_tone_bound] Dark). Higher is darker.", "Character Generation")  as text
 
-	if (new_tone)
-		selected_human.s_tone = 35 - clamp(round(text2num(new_tone)), selected_human.species.lower_skin_tone_bound, selected_human.species.upper_skin_tone_bound)
+		if (new_tone)
+			selected_human.s_tone = 35 - clamp(round(text2num(new_tone)), selected_human.species.lower_skin_tone_bound, selected_human.species.upper_skin_tone_bound)
 
-	// hair
-	var/new_hstyle = input(usr, "Select a hair style", "Grooming")  as null|anything in GLOB.hair_styles_list
-	if(new_hstyle)
-		selected_human.h_style = new_hstyle
+		// hair
+		var/new_hstyle = input(usr, "Select a hair style", "Grooming")  as null|anything in GLOB.hair_styles_list
+		if(new_hstyle)
+			selected_human.h_style = new_hstyle
 
-	// facial hair
-	var/new_fstyle = input(usr, "Select a facial hair style", "Grooming")  as null|anything in GLOB.facial_hair_styles_list
-	if(new_fstyle)
-		selected_human.f_style = new_fstyle
+		// facial hair
+		var/new_fstyle = input(usr, "Select a facial hair style", "Grooming")  as null|anything in GLOB.facial_hair_styles_list
+		if(new_fstyle)
+			selected_human.f_style = new_fstyle
 
-	var/new_gender = alert(usr, "Please select gender.", "Character Generation", "Male", "Female")
-	if (new_gender)
-		if(new_gender == "Male")
-			selected_human.gender = MALE
-		else
-			selected_human.gender = FEMALE
-	selected_human.update_hair()
-	selected_human.update_body()
-	selected_human.check_dna(selected_human)
+		var/new_gender = alert(usr, "Please select gender.", "Character Generation", "Male", "Female")
+		if (new_gender)
+			if(new_gender == "Male")
+				selected_human.gender = MALE
+			else
+				selected_human.gender = FEMALE
+		selected_human.update_hair()
+		selected_human.update_body()
+		selected_human.check_dna(selected_human)
 
 /client/proc/playernotes()
 	set name = "Show Player Info"

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -9,66 +9,60 @@
 	set desc = "Area to jump to"
 	set category = "Admin"
 
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_DEV))
-		return
+	if(check_rights(R_ADMIN|R_MOD|R_DEBUG|R_DEV) || isstoryteller(src.mob))
+		if(istype(usr, /mob/abstract/new_player))
+			return
 
-	if(istype(usr, /mob/abstract/new_player))
-		return
+		if(GLOB.config.allow_admin_jump)
+			usr.on_mob_jump()
+			usr.forceMove(pick(get_area_turfs(A)))
 
-	if(GLOB.config.allow_admin_jump)
-		usr.on_mob_jump()
-		usr.forceMove(pick(get_area_turfs(A)))
-
-		log_admin("[key_name(usr)] jumped to [A]")
-		message_admins("[key_name_admin(usr)] jumped to [A]", 1)
-		feedback_add_details("admin_verb","JA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	else
-		alert("Admin jumping disabled")
+			log_admin("[key_name(usr)] jumped to [A]")
+			message_admins("[key_name_admin(usr)] jumped to [A]", 1)
+			feedback_add_details("admin_verb","JA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		else
+			alert("Admin jumping disabled")
 
 /client/proc/jumptoturf(var/turf/T in world)
 	set name = "Jump to Turf"
 	set category = "Admin"
 
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_DEV))
-		return
+	if(check_rights(R_ADMIN|R_MOD|R_DEBUG|R_DEV) || isstoryteller(src.mob))
+		if(isnewplayer(usr))
+			return
 
-	if(isnewplayer(usr))
+		if(GLOB.config.allow_admin_jump)
+			log_admin("[key_name(usr)] jumped to [T.x],[T.y],[T.z] in [T.loc]")
+			message_admins("[key_name_admin(usr)] jumped to [T.x],[T.y],[T.z] in [T.loc]", 1)
+			usr.on_mob_jump()
+			usr.forceMove(T)
+			feedback_add_details("admin_verb","JT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		else
+			alert("Admin jumping disabled")
 		return
-
-	if(GLOB.config.allow_admin_jump)
-		log_admin("[key_name(usr)] jumped to [T.x],[T.y],[T.z] in [T.loc]")
-		message_admins("[key_name_admin(usr)] jumped to [T.x],[T.y],[T.z] in [T.loc]", 1)
-		usr.on_mob_jump()
-		usr.forceMove(T)
-		feedback_add_details("admin_verb","JT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	else
-		alert("Admin jumping disabled")
-	return
 
 /client/proc/jumptomob(var/mob/M in GLOB.mob_list)
 	set category = "Admin"
 	set name = "Jump to Mob Admin"
 
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_DEV))
-		return
+	if(check_rights(R_ADMIN|R_MOD|R_DEBUG|R_DEV) || isstoryteller(src.mob))
+		if(isnewplayer(usr))
+			return
 
-	if(isnewplayer(usr))
-		return
-
-	if(GLOB.config.allow_admin_jump)
-		log_admin("[key_name(usr)] jumped to [key_name(M)]")
-		message_admins("[key_name_admin(usr)] jumped to [key_name_admin(M)]", 1)
-		if(src.mob)
-			var/mob/A = src.mob
-			var/turf/T = get_turf(M)
-			if(isturf(T))
-				feedback_add_details("admin_verb","JM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-				A.on_mob_jump()
-				A.forceMove(T)
-			else
-				to_chat(A, "This mob is not located in the game world.")
-	else
-		alert("Admin jumping disabled")
+		if(GLOB.config.allow_admin_jump)
+			log_admin("[key_name(usr)] jumped to [key_name(M)]")
+			message_admins("[key_name_admin(usr)] jumped to [key_name_admin(M)]", 1)
+			if(src.mob)
+				var/mob/A = src.mob
+				var/turf/T = get_turf(M)
+				if(isturf(T))
+					feedback_add_details("admin_verb","JM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+					A.on_mob_jump()
+					A.forceMove(T)
+				else
+					to_chat(A, "This mob is not located in the game world.")
+		else
+			alert("Admin jumping disabled")
 
 /client/proc/jumptocoord(tx as num, ty as num, tz as num)
 	set category = "Admin"
@@ -94,102 +88,94 @@
 	set category = "Admin"
 	set name = "Jump to Z-Level"
 
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_DEV))
-		return
-
-	if(GLOB.config.allow_admin_jump)
-		var/list/zlevels = list()
-		for(var/z=0, z<world.maxz, z++)
-			zlevels += z
-		var/selection = input("Select z-level to jump to.", "Admin Jumping", null, null) as null|anything in zlevels
-		if(!selection)
-			to_chat(src, "No z-level selected.")
-			return
-		if(src && src.mob)
-			var/mob/A = src.mob
-			A.on_mob_jump()
-			A.x = world.maxx/2
-			A.y = world.maxy/2
-			A.z = selection
-			message_admins("[key_name_admin(usr)] jumped to z-level [selection]", 1)
-			feedback_add_details("admin_verb","JZ") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	else
-		alert("Admin jumping disabled")
+	if(check_rights(R_ADMIN|R_MOD|R_DEBUG|R_DEV) || isstoryteller(src.mob))
+		if(GLOB.config.allow_admin_jump)
+			var/list/zlevels = list()
+			for(var/z=0, z<world.maxz, z++)
+				zlevels += z
+			var/selection = input("Select z-level to jump to.", "Admin Jumping", null, null) as null|anything in zlevels
+			if(!selection)
+				to_chat(src, "No z-level selected.")
+				return
+			if(src && src.mob)
+				var/mob/A = src.mob
+				A.on_mob_jump()
+				A.x = world.maxx/2
+				A.y = world.maxy/2
+				A.z = selection
+				message_admins("[key_name_admin(usr)] jumped to z-level [selection]", 1)
+				feedback_add_details("admin_verb","JZ") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		else
+			alert("Admin jumping disabled")
 
 /client/proc/jumptoshuttle()
 	set category = "Admin"
 	set name = "Jump to Shuttle"
 
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_DEV))
-		return
-
-	if(GLOB.config.allow_admin_jump)
-		var/list/shuttles = list()
-		for(var/shuttle_tag in SSshuttle.shuttles)
-			shuttles += shuttle_tag
-		var/selection = input("Select shuttle to jump to.", "Admin Jumping", null, null) as null|anything in shuttles
-		if(!selection)
-			to_chat(src, "No shuttle selected.")
-			return
-		var/datum/shuttle/shuttle = SSshuttle.shuttles[selection]
-		if(src && src.mob && shuttle && shuttle.current_location && shuttle.current_location.loc)
-			usr.on_mob_jump()
-			usr.forceMove(shuttle.current_location.loc)
-			message_admins("[key_name_admin(usr)] jumped to shuttle [selection]", 1)
-			feedback_add_details("admin_verb","JSHU") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	else
-		alert("Admin jumping disabled")
+	if(check_rights(R_ADMIN|R_MOD|R_DEBUG|R_DEV) || isstoryteller(src.mob))
+		if(GLOB.config.allow_admin_jump)
+			var/list/shuttles = list()
+			for(var/shuttle_tag in SSshuttle.shuttles)
+				shuttles += shuttle_tag
+			var/selection = input("Select shuttle to jump to.", "Admin Jumping", null, null) as null|anything in shuttles
+			if(!selection)
+				to_chat(src, "No shuttle selected.")
+				return
+			var/datum/shuttle/shuttle = SSshuttle.shuttles[selection]
+			if(src && src.mob && shuttle && shuttle.current_location && shuttle.current_location.loc)
+				usr.on_mob_jump()
+				usr.forceMove(shuttle.current_location.loc)
+				message_admins("[key_name_admin(usr)] jumped to shuttle [selection]", 1)
+				feedback_add_details("admin_verb","JSHU") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		else
+			alert("Admin jumping disabled")
 
 /client/proc/jumptoship()
 	set category = "Admin"
 	set name = "Jump to Ship"
 
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_DEV))
-		return
-
-	if(GLOB.config.allow_admin_jump)
-		var/list/ships = list()
-		for(var/ship in SSshuttle.ships)
-			ships += ship
-		var/selection = input("Select ship to jump to.", "Admin Jumping", null, null) as null|anything in ships
-		if(!selection)
-			to_chat(src, "No ship selected.")
-			return
-		var/obj/effect/overmap/visitable/ship/ship = selection
-		if(src && src.mob && ship && ship.entry_points && ship.entry_points[1])
-			usr.on_mob_jump()
-			usr.forceMove(ship.entry_points[1].loc)
-			message_admins("[key_name_admin(usr)] jumped to ship [selection]", 1)
-			feedback_add_details("admin_verb","JSHI") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	else
-		alert("Admin jumping disabled")
+	if(check_rights(R_ADMIN|R_MOD|R_DEBUG|R_DEV) || isstoryteller(src.mob))
+		if(GLOB.config.allow_admin_jump)
+			var/list/ships = list()
+			for(var/ship in SSshuttle.ships)
+				ships += ship
+			var/selection = input("Select ship to jump to.", "Admin Jumping", null, null) as null|anything in ships
+			if(!selection)
+				to_chat(src, "No ship selected.")
+				return
+			var/obj/effect/overmap/visitable/ship/ship = selection
+			if(src && src.mob && ship && ship.entry_points && ship.entry_points[1])
+				usr.on_mob_jump()
+				usr.forceMove(ship.entry_points[1].loc)
+				message_admins("[key_name_admin(usr)] jumped to ship [selection]", 1)
+				feedback_add_details("admin_verb","JSHI") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		else
+			alert("Admin jumping disabled")
 
 /client/proc/jumptosector()
 	set category = "Admin"
 	set name = "Jump to Sector"
 
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_DEV))
-		return
-
-	if(GLOB.config.allow_admin_jump)
-		var/list/sectors = list()
-		for(var/sector in SSshuttle.initialized_sectors)
-			sectors += sector
-		var/selection = input("Select sector to jump to.", "Admin Jumping", null, null) as null|anything in sectors
-		if(!selection)
-			to_chat(src, "No sector selected.")
-			return
-		var/obj/effect/overmap/visitable/sector/sector = selection
-		if(src && src.mob && sector && sector.map_z && sector.map_z[1])
-			var/mob/A = src.mob
-			A.on_mob_jump()
-			A.x = world.maxx/2
-			A.y = world.maxy/2
-			A.z = sector.map_z[1]
-			message_admins("[key_name_admin(usr)] jumped to sector [selection]", 1)
-			feedback_add_details("admin_verb","JSEC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	else
-		alert("Admin jumping disabled")
+	if(check_rights(R_ADMIN|R_MOD|R_DEBUG|R_DEV) || isstoryteller(src.mob))
+		if(GLOB.config.allow_admin_jump)
+			var/list/sectors = list()
+			for(var/sector in SSshuttle.initialized_sectors)
+				sectors += sector
+			var/selection = input("Select sector to jump to.", "Admin Jumping", null, null) as null|anything in sectors
+			if(!selection)
+				to_chat(src, "No sector selected.")
+				return
+			var/obj/effect/overmap/visitable/sector/sector = selection
+			if(src && src.mob && sector && sector.map_z && sector.map_z[1])
+				var/mob/A = src.mob
+				A.on_mob_jump()
+				A.x = world.maxx/2
+				A.y = world.maxy/2
+				A.z = sector.map_z[1]
+				message_admins("[key_name_admin(usr)] jumped to sector [selection]", 1)
+				feedback_add_details("admin_verb","JSEC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		else
+			alert("Admin jumping disabled")
 
 /client/proc/jumptokey()
 	set category = "Admin"
@@ -219,16 +205,15 @@
 	set category = "Admin"
 	set name = "Get Mob"
 	set desc = "Mob to teleport"
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
-		return
-	if(GLOB.config.allow_admin_jump)
-		log_admin("[key_name(usr)] teleported [key_name(M)]")
-		message_admins("[key_name_admin(usr)] teleported [key_name_admin(M)]", 1)
-		M.on_mob_jump()
-		M.forceMove(get_turf(usr))
-		feedback_add_details("admin_verb","GM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	else
-		alert("Admin jumping disabled")
+	if(check_rights(R_ADMIN|R_MOD|R_DEBUG) || isstoryteller(src.mob))
+		if(GLOB.config.allow_admin_jump)
+			log_admin("[key_name(usr)] teleported [key_name(M)]")
+			message_admins("[key_name_admin(usr)] teleported [key_name_admin(M)]", 1)
+			M.on_mob_jump()
+			M.forceMove(get_turf(usr))
+			feedback_add_details("admin_verb","GM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		else
+			alert("Admin jumping disabled")
 
 /client/proc/Getkey()
 	set category = "Admin"

--- a/code/modules/admin/verbs/clear_toxins.dm
+++ b/code/modules/admin/verbs/clear_toxins.dm
@@ -1,8 +1,9 @@
 /client/proc/clear_toxins()
 	set category = "Special Verbs"
 	set name = "Clear Toxin/Fire in Zone"
+	set desc = "Remove fires from your current zone and reset the atmosphere to human-perfect gas mix, pressure, and temp."
 
-	if (!check_rights(R_ADMIN))
+	if (!check_rights(R_ADMIN) && !isstoryteller(usr))
 		return
 
 	if(!usr.loc) return

--- a/code/modules/cciaa/cciaa.dm
+++ b/code/modules/cciaa/cciaa.dm
@@ -3,93 +3,94 @@
 	set desc = "Send a fax from Central Command."
 	set category = "Special Verbs"
 
-	if (!check_rights(R_ADMIN|R_CCIAA|R_FUN))
+	if (check_rights(R_ADMIN|R_CCIAA|R_FUN) || isstoryteller(usr))
+		var/list/faxes = list()
+		for(var/obj/machinery/photocopier/faxmachine/F in GLOB.allfaxes)
+			faxes[F.department] = F
+
+		if(!length(faxes))
+			to_chat(usr, SPAN_WARNING("No valid fax machines located!"))
+			return
+
+		var/department = tgui_input_list(usr, "Pick a fax machine.", "Send Admin Fax", faxes)
+		var/obj/machinery/photocopier/faxmachine/fax = faxes[department]
+		if (!istype(fax))
+			to_chat(usr, SPAN_WARNING("Couldn't find a fax machine to send this to!"))
+			return
+
+		//todo: sanitize
+		var/input = tgui_input_text(usr, "Please enter a message to reply to via secure connection. BBCode and HTML allowed.", \
+					"Outgoing message from Centcomm", "", MAX_BOOK_MESSAGE_LEN, TRUE)
+		if (!input)
+			to_chat(usr, SPAN_WARNING("Cancelled."))
+			return
+
+		var/customname = tgui_input_text(usr, "Pick a title for the report.", "Title")
+		if (!customname)
+			to_chat(usr, SPAN_WARNING("Cancelled."))
+			return
+
+		var/announce = alert(usr, "Do you wish to announce the fax being sent?", "Announce Fax", "Yes", "No")
+		if(announce == "Yes")
+			announce = TRUE
+
+		// Create the reply message
+		var/obj/item/paper/P = new /obj/item/paper(null) //hopefully the null loc won't cause trouble for us
+		P.set_content("[SSatlas.current_map.boss_name] - [customname]", input)
+
+		// Stamps
+		var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
+		stampoverlay.icon_state = "paper_stamp-cent"
+		if(!P.stamped)
+			P.stamped = new
+		P.stamped += /obj/item/stamp
+		P.AddOverlays(stampoverlay)
+		P.stamps += "<HR><i>This paper has been stamped by the Central Command Quantum Relay.</i>"
+
+		if(fax.receivefax(P))
+			if(announce == 1)
+				command_announcement.Announce("A fax has been sent to the [department] fax machine.", "Fax Sent")
+			to_chat(usr, SPAN_NOTICE("Message transmitted successfully."))
+			log_and_message_admins("sent a fax message to the [department] fax machine. (<A href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[fax.x];Y=[fax.y];Z=[fax.z]'>JMP</a>)")
+
+			GLOB.sent_faxes += P
+		else
+			to_chat(usr, SPAN_WARNING("Message reply failed."))
+			qdel(P)
+		return
+	else
 		to_chat(usr, SPAN_WARNING("You do not have enough powers to do this."))
 		return
-
-	var/list/faxes = list()
-	for(var/obj/machinery/photocopier/faxmachine/F in GLOB.allfaxes)
-		faxes[F.department] = F
-
-	if(!length(faxes))
-		to_chat(usr, SPAN_WARNING("No valid fax machines located!"))
-		return
-
-	var/department = tgui_input_list(usr, "Pick a fax machine.", "Send Admin Fax", faxes)
-	var/obj/machinery/photocopier/faxmachine/fax = faxes[department]
-	if (!istype(fax))
-		to_chat(usr, SPAN_WARNING("Couldn't find a fax machine to send this to!"))
-		return
-
-	//todo: sanitize
-	var/input = tgui_input_text(usr, "Please enter a message to reply to via secure connection. BBCode and HTML allowed.", \
-				"Outgoing message from Centcomm", "", MAX_BOOK_MESSAGE_LEN, TRUE)
-	if (!input)
-		to_chat(usr, SPAN_WARNING("Cancelled."))
-		return
-
-	var/customname = tgui_input_text(usr, "Pick a title for the report.", "Title")
-	if (!customname)
-		to_chat(usr, SPAN_WARNING("Cancelled."))
-		return
-
-	var/announce = alert(usr, "Do you wish to announce the fax being sent?", "Announce Fax", "Yes", "No")
-	if(announce == "Yes")
-		announce = TRUE
-
-	// Create the reply message
-	var/obj/item/paper/P = new /obj/item/paper(null) //hopefully the null loc won't cause trouble for us
-	P.set_content("[SSatlas.current_map.boss_name] - [customname]", input)
-
-	// Stamps
-	var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
-	stampoverlay.icon_state = "paper_stamp-cent"
-	if(!P.stamped)
-		P.stamped = new
-	P.stamped += /obj/item/stamp
-	P.AddOverlays(stampoverlay)
-	P.stamps += "<HR><i>This paper has been stamped by the Central Command Quantum Relay.</i>"
-
-	if(fax.receivefax(P))
-		if(announce == 1)
-			command_announcement.Announce("A fax has been sent to the [department] fax machine.", "Fax Sent")
-		to_chat(usr, SPAN_NOTICE("Message transmitted successfully."))
-		log_and_message_admins("sent a fax message to the [department] fax machine. (<A href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[fax.x];Y=[fax.y];Z=[fax.z]'>JMP</a>)")
-
-		GLOB.sent_faxes += P
-	else
-		to_chat(usr, SPAN_WARNING("Message reply failed."))
-		qdel(P)
-	return
 
 /client/proc/check_fax_history()
 	set name = "Check fax history"
 	set desc = "Look up the faxes sent this round."
 	set category = "Special Verbs"
 
-	if (!check_rights(R_ADMIN|R_CCIAA|R_FUN))
+	if (check_rights(R_ADMIN|R_CCIAA|R_FUN) || isstoryteller(usr))
+		var/data = "<center><a href='byond://?_src_=holder;CentcommFaxReply=1'>Send New Fax</a></center>"
+		data += "<hr>"
+		data += "<center><b>Received Faxes:</b></center><br>"
+
+		if (GLOB.arrived_faxes && GLOB.arrived_faxes.len)
+			for (var/obj/item/item in GLOB.arrived_faxes)
+				data += "[item.name] - <a href='byond://?_src_=holder;AdminFaxView=[REF(item)]'>view message</a><br>"
+		else
+			data += "<center>No faxes have been received.</center>"
+
+		data += "<hr><center><b>Sent Faxes:</b></center><br>"
+
+		if (GLOB.sent_faxes && GLOB.sent_faxes.len)
+			for (var/obj/item/item in GLOB.sent_faxes)
+				data += "[item.name] - <a href='byond://?_src_=holder;AdminFaxView=[REF(item)]'>view message</a><br>"
+		else
+			data += "<center>No faxes have been sent out.</center>"
+
+		usr << browse("<HTML><HEAD><TITLE>Centcomm Fax History</TITLE></HEAD><BODY>[data]</BODY></HTML>", "window=Centcomm Fax History")
+		return
+	else
 		to_chat(usr, SPAN_WARNING("You do not have enough powers to do this."))
 		return
-
-	var/data = "<center><a href='byond://?_src_=holder;CentcommFaxReply=1'>Send New Fax</a></center>"
-	data += "<hr>"
-	data += "<center><b>Received Faxes:</b></center><br>"
-
-	if (GLOB.arrived_faxes && GLOB.arrived_faxes.len)
-		for (var/obj/item/item in GLOB.arrived_faxes)
-			data += "[item.name] - <a href='byond://?_src_=holder;AdminFaxView=[REF(item)]'>view message</a><br>"
-	else
-		data += "<center>No faxes have been received.</center>"
-
-	data += "<hr><center><b>Sent Faxes:</b></center><br>"
-
-	if (GLOB.sent_faxes && GLOB.sent_faxes.len)
-		for (var/obj/item/item in GLOB.sent_faxes)
-			data += "[item.name] - <a href='byond://?_src_=holder;AdminFaxView=[REF(item)]'>view message</a><br>"
-	else
-		data += "<center>No faxes have been sent out.</center>"
-
-	usr << browse("<HTML><HEAD><TITLE>Centcomm Fax History</TITLE></HEAD><BODY>[data]</BODY></HTML>", "window=Centcomm Fax History")
 
 
 /client/proc/launch_ccia_shuttle()

--- a/code/modules/mob/abstract/ghost/storyteller/storyteller.dm
+++ b/code/modules/mob/abstract/ghost/storyteller/storyteller.dm
@@ -39,6 +39,7 @@
 		name = "Storyteller ([client.ckey])"
 		SSodyssey.add_storyteller(src)
 		GLOB.storytellers.add_antagonist(mind)
+		C.add_storyteller_verbs()
 
 /mob/abstract/ghost/storyteller/ghostize(can_reenter_corpse, should_set_timer)
 	. = ..()

--- a/code/modules/random_map/drop/supply.dm
+++ b/code/modules/random_map/drop/supply.dm
@@ -37,57 +37,56 @@
 	set desc = "Call an immediate supply drop on your location."
 	set name = "Call Supply Drop"
 
-	if(!check_rights(R_FUN)) return
+	if(check_rights(R_FUN) || isstoryteller(usr))
+		var/chosen_loot_type
+		var/list/chosen_loot_types
+		var/choice = alert("Do you wish to supply a custom loot list?",,"No","Yes")
+		if(choice == "Yes")
+			chosen_loot_types = list()
 
-	var/chosen_loot_type
-	var/list/chosen_loot_types
-	var/choice = alert("Do you wish to supply a custom loot list?",,"No","Yes")
-	if(choice == "Yes")
-		chosen_loot_types = list()
+			choice = alert("Do you wish to add mobs?",,"No","Yes")
+			if(choice == "Yes")
+				while(1)
+					var/adding_loot_type = input("Select a new loot path. Cancel to finish.", "Loot Selection", null) as null|anything in typesof(/mob/living)
+					if(!adding_loot_type)
+						break
+					chosen_loot_types |= adding_loot_type
+			choice = alert("Do you wish to add structures or machines?",,"No","Yes")
+			if(choice == "Yes")
+				while(1)
+					var/adding_loot_type = input("Select a new loot path. Cancel to finish.", "Loot Selection", null) as null|anything in typesof(/obj) - typesof(/obj/item)
+					if(!adding_loot_type)
+						break
+					chosen_loot_types |= adding_loot_type
+			choice = alert("Do you wish to add any non-weapon items?",,"No","Yes")
+			if(choice == "Yes")
+				while(1)
+					var/adding_loot_type = input("Select a new loot path. Cancel to finish.", "Loot Selection", null) as null|anything in typesof(/obj/item) - typesof(/obj/item)
+					if(!adding_loot_type)
+						break
+					chosen_loot_types |= adding_loot_type
 
-		choice = alert("Do you wish to add mobs?",,"No","Yes")
-		if(choice == "Yes")
-			while(1)
-				var/adding_loot_type = input("Select a new loot path. Cancel to finish.", "Loot Selection", null) as null|anything in typesof(/mob/living)
-				if(!adding_loot_type)
-					break
-				chosen_loot_types |= adding_loot_type
-		choice = alert("Do you wish to add structures or machines?",,"No","Yes")
-		if(choice == "Yes")
-			while(1)
-				var/adding_loot_type = input("Select a new loot path. Cancel to finish.", "Loot Selection", null) as null|anything in typesof(/obj) - typesof(/obj/item)
-				if(!adding_loot_type)
-					break
-				chosen_loot_types |= adding_loot_type
-		choice = alert("Do you wish to add any non-weapon items?",,"No","Yes")
-		if(choice == "Yes")
-			while(1)
-				var/adding_loot_type = input("Select a new loot path. Cancel to finish.", "Loot Selection", null) as null|anything in typesof(/obj/item) - typesof(/obj/item)
-				if(!adding_loot_type)
-					break
-				chosen_loot_types |= adding_loot_type
+			choice = alert("Do you wish to add weapons?",,"No","Yes")
+			if(choice == "Yes")
+				while(1)
+					var/adding_loot_type = input("Select a new loot path. Cancel to finish.", "Loot Selection", null) as null|anything in typesof(/obj/item)
+					if(!adding_loot_type)
+						break
+					chosen_loot_types |= adding_loot_type
+			choice = alert("Do you wish to add ABSOLUTELY ANYTHING ELSE? (you really shouldn't need to)",,"No","Yes")
+			if(choice == "Yes")
+				while(1)
+					var/adding_loot_type = input("Select a new loot path. Cancel to finish.", "Loot Selection", null) as null|anything in typesof(/atom/movable)
+					if(!adding_loot_type)
+						break
+					chosen_loot_types |= adding_loot_type
+		else
+			choice = alert("Do you wish to specify a loot type?",,"No","Yes")
+			if(choice == "Yes")
+				chosen_loot_type = input("Select a loot type.", "Loot Selection", null) as null|anything in supply_drop_random_loot_types()
 
-		choice = alert("Do you wish to add weapons?",,"No","Yes")
-		if(choice == "Yes")
-			while(1)
-				var/adding_loot_type = input("Select a new loot path. Cancel to finish.", "Loot Selection", null) as null|anything in typesof(/obj/item)
-				if(!adding_loot_type)
-					break
-				chosen_loot_types |= adding_loot_type
-		choice = alert("Do you wish to add ABSOLUTELY ANYTHING ELSE? (you really shouldn't need to)",,"No","Yes")
-		if(choice == "Yes")
-			while(1)
-				var/adding_loot_type = input("Select a new loot path. Cancel to finish.", "Loot Selection", null) as null|anything in typesof(/atom/movable)
-				if(!adding_loot_type)
-					break
-				chosen_loot_types |= adding_loot_type
-	else
-		choice = alert("Do you wish to specify a loot type?",,"No","Yes")
-		if(choice == "Yes")
-			chosen_loot_type = input("Select a loot type.", "Loot Selection", null) as null|anything in supply_drop_random_loot_types()
-
-	choice = alert("Are you SURE you wish to deploy this supply drop? It will cause a sizable explosion and gib anyone underneath it.",,"No","Yes")
-	if(choice == "No")
-		return
-	log_admin("[key_name(usr)] dropped supplies at ([usr.x],[usr.y],[usr.z])")
-	new /datum/random_map/droppod/supply(null, usr.x-2, usr.y-2, usr.z, supplied_drops = chosen_loot_types, supplied_drop = chosen_loot_type)
+		choice = alert("Are you SURE you wish to deploy this supply drop? It will cause a sizable explosion and gib anyone underneath it.",,"No","Yes")
+		if(choice == "No")
+			return
+		log_admin("[key_name(usr)] dropped supplies at ([usr.x],[usr.y],[usr.z])")
+		new /datum/random_map/droppod/supply(null, usr.x-2, usr.y-2, usr.z, supplied_drops = chosen_loot_types, supplied_drop = chosen_loot_type)


### PR DESCRIPTION
As title: grants STs a small selection of admin/mod/fun verbs without needing them to have an admin_rank configured on the back end.

I've been extra permissive here on the assumption that Those That Be will veto anything they don't like. The granted verbs:
	/client/proc/toggle_view_range,
	/client/proc/jumptozlevel,
	/client/proc/jumptoshuttle,
	/client/proc/jumptoship,
	/client/proc/jumptosector,
	/client/proc/Getmob,
	/client/proc/Jump,
	/client/proc/jumptomob,
	/client/proc/jumptoturf,
	/client/proc/check_ai_laws,
	/client/proc/manage_silicon_laws,
	/client/proc/odyssey_panel,
	/client/proc/damage_menu,
	/client/proc/change_human_appearance_admin,
	/client/proc/change_security_level,
	/datum/admins/proc/create_admin_fax,
	/client/proc/check_fax_history,
	/client/proc/clear_toxins,
	/datum/admins/proc/call_supply_drop,
	/datum/admins/proc/call_drop_pod,
	
This PR is full of _gross code_ but it _does_ work.