### PR TITLE
Expands hydroponics temperature/light mechanics

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -3819,6 +3819,7 @@
 #include "code\unit_tests\equipment_tests.dm"
 #include "code\unit_tests\foundation_tests.dm"
 #include "code\unit_tests\gamemode_tests.dm"
+#include "code\unit_tests\hydroponics_tests.dm"
 #include "code\unit_tests\icon_tests.dm"
 #include "code\unit_tests\language_test.dm"
 #include "code\unit_tests\loadout_tests.dm"

--- a/code/__DEFINES/hydroponics.dm
+++ b/code/__DEFINES/hydroponics.dm
@@ -66,6 +66,21 @@
 #define TRAIT_PARASITE             16
 /// Can cause damage/inject reagents when thrown or handled.
 #define TRAIT_STINGS               17
+/// The temperature from which the heat tolerance is calculated.
+/// At this temperature, plus or minus the heat tolerance, is where the plant can grow without dying.
+#define TRAIT_IDEAL_HEAT           18
+/// The departure from ideal light that is survivable. If the departure goes above this value, damage will be dealt.
+/// Has nothing to do with growth speed, only when the plant will begin taking damage!
+#define TRAIT_HEAT_TOLERANCE       19
+/// The temperature from which the light tolerance is calculated.
+#define TRAIT_IDEAL_LIGHT          20
+/// The departure from ideal light that is survivable. If the departure goes above this value, damage will be dealt.
+/// Has nothing to do with growth speed, only when the plant will begin taking damage!
+#define TRAIT_LIGHT_TOLERANCE      21
+/// Low pressure capacity. Below this value in kPa, the plant begins taking damage.
+#define TRAIT_LOWKPA_TOLERANCE     22
+/// High pressure capacity. Above this value in kPa, the plant begins taking damage.
+#define TRAIT_HIGHKPA_TOLERANCE    23
 /// When thrown, acts as a grenade.
 #define TRAIT_EXPLOSIVE            24
 /// Resistance to poison.
@@ -104,28 +119,10 @@
 /// 0 = normal plant, 1 = big tree
 #define TRAIT_LARGE                42
 /// The color of the leaves, if the plant has any.
-#define TRAIT_LEAVES_COLOUR		   43
-
-/* --- ### TOLERANCE-RELATED TRAITS ### --- */
-
-/// The temperature from which the heat tolerance is calculated.
-/// At this temperature, plus or minus the heat tolerance, is where the plant can grow without dying.
-#define TRAIT_IDEAL_HEAT           18
-/// The departure from ideal light that is survivable. If the departure goes above this value, damage will be dealt.
-/// Has nothing to do with growth speed, only when the plant will begin taking damage!
-#define TRAIT_HEAT_TOLERANCE       19
-/// The temperature from which the light tolerance is calculated.
-#define TRAIT_IDEAL_LIGHT          20
-/// The departure from ideal light that is survivable. If the departure goes above this value, damage will be dealt.
-/// Has nothing to do with growth speed, only when the plant will begin taking damage!
-#define TRAIT_LIGHT_TOLERANCE      21
-/// Low pressure capacity. Below this value in kPa, the plant begins taking damage.
-#define TRAIT_LOWKPA_TOLERANCE     22
-/// High pressure capacity. Above this value in kPa, the plant begins taking damage.
-#define TRAIT_HIGHKPA_TOLERANCE    23
+#define TRAIT_LEAVES_COLOUR        43
 /// The range of temperature from the ideal in which the plant will grow faster than otherwise.
 /// This does not kill the plant if they go outside it, it only determines growth speed!
-#define TRAIT_HEAT_PREFERENCE      24
+#define TRAIT_HEAT_PREFERENCE      44
 /// The range of lumens from the ideal in which the plant will grow faster than otherwise.
 /// This does not kill the plant if they go outside it, it only determines growth speed!
-#define TRAIT_LIGHT_PREFERENCE     25
+#define TRAIT_LIGHT_PREFERENCE     45

--- a/code/__DEFINES/hydroponics.dm
+++ b/code/__DEFINES/hydroponics.dm
@@ -1,4 +1,4 @@
-//Misc
+/// The colour of dead plant sprites.
 #define DEAD_PLANT_COLOUR "#C2A180"
 
 // Seed noun datums
@@ -30,47 +30,102 @@
 
 #define ALL_GENES list(GENE_BIOCHEMISTRY,GENE_HARDINESS,GENE_ENVIRONMENT,GENE_METABOLISM,GENE_STRUCTURE,GENE_DIET,GENE_PIGMENT,GENE_OUTPUT,GENE_ATMOSPHERE,GENE_VIGOUR,GENE_FRUIT,GENE_SPECIAL)
 
-//Definitions for traits (individual descriptors)
+/* --- ### GENERAL TRAITS ### --- */
+
+/// Which chemicals are inside the plant?
 #define TRAIT_CHEMS                1
+/// Will the plant emit gasses into its environment?
 #define TRAIT_EXUDE_GASSES         2
+/// If set, the plant will periodically alter local temp by this amount.
 #define TRAIT_ALTER_TEMP           3
+/// General purpose plant strength value.
 #define TRAIT_POTENCY              4
+/// If 1, this plant will fruit repeatedly.
 #define TRAIT_HARVEST_REPEAT       5
+/// Can be used to make a battery.
 #define TRAIT_PRODUCES_POWER       6
+/// When thrown, causes a splatter decal.
 #define TRAIT_JUICY                7
+/// Icon to use for fruit coming from this plant.
 #define TRAIT_PRODUCT_ICON         8
+/// Icon to use for the plant growing in the tray.
 #define TRAIT_PLANT_ICON           0
+/// Will the plant remove gasses from its environment?
 #define TRAIT_CONSUME_GASSES       10
+/// The plant can starve.
 #define TRAIT_REQUIRES_NUTRIENTS   11
+/// Plant eats this much per tick.
 #define TRAIT_NUTRIENT_CONSUMPTION 12
+/// The plant can become dehydrated.
 #define TRAIT_REQUIRES_WATER       13
+/// Plant drinks this much per tick.
 #define TRAIT_WATER_CONSUMPTION    14
+/// 0 = none, 1 = eat pests in tray, 2 = eat living things (when a vine).
 #define TRAIT_CARNIVOROUS          15
+/// 0 = no, 1 = gain health from weed level.
 #define TRAIT_PARASITE             16
+/// Can cause damage/inject reagents when thrown or handled.
 #define TRAIT_STINGS               17
-#define TRAIT_IDEAL_HEAT           18
-#define TRAIT_HEAT_TOLERANCE       19
-#define TRAIT_IDEAL_LIGHT          20
-#define TRAIT_LIGHT_TOLERANCE      21
-#define TRAIT_LOWKPA_TOLERANCE     22
-#define TRAIT_HIGHKPA_TOLERANCE    23
+/// When thrown, acts as a grenade.
 #define TRAIT_EXPLOSIVE            24
+/// Resistance to poison.
 #define TRAIT_TOXINS_TOLERANCE     25
+/// Threshold for pests to impact health.
 #define TRAIT_PEST_TOLERANCE       26
+/// Threshold for weeds to impact health.
 #define TRAIT_WEED_TOLERANCE       27
+/// Maximum plant HP when growing. Determines for how long it can be taking damage until it dies.
 #define TRAIT_ENDURANCE            28
+/// Amount of product the plant will yield.
 #define TRAIT_YIELD                29
+/// 0 limits plant to tray, 1 = creepers, 2 = vines.
 #define TRAIT_SPREAD               30
+/// Time taken before the plant is mature. The higher this value, the longer it will take to mature.
 #define TRAIT_MATURATION           31
+/// Time before harvesting can be undertaken again.
 #define TRAIT_PRODUCTION           32
