### PR TITLE
Pharmacy Over The Counter Gaming - Mapping/Balance/Bugfix

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -759,13 +759,13 @@
 		/obj/item/storage/pill_bottle/rmt = 2
 	)
 	prices = list(
-		/obj/item/storage/pill_bottle/antidexafen = 70,
-		/obj/item/storage/pill_bottle/dexalin = 60,
-		/obj/item/storage/pill_bottle/dylovene = 75,
-		/obj/item/storage/pill_bottle/vitamin = 55,
-		/obj/item/storage/pill_bottle/cetahydramine  = 60,
-		/obj/item/storage/pill_bottle/caffeine = 90,
-		/obj/item/storage/pill_bottle/nicotine  = 85,
+		/obj/item/storage/pill_bottle/antidexafen = 140,
+		/obj/item/storage/pill_bottle/dexalin = 120,
+		/obj/item/storage/pill_bottle/dylovene = 150,
+		/obj/item/storage/pill_bottle/vitamin = 110,
+		/obj/item/storage/pill_bottle/cetahydramine  = 120,
+		/obj/item/storage/pill_bottle/caffeine = 180,
+		/obj/item/storage/pill_bottle/nicotine  = 170,
 		/obj/item/storage/pill_bottle/rmt = 550
 	)
 	contraband = list(

--- a/html/changelogs/courierbravo - overthecountergaming.yml
+++ b/html/changelogs/courierbravo - overthecountergaming.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: CourierBravo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a quikpay device and some shelving to the pharmacy to encourage the pharmacist to sell things over the counter."
+  - bugfix: "Fixed the service quikpay paying into the operations account instead of the service account."
+  - balance: "Doubled the prices for almost everything in the OTC medical wall vender in the lobby. Everything is still very much affordable, but this should encourage pharmacists to undercut the vending machine."


### PR DESCRIPTION
This PR was made at request of Kermit to slightly enhance the pharmacist game-play loop by introducing selling medication OTC. Legally or otherwise >;)

- Adds a quikpay to the pharmacy along with some shelving. Moves some stuff around to accommodate this
- Fixes the hydroponics quikpay paying into the operations account instead of the service account. That's a whoopsie on my part.
- Doubles the price of most drugs in the OTC/Wall vendor. Everything is still very much affordable, but this should encourage pharmacist players to undercut the vending machine without getting peanuts in return.
