### PR TITLE
Rename a proc arg from `args` to `arguments`

### DIFF
--- a/code/datums/uplink/announcements.dm
+++ b/code/datums/uplink/announcements.dm
@@ -25,8 +25,8 @@
 		return
 	return list("title" = strip_html_readd_newlines(title), "message" = strip_html_readd_newlines(message))
 
-/datum/uplink_item/abstract/announcements/fake_centcom/get_goods(var/obj/item/device/uplink/U, var/loc, var/mob/user, var/list/args)
-	command_announcement.Announce(args["message"], args["title"], do_newscast=1, do_print=1, msg_sanitized=TRUE)
+/datum/uplink_item/abstract/announcements/fake_centcom/get_goods(var/obj/item/device/uplink/U, var/loc, var/mob/user, var/list/arguments)
+	command_announcement.Announce(arguments["message"], arguments["title"], do_newscast=1, do_print=1, msg_sanitized=TRUE)
 	return TRUE
 
 /datum/uplink_item/abstract/announcements/fake_crew_arrival


### PR DESCRIPTION
ike missed one, smdh

don't use reserved keywords as var names lol