+/// Uses the bluespace tomato effect.
 #define TRAIT_TELEPORTING          33
+/// Colour of the plant icon.
 #define TRAIT_PLANT_COLOUR         34
+/// Colour to apply to product icon.
 #define TRAIT_PRODUCT_COLOUR       35
+/// Plant is bioluminescent.
 #define TRAIT_BIOLUM               36
+/// The colour of the plant's radiance.
 #define TRAIT_BIOLUM_COLOUR        37
+/// If set, plant will never mutate. If -1, plant is highly mutable.
 #define TRAIT_IMMUTABLE            38
 #define TRAIT_FLESH_COLOUR         39
+/// If set, plant will periodically release smoke clouds of its reagent.
 #define TRAIT_SPOROUS              40
+/// The power of the plant's radiance.
 #define TRAIT_BIOLUM_PWR           41
+/// 0 = normal plant, 1 = big tree
 #define TRAIT_LARGE                42
+/// The color of the leaves, if the plant has any.
 #define TRAIT_LEAVES_COLOUR		   43
+
+/* --- ### TOLERANCE-RELATED TRAITS ### --- */
+
+/// The temperature from which the heat tolerance is calculated.
+/// At this temperature, plus or minus the heat tolerance, is where the plant can grow without dying.
+#define TRAIT_IDEAL_HEAT           18
+/// The departure from ideal light that is survivable. If the departure goes above this value, damage will be dealt.
+/// Has nothing to do with growth speed, only when the plant will begin taking damage!
+#define TRAIT_HEAT_TOLERANCE       19
+/// The temperature from which the light tolerance is calculated.
+#define TRAIT_IDEAL_LIGHT          20
+/// The departure from ideal light that is survivable. If the departure goes above this value, damage will be dealt.
+/// Has nothing to do with growth speed, only when the plant will begin taking damage!
+#define TRAIT_LIGHT_TOLERANCE      21
+/// Low pressure capacity. Below this value in kPa, the plant begins taking damage.
+#define TRAIT_LOWKPA_TOLERANCE     22
+/// High pressure capacity. Above this value in kPa, the plant begins taking damage.
+#define TRAIT_HIGHKPA_TOLERANCE    23
+/// The range of temperature from the ideal in which the plant will grow faster than otherwise.
+/// This does not kill the plant if they go outside it, it only determines growth speed!
+#define TRAIT_HEAT_PREFERENCE      24
+/// The range of lumens from the ideal in which the plant will grow faster than otherwise.
+/// This does not kill the plant if they go outside it, it only determines growth speed!
+#define TRAIT_LIGHT_PREFERENCE     25

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -122,7 +122,7 @@
 #define EVENT_LEVEL_MODERATE 2
 #define EVENT_LEVEL_MAJOR    3
 
-//General-purpose life speed define for plants.
+/// General-purpose life speed define for plants.
 #define HYDRO_SPEED_MULTIPLIER 1
 
 #define DEFAULT_JOB_TYPE /datum/job/assistant

--- a/code/controllers/subsystems/plants.dm
+++ b/code/controllers/subsystems/plants.dm
@@ -6,14 +6,22 @@ SUBSYSTEM_DEF(plants)
 	priority = SS_PRIORITY_PLANTS
 	runlevels = RUNLEVELS_PLAYING
 
-	var/list/product_descs = list()         // Stores generated fruit descs.
-	var/list/seeds = list()                 // All seed data stored here.
-	var/list/gene_tag_masks = list()        // Gene obfuscation for delicious trial and error goodness.
-	var/list/plant_icon_cache = list()      // Stores images of growth, fruits and seeds.
-	var/list/plant_sprites = list()         // List of all harvested product sprites.
-	var/list/plant_product_sprites = list() // List of all growth sprites plus number of growth stages.
-	var/list/gene_masked_list = list()      // Stores list of masked genes rather than recreating it later
-	var/list/plant_gene_datums = list()     // Stores gene masked list as datums
+	/// Stores generated fruit descs.
+	var/list/product_descs = list()
+	/// All seed data stored here.
+	var/list/seeds = list()
+	/// Gene obfuscation for delicious trial and error goodness.
+	var/list/gene_tag_masks = list()
+	/// Stores images of growth, fruits and seeds.
+	var/list/plant_icon_cache = list()
+	/// List of all harvested product sprites.
+	var/list/plant_sprites = list()
+	/// List of all growth sprites plus number of growth stages.
+	var/list/plant_product_sprites = list()
+	/// Stores list of masked genes rather than recreating it later
+	var/list/gene_masked_list = list()
+	/// Stores gene masked list as datums
+	var/list/plant_gene_datums = list()
 
 
 	var/list/processing = list()
@@ -114,7 +122,7 @@ SUBSYSTEM_DEF(plants)
 /datum/controller/subsystem/plants/proc/remove_plant(obj/effect/plant/plant)
 	processing -= plant
 
-// Proc for creating a random seed type.
+/// Proc for creating a random seed type.
 /datum/controller/subsystem/plants/proc/create_random_seed(var/survive_on_station)
 	var/datum/seed/seed = new()
 	seed.randomize()
@@ -137,7 +145,7 @@ SUBSYSTEM_DEF(plants)
 		seed.set_trait(TRAIT_HIGHKPA_TOLERANCE,200)
 	return seed
 
-// Debug for testing seed genes.
+/// Debug for testing seed genes.
 /client/proc/show_plant_genes()
 	set category = "Debug"
 	set name = "Show Plant Genes"

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -55,44 +55,46 @@
 /datum/seed/proc/setup_traits()
 
 /datum/seed/New()
