### PR TITLE
Appends the cans in a yoke to its name

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks/yoke.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/yoke.dm
@@ -36,6 +36,32 @@
 		can.pixel_y = positions[2]
 		underlays += can
 
+	// Calling this here so the appended names change when cans are removed from the yoke.
+	append_cans()
+
+/// We use this to append the names of the cans in a yoke to its name, for QoL.
+/obj/item/storage/box/fancy/yoke/proc/append_cans()
+	// Return early and use the initial name if there's no cans, so we don't have stray brackets.
+	if(!length(cans))
+		name = initial(name)
+		return
+
+	// Names of cans in the yoke that we are selecting to append to the name. No names in this should repeat.
+	var/list/taken_names = list()
+
+	for(var/obj/can in cans)
+		taken_names |= can.name
+
+	// We end this at the third item, so at maximum two items in the yoke will be in the name.
+	var/can_name_string = initial(name) + " (" + jointext(taken_names, ", ", 1, 3)
+
+	if(length(taken_names) > 2)
+		can_name_string += ", ...)"
+	else
+		can_name_string += ")"
+
+	name = can_name_string
+
 /obj/item/storage/box/fancy/yoke/mouse_drop_dragged(atom/over, mob/user, src_location, over_location, params)
 	var/mob/mob_dropped_over = over
 	if(use_check_and_message(mob_dropped_over))
@@ -193,8 +219,7 @@
 /obj/item/storage/box/fancy/yoke/threetowns
 	starts_with = list(/obj/item/reagent_containers/food/drinks/cans/threetowns = 6)
 
-// energy drinks
-
+// Energy drinks
 /obj/item/storage/box/fancy/yoke/energy
 	icon_state = "yoke_energy" //energy drinks are 2 pixels taller
 

--- a/html/changelogs/hazelmouse-yokewars.yml
+++ b/html/changelogs/hazelmouse-yokewars.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Yokes now have their contents appended to their name, allowing them to be more easily sorted in stacks. If a yoke contains more than one kind of drink, only the first two are appended."


### PR DESCRIPTION
As title, up to two cans inside a yoke are automatically appended to its name. This is capped at two so the name doesn't get relaly long. This updates if cans are removed from the yoke.

Currently there is no way to tell what is in a yoke without seeing its icon, which is troublesome for bartenders who have stacks of the things. This is intended to alleviate that issue.