### PR TITLE
Additional hydroponics QoL + additions

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -5,7 +5,7 @@
 #define WEIGHT_CLASS_TINY 1
 /// Pockets can hold small and tiny items, (e.g. flashlight, multitool, grenades, GPS device)
 #define WEIGHT_CLASS_SMALL 2
-/// Standard backpacks can carry tiny, small & normal items, (e.g. fire extinguisher, stun baton, gas mask, metal sheets)
+/// Standard backpacks can carry tiny, 1small & normal items, (e.g. fire extinguisher, stun baton, gas mask, metal sheets)
 #define WEIGHT_CLASS_NORMAL 3
 /// Items that can be wielded or equipped but not stored in an inventory, (e.g. defibrillator, backpack, space suits)
 #define WEIGHT_CLASS_BULKY 4

--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -5,7 +5,7 @@
 #define WEIGHT_CLASS_TINY 1
 /// Pockets can hold small and tiny items, (e.g. flashlight, multitool, grenades, GPS device)
 #define WEIGHT_CLASS_SMALL 2
-/// Standard backpacks can carry tiny, 1small & normal items, (e.g. fire extinguisher, stun baton, gas mask, metal sheets)
+/// Standard backpacks can carry tiny, small & normal items, (e.g. fire extinguisher, stun baton, gas mask, metal sheets)
 #define WEIGHT_CLASS_NORMAL 3
 /// Items that can be wielded or equipped but not stored in an inventory, (e.g. defibrillator, backpack, space suits)
 #define WEIGHT_CLASS_BULKY 4

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -239,11 +239,6 @@ ITEMS
 	object = /obj/item/storage/stickersheet/goldstar
 	cost = 600
 
-/singleton/biorecipe/item/cash
-	name = "Money Bag"
-	object = /obj/item/storage/bag/money
-	cost = 200
-
 /singleton/biorecipe/item/plantbag
 	name = "Plant Bag"
 	object = /obj/item/storage/bag/plants
@@ -270,6 +265,152 @@ ITEMS
 	name = "Empty First Aid Kit"
 	object = /obj/item/storage/firstaid/empty
 	cost = 200