-	set_trait(TRAIT_SPOROUS,              0)            // If set, plant will periodically release smoke clouds of its reagent.
-	set_trait(TRAIT_IMMUTABLE,            0)            // If set, plant will never mutate. If -1, plant is highly mutable.
-	set_trait(TRAIT_HARVEST_REPEAT,       0)            // If 1, this plant will fruit repeatedly.
-	set_trait(TRAIT_PRODUCES_POWER,       0)            // Can be used to make a battery.
-	set_trait(TRAIT_JUICY,                0)            // When thrown, causes a splatter decal.
-	set_trait(TRAIT_EXPLOSIVE,            0)            // When thrown, acts as a grenade.
-	set_trait(TRAIT_CARNIVOROUS,          0)            // 0 = none, 1 = eat pests in tray, 2 = eat living things  (when a vine).
-	set_trait(TRAIT_PARASITE,             0)            // 0 = no, 1 = gain health from weed level.
-	set_trait(TRAIT_STINGS,               0)            // Can cause damage/inject reagents when thrown or handled.
-	set_trait(TRAIT_YIELD,                0)            // Amount of product.
-	set_trait(TRAIT_SPREAD,               0)            // 0 limits plant to tray, 1 = creepers, 2 = vines.
-	set_trait(TRAIT_MATURATION,           0)            // Time taken before the plant is mature.
-	set_trait(TRAIT_PRODUCTION,           0)            // Time before harvesting can be undertaken again.
-	set_trait(TRAIT_TELEPORTING,          0)            // Uses the bluespace tomato effect.
-	set_trait(TRAIT_BIOLUM,               0)            // Plant is bioluminescent.
-	set_trait(TRAIT_ALTER_TEMP,           0)            // If set, the plant will periodically alter local temp by this amount.
-	set_trait(TRAIT_PRODUCT_ICON,         0)            // Icon to use for fruit coming from this plant.
-	set_trait(TRAIT_PLANT_ICON,           0)            // Icon to use for the plant growing in the tray.
-	set_trait(TRAIT_PRODUCT_COLOUR,       0)            // Colour to apply to product icon.
-	set_trait(TRAIT_BIOLUM_COLOUR,        0)            // The colour of the plant's radiance.
-	set_trait(TRAIT_BIOLUM_PWR,           1)            // The power of the plant's radiance.
-	set_trait(TRAIT_POTENCY,              1)            // General purpose plant strength value.
-	set_trait(TRAIT_REQUIRES_NUTRIENTS,   1)            // The plant can starve.
-	set_trait(TRAIT_REQUIRES_WATER,       1)            // The plant can become dehydrated.
-	set_trait(TRAIT_WATER_CONSUMPTION,    3)            // Plant drinks this much per tick.
-	set_trait(TRAIT_LIGHT_TOLERANCE,      3)            // Departure from ideal that is survivable.
-	set_trait(TRAIT_TOXINS_TOLERANCE,     5)            // Resistance to poison.
-	set_trait(TRAIT_PEST_TOLERANCE,       5)            // Threshold for pests to impact health.
-	set_trait(TRAIT_WEED_TOLERANCE,       5)            // Threshold for weeds to impact health.
-	set_trait(TRAIT_IDEAL_LIGHT,          5)            // Preferred light level in luminosity.
-	set_trait(TRAIT_HEAT_TOLERANCE,       20)           // Departure from ideal that is survivable.
-	set_trait(TRAIT_LOWKPA_TOLERANCE,     25)           // Low pressure capacity.
-	set_trait(TRAIT_ENDURANCE,            100)          // Maximum plant HP when growing.
-	set_trait(TRAIT_HIGHKPA_TOLERANCE,    200)          // High pressure capacity.
-	set_trait(TRAIT_IDEAL_HEAT,           293)          // Preferred temperature in Kelvin.
-	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.25)         // Plant eats this much per tick.
-	set_trait(TRAIT_PLANT_COLOUR,         "#46B543")    // Colour of the plant icon.
-	set_trait(TRAIT_LARGE,				  0)			//0 = normal plant, 1 = big tree
+	set_trait(TRAIT_SPOROUS,              0)
+	set_trait(TRAIT_IMMUTABLE,            0)
+	set_trait(TRAIT_HARVEST_REPEAT,       0)
+	set_trait(TRAIT_PRODUCES_POWER,       0)
+	set_trait(TRAIT_JUICY,                0)
+	set_trait(TRAIT_EXPLOSIVE,            0)
+	set_trait(TRAIT_CARNIVOROUS,          0)
+	set_trait(TRAIT_PARASITE,             0)
+	set_trait(TRAIT_STINGS,               0)
+	set_trait(TRAIT_YIELD,                0)
+	set_trait(TRAIT_SPREAD,               0)
+	set_trait(TRAIT_MATURATION,           0)
+	set_trait(TRAIT_PRODUCTION,           0)
+	set_trait(TRAIT_TELEPORTING,          0)
+	set_trait(TRAIT_BIOLUM,               0)
+	set_trait(TRAIT_ALTER_TEMP,           0)
+	set_trait(TRAIT_PRODUCT_ICON,         0)
+	set_trait(TRAIT_PLANT_ICON,           0)
+	set_trait(TRAIT_PRODUCT_COLOUR,       0)
+	set_trait(TRAIT_BIOLUM_COLOUR,        0)
+	set_trait(TRAIT_BIOLUM_PWR,           1)
+	set_trait(TRAIT_POTENCY,              1)
+	set_trait(TRAIT_REQUIRES_NUTRIENTS,   1)
+	set_trait(TRAIT_REQUIRES_WATER,       1)
+	set_trait(TRAIT_WATER_CONSUMPTION,    3)
+	set_trait(TRAIT_LIGHT_TOLERANCE,      3) // Plants will begin to die if the light levels are three or more lumens from their ideal.
+	set_trait(TRAIT_TOXINS_TOLERANCE,     5)
+	set_trait(TRAIT_PEST_TOLERANCE,       5)
+	set_trait(TRAIT_WEED_TOLERANCE,       5)
+	set_trait(TRAIT_IDEAL_LIGHT,          5)
+	set_trait(TRAIT_HEAT_TOLERANCE,       20) // Plants will begin to die if they're twenty or more degrees from their ideal temperature.
+	set_trait(TRAIT_LOWKPA_TOLERANCE,     25) // Plants survive all the way down to a quarter of an atmosphere!
+	set_trait(TRAIT_ENDURANCE,            100)
+	set_trait(TRAIT_HIGHKPA_TOLERANCE,    200)
+	set_trait(TRAIT_IDEAL_HEAT,           293)
+	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.25)
+	set_trait(TRAIT_PLANT_COLOUR,         "#46B543")
+	set_trait(TRAIT_LARGE,                0)
+	set_trait(TRAIT_HEAT_PREFERENCE,      5) // By default, plants grow faster in a temperature within five degrees of their ideal.
+	set_trait(TRAIT_LIGHT_PREFERENCE,     2) // Similarly, they grow faster under lumens within two of their ideal.
 
 	setup_traits()
 
@@ -129,7 +131,7 @@
 	S.set_up(R, round(get_trait(TRAIT_POTENCY)/4), 0, T, 40)
 	S.start()
 
-// Does brute damage to a target.
+/// Does brute damage to a target.
 /datum/seed/proc/do_thorns(var/mob/living/carbon/human/target, var/obj/item/fruit, var/target_limb)
 
 	if(!get_trait(TRAIT_CARNIVOROUS))
@@ -173,7 +175,7 @@
 	target.UpdateDamageIcon()
 	target.updatehealth()
 
-// Adds reagents to a target.
+/// Adds reagents to a target.
 /datum/seed/proc/do_sting(var/mob/living/carbon/human/target, var/obj/item/fruit)
 	if(!get_trait(TRAIT_STINGS))
 		return
@@ -194,7 +196,7 @@
 			var/injecting = min(5,max(1,get_trait(TRAIT_POTENCY)/5))
 			target.reagents.add_reagent(rid,injecting)
 
-//Splatter a turf.
+/// Splatter a turf.
 /datum/seed/proc/splatter(var/turf/T,var/obj/item/thrown)
 	if(splat_type && !(locate(/obj/effect/plant) in T))
 		var/obj/effect/plant/splat = new splat_type(T, src)
@@ -223,7 +225,7 @@
 				var/injecting = min(5,max(1,get_trait(TRAIT_POTENCY)/3))
 				M.reagents.add_reagent(chem,injecting)
 
-//Applies an effect to a target atom.
+/// Applies an effect to a target atom.
 /datum/seed/proc/thrown_at(var/obj/item/thrown,var/atom/target, var/force_explode)
 
 	var/splatted
@@ -307,8 +309,8 @@
 			P.set_target(picked)
 			P.creator = null
 
+/// Checks the plant's environment. If anything is improper, adds to a value that will ultimately be used to damage the plant.
 /datum/seed/proc/handle_environment(var/turf/current_turf, var/datum/gas_mixture/environment, var/light_supplied, var/check_only)
-
 	var/health_change = 0
 	// Handle gas consumption.
 	if(consume_gasses && consume_gasses.len)
@@ -329,6 +331,8 @@
 	if(pressure < get_trait(TRAIT_LOWKPA_TOLERANCE)|| pressure > get_trait(TRAIT_HIGHKPA_TOLERANCE))
 		health_change += rand(1,3) * HYDRO_SPEED_MULTIPLIER
 
+	// We take the absolute value of the environment's temperature minus the ideal heat - closer to 0 is better, in this case.
+	// If that value is greater than the heat tolerance, we apply some damage to the plant.
 	if(abs(environment.temperature - get_trait(TRAIT_IDEAL_HEAT)) > get_trait(TRAIT_HEAT_TOLERANCE))
 		health_change += rand(1,3) * HYDRO_SPEED_MULTIPLIER
 
@@ -396,7 +400,7 @@
 	display_name = name
 	display_name = "[name] plant"
 
