### PR TITLE
Rename vars that override internal vars

### DIFF
--- a/code/controllers/hooks.dm
+++ b/code/controllers/hooks.dm
@@ -23,7 +23,7 @@
  * @param hook	Identifier of the hook to call.
  * @returns		1 if all hooked code runs successfully, 0 otherwise.
  */
-/proc/callHook(hook, list/args=null)
+/proc/callHook(hook, list/arguments=null)
 	var/hook_path = text2path("/hook/[hook]")
 	if(!hook_path)
 		log_world("ERROR: Invalid hook '/hook/[hook]' called.")
@@ -32,7 +32,7 @@
 	var/requester = new hook_path
 	var/status = 1
 	for(var/P in typesof("[hook_path]/proc"))
-		if(!call(requester, P)(arglist(args)))
+		if(!call(requester, P)(arglist(arguments)))
 			log_world("ERROR: Hook '[P]' failed or runtimed.")
 			status = 0
 

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -475,13 +475,13 @@
 	throw_speed = 4
 	throw_range = 20
 
-/obj/item/camera_bug/attack_self(mob/usr as mob)
+/obj/item/camera_bug/attack_self(mob/user as mob)
 	var/list/cameras = new/list()
 	for (var/obj/machinery/camera/C in GLOB.cameranet.cameras)
 		if (C.bugged && C.status)
 			cameras.Add(C)
 	if (length(cameras) == 0)
-		to_chat(usr, SPAN_WARNING("No bugged functioning cameras found."))
+		to_chat(user, SPAN_WARNING("No bugged functioning cameras found."))
 		return
 
 	var/list/friendly_cameras = new/list()
@@ -489,16 +489,16 @@
 	for (var/obj/machinery/camera/C in cameras)
 		friendly_cameras.Add(C.c_tag)
 
-	var/target = tgui_input_list(usr, "Select the camera to observe", "Camera Bug", friendly_cameras)
+	var/target = tgui_input_list(user, "Select the camera to observe", "Camera Bug", friendly_cameras)
 	if (!target)
 		return
 	for (var/obj/machinery/camera/C in cameras)
 		if (C.c_tag == target)
 			target = C
 			break
-	if (usr.stat == 2) return
+	if (user.stat == 2) return
 
-	usr.client.eye = target
+	user.client.eye = target
 
 /obj/item/pai_cable
 	desc = "A flexible coated cable with a universal jack on one end."

--- a/code/game/machinery/computer/slotmachine.dm
+++ b/code/game/machinery/computer/slotmachine.dm
@@ -324,14 +324,14 @@
 	money = max(0, money - amount)
 	balance += surplus
 
-/obj/machinery/computer/slot_machine/proc/give_payout(amount, usr)
+/obj/machinery/computer/slot_machine/proc/give_payout(amount, user)
 	if(paymode == CREDITCHIP)
 		cointype = /obj/item/spacecash
 	else
 		cointype = emagged ? /obj/item/coin/iron : /obj/item/coin/silver
 
 	if(!(emagged))
-		amount = dispense(amount, cointype, usr, 0)
+		amount = dispense(amount, cointype, user, 0)
 
 	else
 		var/mob/living/target = locate() in range(2, src)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -117,9 +117,9 @@
 		I.AddOverlays(over)
 	return I
 
-/obj/item/storage/backpack/AltClick(mob/usr)
-	if(attached_bag && ishuman(usr))
-		var/mob/living/carbon/human/H = usr
+/obj/item/storage/backpack/AltClick(mob/user)
+	if(attached_bag && ishuman(user))
+		var/mob/living/carbon/human/H = user
 		H.put_in_hands(attached_bag)
 		attached_bag = null
 		update_icon()

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -239,12 +239,12 @@
 				user.equip_to_slot_if_possible(src, slot_l_hand)
 		src.add_fingerprint(user)
 
-/obj/item/storage/AltClick(var/mob/usr)
+/obj/item/storage/AltClick(var/mob/user)
 	if(!canremove)
 		return ..()
-	if (!use_check_and_message(usr))
-		add_fingerprint(usr)
-		open(usr)
+	if (!use_check_and_message(user))
+		add_fingerprint(user)
+		open(user)
 		return TRUE
 	. = ..()
 

--- a/code/modules/ext_scripts/python.dm
+++ b/code/modules/ext_scripts/python.dm
@@ -1,9 +1,9 @@
-/proc/ext_python(var/script, var/args, var/scriptsprefix = 1)
+/proc/ext_python(var/script, var/arguments, var/scriptsprefix = 1)
 	if(scriptsprefix) script = "scripts/" + script
 
 	if(world.system_type == MS_WINDOWS)
 		script = replacetext(script, "/", "\\")
 
-	var/command = GLOB.config.python_path + " " + script + " " + args
+	var/command = GLOB.config.python_path + " " + script + " " + arguments
 
 	return shell(command)

--- a/code/modules/synthesized_instruments/real_instruments.dm
+++ b/code/modules/synthesized_instruments/real_instruments.dm
@@ -18,11 +18,11 @@
 	maximum_line_length = GLOB.musical_config.max_line_length
 	instruments = what //This can be a list, or it can also not be one
 
-/datum/real_instrument/proc/Topic_call(href, href_list, usr)
+/datum/real_instrument/proc/Topic_call(href, href_list, user)
 	var/target = href_list["target"]
 	var/value = text2num(href_list["value"])
 	if (href_list["value"] && !isnum(value))
-		to_chat(usr, "Non-numeric value was given")
+		to_chat(user, "Non-numeric value was given")
 		return 0
 
 
