### PR TITLE
Sec Subgrid fix

### DIFF
--- a/html/changelogs/Batrachophreno-PowernetFix.yml
+++ b/html/changelogs/Batrachophreno-PowernetFix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Batrachophreno
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "APCs in Security Deck 2 and 3 no longer populate in the Deck 2 Civilian Subgrid, now instead populating the Deck 2 and 3 Security Subgrid, as God intended (offending crosswire removed)."


### PR DESCRIPTION
A crosswire in the power grid from the Deck 2 Civ and Deck 2/3 Sec substations caused all the APCs in the latter to populate in the powernet of the former, making the Power Monitoring app very sad and confused. This PR removes that crosswire (located in D2 maints aft of Hydro and fore of HoS office).
![Screenshot 2025-06-14 184741](https://github.com/user-attachments/assets/13c0f709-f0dc-4f1a-9331-62aa3858122e)
![Screenshot 2025-06-14 184830](https://github.com/user-attachments/assets/f2d55e9b-bc28-4d80-b10b-b870353547b5)