-//Creates a random seed. MAKE SURE THE LINE HAS DIVERGED BEFORE THIS IS CALLED.
+/// Creates a random seed. MAKE SURE THE LINE HAS DIVERGED BEFORE THIS IS CALLED.
 /datum/seed/proc/randomize(var/list/native_gases = list(GAS_OXYGEN, GAS_NITROGEN, GAS_CO2, GAS_PHORON, GAS_HYDROGEN))
 	roundstart = FALSE
 	mysterious = TRUE
@@ -556,12 +560,12 @@
 
 	generate_name()
 
-//Returns a key corresponding to an entry in the global seed list.
+/// Returns a key corresponding to an entry in the global seed list.
 /datum/seed/proc/get_mutant_variant()
 	if(!mutants || !mutants.len || get_trait(TRAIT_IMMUTABLE) > 0) return 0
 	return pick(mutants)
 
-//Mutates the plant overall (randomly).
+/// Mutates the plant overall (randomly).
 /datum/seed/proc/mutate(var/degree,var/turf/source_turf)
 
 	if(!degree || get_trait(TRAIT_IMMUTABLE) > 0) return
@@ -632,7 +636,7 @@
 
 	return
 
-//Mutates a specific trait/set of traits.
+/// Mutates a specific trait/set of traits.
 /datum/seed/proc/apply_gene(var/datum/plantgene/gene)
 
 	if(!gene || !gene.values || get_trait(TRAIT_IMMUTABLE) > 0) return
@@ -687,7 +691,7 @@
 
 	update_growth_stages()
 
-//Returns a list of the desired trait values.
+/// Returns a list of the desired trait values.
 /datum/seed/proc/get_gene(var/genetype)
 
 	if(!genetype) return 0
@@ -731,9 +735,8 @@
 		P.values["[trait]"] = get_trait(trait)
 	return (P ? P : 0)
 
-//Place the plant products at the feet of the user.
+/// Place the plant products at the feet of the user.
 /datum/seed/proc/harvest(var/mob/user,var/yield_mod,var/harvest_sample,var/force_amount)
-
 	if(!user)
 		return
 
@@ -807,9 +810,9 @@
 			var/mob/living/simple_animal/mushroom/mush = product
 			mush.seed = src
 
-// When the seed in this machine mutates/is modified, the tray seed value
-// is set to a new datum copied from the original. This datum won't actually
-// be put into the global datum list until the product is harvested, though.
+/** When the seed in this machine mutates/is modified, the tray seed value
+is set to a new datum copied from the original. This datum won't actually
+be put into the global datum list until the product is harvested, though. */
 /datum/seed/proc/diverge(var/modified)
 
 	if(get_trait(TRAIT_IMMUTABLE) > 0) return

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -94,7 +94,7 @@
 	set_trait(TRAIT_PLANT_COLOUR,         "#46B543")
 	set_trait(TRAIT_LARGE,                0)
 	set_trait(TRAIT_HEAT_PREFERENCE,      5) // By default, plants grow faster in a temperature within five degrees of their ideal.
-	set_trait(TRAIT_LIGHT_PREFERENCE,     2) // Similarly, they grow faster under lumens within two of their ideal.
+	set_trait(TRAIT_LIGHT_PREFERENCE,     4) // Similarly, they grow faster under lumens within two of their ideal.
 
 	setup_traits()
 

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -94,7 +94,7 @@
 	set_trait(TRAIT_PLANT_COLOUR,         "#46B543")
 	set_trait(TRAIT_LARGE,                0)
 	set_trait(TRAIT_HEAT_PREFERENCE,      5) // By default, plants grow faster in a temperature within five degrees of their ideal.
-	set_trait(TRAIT_LIGHT_PREFERENCE,     4) // Similarly, they grow faster under lumens within two of their ideal.
+	set_trait(TRAIT_LIGHT_PREFERENCE,     2) // Similarly, they grow faster under lumens within two of their ideal.
 
 	setup_traits()
 

--- a/code/modules/hydroponics/seed_datums/adhomai.dm
+++ b/code/modules/hydroponics/seed_datums/adhomai.dm
@@ -20,7 +20,7 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#378C61")
 	set_trait(TRAIT_PLANT_COLOUR,"#378C61")
 	set_trait(TRAIT_PLANT_ICON,"tree5")
-	set_trait(TRAIT_IDEAL_HEAT, 283)
+	set_trait(TRAIT_IDEAL_HEAT, 278)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 
 /obj/item/seeds/shandseed
@@ -45,7 +45,7 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#4CC5C7")
 	set_trait(TRAIT_PLANT_COLOUR,"#4CC789")
 	set_trait(TRAIT_PLANT_ICON,"bush7")
-	set_trait(TRAIT_IDEAL_HEAT, 283)
+	set_trait(TRAIT_IDEAL_HEAT, 278)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 
 /obj/item/seeds/mtearseed
@@ -70,7 +70,7 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#87CEEB")
 	set_trait(TRAIT_PLANT_COLOUR,"#4D8F53")
 	set_trait(TRAIT_PLANT_ICON,"alien2")
-	set_trait(TRAIT_IDEAL_HEAT, 283)
+	set_trait(TRAIT_IDEAL_HEAT, 278)
 	set_trait(TRAIT_WATER_CONSUMPTION, 8)
 
 /obj/item/seeds/earthenroot
@@ -97,7 +97,7 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#C4AE7A")
 	set_trait(TRAIT_PLANT_COLOUR,"#4D8F53")
 	set_trait(TRAIT_PLANT_ICON,"bush4")
-	set_trait(TRAIT_IDEAL_HEAT, 283)
+	set_trait(TRAIT_IDEAL_HEAT, 278)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 

--- a/code/modules/hydroponics/seed_datums/aquaculture.dm
+++ b/code/modules/hydroponics/seed_datums/aquaculture.dm
@@ -15,7 +15,7 @@
 	set_trait(TRAIT_PRODUCT_ICON,      "mollusc")
 	set_trait(TRAIT_PLANT_ICON,        "mollusc")
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
-	set_trait(TRAIT_IDEAL_HEAT,        288)
+	set_trait(TRAIT_IDEAL_HEAT,        284)
 	set_trait(TRAIT_LIGHT_TOLERANCE,   6)
 	set_trait(TRAIT_PRODUCT_COLOUR,    "#aaabba")
 	set_trait(TRAIT_PLANT_COLOUR,      "#aaabba")

--- a/code/modules/hydroponics/seed_datums/fruits.dm
+++ b/code/modules/hydroponics/seed_datums/fruits.dm
@@ -368,7 +368,7 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#FFEC1F")
 	set_trait(TRAIT_PLANT_COLOUR,"#69AD50")
 	set_trait(TRAIT_PLANT_ICON,"tree4")
-	set_trait(TRAIT_IDEAL_HEAT, 298)
+	set_trait(TRAIT_IDEAL_HEAT, 304)
 	set_trait(TRAIT_IDEAL_LIGHT, 7)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 
@@ -419,7 +419,7 @@
 	set_trait(TRAIT_PLANT_COLOUR,"#49be45")
 	set_trait(TRAIT_PLANT_ICON,"vine2")
 	set_trait(TRAIT_FLESH_COLOUR,"#ff5858")
-	set_trait(TRAIT_IDEAL_HEAT, 298)
+	set_trait(TRAIT_IDEAL_HEAT, 304)
 	set_trait(TRAIT_IDEAL_LIGHT, 6)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 

--- a/code/modules/hydroponics/seed_datums/misc.dm
+++ b/code/modules/hydroponics/seed_datums/misc.dm
@@ -35,7 +35,7 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#B4D6BD")
 	set_trait(TRAIT_PLANT_COLOUR,"#6BBD68")
 	set_trait(TRAIT_PLANT_ICON,"stalk3")
