### PR TITLE
Nerfs stinger grenades by about 50%

### DIFF
--- a/code/game/objects/items/weapons/grenades/stinger.dm
+++ b/code/game/objects/items/weapons/grenades/stinger.dm
@@ -1,7 +1,7 @@
 ///Stinger grenade projectile
 /obj/projectile/bullet/rubberball/stinger_ball
 	damage = 2
-	agony = 50
+	agony = 25
 	armor_penetration = 10
 	range_step = 2
 	embed = FALSE
@@ -17,7 +17,7 @@
 	desc = "A stinger grenade, designed to explode and expel rubber balls over an area for less-lethal takedowns. Popular with many law enforcement agencies."
 	icon_state = "stinger"
 
-	var/num_fragments = 100  ///total number of balls produced by the grenade
+	var/num_fragments = 50  ///total number of balls produced by the grenade
 	var/fragment_damage = 2
 	var/damage_step = 3      //projectiles lose a fragment each time they travel this distance. Can be a non-integer.
 	var/explosion_size = 1   ///size of the center explosion

--- a/html/changelogs/flaminglily-stingernerf.yml
+++ b/html/changelogs/flaminglily-stingernerf.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FlamingLily
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Nerfs stinger grenades. Reduces projectile count and pain per projectile by half (now 50 and 25 respectively)"


### PR DESCRIPTION
Stingers are, in my opinion, one of if not the single most lethal grenade type in our codebase.
They are a LTL option.
Considering they're also standard armoury equiment, I think it's fair to bring them down a little. Hopefully they'll see more use.