### PR TITLE
Horizon Tweaks and Fixes

### DIFF
--- a/html/changelogs/SleepyGemmy-map_tweaks.yml
+++ b/html/changelogs/SleepyGemmy-map_tweaks.yml
@@ -12,4 +12,4 @@ changes:
   - rscadd: "Added an account console to the captain office."
   - rscadd: "Added an ATM to the bridge hallway."
   - rscadd: "Fixed a turf in the engineering hard storage not being the correct type."
-  - rsacadd: "Fixed the crusher disposal placing items on top of the crusher pistons."
+  - rscadd: "Fixed the crusher disposal placing items on top of the crusher pistons."

--- a/html/changelogs/SleepyGemmy-map_tweaks.yml
+++ b/html/changelogs/SleepyGemmy-map_tweaks.yml
@@ -1,0 +1,15 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - rscdel: "Removed a duplicate candle in the chapel."
+  - bugfix: "Fixed a lightswitch that had the wrong direction set in the auxiliary custodial closet."
+  - bugfix: "Fixed some doors having the wrong access set in research."
+  - bugfix: "Added a missing emergency closet decal in research."
+  - rscadd: "Added a charger and some minor furnishing to the RD office's empty corner."
+  - rscadd: "Added a camera to the security equipment room."
+  - rscadd: "Added an account console to the captain office."
+  - rscadd: "Added an ATM to the bridge hallway."
+  - rscadd: "Fixed a turf in the engineering hard storage not being the correct type."
+  - rsacadd: "Fixed the crusher disposal placing items on top of the crusher pistons."


### PR DESCRIPTION
this PR does some tweaks and fixes to the Horizon. please see the changelog below for all changes.
```
changes:
  - rscdel: "Removed a duplicate candle in the chapel."
  - bugfix: "Fixed a lightswitch that had the wrong direction set in the auxiliary custodial closet."
  - bugfix: "Fixed some doors having the wrong access set in research."
  - bugfix: "Added a missing emergency closet decal in research."
  - rscadd: "Added a charger and some minor furnishing to the RD office's empty corner."
  - rscadd: "Added a camera to the security equipment room."
  - rscadd: "Added an account console to the captain office."
  - rscadd: "Added an ATM to the bridge hallway."
  - rscadd: "Fixed a turf in the engineering hard storage not being the correct type."
  - rscadd: "Fixed the crusher disposal placing items on top of the crusher pistons."
```