-	set_trait(TRAIT_IDEAL_HEAT, 298)
+	set_trait(TRAIT_IDEAL_HEAT, 304)
 
 /obj/item/seeds/sugarcaneseed
 	seed_type = "sugarcane"

--- a/code/modules/hydroponics/seed_datums/mushrooms.dm
+++ b/code/modules/hydroponics/seed_datums/mushrooms.dm
@@ -25,7 +25,7 @@
 	set_trait(TRAIT_PLANT_COLOUR,"#D9C94E")
 	set_trait(TRAIT_PLANT_ICON,"mushroom")
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
-	set_trait(TRAIT_IDEAL_HEAT, 288)
+	set_trait(TRAIT_IDEAL_HEAT, 282)
 	set_trait(TRAIT_LIGHT_TOLERANCE, 6)
 
 /datum/seed/koisspore

--- a/code/modules/hydroponics/seed_datums/smokables.dm
+++ b/code/modules/hydroponics/seed_datums/smokables.dm
@@ -17,7 +17,7 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#749733")
 	set_trait(TRAIT_PLANT_COLOUR,"#749733")
 	set_trait(TRAIT_PLANT_ICON,"vine2")
-	set_trait(TRAIT_IDEAL_HEAT, 299)
+	set_trait(TRAIT_IDEAL_HEAT, 304)
 	set_trait(TRAIT_IDEAL_LIGHT, 7)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)

--- a/code/modules/hydroponics/seed_datums/vegetables.dm
+++ b/code/modules/hydroponics/seed_datums/vegetables.dm
@@ -19,7 +19,7 @@
 	set_trait(TRAIT_PRODUCT_ICON,"chili")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#ED3300")
 	set_trait(TRAIT_PLANT_ICON,"bush2")
-	set_trait(TRAIT_IDEAL_HEAT, 298)
+	set_trait(TRAIT_IDEAL_HEAT, 304)
 	set_trait(TRAIT_IDEAL_LIGHT, 7)
 
 /obj/item/seeds/chiliseed

--- a/code/modules/hydroponics/seed_datums/vegetables.dm
+++ b/code/modules/hydroponics/seed_datums/vegetables.dm
@@ -61,7 +61,7 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#ff922d")
 	set_trait(TRAIT_PLANT_COLOUR,"#35d65d")
 	set_trait(TRAIT_PLANT_ICON,"bush2")
-	set_trait(TRAIT_IDEAL_HEAT, 298)
+	set_trait(TRAIT_IDEAL_HEAT, 293)
 	set_trait(TRAIT_IDEAL_LIGHT, 6)
 	set_trait(TRAIT_WATER_CONSUMPTION, 5)
 

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -652,7 +652,7 @@
 	else if(attacking_item.force && seed && !closed_system)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)
-		playsound(loc, /singleton/sound_category/swing_hit_sound, 25, 1)
+		playsound(loc, /singleton/sound_category/swing_hit_sound, 25, TRUE)
 		user.visible_message(SPAN_DANGER("\The [seed.display_name] has been attacked by [user] with \the [attacking_item]!"))
 		if(!dead)
 			var/total_damage = attacking_item.force

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -764,6 +764,6 @@
 	else
 		density = TRUE
 	closed_system = !closed_system
-	playsound(src, 'sound/items/pickup/device.ogg', 25, 1)
+	playsound(src, 'sound/items/pickup/device.ogg', 25, TRUE)
 	to_chat(user, "You [closed_system ? "close" : "open"] the tray's lid.")
 	update_icon()

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -202,7 +202,6 @@
 		harvest()
 
 /obj/machinery/portable_atmospherics/hydroponics/attack_generic(var/mob/user)
-
 	// Why did I ever think this was a good idea. TODO: move this onto the nymph mob.
 	if(istype(user,/mob/living/carbon/alien/diona))
 		var/mob/living/carbon/alien/diona/nymph = user
@@ -243,7 +242,6 @@
 	update_icon()
 
 /obj/machinery/portable_atmospherics/hydroponics/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit)
-
 	//Don't act on seeds like dionaea that shouldn't change.
 	if(seed && seed.get_trait(TRAIT_IMMUTABLE) > 0)
 		return BULLET_ACT_HIT
@@ -275,12 +273,14 @@
 	else
 		return !density
 
+/// If the plant should be dead, kill it. Otherwise, don't.
 /obj/machinery/portable_atmospherics/hydroponics/proc/check_health()
 	if(seed && !dead && health <= 0)
 		die()
 	check_level_sanity()
 	update_icon()
 
+/// Call this to kill a plant. Don't modify the dead variable directly.
 /obj/machinery/portable_atmospherics/hydroponics/proc/die()
 	dead = 1
 	mutation_level = 0
@@ -294,7 +294,6 @@
 
 /// Process reagents being input into the tray.
 /obj/machinery/portable_atmospherics/hydroponics/proc/process_reagents()
-
 	if(!reagents) return
 
 	if(reagents.total_volume <= 0)
@@ -345,7 +344,6 @@
 
 /// Harvests the product of a plant.
 /obj/machinery/portable_atmospherics/hydroponics/proc/harvest(var/mob/user)
-
 	//Harvest the product of the plant,
 	if(!seed || !harvest)
 		return
@@ -399,7 +397,6 @@
 
 /// If a weed growth is sufficient, this proc is called.
 /obj/machinery/portable_atmospherics/hydroponics/proc/weed_invasion()
-
 	//Remove the seed if something is already planted.
 	if(seed) seed = null
 	seed = SSplants.seeds[pick(list("reishi","nettles","amanita","mushrooms","plumphelmet","towercap","harebells","weeds"))]
@@ -419,7 +416,6 @@
 	return
 
 /obj/machinery/portable_atmospherics/hydroponics/proc/mutate(var/severity)
-
 	// No seed, no mutations.
 	if(!seed)
 		return
@@ -445,22 +441,21 @@
 
 	return
 
-/obj/machinery/portable_atmospherics/hydroponics/verb/setlight()
-	set name = "Set Light"
-	set category = "Object"
-	set src in view(1)
+/// This is in its own proc so we can also call it via a ctrl + click.
+/obj/machinery/portable_atmospherics/hydroponics/proc/change_lighting()
+	var/new_light = tgui_input_list(usr, "Specify a light level.", "Set Light", list(0,1,2,3,4,5,6,7,8,9,10))
+	if(new_light)
+		tray_light = new_light
+		to_chat(usr, "You set the tray to a light level of [tray_light] lumens.")
 
+/obj/machinery/portable_atmospherics/hydroponics/CtrlClick(var/mob/user)
 	if(usr.incapacitated())
 		return
 	if(ishuman(usr) || istype(usr, /mob/living/silicon/robot))
-		var/new_light = tgui_input_list(usr, "Specify a light level.", "Set Light", list(0,1,2,3,4,5,6,7,8,9,10))
-		if(new_light)
-			tray_light = new_light
-			to_chat(usr, "You set the tray to a light level of [tray_light] lumens.")
-	return
+		change_lighting()
 
+/// Verifies that all values are where they should be.
 /obj/machinery/portable_atmospherics/hydroponics/proc/check_level_sanity()
-	//Make sure various values are sane.
 	if(seed)
 		health =     max(0,min(seed.get_trait(TRAIT_ENDURANCE),health))
 	else
@@ -475,7 +470,6 @@
 	toxins =         max(0,min(toxins,10))
 
 /obj/machinery/portable_atmospherics/hydroponics/proc/mutate_species()
-
 	var/previous_plant = seed.display_name
 	var/newseed = seed.get_mutant_variant()
 	if(newseed in SSplants.seeds)
@@ -497,7 +491,6 @@
 	return
 
 /obj/machinery/portable_atmospherics/hydroponics/attackby(obj/item/attacking_item, mob/user)
