### PR TITLE
Tweaks Freebooter Salvager ship

### DIFF
--- a/html/changelogs/kano-dot-freebooter-salvager-oops.yml
+++ b/html/changelogs/kano-dot-freebooter-salvager-oops.yml
@@ -1,0 +1,6 @@
+author: Kano
+
+delete-after: True
+
+changes:
+  - rscadd: "Tweaks Freebooter Salvager ship to have insulated gloves for all species and an empty suit cycler, alongside with a few small tweaks."

--- a/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
+++ b/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
@@ -131,7 +131,7 @@
 	<br><br>
 	<h3>How does it work?</h3><hr>
 	<br><br>
-	This generator model has two circuits that receives the gas. As the gas flows, integrated turbine fans begin to spin and generate electricity. The principle behind this structure is
+	This generator model has two circuits that receives the gas. As the gas flows, integrated turbine fans begin to spin and generate electricity. The principle behind this is
 	that the greater the temperature difference between circuits, the faster the fans will spin and subsequently the more energy is produced. Each time the gas flows through circuits, temperature difference
 	(delta temperature) will decrease, this means in time the generator will produce less energy. The engine installed in your vessel has its hot loop in the port side, cold loop in
 	the starboard side. If confused, the loops can be identified by determining which one is the connected to the radiator array in vessel exterior.

--- a/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
+++ b/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
@@ -138,22 +138,22 @@
 	<br><br>
 	<h3>Hot Loop</h3><hr>
 	<br><br>
-	Following is the steps of setting hot flow successfully:
+	Following is the steps of setting the hot flow successfully:
 	<br><br>
-	- Locate the gas mixer device in aft-port side. Make sure it outputs the mixed gas to the west. Make sure oxidizer (oxygen) and fuel (hydrogen) is connected in relevant ports.
+	- Locate the gas mixer device in the aft-port side. Make sure it outputs the mixed gas to the west. Make sure that oxidizer (oxygen) and fuel (hydrogen) is connected to the relevant ports.
 	The target ratio should be 60% oxidizer and 40% fuel. Turn on the mixer. <br><br>
-	- Turn on the injection on the console (read the tag written on consoles to identify it) in front of combustion chamber. Make sure the fuel canister is spent and there's no residual burn mixture in
-	combustion chamber feed pipe. The recommended amount of fuels to inject is two canisters. Bear in mind the mixer will stop working if both inputs aren't receiving gas simultaneously. <br><br>
-	- After the injection is complete, turn off the injection on console. <b>Never start ignition sequence while injecting fuel into the chamber</b>. Hit the ignition button
+	- Turn on the injection on the console (read the tag written on the console to identify it) in front of the combustion chamber. Make sure the fuel canister is spent and there's no residual burn mixture in
+	the combustion chamber feed pipe. The recommended amount of fuels to inject is 2 canisters. Bear in mind the mixer will stop working if both inputs aren't receiving gas simultaneously. <br><br>
+	- After the injection is complete, turn off the injection on the console. <b>Never start ignition sequence while injecting fuel into the chamber</b>. Hit the ignition button
 	to start the combustion. <br><br>
-	- After making sure the burn reaction is complete, turn on the input in the console tagged 'Combustion Chamber Control' to maximum value and adjust the output rate to a value
-	compensating power draw. The higher output rate the more power produced, in contrast of sustainability.
+	- After making sure that the combustion has finished, turn on the input in the console tagged 'Combustion Chamber Control' to maximum value and adjust the output rate to a value
+	compensating power draw. The higher output rate the more power produced, at the cost of sustainability.
 	<br><br>
 	<h3>Cold Loop</h3><hr>
 	<br><br>
-	- Locate the pump tagged as 'Cold Loop Supply Pump' in starboard side of the TEG. Turn it on at maximum transfer rate. <br><br>
-	- (Optional) Add more gas to the cold loop by securing more canisters at the aft-starboard connectors. Do not overdo this. One or two more canisters is the ideal amount. <br><br>
-	- Turn on the pump leading directly to cold circuit, tagged as 'Cold Loop Flow Pump' and set the transfer rate to maxiumm.
+	- Locate the pump tagged as 'Cold Loop Supply Pump' in the starboard side of the TEG. Turn it on at maximum transfer rate. <br><br>
+	- (Optional) Add more gas to the cold loop by securing more canisters at the aft-starboard connectors. Do not overdo this. 1 or 2 more canisters is the ideal amount. <br><br>
+	- Turn on the pump leading directly to the cold circuit, tagged as 'Cold Loop Flow Pump' and set the transfer rate to maximum.
 	<br><br>
 	<h3>Things to Note</h3><hr>
 	<br><br>

