### PR TITLE
Adds Radiation Collector Arrays to the Operations order list.

### DIFF
--- a/code/modules/cargo/items/engineering.dm
+++ b/code/modules/cargo/items/engineering.dm
@@ -882,4 +882,16 @@
 	groupable = TRUE
 	spawn_amount = 1
 
-
+/singleton/cargo_item/rad_collector
+	category = "engineering"
+	name = "radiation collector array"
+	supplier = "hephaestus"
+	description = "A radiation collector array. Used to augment the power generation of a generator that emits ionising radiation."
+	price = 2000
+	items = list(
+		/obj/machinery/power/rad_collector
+	)
+	access = ACCESS_ENGINE
+	container_type = "crate"
+	groupable = FALSE
+	spawn_amount = 1

--- a/html/changelogs/kermit-operations-radcollectors.yml
+++ b/html/changelogs/kermit-operations-radcollectors.yml
@@ -1,0 +1,6 @@
+author: kermit
+
+delete-after: True
+
+changes:
+  - rscadd: "Added Radiation Collector Arrays to the Operations order list."


### PR DESCRIPTION
Adds Radiation Collector Arrays to the Operations order list.

For only 2,000 BSC (compared to 7,500 BSC for a TEG) considering it only buffs a pre-existing reactor and has limited applications on its own.