### PR TITLE
Auto-Tech Processing

### DIFF
--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -16,6 +16,8 @@
 
 	var/list/linked_processors
 
+	var/local_processing_stage = 0
+
 	component_types = list(
 		/obj/item/circuitboard/rdserver,
 		/obj/item/stock_parts/scanning_module,
@@ -93,6 +95,16 @@
 				if(T.level)
 					files.UpdateTech(T.id, round(TP.tech_rate))
 			TP.processing_stage = 0
+
+	// Server automatically generates its own research, slowly.
+	local_processing_stage++
+	if(local_processing_stage == 5)
+		for(var/tech_id in files.known_tech)
+			var/datum/tech/T = files.known_tech[tech_id]
+			// Tech processing speed cannot be upgraded.
+			if(T.level)
+				files.UpdateTech(T.id, 5)
+		local_processing_stage = 0
 
 /obj/machinery/r_n_d/server/emp_act(severity)
 	. = ..()

--- a/html/changelogs/Batrachophreno-TechAutoProcessing.yml
+++ b/html/changelogs/Batrachophreno-TechAutoProcessing.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Batrachophreno
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Research servers will slowly generate research points over the course of a round by themselves, like a single Tech Processor that cannot be upgraded."


### PR DESCRIPTION
Makes it so the Research Server will slowly auto-generate research points as though it had a single tech processor linked, except the speed cannot be upgraded.

No need to bring up the issue of who is allowed to build tech processors; if it's a standard 2hr round, then Machine Shop gets a small handful of extra gadgets, which lends itself to the rest of the pop. If it's a longer round, they get a bit more.

And in both cases, Science isn't completely obsoleted because at the slow rate the server autogenerates research points, Science would still be needed to reach the highest tech levels, ensuring they remain valued when one joins and mercifully builds a couple tech processors. Until Science gets its insane rework, it doesn't make much sense to me to strip the server of a ton of its research-gated content.