### PR TITLE
Links the SM chamber airlocks to the button in CE's office

### DIFF
--- a/html/changelogs/kano-dot-door-unstuckening.yml
+++ b/html/changelogs/kano-dot-door-unstuckening.yml
@@ -1,0 +1,6 @@
+author: Kano
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes the SM chamber airlocks not being linked to the button in CE office. Moves SM ejection button to somewhere more visible."


### PR DESCRIPTION
## About PR

Alongside the title, moves the ejection button near to rest of the SM related buttons, which is actually more visible.