--- a/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
+++ b/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
@@ -6,7 +6,6 @@
 	prefix = "ships/freebooter/freebooter_salvager/"
 	suffix = "freebooter_salvager.dmm"
 
-	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 	traits = list(
 		list(ZTRAIT_AWAY = TRUE, ZTRAIT_UP = TRUE, ZTRAIT_DOWN = FALSE),
 		list(ZTRAIT_AWAY = TRUE, ZTRAIT_UP = FALSE, ZTRAIT_DOWN = TRUE),

--- a/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
+++ b/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
@@ -133,8 +133,8 @@
 	<br><br>
 	This generator model has two circuits that receives the gas. As the gas flows, integrated turbine fans begin to spin and generate electricity. The principle behind this is
 	that the greater the temperature difference between circuits, the faster the fans will spin and subsequently the more energy is produced. Each time the gas flows through circuits, temperature difference
-	(delta temperature) will decrease, this means in time the generator will produce less energy. The engine installed in your vessel has its hot loop in the port side, cold loop in
-	the starboard side. If confused, the loops can be identified by determining which one is the connected to the radiator array in vessel exterior.
+	(delta temperature) will decrease, this means in time the generator will produce less energy. The engine installed in your vessel has its hot loop on the port side and cold loop on
+	the starboard side. If confused, the loops can be identified by determining which one is connected to the radiator array on your vessel's exterior.
 	<br><br>
 	<h3>Hot Loop</h3><hr>
 	<br><br>

--- a/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
+++ b/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
@@ -6,6 +6,7 @@
 	prefix = "ships/freebooter/freebooter_salvager/"
 	suffix = "freebooter_salvager.dmm"
 
+	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 	traits = list(
 		list(ZTRAIT_AWAY = TRUE, ZTRAIT_UP = TRUE, ZTRAIT_DOWN = FALSE),
 		list(ZTRAIT_AWAY = TRUE, ZTRAIT_UP = FALSE, ZTRAIT_DOWN = TRUE),
@@ -94,12 +95,14 @@
 	logging_home_tag = "freebooter_salvager_nav_hangar"
 	defer_initialisation = TRUE
 
+// shuttle airlock
 /obj/effect/map_effect/marker/airlock/shuttle/freebooter_salvager
 	name = "Freebooter Salvager Shuttle"
 	shuttle_tag = "Freebooter Salvager Shuttle"
 	master_tag = "airlock_freebooter_salvager_shuttle"
 	cycle_to_external_air = TRUE
 
+// docking airlock for shuttle
 /obj/effect/map_effect/marker/airlock/docking/freebooter_salvager/shuttle_hangar
 	name = "Shuttle Dock"
 	landmark_tag = "freebooter_salvager_nav_hangar"
@@ -125,25 +128,47 @@
 /obj/item/paper/fluff/freebooter_salvager/teg_manual
 	name = "crumpled TEG manual"
 	desc = "A bundle of paper with instructions on how to safely run a thermoelectric generator. Watermark of Einstein Engines suggests this manual likely was stolen along with the engine itself. It's missing some pages."
-	info = {"<hr><center><h2>Introduction</h2></center><hr>
+	info = {"<hr><center><h2>Quick Introduction</h2></center><hr>
 	<br><br>
-	Firstly, a burn mixture is required to produce sufficiently hot gas to run the hot loop. This can be achieved via an omni-mixer. Attach a fuel canister (typically hydrogen)
-	to one port, oxidizer (typically oxygen) to the other one. For an efficient burn reaction, universal value is 60% oxidizer and 40% fuel. Make sure correct ratio is set
-	in the omni-mixer's configuration section. Then activate the omni-mixer and route your burn mix to the combustion chamber, start the injection with control console.
-	Injected amount of canisters is up for discretion, advised amount for kickstarting the generator is two (2) fuels and two (2) oxidizers.
-	It is advised to increase transfer rate for faster results.
+	<h3>How does it work?</h3><hr>
 	<br><br>
-	While burn mix is in the process of injection, cold loop may be supplied. Any amount between two (2) to four (4) canisters would be sufficient. Higher heat capacity
-	is bound to give better results, standard being hydrogen. After making sure the canisters are secured on relevant ports, supply pump alongside with flow pump may be activated.
-	Check the tag written on the pumps of your setup to identify the function of the components.
+	This generator model has two circuits that receives the gas. As the gas flows, integrated turbine fans begin to spin and generate electricity. The principle behind this structure is
+	that the greater the temperature difference between circuits, the faster the fans will spin and subsequently the more energy is produced. Each time the gas flows through circuits, temperature difference
+	(delta temperature) will decrease, this means in time the generator will produce less energy. The engine installed in your vessel has its hot loop in the port side, cold loop in
+	the starboard side. If confused, the loops can be identified by determining which one is the connected to the radiator array in vessel exterior.
 	<br><br>
-	After burn mix injection is complete, the ignition may begin. Locate the button next to the combustion chamber and press the button. If it wasn't oversupplied, provided chamber
-	will be sufficient to endure the heat without melting down. In this state combustion chamber blast doors may be sealed, be careful not to press 'Emergency Chamber Vent'
-	button. After burn is compelte the hot gas may be injected to hot loop via 'Combustion Chamber Control' console. Adjusting the transfer rate regarding to power demand
-	would be advised. Higher output value will produce more energy in the cost of rather quickly decreased delta temperature, which means lower energy output.
+	<h3>Hot Loop</h3><hr>
+	<br><br>
+	Following is the steps of setting hot flow successfully:
+	<br><br>
+	- Locate the gas mixer device in aft-port side. Make sure it outputs the mixed gas to the west. Make sure oxidizer (oxygen) and fuel (hydrogen) is connected in relevant ports.
+	The target ratio should be 60% oxidizer and 40% fuel. Turn on the mixer. <br><br>
+	- Turn on the injection on the console (read the tag written on consoles to identify it) in front of combustion chamber. Make sure the fuel canister is spent and there's no residual burn mixture in
+	combustion chamber feed pipe. The recommended amount of fuels to inject is two canisters. Bear in mind the mixer will stop working if both inputs aren't receiving gas simultaneously. <br><br>
+	- After the injection is complete, turn off the injection on console. <b>Never start ignition sequence while injecting fuel into the chamber</b>. Hit the ignition button
+	to start the combustion. <br><br>
+	- After making sure the burn reaction is complete, turn on the input in the console tagged 'Combustion Chamber Control' to maximum value and adjust the output rate to a value
+	compensating power draw. The higher output rate the more power produced, in contrast of sustainability.
+	<br><br>
+	<h3>Cold Loop</h3><hr>
+	<br><br>
+	- Locate the pump tagged as 'Cold Loop Supply Pump' in starboard side of the TEG. Turn it on at maximum transfer rate. <br><br>
+	- (Optional) Add more gas to the cold loop by securing more canisters at the aft-starboard connectors. Do not overdo this. One or two more canisters is the ideal amount. <br><br>
+	- Turn on the pump leading directly to cold circuit, tagged as 'Cold Loop Flow Pump' and set the transfer rate to maxiumm.
+	<br><br>
+	<h3>Things to Note</h3><hr>
+	<br><br>
+	- If the combustion chamber cools below operational temperature, do <b>NOT</b> inject a new burn mixture until the chamber temperatures reaches below 400K. Otherwise the injected
+	burn mix will ignite immediately on contact, preventing safe injection of the remaining mix. If it has to be replaced hastily, press the 'Emergency Chanber Vent' button to release
+	combustion chamber contents. <br><br>
+	- Any modifications to the setup made by parties other than Einstein Engines Inc. and its affiliates will void the warranty.
 	<br><br>
 	For the emergency procedures, see the next page."}
 
 /obj/item/paper/fluff/freebooter_salvager/crew_note
-	name = "former crew's note"
-	info = "...and as inevitable it was, the number of installed thrusters isn't fully compatible with the vessel's structure. If you're planning to run all the engines at once, you better amplify the power input to the main grid or expect the lights to start flickering."
+	name = "stapled note"
+	layer = ABOVE_ABOVE_HUMAN_LAYER // otherwise this would appear under the console
+	info = {"...the number of installed thrusters isn't fully compatible with the vessel's structure. If you're planning to run all the engines at once, you better amplify
+	the power input to the main grid or expect the lights to start flickering.
+	<br><br>
+	Until we have a more robust solution, the nacelle thruster feed valves will remain closed."}

--- a/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
+++ b/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
@@ -158,7 +158,7 @@
 	<h3>Things to Note</h3><hr>
 	<br><br>
 	- If the combustion chamber cools below operational temperature, do <b>NOT</b> inject a new burn mixture until the chamber temperatures reaches below 400K. Otherwise the injected
-	burn mix will ignite immediately on contact, preventing safe injection of the remaining mix. If it has to be replaced hastily, press the 'Emergency Chanber Vent' button to release
+	burn mix will ignite immediately on contact, preventing safe injection of the remaining mix. If it has to be replaced hastily, press the 'Emergency Chamber Vent' button to release
 	combustion chamber contents. <br><br>
 	- Any modifications to the setup made by parties other than Einstein Engines Inc. and its affiliates will void the warranty.
 	<br><br>

--- a/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
+++ b/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
@@ -132,7 +132,7 @@
 	<h3>How does it work?</h3><hr>
 	<br><br>
 	This generator model has two circuits that receives the gas. As the gas flows, integrated turbine fans begin to spin and generate electricity. The principle behind this is
-	that the greater the temperature difference between circuits, the faster the fans will spin and subsequently the more energy is produced. Each time the gas flows through circuits, temperature difference
+	that the greater the temperature difference between circuits is, the faster the fans will spin and subsequently the more energy is produced. Each time the gas flows through the circuits, the temperature difference
 	(delta temperature) will decrease, this means in time the generator will produce less energy. The engine installed in your vessel has its hot loop on the port side and cold loop on
 	the starboard side. If confused, the loops can be identified by determining which one is connected to the radiator array on your vessel's exterior.
 	<br><br>

--- a/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dmm
+++ b/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dmm
@@ -663,6 +663,7 @@
 	req_one_access = null
 	},
 /obj/structure/dispenser/oxygen,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/afthallway)
 "cJ" = (
@@ -6446,7 +6447,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/engineering)
 "DU" = (

--- a/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dmm
+++ b/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dmm
@@ -154,6 +154,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/structure/table/rack/folding_table,
+/obj/item/paper/fluff/freebooter_salvager/teg_manual,
 /turf/simulated/floor,
 /area/ship/freebooter_salvager/engineering)
 "aM" = (
@@ -183,28 +185,31 @@
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
+/obj/item/device/flashlight/flare{
+	pixel_x = -9
+	},
+/obj/item/device/flashlight/flare{
+	pixel_x = -9
+	},
+/obj/item/device/flashlight/flare{
+	pixel_x = -9
+	},
+/obj/item/device/flashlight/flare{
+	pixel_x = -9
+	},
+/obj/item/device/flashlight/flare{
+	pixel_x = -9
+	},
+/obj/item/device/flashlight/flare{
+	pixel_x = -9
+	},
+/obj/effect/floor_decal/industrial/outline_door/operations{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline_door/operations{
+	dir = 1
+	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/spline/plain/beige{
-	dir = 5
-	},
-/obj/item/device/flashlight/flare{
-	pixel_x = -9
-	},
-/obj/item/device/flashlight/flare{
-	pixel_x = -9
-	},
-/obj/item/device/flashlight/flare{
-	pixel_x = -9
-	},
-/obj/item/device/flashlight/flare{
-	pixel_x = -9
-	},
-/obj/item/device/flashlight/flare{
-	pixel_x = -9
-	},
-/obj/item/device/flashlight/flare{
-	pixel_x = -9
-	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_salvager/armory)
 "aR" = (
@@ -433,10 +438,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/holding_cell)
 "bE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 1
-	},
-/obj/machinery/meter,
+/obj/effect/floor_decal/industrial/hatch_tiny/yellow,
+/obj/machinery/atmospherics/valve,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_salvager/crew_quarters)
 "bH" = (
@@ -560,6 +563,9 @@
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/outline_door/operations{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/afthallway)
 "cp" = (
@@ -656,6 +662,7 @@
 /obj/machinery/alarm/north{
 	req_one_access = null
 	},
+/obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/afthallway)
 "cJ" = (
@@ -1032,7 +1039,6 @@
 /area/ship/freebooter_salvager/captains_quarters)
 "eH" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/floor_decal/industrial/hatch_tiny/operations,
 /obj/machinery/computer/shuttle_control/multi/lift/freebooter_salvager{
 	pixel_y = 9
 	},
@@ -1063,10 +1069,6 @@
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/einstein/alt{
 	pixel_x = 7
-	},
-/obj/item/paper/fluff/freebooter_salvager/crew_note{
-	pixel_y = -4;
-	pixel_x = -6
 	},
 /turf/simulated/floor/tiled/gunmetal,
 /area/ship/freebooter_salvager/bridge)
@@ -1481,6 +1483,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/paper/fluff/freebooter_salvager/crew_note,
 /turf/simulated/floor/tiled/gunmetal,
 /area/ship/freebooter_salvager/bridge)
 "gQ" = (
@@ -1655,8 +1658,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/forehallway)
 "hX" = (
-/obj/effect/floor_decal/corner/yellow,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/outline_door/operations,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/mining)
 "ia" = (
@@ -1725,11 +1727,10 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/ore_extraction)
 "iq" = (
-/obj/structure/bed/stool/chair/folding,
-/obj/machinery/atmospherics/valve/open{
-	name = "Thrust Supply Valve"
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/hatch_tiny/yellow,
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/crew_quarters)
 "it" = (
@@ -1848,16 +1849,11 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/medbay)
 "iR" = (
-/obj/structure/table/rack,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/tank/jetpack/oxygen,
 /obj/effect/floor_decal/corner/dark_blue/full{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/suit_cycler/offship,
 /turf/simulated/floor/tiled/gridded,
 /area/ship/freebooter_salvager/armory)
 "iS" = (
@@ -1911,9 +1907,11 @@
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/ship/freebooter_salvager/engineering)
 "jh" = (
-/obj/effect/floor_decal/corner/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline_door/operations{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/mining)
@@ -2118,9 +2116,6 @@
 /obj/item/device/gps{
 	pixel_x = 9
 	},
-/obj/effect/floor_decal/spline/plain/beige{
-	dir = 1
-	},
 /obj/item/clothing/head/helmet/riot{
 	pixel_y = -3;
 	pixel_x = -7
@@ -2144,6 +2139,9 @@
 /obj/item/clothing/glasses/sunglasses/aviator{
 	pixel_y = 9;
 	pixel_x = -6
+	},
+/obj/effect/floor_decal/industrial/outline_door/operations{
+	dir = 1
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_salvager/armory)
@@ -2415,6 +2413,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/outline_door/operations,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/forehallway)
 "ll" = (
@@ -3649,8 +3648,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/engineering)
 "qR" = (
-/obj/effect/floor_decal/spline/plain/beige,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3692,6 +3689,7 @@
 	pixel_x = -3;
 	pixel_y = 8
 	},
+/obj/effect/floor_decal/industrial/outline_door/operations,
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_salvager/armory)
 "qT" = (
@@ -3763,7 +3761,6 @@
 /area/ship/freebooter_salvager/toilets)
 "rl" = (
 /obj/effect/floor_decal/corner/dark_blue,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/remote/blast_door{
 	pixel_y = -21;
 	pixel_x = -3;
@@ -3893,7 +3890,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor,
 /area/ship/freebooter_salvager/atmospherics)
 "rH" = (
@@ -4113,10 +4109,20 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/gym)
 "sH" = (
-/obj/effect/floor_decal/spline/plain/beige{
-	dir = 9
+/obj/structure/table/rack,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/effect/floor_decal/industrial/outline_door/operations{
+	dir = 8
 	},
-/obj/structure/dispenser/oxygen,
+/obj/effect/floor_decal/industrial/outline_door/operations{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_salvager/armory)
 "sI" = (
@@ -4314,6 +4320,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/gridded,
 /area/ship/freebooter_salvager/armory)
 "tM" = (
@@ -4458,6 +4465,13 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 4
 	},
+/obj/structure/closet/walllocker{
+	pixel_y = 32;
+	name = "Gloves"
+	},
+/obj/item/clothing/gloves/yellow,
+/obj/item/clothing/gloves/yellow/specialt,
+/obj/item/clothing/gloves/yellow/specialu,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/engineering)
 "uj" = (
@@ -4611,10 +4625,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/atmospherics)
 "uZ" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/map_effect/perma_light/starlight/wide,
-/turf/space,
-/area/ship/freebooter_salvager/exterior)
+/obj/effect/floor_decal/industrial/outline_door/operations{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_salvager/mining)
 "vc" = (
 /obj/machinery/light/colored/dying{
 	dir = 4
@@ -4830,6 +4845,7 @@
 	req_access = null
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/gridded,
 /area/ship/freebooter_salvager/armory)
 "wh" = (
@@ -5085,7 +5101,10 @@
 /turf/simulated/floor/tiled/dark/full/airless,
 /area/shuttle/freebooter_salvager)
 "xD" = (
-/obj/item/reagent_containers/glass/bucket/wood,
+/obj/item/reagent_containers/glass/bucket/wood{
+	pixel_y = 10;
+	pixel_x = 7
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -5235,12 +5254,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/holding_cell)
 "yd" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline_door/operations{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/mining)
@@ -5345,7 +5363,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor,
 /area/ship/freebooter_salvager/atmospherics)
 "yr" = (
@@ -5382,13 +5399,11 @@
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_salvager/gym)
 "yz" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/mapped{
+/obj/effect/floor_decal/industrial/outline_door/operations{
 	dir = 4
 	},
-/obj/effect/map_effect/perma_light/starlight/wide,
-/turf/space,
-/area/ship/freebooter_salvager/exterior)
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_salvager/mining)
 "yC" = (
 /obj/effect/shuttle_landmark/freebooter_salvager/port{
 	dir = 8
@@ -6242,6 +6257,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/outline_door/operations,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/forehallway)
 "CU" = (
@@ -6430,6 +6446,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/engineering)
 "DU" = (
@@ -6536,14 +6553,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/warehouse)
 "Ep" = (
-/obj/effect/floor_decal/spline/plain/beige{
-	dir = 10
-	},
 /obj/structure/bed/stool/padded{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline_door/operations,
+/obj/effect/floor_decal/industrial/outline_door/operations{
+	dir = 8
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_salvager/armory)
@@ -7031,6 +7049,8 @@
 /area/ship/freebooter_salvager/mining)
 "GD" = (
 /obj/effect/decal/cleanable/confetti,
+/obj/structure/closet,
+/obj/random/loot,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/crew_quarters)
 "GE" = (
@@ -7144,13 +7164,11 @@
 /area/ship/freebooter_salvager/mining)
 "Hi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/valve/open{
-	name = "Thrust Supply Valve"
-	},
 /obj/effect/floor_decal/industrial/hatch_tiny/yellow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/valve,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/atmospherics)
 "Hk" = (
@@ -7204,6 +7222,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/paper/fluff/freebooter_salvager/crew_note,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/engineering)
 "Hx" = (
@@ -7416,13 +7435,10 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_salvager/engineering)
 "Ij" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/effect/map_effect/perma_light/starlight/wide,
-/turf/space,
-/area/ship/freebooter_salvager/exterior)
+/obj/effect/floor_decal/industrial/outline_door/operations,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/gridded,
+/area/ship/freebooter_salvager/armory)
 "Il" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics";
@@ -8415,7 +8431,7 @@
 /area/ship/freebooter_salvager/toilets)
 "MS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash,
+/obj/structure/bed/stool/chair/folding,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/crew_quarters)
 "MW" = (
@@ -9140,10 +9156,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/afthallway)
 "PZ" = (
-/obj/effect/floor_decal/corner/yellow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/industrial/outline_door/operations,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/mining)
 "Qa" = (
@@ -9710,9 +9726,6 @@
 /area/ship/freebooter_salvager/kitchen)
 "SF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/stool/padded{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/crew_quarters)
 "SK" = (
@@ -9838,8 +9851,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/afthallway)
 "Tp" = (
-/obj/structure/bed/stool/chair/folding{
-	dir = 8
+/obj/structure/table/rack/folding_table,
+/obj/item/reagent_containers/inhaler/space_drugs,
+/obj/item/reagent_containers/syringe/drugs{
+	pixel_y = 7;
+	pixel_x = -6
 	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_salvager/crew_quarters)
@@ -10161,6 +10177,12 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/freebooter_salvager/exterior)
+"UN" = (
+/obj/effect/floor_decal/industrial/outline_door/operations{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_salvager/afthallway)
 "UW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 5
@@ -10174,14 +10196,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/crew_quarters)
 "Va" = (
-/obj/effect/floor_decal/spline/plain/beige{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/industrial/outline_door/operations,
+/obj/effect/floor_decal/industrial/outline_door/operations{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_salvager/armory)
@@ -10349,7 +10372,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/black{
 	dir = 4
 	},
-/obj/item/paper/fluff/freebooter_salvager/teg_manual,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/ship/freebooter_salvager/engineering)
@@ -10409,14 +10431,11 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_salvager/mining)
 "VX" = (
-/obj/structure/table/rack/folding_table,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 1
 	},
-/obj/item/reagent_containers/inhaler/space_drugs,
-/obj/item/reagent_containers/syringe/drugs{
-	pixel_y = 7;
-	pixel_x = -6
+/obj/structure/bed/stool/padded{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/crew_quarters)
@@ -10596,8 +10615,9 @@
 /area/ship/freebooter_salvager/atmospherics)
 "Xf" = (
 /obj/effect/decal/cleanable/cobweb2,
-/obj/structure/closet,
-/obj/random/loot,
+/obj/structure/bed/stool/chair/folding{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_salvager/crew_quarters)
 "Xg" = (
@@ -10625,9 +10645,6 @@
 /turf/simulated/floor,
 /area/ship/freebooter_salvager/atmospherics)
 "Xn" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet/north,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_salvager/afthallway)
@@ -10832,6 +10849,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/gridded,
 /area/ship/freebooter_salvager/armory)
 "Yu" = (
@@ -39263,13 +39281,7 @@ QM
 QM
 QM
 dd
-Ij
 Tl
-Tl
-Tl
-fM
-fM
-uZ
 Tl
 Tl
 Tl
@@ -39278,7 +39290,13 @@ fM
 fM
 Tl
 Tl
-uZ
+Tl
+fM
+fM
+fM
+Tl
+Tl
+fM
 fM
 Tl
 Tl
@@ -39287,7 +39305,7 @@ fM
 fM
 Tl
 Tl
-Ij
+Tl
 Tl
 QM
 QM
@@ -40821,7 +40839,7 @@ Al
 Bw
 mL
 yd
-zQ
+uZ
 mD
 MZ
 MZ
@@ -43391,7 +43409,7 @@ TK
 Kb
 ZY
 jh
-hX
+yz
 Tb
 wK
 Fv
@@ -44917,13 +44935,7 @@ QM
 QM
 QM
 us
-yz
 us
-us
-us
-fM
-fM
-uZ
 us
 us
 us
@@ -44932,7 +44944,13 @@ fM
 fM
 us
 us
-uZ
+us
+fM
+fM
+fM
+us
+us
+fM
 fM
 us
 us
@@ -44941,7 +44959,7 @@ fM
 fM
 us
 us
-yz
+us
 us
 QM
 QM
@@ -105572,9 +105590,9 @@ Zm
 QC
 Np
 gy
-gy
-Ys
 Qu
+Ys
+Ij
 iv
 co
 oj
@@ -105831,9 +105849,9 @@ dt
 Qu
 sH
 Ep
-gy
+Ij
 Fj
-Lk
+UN
 Gx
 Tm
 wo
@@ -106342,7 +106360,7 @@ ug
 Tr
 QC
 dt
-gy
+Qu
 aP
 Va
 wg


### PR DESCRIPTION
## About PR

Adds:
- Insulated gloves for tajara and unathi.
- Empty suit cycler for non-human species.

Tweaks:
- TEG manual to be concise and easier to follow. Reformatted to be less hurtful to the eye.
- Nacelle thruster feed valves to be off at round start. Making it harder to create a powersink while traversing space.
- crew_note to mention about nacelle valves being off. Also moving it on top of the engine consoles.
- Replaced some decals with its fancier counterparts!