-
 	//A special case for if the container has only water, for manual watering with buckets
 	if (istype(attacking_item, /obj/item/reagent_containers))
 		var/obj/item/reagent_containers/RC = attacking_item
@@ -520,7 +513,6 @@
 		return FALSE
 
 	if((attacking_item.iswirecutter() || istype(attacking_item, /obj/item/surgery/scalpel)) && !closed_system)
-
 		if(!seed)
 			to_chat(user, "There is nothing to take a sample from in \the [src].")
 			return
@@ -569,9 +561,7 @@
 			return TRUE
 
 	else if (istype(attacking_item, /obj/item/seeds))
-
 		if(!seed)
-
 			var/obj/item/seeds/S = attacking_item
 			user.remove_from_mob(attacking_item)
 
@@ -631,9 +621,7 @@
 			to_chat(user, SPAN_DANGER("There is nothing in this plot for you to uproot!"))
 
 	else if (istype(attacking_item, /obj/item/storage/bag/plants))
-
 		attack_hand(user)
-
 		var/obj/item/storage/bag/plants/S = attacking_item
 		for (var/obj/item/reagent_containers/food/snacks/grown/G in locate(user.x,user.y,user.z))
 			if(!S.can_be_inserted(G))
@@ -641,7 +629,6 @@
 			S.handle_item_insertion(G, 1)
 
 	else if (istype(attacking_item, /obj/item/plantspray))
-
 		var/obj/item/plantspray/spray = attacking_item
 		user.remove_from_mob(attacking_item)
 		toxins += spray.toxicity
@@ -653,7 +640,6 @@
 		check_health()
 
 	else if(mechanical && attacking_item.iswrench())
-
 		//If there's a connector here, the portable_atmospherics setup can handle it.
 		if(locate(/obj/machinery/atmospherics/portables_connector/) in loc)
 			return ..()
@@ -664,6 +650,8 @@
 
 	else if(attacking_item.force && seed && !closed_system)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.do_attack_animation(src)
+		playsound(loc, /singleton/sound_category/swing_hit_sound, 25, 1)
 		user.visible_message(SPAN_DANGER("\The [seed.display_name] has been attacked by [user] with \the [attacking_item]!"))
 		if(!dead)
 			var/total_damage = attacking_item.force
@@ -680,7 +668,6 @@
 		harvest(user)
 
 /obj/machinery/portable_atmospherics/hydroponics/attack_hand(mob/user as mob)
-
 	if(istype(usr,/mob/living/silicon))
 		return
 
@@ -706,6 +693,7 @@
 	else if(dead)
 		remove_dead(user)
 
+/// TODO: Need to modernise this.
 /obj/machinery/portable_atmospherics/hydroponics/get_examine_text(mob/user, distance, is_adjacent, infix, suffix)
 	. = ..()
 	if(!seed)
@@ -765,21 +753,15 @@
 			stasis_string = "Stasis is disabled."
 		. += SPAN_NOTICE(stasis_string)
 
-/obj/machinery/portable_atmospherics/hydroponics/verb/close_lid_verb()
-	set name = "Toggle Tray Lid"
-	set category = "Object"
-	set src in view(1)
-	if(usr.incapacitated())
-		return
-
-	if(ishuman(usr) || istype(usr, /mob/living/silicon/robot))
-		close_lid(usr)
-	return
-
+/// Opens and closes the lid.
 /obj/machinery/portable_atmospherics/hydroponics/proc/close_lid(var/mob/living/user)
 	if(closed_system)
 		stasis = FALSE
+		density = FALSE
 		update_use_power(POWER_USE_IDLE)
+	else
+		density = TRUE
 	closed_system = !closed_system
+	playsound(src, /singleton/sound_category/generic_pickup_sound, 25, 1)
 	to_chat(user, "You [closed_system ? "close" : "open"] the tray's lid.")
 	update_icon()

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -448,7 +448,7 @@
 		tray_light = new_light
 		user.visible_message(SPAN_NOTICE("\The [user] sets \the [src] to a light level of [tray_light] lumens."),
 		SPAN_NOTICE("You set the \the [src] to a light level of [tray_light] lumens."))
-		playsound(src, /singleton/sound_category/button_sound, 25, 1)
+		playsound(src, /singleton/sound_category/button_sound, 25, TRUE)
 
 /obj/machinery/portable_atmospherics/hydroponics/CtrlClick(var/mob/user)
 	if(usr.incapacitated())

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -441,20 +441,22 @@
 
 	return
 
-/// This is in its own proc so we can also call it via a ctrl + click.
-/obj/machinery/portable_atmospherics/hydroponics/proc/change_lighting()
+/// This is in its own proc so we can call it via a ctrl + click.
+/obj/machinery/portable_atmospherics/hydroponics/proc/change_lighting(var/mob/user)
 	var/new_light = tgui_input_list(usr, "Specify a light level.", "Set Light", list(0,1,2,3,4,5,6,7,8,9,10))
 	if(new_light)
 		tray_light = new_light
-		to_chat(usr, "You set the tray to a light level of [tray_light] lumens.")
+		user.visible_message(SPAN_NOTICE("\The [user] sets \the [src] to a light level of [tray_light] lumens."),
+		SPAN_NOTICE("You set the \the [src] to a light level of [tray_light] lumens."))
+		playsound(src, /singleton/sound_category/button_sound, 25, 1)
 
 /obj/machinery/portable_atmospherics/hydroponics/CtrlClick(var/mob/user)
 	if(usr.incapacitated())
 		return
 	if(ishuman(usr) || istype(usr, /mob/living/silicon/robot))
-		change_lighting()
+		change_lighting(user)
 
-/// Verifies that all values are where they should be.
+/// Verifies that all values are what they should be.
 /obj/machinery/portable_atmospherics/hydroponics/proc/check_level_sanity()
 	if(seed)
 		health =     max(0,min(seed.get_trait(TRAIT_ENDURANCE),health))
@@ -543,7 +545,6 @@
 		return
 
 	else if(istype(attacking_item, /obj/item/reagent_containers/syringe) && !closed_system)
-
 		var/obj/item/reagent_containers/syringe/S = attacking_item
 
 		if (S.mode == 1)
@@ -672,6 +673,7 @@
 		return
 
 	// If the lid is closed and stasis enabled, disable it. Otherwise, enable it. If there's no power, cut it early.
+	// TODO: Split this to its own proc?
 	if(closed_system)
 		if(stat & (NOPOWER|BROKEN))
 			to_chat(user, SPAN_NOTICE("You flick the stasis mode switch, but nothing happens."))
@@ -684,7 +686,7 @@
 			update_use_power(POWER_USE_ACTIVE)
 			stasis = TRUE
 
-		playsound(src, /singleton/sound_category/button_sound, 50, 1)
+		playsound(src, /singleton/sound_category/button_sound, 25, 1)
 		update_icon()
 		return
 
@@ -762,6 +764,6 @@
 	else
 		density = TRUE
 	closed_system = !closed_system
-	playsound(src, /singleton/sound_category/generic_pickup_sound, 25, 1)
+	playsound(src, 'sound/items/pickup/device.ogg', 25, 1)
 	to_chat(user, "You [closed_system ? "close" : "open"] the tray's lid.")
 	update_icon()

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -686,7 +686,7 @@
 			update_use_power(POWER_USE_ACTIVE)
 			stasis = TRUE
 
-		playsound(src, /singleton/sound_category/button_sound, 25, 1)
+		playsound(src, /singleton/sound_category/button_sound, 25, TRUE)
 		update_icon()
 		return
 

--- a/code/modules/hydroponics/trays/tray_process.dm
+++ b/code/modules/hydroponics/trays/tray_process.dm
@@ -45,9 +45,6 @@
 		if(mechanical) update_icon() //Harvesting would fail to set alert icons properly.
 		return
 
