### PR TITLE
Generic Augment Customization

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/augments.dm
+++ b/code/modules/client/preference_setup/loadout/items/augments.dm
@@ -14,6 +14,7 @@
 	path = /obj/item/organ/internal/augment/eye_sensors
 	cost = 1
 	whitelisted = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI, SPECIES_UNATHI, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_ATTENDANT)
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/eye_sensors/New()
 	..()
@@ -27,6 +28,7 @@
 	description = "A hair augment that allows the user to change the shape and color of their hair."
 	path = /obj/item/organ/internal/augment/cyber_hair
 	whitelisted = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI, SPECIES_IPC_SHELL)
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/synthetic_cords
 	display_name = "synthetic vocal cords selection"
@@ -34,6 +36,7 @@
 	path = /obj/item/organ/internal/augment/synthetic_cords
 	whitelisted = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_ATTENDANT, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER, SPECIES_UNATHI)
 	cost = 1
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/synthetic_cords/New()
 	..()
@@ -47,6 +50,7 @@
 	description = "An augment that allows the user to deploy a robotic combitool."
 	path = /obj/item/organ/internal/augment/tool/combitool
 	cost = 5
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/combitool/New()
 	..()
@@ -60,6 +64,7 @@
 	description = "An augment that allows the user to project a lighter out of their fingertip."
 	path = /obj/item/organ/internal/augment/tool/combitool/lighter
 	cost = 2
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/lighter/New()
 	..()
@@ -73,6 +78,7 @@
 	description = "An augment that allows the user to deploy a retractable pen."
 	path = /obj/item/organ/internal/augment/tool/pen
 	cost = 1
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/pen/New()
 	..()
@@ -86,6 +92,7 @@
 	description = "An augment that allows the user to deploy a retractable crayon."
 	path = /obj/item/organ/internal/augment/tool/crayon
 	cost = 1
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/crayon/New()
 	..()
@@ -100,6 +107,7 @@
 	path = /obj/item/organ/internal/augment/cochlear
 	whitelisted = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_ATTENDANT, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER, SPECIES_UNATHI)
 	cost = 1
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/analyzer
 	display_name = "retractable cyborg analyzer"
@@ -107,6 +115,7 @@
 	path = /obj/item/organ/internal/augment/tool/cyborg_analyzer
 	allowed_roles = list("Machinist", "Operations Personnel")
 	cost = 3
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/analyzer/New()
 	..()
@@ -120,6 +129,7 @@
 	description = "An augment that allows the user scan their own health condition."
 	path = /obj/item/organ/internal/augment/health_scanner
 	cost = 3
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/suspension
 	display_name = "calf suspension"
@@ -127,12 +137,14 @@
 	path = /obj/item/organ/internal/augment/suspension
 	cost = 4
 	whitelisted = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA_ZHAN, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_IPC, SPECIES_IPC_XION, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL, SPECIES_VAURCA_WORKER, SPECIES_UNATHI)
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/taste_boosters
 	display_name = "taste booster selection"
 	description = "A selection of augments that modify the user's taste sensitivity."
 	path = /obj/item/organ/internal/augment/taste_booster
 	whitelisted = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_ATTENDANT, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER, SPECIES_UNATHI)
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/taste_boosters/New()
 	..()
@@ -146,12 +158,14 @@
 	description = "An augment that allows the user to synthetize welding fuel into nutrients."
 	path = /obj/item/organ/internal/augment/fuel_cell
 	cost = 2
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/psiaug
 	display_name = "psionic receiver"
 	description = "An augment installed into the head that functions as a surrogate for a missing zona bovinae, also functioning as a filter for the psionically-challenged."
 	path = /obj/item/organ/internal/augment/psi
 	whitelisted = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI, SPECIES_UNATHI, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_ATTENDANT, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER, SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL)
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/memory_inhibitor
 	display_name = "memory inhibitor"
@@ -206,6 +220,7 @@
 	display_name = "retractable corrective lenses"
 	description = "A set of corrective lenses that can be deployed & retracted."
 	path = /obj/item/organ/internal/augment/tool/correctivelens
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/glare_dampeners
 	display_name = "retractable glare dampeners"
@@ -213,6 +228,7 @@
 	path = /obj/item/organ/internal/augment/tool/correctivelens/glare_dampener
 	allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician", "Engineering Apprentice", "Machinist", "Engineering Personnel", "Operations Personnel")
 	cost = 2
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/drill
 	display_name = "integrated drill"
@@ -221,6 +237,7 @@
 	whitelisted = list(SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_WORKER)
 	allowed_roles = list("Shaft Miner", "Operations Personnel")
 	cost = 5
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/augment/head_fluff
 	display_name = "custom head augmentation"

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -82,7 +82,7 @@
 			var/organ_found
 			if(length(H.internal_organs))
 				for(var/obj/item/organ/external/E in H.organs)
-					if(!(E.status & ORGAN_ROBOT))
+					if(!(E.status & (ORGAN_ROBOT | ORGAN_ASSISTED)))
 						continue
 					organ_found = TRUE
 					to_chat(user, "[E.name]: <span class='warning'>[E.brute_dam]</span> <font color='#FFA500'>[E.burn_dam]</font>")
@@ -97,12 +97,13 @@
 				if(head?.open == 3) // Hatch open
 					show_tag = TRUE
 				for(var/obj/item/organ/O in H.internal_organs)
-					if(!(O.status & ORGAN_ROBOT))
+					if(!(O.status & (ORGAN_ROBOT | ORGAN_ASSISTED)))
 						continue
 					if(!show_tag && istype(O, /obj/item/organ/internal/ipc_tag))
 						continue
 					organ_found = TRUE
 					to_chat(user, "[O.name]: <span class='warning'>[O.damage]</span>")
+					to_chat(user, "<i>[O.description]</i>")
 			if(!organ_found)
 				to_chat(user, SPAN_NOTICE("No prosthetics located."))
 

--- a/html/changelogs/VMSolidus-generic-augment-customization.yml
+++ b/html/changelogs/VMSolidus-generic-augment-customization.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: VMSolidus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added the option to give custom names and descriptions to most generic(non-corporate) augments in loadouts."
+  - rscadd: "Descriptions for augments will now appear in cyborg analyzer scans. Assisted organs will also show up there as well."


### PR DESCRIPTION
This PR makes small adjustments to the code for the cyborg analyzer tool, making it so that it also provides the description given for augments taken as part of a character's loadout. Additionally, this sets loadout flags for most generic augments (anything not explicitly tied to a specific corporation) to allow for custom names and descriptions. 

Lastly, I've extended the analyzer in its human-mode to also display assisted implants. While I can't imagine a machinist would have much to do with a pacemaker, it is a metal implant. I actually mainly had in mind that I was annoyed with the positronic brain implant not showing up on cyborg analyzers, and wanted to correct the injustice. 