@@ -32,10 +32,10 @@
 			src.player.song.playing = value
 			if (src.player.song.playing)
 				GLOB.instrument_synchronizer.raise_event(player.actual_instrument)
-				src.player.song.play_song(usr)
+				src.player.song.play_song(user)
 		if ("wait")
 			if(value)
-				src.player.wait = WEAKREF(usr)
+				src.player.wait = WEAKREF(user)
 			else
 				src.player.wait = null
 		if ("newsong")
@@ -44,13 +44,13 @@
 		if ("import")
 			var/t = ""
 			do
-				t = html_encode(input(usr, "Please paste the entire song, formatted:", "[owner.name]", t)  as message)
-				if(!CanInteractWith(usr, owner, GLOB.physical_state))
+				t = html_encode(input(user, "Please paste the entire song, formatted:", "[owner.name]", t)  as message)
+				if(!CanInteractWith(user, owner, GLOB.physical_state))
 					return
 
 				if(length(t) >= 2*src.maximum_lines*src.maximum_line_length)
-					var/cont = input(usr, "Your message is too long! Would you like to continue editing it?", "", "yes") in list("yes", "no")
-					if(!CanInteractWith(usr, owner, GLOB.physical_state))
+					var/cont = input(user, "Your message is too long! Would you like to continue editing it?", "", "yes") in list("yes", "no")
+					if(!CanInteractWith(user, owner, GLOB.physical_state))
 						return
 					if(cont == "no")
 						break
@@ -66,24 +66,24 @@
 				else
 					src.player.song.tempo = src.player.song.sanitize_tempo(5) // default 120 BPM
 				if(src.player.song.lines.len > maximum_lines)
-					to_chat(usr,"Too many lines!")
+					to_chat(user,"Too many lines!")
 					src.player.song.lines.Cut(maximum_lines+1)
 				var/linenum = 1
 				for(var/l in src.player.song.lines)
 					if(length(l) > maximum_line_length)
-						to_chat(usr, "Line [linenum] too long!")
+						to_chat(user, "Line [linenum] too long!")
 						src.player.song.lines.Remove(l)
 					else
 						linenum++
 		if ("show_song_editor")
 			if (!src.song_editor)
 				src.song_editor = new (host = src.owner, song = src.player.song)
-			src.song_editor.ui_interact(usr)
+			src.song_editor.ui_interact(user)
 
 		if ("show_usage")
 			if (!src.usage_info)
 				src.usage_info = new (owner, src.player)
-			src.usage_info.ui_interact(usr)
+			src.usage_info.ui_interact(user)
 		if ("volume")
 			src.player.volume = min(max(min(player.volume+text2num(value), 100), 0), player.max_volume)
 		if ("transposition")
@@ -97,8 +97,8 @@
 		if ("sustain_timer")
 			src.player.song.sustain_timer = max(min(player.song.sustain_timer+value, GLOB.musical_config.longest_sustain_timer), 1)
 		if ("soft_coeff")
-			var/new_coeff = input(usr, "from [GLOB.musical_config.gentlest_drop] to [GLOB.musical_config.steepest_drop]") as num
-			if(!CanInteractWith(usr, owner, GLOB.physical_state))
+			var/new_coeff = input(user, "from [GLOB.musical_config.gentlest_drop] to [GLOB.musical_config.steepest_drop]") as num
+			if(!CanInteractWith(user, owner, GLOB.physical_state))
 				return
 			new_coeff = round(min(max(new_coeff, GLOB.musical_config.gentlest_drop), GLOB.musical_config.steepest_drop), 0.001)
 			src.player.song.soft_coeff = new_coeff
@@ -111,8 +111,8 @@
 				var/datum/instrument/instrument = as_list[key]
 				categories |= instrument.category
 
-			var/category = input(usr, "Choose a category") as null|anything in categories
-			if(!CanInteractWith(usr, owner, GLOB.physical_state))
+			var/category = input(user, "Choose a category") as null|anything in categories
+			if(!CanInteractWith(user, owner, GLOB.physical_state))
 				return
 			var/list/instruments_available = list()
 			for (var/key in as_list)
@@ -120,8 +120,8 @@
 				if (instrument.category == category)
 					instruments_available += key
 
-			var/new_instrument = input(usr, "Choose an instrument") as null|anything in instruments_available
-			if(!CanInteractWith(usr, owner, GLOB.physical_state))
+			var/new_instrument = input(user, "Choose an instrument") as null|anything in instruments_available
+			if(!CanInteractWith(user, owner, GLOB.physical_state))
 				return
 			if (new_instrument)
 				src.player.song.instrument_data = as_list[new_instrument]
@@ -132,14 +132,14 @@
 			if (GLOB.musical_config.env_settings_available)
 				if (!src.env_editor)
 					src.env_editor = new (src.player)
-				src.env_editor.ui_interact(usr)
+				src.env_editor.ui_interact(user)
 			else
-				to_chat(usr, "Virtual environment is disabled")
+				to_chat(user, "Virtual environment is disabled")
 
 		if ("show_echo_editor")
 			if (!src.echo_editor)
 				src.echo_editor = new (src.player)
-			src.echo_editor.ui_interact(usr)
+			src.echo_editor.ui_interact(user)
 
 		if ("select_env")
 			if (value in -1 to 26)


### PR DESCRIPTION
## About The Pull Request

OpenDream is adding `usr` and `args` to the `SoftReservedKeyword` pragma: https://github.com/OpenDreamProject/OpenDream/pull/2307

This PR renames `var/usr` to `var/user` and `var/args` to `var/arguments`.

## Why It's Good For The Game

This pragma is currently set as an error on Aurora, because using internal var names for declared var names is cringe.