-	// Advance plant age.
-	if(prob(30)) age += 1 * HYDRO_SPEED_MULTIPLIER
-
 	//Highly mutable plants have a chance of mutating every tick.
 	if(seed.get_trait(TRAIT_IMMUTABLE) == -1)
 		var/mut_prob = rand(1,100)
@@ -84,7 +81,7 @@
 	if(!environment && istype(T)) environment = T.return_air()
 	if(!environment) return
 
-	// Seed datum handles gasses, light and pressure.
+	// Seed datum handles gasses, light and pressure relevant to whether the plant should be damaged.
 	if(mechanical && closed_system)
 		health -= seed.handle_environment(T,environment,tray_light)
 	else
@@ -93,6 +90,33 @@
 	// If we're attached to a pipenet, then we should let the pipenet know we might have modified some gasses
 	if (closed_system && connected_port)
 		update_connected_network()
+
+	// By standard, the probability of growth is only 15%. This rises if growing conditions are within their preferences.
+	// This is intended to motivate the use of atmospheric equipment to more viably grow plants with irregular preferences.
+	// You *can* grow plants outside of their preferences without them dying so long as it's within their tolerance, but it'll be pretty slow.
+	var/probability_of_growth = 15
+
+	// Are we within the preference zone for temperature? If so, add 15% to the chance of growth.
+	if(abs(environment.temperature - seed.get_trait(TRAIT_IDEAL_HEAT)) < seed.get_trait(TRAIT_HEAT_PREFERENCE))
+		probability_of_growth += 15
+
+	// The light value we'll be using here.
+	var/actual_light
+
+	// What kind of lighting are we under? If the lid isn't on and the turf isn't dynamically lit, default to 5 lumens.
+	if(closed_system && mechanical)
+		actual_light = tray_light
+	else if(TURF_IS_DYNAMICALLY_LIT(T))
+		actual_light = T.get_lumcount(0, 3) * 10
+	else
+		actual_light = 5
+
+	// If we're within the preference zone for light, add another 5% to the chance for growth.
+	if(abs(actual_light - seed.get_trait(TRAIT_IDEAL_LIGHT)) < seed.get_trait(TRAIT_LIGHT_PREFERENCE))
+		probability_of_growth += 5
+
+	// Roll the dice on advancing plant age, per a probability defined by the previous two checks. At minimum, 15% - at maximum, 35%.
+	if(prob(probability_of_growth)) age += 1 * HYDRO_SPEED_MULTIPLIER
 
 	// Toxin levels beyond the plant's tolerance cause damage, but
 	// toxins are sucked up each tick and slowly reduce over time.

--- a/code/modules/hydroponics/trays/tray_process.dm
+++ b/code/modules/hydroponics/trays/tray_process.dm
@@ -116,6 +116,7 @@
 		probability_of_growth += 5
 
 	// Roll the dice on advancing plant age, per a probability defined by the previous two checks. At minimum, 15% - at maximum, 35%.
+	// TODO: Move to seed datum?
 	if(prob(probability_of_growth)) age += 1 * HYDRO_SPEED_MULTIPLIER
 
 	// Toxin levels beyond the plant's tolerance cause damage, but

--- a/code/modules/hydroponics/trays/tray_reagents.dm
+++ b/code/modules/hydroponics/trays/tray_reagents.dm
@@ -78,14 +78,17 @@
 /obj/item/reagent_containers/glass/fertilizer/ez
 	name = "jug of E-Z-Nutrient"
 	icon_state = "plastic_jug_ez"
+	desc = "Utterly middling in every way, E-Z-Nutrient is a brand of fertiliser without any remarkably defining traits. At least it's cheap."
 	reagents_to_add = list(/singleton/reagent/toxin/fertilizer/eznutrient = 80)
 
 /obj/item/reagent_containers/glass/fertilizer/l4z
 	name = "jug of Left-4-Zed"
 	icon_state = "plastic_jug_l4z"
+	desc = "A brand with a mixed reputation, Left-4-Zed trades nutritional value for a chance to mutate plants it is fed to. Use with caution!"
 	reagents_to_add = list(/singleton/reagent/toxin/fertilizer/left4zed = 80)
 
 /obj/item/reagent_containers/glass/fertilizer/rh
 	name = "jug of Robust Harvest"
 	icon_state = "plastic_jug_rh"
+	desc = "This is a jug of Robust Harvest, among the more reputable - and expensive - brands of fertiliser on the market. Increases yield of crops."
 	reagents_to_add = list(/singleton/reagent/toxin/fertilizer/robustharvest = 80)

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -6,9 +6,12 @@
 	use_power = POWER_USE_OFF
 	mechanical = 0
 	tray_light = 0
+	/// Water level begins at zero.
 	waterlevel = 0
-	nutrilevel = 0 // So they don't spawn with water or nutrient when built. Soil's hard mode, baby.
-	maxWeedLevel = 10 // Retains the ability for soil to grow weeds, as it should.
+	/// Nutrient level begins at zero. Soil's hard mode, baby.
+	nutrilevel = 0
+	/// Retains the ability for soil to grow weeds, as it should.
+	maxWeedLevel = 10
 
 /obj/machinery/portable_atmospherics/hydroponics/soil/attackby(obj/item/attacking_item, mob/user)
 	//A special case for if the container has only water, for manual watering with buckets
@@ -36,14 +39,9 @@
 	else
 		..()
 
-/obj/machinery/portable_atmospherics/hydroponics/soil/New()
-	..()
-	verbs -= /obj/machinery/portable_atmospherics/hydroponics/verb/close_lid_verb
-	verbs -= /obj/machinery/portable_atmospherics/hydroponics/verb/setlight
-
-// Holder for vine plants.
-// Icons for plants are generated as overlays, so setting it to invisible wouldn't work.
-// Hence using a blank icon.
+/** Holder for vine plants.
+Icons for plants are generated as overlays, so setting it to invisible wouldn't work.
+Hence using a blank icon. */
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible
 	name = "plant"
 	desc = null

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -39,7 +39,7 @@
 	else
 		..()
 
-/** Holder for vine plants.
+/* Holder for vine plants.
 Icons for plants are generated as overlays, so setting it to invisible wouldn't work.
 Hence using a blank icon. */
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible

--- a/code/modules/hydroponics/trays/tray_tools.dm
+++ b/code/modules/hydroponics/trays/tray_tools.dm
@@ -10,7 +10,8 @@
 		slot_r_hand_str = 'icons/mob/items/righthand_hydro.dmi',
 		)
 	toolspeed = 0.7
-	bomb_defusal_chance = 40 // 40% chance to successfully defuse a bomb, higher than standard because plant clippers are smaller
+	/// Plant clippers have a 40% chance to successfully defuse a bomb, higher than standard because plant clippers are smaller.
+	bomb_defusal_chance = 40
 	build_from_parts = FALSE
 
 /obj/item/wirecutters/clippers/update_icon()
@@ -21,6 +22,7 @@
 		tf.Translate(-1, 0) //Could do this with pixel_x but let's just update the appearance once.
 	transform = tf
 
+/// Like a health analyzer, but for plants! Tells you everything you need to know.
 /obj/item/device/analyzer/plant_analyzer
 	name = "plant analyzer"
 	icon = 'icons/obj/item/device/plant_analyzer.dmi'

--- a/code/modules/hydroponics/trays/tray_update_icons.dm
+++ b/code/modules/hydroponics/trays/tray_update_icons.dm
@@ -1,4 +1,4 @@
-//Refreshes the icon and sets the luminosity
+/// Refreshes the icon and sets the luminosity.
 /obj/machinery/portable_atmospherics/hydroponics/update_icon()
 	// Update name.
 	if(seed)