+
+/singleton/biorecipe/item/trash
+	name = "Trash Bag"
+	object = /obj/item/storage/bag/trash
+	cost = 200
+
+/*
+CLOTHING
+*/
+
+/singleton/biorecipe/clothes
+	name = "Hazard Vest"
+	class = BIOGEN_CLOTHES
+	object = /obj/item/clothing/suit/storage/hazardvest
+	cost = 200
+
+/singleton/biorecipe/clothes/satchel
+	name = "Leather Satchel"
+	object = /obj/item/storage/backpack/satchel/leather
+	cost = 300
+
+/singleton/biorecipe/clothes/duffel
+	name = "Duffel Bag"
+	object = /obj/item/storage/backpack/duffel
+	cost = 200
+
+/singleton/biorecipe/clothes/backpack
+	name = "Generic Backpack"
+	object = /obj/random/biogenerator/backpack
+	cost = 200
+
+/singleton/biorecipe/clothes/botanic_leather
+	name = "Botanical Gloves"
+	object = /obj/item/clothing/gloves/botanic_leather
+	cost = 150
+
+/singleton/biorecipe/clothes/gloves
+	name = "Random Black Gloves"
+	object = /obj/random/biogenerator/gloves
+	cost = 125
+
+/singleton/biorecipe/clothes/latexgloves
+	name = "Latex Gloves"
+	object = /obj/item/clothing/gloves/latex
+	cost = 200
+
+/singleton/biorecipe/clothes/randomgloves
+	name = "Random Gloves"
+	object = /obj/random/biogenerator/gloves/random
+	cost = 125
+
+/singleton/biorecipe/clothes/medicalbelt
+	name = "Medical Belt"
+	object = /obj/item/storage/belt/medical
+	cost = 200
+
+/singleton/biorecipe/clothes/utility
+	name = "Utility Belt"
+	object = /obj/item/storage/belt/utility
+	cost = 200
+
+/singleton/biorecipe/clothes/hydrobelt
+	name = "Hydroponic Belt"
+	object = /obj/item/storage/belt/hydro
+	cost = 200
+
+/*
+MEDICAL
+*/
+
+/singleton/biorecipe/cube
+	name = "Monkey Cube"
+	class = BIOGEN_SPECIAL
+	object = /obj/item/reagent_containers/food/snacks/monkeycube/wrapped
+
+/singleton/biorecipe/cube/stok
+	name = "Stok Cube"
+	object = /obj/item/reagent_containers/food/snacks/monkeycube/wrapped/stokcube
+
+/singleton/biorecipe/cube/farwa
+	name = "Farwa Cube"
+	object = /obj/item/reagent_containers/food/snacks/monkeycube/wrapped/farwacube
+
+/singleton/biorecipe/cube/neaera
+	name = "Neaera Cube"
+	object = /obj/item/reagent_containers/food/snacks/monkeycube/wrapped/neaeracube
+
+/singleton/biorecipe/cube/cazador
+	name = "V'krexi Cube"
+	object = /obj/item/reagent_containers/food/snacks/monkeycube/wrapped/vkrexicube
+	cost = 500
+
+/singleton/biorecipe/medical
+	name = "Bruise Pack"
+	class = BIOGEN_MEDICAL
+	object = /obj/item/stack/medical/bruise_pack
+	cost = 400
+
+/singleton/biorecipe/medical/ointment
+	name = "Burn Ointment"
+	object = /obj/item/stack/medical/ointment
+
+/singleton/biorecipe/medical/perconol_pill
+	name = "Perconol Pill"
+	object = /obj/item/reagent_containers/pill/perconol
+	cost = 250
+	amount = list(1,2,3,5,7)
+
+/*
+CONSTRUCTION
+*/
+
+/singleton/biorecipe/construction
+	name = "Animal Hide"
+	class = BIOGEN_CONSTRUCTION
+	object = /obj/item/stack/material/animalhide
+	cost = 100
+	amount = list(1,5,10,25,50)
+
+/singleton/biorecipe/construction/leather
+	name = "Leather"
+	object = /obj/item/stack/material/leather
+
+/singleton/biorecipe/construction/cloth
+	name = "Cloth"
+	object = /obj/item/stack/material/cloth
+	cost = 50
+
+/singleton/biorecipe/construction/cardboard
+	name = "Cardboard"
+	object = /obj/item/stack/material/cardboard
+	cost = 50
+
+/singleton/biorecipe/construction/wax
+	name = "Wax"
+	object = /obj/item/stack/wax
+	cost = 10
+
+/singleton/biorecipe/construction/plastic
+	name = "Plastic"
+	object = /obj/item/stack/material/plastic
+	cost = 75
+
+/singleton/biorecipe/construction/wood
+	name = "Wood"
+	object = /obj/item/stack/material/wood
 
 /*
 FLAGS
@@ -345,138 +486,6 @@ FLAGS
 	name = "Orion Express Flag, Large"
 	object = /obj/item/flag/orion_express/l
 	cost = 500
-
-/*
-CONSTRUCTION
-*/
-
-/singleton/biorecipe/construction
-	name = "Animal Hide"
-	class = BIOGEN_CONSTRUCTION
-	object = /obj/item/stack/material/animalhide
-	cost = 100
-	amount = list(1,5,10,25,50)
-
-/singleton/biorecipe/construction/leather
-	name = "Leather"
-	object = /obj/item/stack/material/leather
-
-/singleton/biorecipe/construction/cloth
-	name = "Cloth"
-	object = /obj/item/stack/material/cloth
-	cost = 50
-
-/singleton/biorecipe/construction/cardboard
-	name = "Cardboard"
-	object = /obj/item/stack/material/cardboard
-	cost = 50
-
-/singleton/biorecipe/construction/wax
-	name = "Wax"
-	object = /obj/item/stack/wax
-	cost = 10
-
-/singleton/biorecipe/construction/plastic
-	name = "Plastic"
-	object = /obj/item/stack/material/plastic
-	cost = 75
-
-/singleton/biorecipe/construction/wood
-	name = "Wood"
-	object = /obj/item/stack/material/wood
-
-/*
-CLOTHING
-*/
-
-/singleton/biorecipe/clothes
-	name = "Suit"
-	class = BIOGEN_CLOTHES
-	object = /obj/random/suit
-	cost = 200
-
-/singleton/biorecipe/clothes/satchel
-	name = "Leather Satchel"
-	object = /obj/item/storage/backpack/satchel/leather
-	cost = 300
-
-/singleton/biorecipe/clothes/backpack
-	name = "Generic Backpack"
-	object = /obj/random/biogenerator/backpack
-	cost = 200
-
-/singleton/biorecipe/clothes/backpack
-	name = "Corporate Backpack"
-	object = /obj/random/biogenerator/backpack/corporate
-	cost = 200
-
-/singleton/biorecipe/clothes/botanic_leather
-	name = "Botanical Gloves"
-	object = /obj/item/clothing/gloves/botanic_leather
-	cost = 150
-
-/singleton/biorecipe/clothes/gloves
-	name = "Black Gloves"
-	object = /obj/random/biogenerator/gloves
-	cost = 125
-
-/singleton/biorecipe/clothes/randomgloves
-	name = "Random Gloves"
-	object = /obj/random/biogenerator/gloves/random
-	cost = 125
-
-/singleton/biorecipe/clothes/utility
-	name = "Utility Belt"
-	object = /obj/item/storage/belt/utility
-	cost = 200
-
-/singleton/biorecipe/clothes/hydrobelt
-	name = "Hydroponic Belt"
-	object = /obj/item/storage/belt/hydro
-	cost = 200
-
-
-/*
-MEDICAL
-*/
-
-/singleton/biorecipe/cube
-	name = "Monkey Cube"
-	class = BIOGEN_SPECIAL
-	object = /obj/item/reagent_containers/food/snacks/monkeycube/wrapped
-
-/singleton/biorecipe/cube/stok
-	name = "Stok Cube"
-	object = /obj/item/reagent_containers/food/snacks/monkeycube/wrapped/stokcube
-
-/singleton/biorecipe/cube/farwa
-	name = "Farwa Cube"
-	object = /obj/item/reagent_containers/food/snacks/monkeycube/wrapped/farwacube
-
-/singleton/biorecipe/cube/neaera
-	name = "Neaera Cube"
-	object = /obj/item/reagent_containers/food/snacks/monkeycube/wrapped/neaeracube
-
-/singleton/biorecipe/cube/cazador
-	name = "V'krexi Cube"
-	object = /obj/item/reagent_containers/food/snacks/monkeycube/wrapped/vkrexicube
-	cost = 500
-
-/singleton/biorecipe/medical
-	name = "Bruise Pack"
-	class = BIOGEN_MEDICAL
-	object = /obj/item/stack/medical/bruise_pack
-	cost = 400
-
-/singleton/biorecipe/medical/ointment
-	name = "Burn Ointment"
-	object = /obj/item/stack/medical/ointment
-
-/singleton/biorecipe/medical/perconol_pill
-	name = "Perconol Pill"
-	object = /obj/item/reagent_containers/pill/perconol
-	cost = 250
-	amount = list(1,2,3,5,7)
 
 /*
 EMAG/ILLEGAL

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -12,11 +12,11 @@
 	pickup_sound = 'sound/items/pickup/cardboardbox.ogg'
 	use_sound = 'sound/items/storage/briefcase.ogg'
 	max_w_class = WEIGHT_CLASS_SMALL
-	max_storage_space = 16 // So empty first-aid kits don't start with less space than filled ones.
 
 /obj/item/storage/firstaid/empty
 	name = "empty first-aid kit"
 	desc = "It's a first-aid kit. Comes with nothing, so feel free to put your own stuff in it."
+	max_storage_space = 16 // So empty first-aid kits don't start with less space than filled ones.
 
 /obj/item/storage/firstaid/regular
 	starts_with = list(

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -14,7 +14,6 @@
 	max_w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/firstaid/empty
-	name = "empty first-aid kit"
 	desc = "It's a first-aid kit. Comes with nothing, so feel free to put your own stuff in it."
 	max_storage_space = 16 // So empty first-aid kits don't start with less space than filled ones.
 

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -12,6 +12,7 @@
 	pickup_sound = 'sound/items/pickup/cardboardbox.ogg'
 	use_sound = 'sound/items/storage/briefcase.ogg'
 	max_w_class = WEIGHT_CLASS_SMALL
+	max_storage_space = 16 // So empty first-aid kits don't start with less space than filled ones.
 
 /obj/item/storage/firstaid/empty
 	name = "empty first-aid kit"

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -573,14 +573,44 @@
 
 //This exists so the prespawned hydro crates spawn with their contents.
 /obj/structure/closet/crate/hydroponics/prespawned/fill()
-	new /obj/item/reagent_containers/spray/plantbgone(src)
-	new /obj/item/reagent_containers/spray/plantbgone(src)
 	new /obj/item/material/minihoe(src)
-//	new /obj/item/weedspray(src)
-//	new /obj/item/weedspray(src)
-//	new /obj/item/pestspray(src)
-//	new /obj/item/pestspray(src)
-//	new /obj/item/pestspray(src)
+	new /obj/item/material/hatchet(src)
+	new /obj/item/wirecutters/clippers(src)
+	new /obj/item/reagent_containers/glass/bucket(src)
+	new /obj/item/reagent_containers/spray/plantbgone(src)
+	new /obj/item/reagent_containers/spray/plantbgone(src)
+	new /obj/item/reagent_containers/glass/fertilizer/ez(src)
+	new /obj/item/reagent_containers/glass/fertilizer/ez(src)
+
+// Everything you need for beekeeping, including the bees. Those with allergies need not apply.
+/obj/structure/closet/crate/hydroponics/beekeeping
+	name = "beekeeping crate"
+	desc = "Live bees included! Several small labels warn of the hazards involved therein."
+
+/obj/structure/closet/crate/hydroponics/beekeeping/fill()
+	new /obj/item/bee_pack(src)
+	new /obj/item/honey_frame(src)
+	new /obj/item/honey_frame(src)
+	new /obj/item/beehive_assembly(src)
+	new /obj/item/bee_net(src)
+	new /obj/item/bee_smoker(src)
+
+// Includes everything you need to run your own horticultural medicinal operation. Or something more nefarious, if you prefer.
+/obj/structure/closet/crate/hydroponics/herbalism
+	name = "herbalist crate"
+	desc = "Contains equipment and storage vessels involved in the processing and packaging of herbal medicine."
+
+/obj/structure/closet/crate/hydroponics/beekeeping/fill()
+	new /obj/item/storage/box/spraybottles(src)
+	new /obj/item/storage/box/pillbottles(src)
+	new /obj/item/storage/box/inhalers_auto(src)
+	new /obj/item/storage/box/autoinjectors(src)
+	new /obj/item/reagent_containers/chem_disp_cartridge(src)
+	new /obj/item/reagent_containers/chem_disp_cartridge(src)
+	new /obj/item/reagent_containers/chem_disp_cartridge(src)
+	new /obj/item/reagent_containers/chem_disp_cartridge(src)
+	new /obj/item/reagent_containers/chem_disp_cartridge(src)
+	new /obj/item/reagent_containers/chem_disp_cartridge(src)
 
 // Spawns with everything you need to make your very own field kitchen! (assuming you have power)
 // Contains enough to create a stove and oven. Using loops for anything above one for readability. Best paired with a freezer with ingredients.

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -600,7 +600,7 @@
 	name = "herbalist crate"
 	desc = "Contains equipment and storage vessels involved in the processing and packaging of herbal medicine."
 
-/obj/structure/closet/crate/hydroponics/beekeeping/fill()
+/obj/structure/closet/crate/hydroponics/herbalism/fill()
 	new /obj/item/storage/box/spraybottles(src)
 	new /obj/item/storage/box/pillbottles(src)
 	new /obj/item/storage/box/inhalers_auto(src)

--- a/code/modules/hydroponics/seed_storage.dm
+++ b/code/modules/hydroponics/seed_storage.dm
@@ -1,8 +1,10 @@
 /datum/seed_pile
 	var/name
 	var/amount
-	var/datum/seed/seed_type // Keeps track of what our seed is
-	var/list/obj/item/seeds/seeds = list() // Tracks actual objects contained in the pile
+	/// Keeps track of what our seed is
+	var/datum/seed/seed_type
+	/// Tracks actual objects contained in the pile
+	var/list/obj/item/seeds/seeds = list()
 	var/ID
 
 /datum/seed_pile/New(obj/item/seeds/O, ID)
@@ -35,8 +37,10 @@
 	var/screen_y = 700
 
 	var/list/datum/seed_pile/piles = list()
+	/// The seeds the machine begins with.
 	var/list/starting_seeds = list()
-	var/list/scanner = list() // What properties we can view
+	/// What properties we can view.
+	var/list/scanner = list()
 
 /obj/machinery/seed_storage/Initialize()
 	. = ..()
@@ -350,92 +354,38 @@
 		/obj/item/seeds/whitebeetseed = 3,
 		/obj/item/seeds/wulumunushaseed = 2,
 		/obj/item/seeds/xuiziseed = 3,
-		/obj/item/seeds/ylpha = 2
+		/obj/item/seeds/ylpha = 2,
+		/obj/item/seeds/cranberryseed = 2,
 	)
 
-/obj/machinery/seed_storage/xenobotany
-	name = "Xenobotany seed storage"
+/obj/machinery/seed_storage/garden/hydroponics
+	name = "Hydroponics seed storage"
 	scanner = list("stats", "produce", "soil", "temperature", "light")
-	starting_seeds = list(
-		/obj/item/seeds/aghrasshseed = 3,
-		/obj/item/seeds/ambrosiavulgarisseed = 3,
-		/obj/item/seeds/appleseed = 3,
-		/obj/item/seeds/amanitamycelium = 2,
-		/obj/item/seeds/bananaseed = 3,
-		/obj/item/seeds/bellpepperseed = 3,
-		/obj/item/seeds/berryseed = 3,
-		/obj/item/seeds/blackraspberryseed = 3,
-		/obj/item/seeds/blizzard = 3,
-		/obj/item/seeds/blueberryseed = 3,
-		/obj/item/seeds/blueraspberryseed = 3,
-		/obj/item/seeds/cabbageseed = 3,
-		/obj/item/seeds/carrotseed = 3,
-		/obj/item/seeds/chantermycelium = 3,
-		/obj/item/seeds/cherryseed = 3,
-		/obj/item/seeds/chiliseed = 3,
-		/obj/item/seeds/chickpeas = 3,
-		/obj/item/seeds/cocaseed = 3,
-		/obj/item/seeds/cocoapodseed = 3,
-		/obj/item/seeds/coffeeseed = 3,
-		/obj/item/seeds/cornseed = 3,
-		/obj/item/seeds/dirtberries = 2,
-		/obj/item/seeds/dynseed = 3,
-		/obj/item/seeds/replicapod = 3,
-		/obj/item/seeds/earthenroot = 2,
-		/obj/item/seeds/eggplantseed = 3,
-		/obj/item/seeds/eki = 3,
-		/obj/item/seeds/fjylozyn = 3,
-		/obj/item/seeds/garlicseed = 3,
-		/obj/item/seeds/glowshroom = 2,
-		/obj/item/seeds/grapeseed = 3,
-		/obj/item/seeds/grassseed = 3,
-		/obj/item/seeds/guamiseed = 2,
-		/obj/item/seeds/gukheseed = 3,
-		/obj/item/seeds/koisspore = 3,
-		/obj/item/seeds/lemonseed = 3,
-		/obj/item/seeds/libertymycelium = 2,
-		/obj/item/seeds/limeseed = 3,
-		/obj/item/seeds/mossseed = 2,
-		/obj/item/seeds/mtearseed = 2,
-		/obj/item/seeds/mintseed = 3,
-		/obj/item/seeds/nettleseed = 2,
-		/obj/item/seeds/onionseed = 3,
-		/obj/item/seeds/oracleseed = 3,
-		/obj/item/seeds/orangeseed = 3,
-		/obj/item/seeds/peaseed = 3,
-		/obj/item/seeds/peanutseed = 3,
-		/obj/item/seeds/peppercornseed = 3,
-		/obj/item/seeds/plastiseed = 3,
-		/obj/item/seeds/plumpmycelium = 3,
-		/obj/item/seeds/poppyseed = 3,
-		/obj/item/seeds/potatoseed = 3,
-		/obj/item/seeds/pumpkinseed = 3,
-		/obj/item/seeds/qlortseed = 2,
-		/obj/item/seeds/raspberryseed = 3,
-		/obj/item/seeds/reishimycelium = 2,
-		/obj/item/seeds/riceseed = 3,
-		/obj/item/seeds/richcoffeeseed = 3,
-		/obj/item/seeds/sarezhiseed = 3,
-		/obj/item/seeds/seaweed = 3,
-		/obj/item/seeds/serkiflowerseed,
-		/obj/item/seeds/soyaseed = 3,
-		/obj/item/seeds/sthberryseed = 3,
-		/obj/item/seeds/strawberryseed = 3,
-		/obj/item/seeds/sugarcaneseed = 3,
-		/obj/item/seeds/sunflowerseed = 3,
-		/obj/item/seeds/sugartree = 2,
-		/obj/item/seeds/shandseed = 2,
-		/obj/item/seeds/teaseed = 3,
-		/obj/item/seeds/tobaccoseed = 3,
-		/obj/item/seeds/tomatoseed = 3,
-		/obj/item/seeds/towermycelium = 3,
-		/obj/item/seeds/vanilla = 3,
-		/obj/item/seeds/watermelonseed = 3,
-		/obj/item/seeds/wheatseed = 3,
-		/obj/item/seeds/whitebeetseed = 3,
-		/obj/item/seeds/wulumunushaseed = 3,
-		/obj/item/seeds/xuiziseed = 3,
-		/obj/item/seeds/ylpha = 2
-	)
 	screen_x = 1000
 	screen_y = 700
+
+/obj/machinery/seed_storage/garden/hydroponics/Initialize()
+	starting_seeds = src.starting_seeds.Copy() + list(
+		/obj/item/seeds/libertymycelium = 2,
+		/obj/item/seeds/koisspore = 3,
+		/obj/item/seeds/glowshroom = 2,
+		/obj/item/seeds/nettleseed = 2
+	)
+	return ..()
+
+/obj/machinery/seed_storage/garden/xenobotany
+	name = "Xenobotany seed storage"
+	scanner = list("stats", "produce", "soil", "temperature", "light")
+	screen_x = 1000
+	screen_y = 700
+
+/obj/machinery/seed_storage/garden/xenobotany/Initialize()
+	starting_seeds = src.starting_seeds.Copy() + list(
+		/obj/item/seeds/libertymycelium = 2,
+		/obj/item/seeds/cocaseed = 3,
+		/obj/item/seeds/koisspore = 3,
+		/obj/item/seeds/amanitamycelium = 2,
+		/obj/item/seeds/glowshroom = 2,
+		/obj/item/seeds/nettleseed = 2
+	)
+	return ..()

--- a/html/changelogs/hazelmouse-hydrobuffs.yml
+++ b/html/changelogs/hazelmouse-hydrobuffs.yml
@@ -1,0 +1,66 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Hydroponics has been partially remapped, implementing atmospheric equipment for some trays allowing their temperature to be controlled."
+  - rscadd: "Hydroponics now has access to cranberry seeds, glowshroom spores, nettle seeds, k'ois spores, and liberty cap spores. Of these, only cranberry seeds are accessible in the public garden."
+  - rscadd: "Hydroponics now contains a secure and sealed chamber for growing hazardous specimens. You probably shouldn't plant your k'ois anywhere but here, and be sure to wear your hazmat suit and face mask! Lethal consequences may lay in malpractice!"
+  - rscadd: "A few new items have been added to the biogenerator, including trash bags, medical belts, and latex gloves."
+  - rscadd: "Hydroponics now has access to autoinhalers and autoinjectors."
+  - refactor: "Prefilled hydroponics-related crates now spawn with all the necessary tools, and the beekeeping and herbalist crates on the Horizon are now filled by code rather than by mapping."
+  - refactor: "Refactored code of seed dispensers to avoid duplicated lists. This does mean, entirely inadvertantly, that Xenobotany has clams now."
+  - rscadd: "Slightly expanded hydroponics access to immediately adjacent maintenance."
+  - bugfix: "Empty first-aid kits are no longer inferior in storage capacity to filled first-aid kits."


### PR DESCRIPTION
This implements a bunch of little QoL improvements and a few substantial expansions in hydroponics intended to deepen the job's interactions with hydroponics mechanics.

- Adds k'ois spores to hydroponics! Note these are only available in hydroponics proper, the seed storage machine for the garden has been split into a separate subtype that does not contain k'ois. This is packaged with a small hazardous containment chamber to safely grow dangerous crops, in addition to a decontamination area and a hazmat closet. K'ois is something the kitchen is continually in demand of, and it is the sole foodstuff of an entire species - I don't see why hydroponics wouldn't be able to grow it.
- D1 hydroponics now has the same atmos equipment for changing the temperature of trays as xenobotany, allowing you to take air from distro and change its temperature across two separate reservoirs feeding into trays. Different crops grow optimally at different temperatures, this lets hydroponicists engage with this mechanic.
- A bunch of misc code QoL changes, including shifting the crates in hydroponics from mapping to code.
- Makes empty first-aid kits spawn with a minimum of 16 storage space. Previously, the storage you'd see in empty first aid kits was well, well below how much actual first-aid kits with prefilled contents had.
- Expanded hydroponicist maintenance access a little, so they can now access the garden and hangars through adjacent maints.
- Seed storage machines have cranberry seeds now.
- A few more items are in the biogenerator, in the interest of making the hydroponicist a better generalist.
- Shifted around some of the contents of the biogenerator to prioritise more important stuff, including moving flags to the bottom of the list. The only item actually removed is the money bag - I'm not sure what use you'd find for that.
- Adds autoinjectors and autoinhalers to the hydroponicist's herbalism crate.

![image](https://github.com/user-attachments/assets/fdac2923-b112-4e9d-b9f3-dbab125d7382)

![image](https://github.com/user-attachments/assets/f04a2480-7643-4d49-a46f-610f8495e691)