--- a/code/unit_tests/hydroponics_tests.dm
+++ b/code/unit_tests/hydroponics_tests.dm
@@ -1,4 +1,6 @@
-/* For unit tests relating to hydroponics mechanics, with no direct relation to cooking. */
+/*
+For unit tests relating to hydroponics mechanics, with no direct relation to cooking.
+*/
 
 /**
 Checks if the preference values of a seed are lesser than their tolerance values.
@@ -18,5 +20,8 @@ while simultaneously growing faster from being within its preferences.
 
 		if(S.get_trait(TRAIT_HEAT_TOLERANCE) < S.get_trait(TRAIT_HEAT_PREFERENCE))
 			TEST_FAIL("Seed [S] has a heat preference value set higher than its heat tolerance.")
+
+	if(!reported)
+		TEST_PASS("All seeds have preference values that are lower than their tolerance values.")
 
 	return 1

--- a/code/unit_tests/hydroponics_tests.dm
+++ b/code/unit_tests/hydroponics_tests.dm
@@ -1,0 +1,22 @@
+/* For unit tests relating to hydroponics mechanics, with no direct relation to cooking. */
+
+/**
+Checks if the preference values of a seed are lesser than their tolerance values.
+Preferences should always be within tolerances. We don't want any plant to be dying from intolerance
+while simultaneously growing faster from being within its preferences.
+*/
+/datum/unit_test/seed_preferences_check
+	name = "HYDROPONICS: Check preference and tolerance validity"
+	groups = list("generic", "cooking")
+
+/datum/unit_test/seed_preferences_check/start_test()
+	for(var/seed_name in SSplants.seeds)
+		var/datum/seed/S = SSplants.seeds[seed_name]
+
+		if(S.get_trait(TRAIT_LIGHT_TOLERANCE) < S.get_trait(TRAIT_LIGHT_PREFERENCE))
+			TEST_FAIL("Seed [S] has a light preference value set higher than its light tolerance.")
+
+		if(S.get_trait(TRAIT_HEAT_TOLERANCE) < S.get_trait(TRAIT_HEAT_PREFERENCE))
+			TEST_FAIL("Seed [S] has a heat preference value set higher than its heat tolerance.")
+
+	return 1

--- a/html/changelogs/hazelmouse-morehydrostuff.yml
+++ b/html/changelogs/hazelmouse-morehydrostuff.yml
@@ -60,4 +60,5 @@ changes:
   - rscdel: "All verbs have been removed from hydroponics trays - namely for closing the lid and for changing the lighting - now that both are accessible via an alt + click and a ctrl + click respectively."
   - balance: "Several plants in hydroponics now have more dramatic temperature requirements - mushrooms and Adhomian plants require cooler temperatures, and several others require warmer temperatures."
   - rscadd: "More feedback has been added to attacking the contents of hydroponics trays, opening and closing their lids, and changing their light levels."
+  - rscadd: "Fertiliser jugs now have descriptions defining their niche."
   - code_imp: "Introduced and shuffled a lot of documentation in hydroponics code."

--- a/html/changelogs/hazelmouse-morehydrostuff.yml
+++ b/html/changelogs/hazelmouse-morehydrostuff.yml
@@ -1,0 +1,62 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "The internal lighting setting of hydroponics trays can now be edited with a ctrl + click."
+  - rscdel: "All verbs have been removed from hydroponics trays - namely for closing the lid and for changing the lighting - now that both are accessible via an alt + click and a ctrl + click respectively."
+  - balance: "Several plants in hydroponics now have more dramatic temperature requirements - mushrooms and Adhomian plants require cooler temperatures, and several others require warmer temperatures. Remember to use atmospheric equipment if you want them to grow fast!"
+  - rscadd: "More feedback has been added to attacking the contents of hydroponics trays."
+  - code_imp: "Introduced and shuffled some more documentation to hydroponics code."

--- a/html/changelogs/hazelmouse-morehydrostuff.yml
+++ b/html/changelogs/hazelmouse-morehydrostuff.yml
@@ -55,9 +55,9 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Plants now grow faster if within their ideal heat and light preferences! If you notice plants growing unusually slowly, try checking their requirements with a plant analyzer - you might be able to speed it up drastically by giving them the right conditions."
+  - rscadd: "Plants now grow faster if within their ideal heat and light preferences! If you notice plants growing unusually slowly, try checking their requirements with a plant analyzer - you might be able to speed it up drastically by giving them the right conditions. Currently, preferential temperatures are within 5 kelvin of their ideal, and preferential lighting is within 2 lumens of their ideal."
   - rscadd: "The internal lighting setting of hydroponics trays can now be edited with a ctrl + click."
   - rscdel: "All verbs have been removed from hydroponics trays - namely for closing the lid and for changing the lighting - now that both are accessible via an alt + click and a ctrl + click respectively."
   - balance: "Several plants in hydroponics now have more dramatic temperature requirements - mushrooms and Adhomian plants require cooler temperatures, and several others require warmer temperatures."
-  - rscadd: "More feedback has been added to attacking the contents of hydroponics trays."
+  - rscadd: "More feedback has been added to attacking the contents of hydroponics trays, opening and closing their lids, and changing their light levels."
   - code_imp: "Introduced and shuffled a lot of documentation in hydroponics code."

--- a/html/changelogs/hazelmouse-morehydrostuff.yml
+++ b/html/changelogs/hazelmouse-morehydrostuff.yml
@@ -55,8 +55,9 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
+  - rscadd: "Plants now grow faster if within their ideal heat and light preferences! If you notice plants growing unusually slowly, try checking their requirements with a plant analyzer - you might be able to speed it up drastically by giving them the right conditions."
   - rscadd: "The internal lighting setting of hydroponics trays can now be edited with a ctrl + click."
   - rscdel: "All verbs have been removed from hydroponics trays - namely for closing the lid and for changing the lighting - now that both are accessible via an alt + click and a ctrl + click respectively."
-  - balance: "Several plants in hydroponics now have more dramatic temperature requirements - mushrooms and Adhomian plants require cooler temperatures, and several others require warmer temperatures. Remember to use atmospheric equipment if you want them to grow fast!"
+  - balance: "Several plants in hydroponics now have more dramatic temperature requirements - mushrooms and Adhomian plants require cooler temperatures, and several others require warmer temperatures."
   - rscadd: "More feedback has been added to attacking the contents of hydroponics trays."
-  - code_imp: "Introduced and shuffled some more documentation to hydroponics code."
+  - code_imp: "Introduced and shuffled a lot of documentation in hydroponics code."


### PR DESCRIPTION
This is sorta bulky on the changes since it includes a lot of shuffled documentation, so I'll try to thoroughly summarise here.

- Introduces 'preferential' temperature and light values  to plants. This means that, while a plant is _within_ 5K and 2 lumens of their ideal heat and ideal light, they will grow faster than otherwise. In the current implementation, the base growth is a 15% chance of age being increased, plus another 15% if you're within preferential temps, and another 5% if within preferential lumens for a maximum of 35%. This is intended to incentivise engaging with temperature mechanics to grow plants with unusual requirements.
- This is different to the existing tolerance values, which instead check whether the plant is _outside_ of them - if they are, it damages them. Tolerances cause the plant to die if they're too far from their ideals, preferences cause the plant to grow faster if they're very close to their ideals. The range of preferences should always be inside tolerances.
- To work better with this, the ideals of a few kinds of plant have been tweaked. Mushrooms, Adhomian plants, and molluscs will all **not** be in their preferences at room temperature - they will need to be cooled, which can currently be done in D1 hydroponics. A few warmer plants, such as sugarcane, will need to be warmed up to reach their preferences. 
- None of these will go outside of their tolerances at room temperature - they won't die, they'll just grow slower.
- Most plants will be within all their preferences without any action by the gardener.

There's also a few assorted QoL changes to hydrotrays, see the changelog. 