### PR TITLE
Stock parts power usage and examine handling

### DIFF
--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -54,9 +54,18 @@
 	var/gfi_layer_rotation = GFI_ROTATION_DEFAULT
 
 	// Extra descriptions.
-	var/desc_extended = null // Regular text about the atom's extended description, if any exists.
-	var/desc_info = null // Blue text (SPAN_NOTICE()), informing the user about how to use the item or about game controls.
-	var/desc_antag = null // Red text (SPAN_ALERT()), informing the user about how they can use an object to antagonize.
+	// Regular text about the atom's extended description, if any exists.
+	var/desc_extended = null
+	// Blue text (SPAN_NOTICE()), informing the user about how to use the item or about game controls.
+	var/desc_info = null
+	// Blue text (SPAN_NOTICE()), informing the user about how to assemble or disassemble the item.
+	var/desc_build = null
+	// Blue text (SPAN_NOTICE()), informing the user about what upgrades the item has and what they do.
+	// Format desc_upgrade = "This object/item/machine/structure/etc has the following upgrades available:"
+	// Currently only supports machines- see code\game\machinery\machinery.dm for example.
+	var/desc_upgrade = null
+	// Red text (SPAN_ALERT()), informing the user about how they can use an object to antagonize.
+	var/desc_antag = null
 
 	/* SSicon_update VARS */
 

--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -63,28 +63,55 @@
 		else
 			f_name += "oil-stained [name][infix]."
 
-	. += "[icon2html(src, user)] That's [f_name] [suffix]" // Object name. I.e. "This is an Object. It is a normal-sized item."
+	// Object name. I.e. "This is an Object. It is a normal-sized item."
+	. += "[icon2html(src, user)] That's [f_name] [suffix]" 
 
 	if(src.desc)
 		. += src.desc	// Object description.
 
 	// Extra object descriptions examination code.
 	if(show_extended)
-		if(desc_extended) // If the item has a extended description, show it.
+		// If the item has a extended description, show it.
+		if(desc_extended)
 			. += desc_extended
-		if(desc_info) // If the item has a description regarding game mechanics, show it.
+		// If the item has a description regarding game mechanics, show it.
+		if(desc_info)
+			. += FONT_SMALL(SPAN_NOTICE("<b>Mechanics</b>"))
 			. += FONT_SMALL(SPAN_NOTICE("- [desc_info]"))
-		if(desc_antag && player_is_antag(user.mind)) // If the item has an antagonist description and the user is an antagonist, show it.
+		// If the item has a description with assembly/disassembly instructions, show it.
+		if(desc_build)
+			. += FONT_SMALL(SPAN_NOTICE("<b>Assembly/Disassembly</b>"))
+			. += FONT_SMALL(SPAN_NOTICE("- [desc_build]"))
+		// If the item has a description about its upgrade components and what they do, show it.
+		// This one doesnt come prepended with a hyphen because theyre added when the desc is dynamically built.
+		if(desc_upgrade) 
+			. += FONT_SMALL(SPAN_NOTICE("<b>Upgrades</b>"))
+			. += FONT_SMALL(SPAN_NOTICE("[desc_upgrade]"))
+		// If the item has an antagonist description and the user is an antagonist/ghost, show it.
+		if(desc_antag && (player_is_antag(user.mind) || isghost(user) || isstoryteller(user)))
+			. += FONT_SMALL(SPAN_ALERT("<b>Antagonism</b>"))
 			. += FONT_SMALL(SPAN_ALERT("- [desc_antag]"))
 	else
-		if(desc_extended || desc_info || (desc_antag && player_is_antag(user.mind))) // Checks if the object has a extended description, a mechanics description, and/or an antagonist description (and if the user is an antagonist).
-			. += FONT_SMALL(SPAN_NOTICE("\[?\] This object has additional examine information available. <a href='byond://?src=[REF(src)];examine_fluff=1'>\[Show In Chat\]</a>")) // If any of the above are true, show that the object has more information available.
-			if(desc_extended) // If the item has a extended description, show that it is available.
-				. +=  FONT_SMALL("- This object has an extended description.")
-			if(desc_info) // If the item has a description regarding game mechanics, show that it is available.
-				. += FONT_SMALL(SPAN_NOTICE("- This object has additional information about mechanics."))
-			if(desc_antag && player_is_antag(user.mind)) // If the item has an antagonist description and the user is an antagonist, show that it is available.
-				. += FONT_SMALL(SPAN_ALERT("- This object has additional information for antagonists."))
+		// Checks if the object has a extended desc blocks (and if the user is allowed to see it).
+		if(desc_extended || desc_info || desc_build || desc_upgrade || (desc_antag && (player_is_antag(user.mind) || isghost(user) || isstoryteller(user))))
+			. += FONT_SMALL(SPAN_NOTICE("\[?\] This object has the following additional examine information available:"))
+			// If the item has a extended description, show that it is available.
+			if(desc_extended) 
+				. +=  FONT_SMALL("- Extended description")
+			// If the item has a description regarding game mechanics, show that it is available.
+			if(desc_info) 
+				. += FONT_SMALL(SPAN_NOTICE("- Mechanics"))
+			// If the item has a description with assembly/disassembly instructions, show that it is available.
+			if(desc_build) 
+				. += FONT_SMALL(SPAN_NOTICE("- Assembly/disassembly"))
+			// If the item has a description about its upgrade components and what they do, show that it is available.
+			if(desc_upgrade) 
+				. += FONT_SMALL(SPAN_NOTICE("- Upgrades"))
+			// If the item has an antagonist description and the user is an antagonist/ghost, show that it is available.
+			if(desc_antag && (player_is_antag(user.mind) || isghost(user) || isstoryteller(user)))
+				. += FONT_SMALL(SPAN_ALERT("- Antagonist info"))
+			// If any of the above are true, show that the object has more information available.
+			. += FONT_SMALL(SPAN_NOTICE("<a href='byond://?src=[REF(src)];examine_fluff=1'>\[Show In Chat\]</a>"))
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -38,7 +38,6 @@
 
 	idle_power_usage = 15
 	active_power_usage = 250 //builtin health analyzer, dialysis machine, injectors.
-	var/parts_power_usage
 	var/stasis_power = 500
 
 	component_types = list(
@@ -92,22 +91,6 @@
 		return
 	else
 		icon_state = initial(icon_state)
-
-/obj/machinery/sleeper/RefreshParts()
-	..()
-	var/scan_rating = 0
-	var/cap_rating = 0
-
-	for(var/obj/item/stock_parts/P in component_parts)
-		if(isscanner(P))
-			scan_rating += P.rating
-		else if(iscapacitor(P))
-			cap_rating += P.rating
-
-	beaker = locate(/obj/item/reagent_containers/glass/beaker) in component_parts
-
-	change_power_consumption((initial(active_power_usage) - (cap_rating + scan_rating)*2), POWER_USE_ACTIVE)
-	parts_power_usage = active_power_usage
 
 /obj/machinery/sleeper/attack_hand(var/mob/user)
 	if(..())

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -48,6 +48,11 @@
 			/obj/item/reagent_containers/glass/beaker/large
 		)
 
+	component_hint_cap = "Upgraded <b>capacitors</b> will reduce power usage."
+	component_hint_scan = "Upgraded <b>scanning modules</b> will reduce power usage."
+
+	parts_power_mgmt = FALSE
+
 /obj/machinery/sleeper/Initialize()
 	. = ..()
 	update_icon()
@@ -91,6 +96,22 @@
 		return
 	else
 		icon_state = initial(icon_state)
+
+/obj/machinery/sleeper/RefreshParts()
+	..()
+	var/scan_rating = 0
+	var/cap_rating = 0
+
+	for(var/obj/item/stock_parts/P in component_parts)
+		if(isscanner(P))
+			scan_rating += P.rating
+		else if(iscapacitor(P))
+			cap_rating += P.rating
+
+	beaker = locate(/obj/item/reagent_containers/glass/beaker) in component_parts
+
+	change_power_consumption((initial(active_power_usage) - (cap_rating + scan_rating)*2), POWER_USE_ACTIVE)
+	parts_power_usage = active_power_usage
 
 /obj/machinery/sleeper/attack_hand(var/mob/user)
 	if(..())

--- a/code/game/machinery/autolathe/autolathe.dm
+++ b/code/game/machinery/autolathe/autolathe.dm
@@ -43,6 +43,9 @@
 		/obj/item/stock_parts/console_screen
 	)
 
+	component_hint_bin = "Upgraded <b>matter bins</b> will increase material storage capacity."
+	component_hint_servo = "Upgraded <b>manipulators</b> will improve material use efficiency and increase fabrication speed."
+
 /obj/machinery/autolathe/Initialize()
 	..()
 	wires = new(src)

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -14,6 +14,10 @@
 	var/eat_eff = 1
 	var/capacity = 100
 
+	component_hint_servo = "Upgraded <b>manipulators</b> will increase the nutrients provided by new inputs."
+	component_hint_bin = "Upgraded <b>matter bins</b> will decrease the conversion cost of bio-goods."
+
+
 	component_types = list(
 		/obj/item/circuitboard/biogenerator,
 		/obj/item/stock_parts/matter_bin,

--- a/code/game/machinery/chem_heater.dm
+++ b/code/game/machinery/chem_heater.dm
@@ -18,6 +18,7 @@
 	var/min_temperature = 100
 	var/max_temperature = 600
 	var/slow_mode = FALSE
+	component_hint_servo = "Upgraded <b>servos</b> increase the speed at which vessel contents are heated."
 
 	component_types = list(
 		/obj/item/circuitboard/chem_heater,

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -54,6 +54,8 @@
 	var/slow_stasis_mult = 1.7
 	var/current_stasis_mult = 1
 
+	component_hint_servo = "Upgraded <b>manipulators</b> will increase effectiveness of both hyper-metabolism and cryostasis functions."
+
 /obj/machinery/atmospherics/unary/cryo_cell/Initialize()
 	. = ..()
 	update_icon()

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -2,8 +2,8 @@
 	name = "\improper IV drip"
 	desc = "A professional standard intravenous stand with supplemental gas support for medical use."
 	desc_info = "IV drips can be supplied beakers/bloodpacks for reagent transfusions, as well as one breath mask and gas tank for supplemental gas therapy. \
-	It can be upgraded. <br>Click and Drag to attach/detach the IV or secure/remove the breath mask on your target. <br>Click the stand with an empty hand to \
-	toggle between various modes. Using a wrench when it has a tank installed will secure it.<br>Alt Click the stand to remove items contained in the stand."
+	<br>- Click and Drag to attach/detach the IV or secure/remove the breath mask on your target. <br>- Click the stand with an empty hand to \
+	toggle between various modes. Using a wrench when it has a tank installed will secure it.<br>- Alt Click the stand to remove items contained in the stand."
 	icon = 'icons/obj/iv_drip.dmi'
 	icon_state = "iv_stand"
 	anchored = 0
@@ -61,7 +61,7 @@
 		/obj/item/stock_parts/scanning_module)
 
 	component_hint_scan = "Upgraded <b>scanning modules</b> will provide the exact volume and composition of attached beakers."
-	component_hint_servo = "Upgraded <b>manipulators</b> will allow IVs to be injectedly more rapidly and increase the maximum reagent transfer rate."
+	component_hint_servo = "Upgraded <b>manipulators</b> will allow patients to be hooked to IV through armor and increase the maximum reagent transfer rate."
 
 /obj/machinery/iv_drip/Initialize(mapload)
 	. = ..()
@@ -699,7 +699,7 @@
 	. = ..()
 	if(distance > 2)
 		return
-	. += SPAN_NOTICE("[src] is [mode ? "injecting" : "taking blood"] at a rate of [src.transfer_amount] u/sec, the automatic injection stop mode is [toggle_stop ? "on" : "off"]. The Emergency Positive Pressure \
+	. += SPAN_NOTICE("<br>[src] is [mode ? "injecting" : "taking blood"] at a rate of [src.transfer_amount] u/sec, the automatic injection stop mode is [toggle_stop ? "on" : "off"]. The Emergency Positive Pressure \
 	system is [epp ? "on" : "off"].")
 	if(attached)
 		. += SPAN_NOTICE("\The [src] is attached to [attached]'s [vein.name].")

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -60,6 +60,9 @@
 		/obj/item/stock_parts/manipulator,
 		/obj/item/stock_parts/scanning_module)
 
+	component_hint_scan = "Upgraded <b>scanning modules</b> will provide the exact volume and composition of attached beakers."
+	component_hint_servo = "Upgraded <b>manipulators</b> will allow IVs to be injectedly more rapidly and increase the maximum reagent transfer rate."
+
 /obj/machinery/iv_drip/Initialize(mapload)
 	. = ..()
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -123,13 +123,16 @@ Class Procs:
 	var/list/component_parts = null
 	/// The total power rating of all parts serves as a power usage multiplier.
 	var/parts_power_usage = 0
-	/// Blurbs for what each component type does.
-	var/component_hint_cap
-	var/component_hint_scan
-	var/component_hint_servo
-	var/component_hint_laser
-	var/component_hint_bin
+	/// Blurbs for what each component type does. Appended to machine's /desc_info.
+	/// Kindly use the format in appended comments for consistency
+	var/component_hint_bin    // "Upgraded <b>matter bins</b> will XYZ."
+	var/component_hint_cap    // "Upgraded <b>capacitors</b> will XYZ."
+	var/component_hint_laser  // "Upgraded <b>micro-lasers</b> will XYZ"
+	var/component_hint_scan   // "Upgraded <b>scanning modules</b> will XYZ"
+	var/component_hint_servo  // "Upgraded <b>manipulators</b> will XYZ"
 
+	component_hint_bin = "Upgraded <b>matter bins</b> will increase material storage capacity."
+	component_hint_servo = "Upgraded <b>manipulators</b> will improve material use efficiency and increase fabrication speed."
 	var/uid
 	var/panel_open = 0
 	var/global/gl_uid = 1
@@ -178,6 +181,7 @@ Class Procs:
 
 		if(component_parts.len)
 			RefreshParts()
+			UpdatePartsDesc()
 
 /obj/machinery/Destroy()
 	//Stupid macro used in power usage
@@ -452,13 +456,6 @@ Class Procs:
 	if(!LAZYLEN(component_parts))
 		LOG_DEBUG("no component parts")
 		return FALSE
-	if(istype(R, /obj/item/device/debugger))
-		LOG_DEBUG("im a debugger!")
-		LOG_DEBUG("debugger go go go")
-		to_chat(user, SPAN_NOTICE("The following parts have been detected in \the [src]:"))
-		to_chat(user, counting_english_list(component_parts))
-		to_chat(part_overview())
-		return TRUE
 	else if(istype(R))
 		var/parts_replaced = FALSE
 		if(panel_open)
@@ -512,24 +509,20 @@ Class Procs:
 	LOG_DEBUG("poop")
 	else return FALSE
 
-/obj/machinery/proc/part_overview()
-	var/list/part_hints
+/obj/machinery/proc/UpdatePartsDesc()
+	. = list()
+	. += desc_info
 	if(component_hint_cap)
-		LOG_DEBUG("component_hint_cap")
-		part_hints += SPAN_NOTICE(component_hint_cap)
+		. += SPAN_NOTICE(component_hint_cap)
 	if(component_hint_scan)
-		LOG_DEBUG("component_hint_scan")
-		part_hints += SPAN_NOTICE(component_hint_scan)
+		. += SPAN_NOTICE(component_hint_scan)
 	if(component_hint_servo)
-		LOG_DEBUG("component_hint_servo")
-		part_hints += SPAN_NOTICE(component_hint_servo)
+		. += SPAN_NOTICE(component_hint_servo)
 	if(component_hint_laser)
-		LOG_DEBUG("component_hint_laser")
-		part_hints += SPAN_NOTICE(component_hint_laser)
+		. += SPAN_NOTICE(component_hint_laser)
 	if(component_hint_bin)
-		LOG_DEBUG("component_hint_bin")
-		part_hints += SPAN_NOTICE(component_hint_bin)
-	return part_hints
+		. += SPAN_NOTICE(component_hint_bin)
+	desc_info = .
 
 /obj/machinery/proc/dismantle()
 	playsound(loc, /singleton/sound_category/crowbar_sound, 50, 1)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -1,84 +1,85 @@
-/*
-Overview:
-	Used to create objects that need a per step proc call.  Default definition of 'New()'
-	stores a reference to src machine in global 'machines list'.  Default definition
-	of 'Del' removes reference to src machine in global 'machines list'.
-
-Class Variables:
-	use_power (num)
-		current state of auto power use.
-		Possible Values:
-			0 -- no auto power use
-			1 -- machine is using power at its idle power level
-			2 -- machine is using power at its active power level
-
-	active_power_usage (num)
-		Value for the amount of power to use when in active power mode
-
-	idle_power_usage (num)
-		Value for the amount of power to use when in idle power mode
-
-	power_channel (num)
-		What channel to draw from when drawing power for power mode
-		Possible Values:
-			AREA_USAGE_EQUIP:0 -- Equipment Channel
-			AREA_USAGE_LIGHT:2 -- Lighting Channel
-			AREA_USAGE_ENVIRON:3 -- Environment Channel
-
-	component_parts (list)
-		A list of component parts of machine used by frame based machines.
-
-	panel_open (num)
-		Whether the panel is open
-
-	uid (num)
-		Unique id of machine across all machines.
-
-	gl_uid (global num)
-		Next uid value in sequence
-
-	stat (bitflag)
-		Machine status bit flags.
-		Possible bit flags:
-			BROKEN:1 -- Machine is broken
-			NOPOWER:2 -- No power is being supplied to machine.
-			POWEROFF:4 -- tbd
-			MAINT:8 -- machine is currently under going maintenance.
-			EMPED:16 -- temporary broken by EMP pulse
-
-Class Procs:
-	New()                     'game/machinery/machine.dm'
-
-	Destroy()                     'game/machinery/machine.dm'
-
-	powered(chan = AREA_USAGE_EQUIP)         'modules/power/power_usage.dm'
-		Checks to see if area that contains the object has power available for power
-		channel given in 'chan'.
-
-	use_power_oneoff(amount, chan=AREA_USAGE_EQUIP, autocalled)   'modules/power/power_usage.dm'
-		Deducts 'amount' from the power channel 'chan' of the area that contains the object.
-		This is not a continuous draw, but rather will be cleared after one APC update.
-
-	power_change()               'modules/power/power_usage.dm'
-		Called by the area that contains the object when ever that area under goes a
-		power state change (area runs out of power, or area channel is turned off).
-
-	RefreshParts()               'game/machinery/machine.dm'
-		Called to refresh the variables in the machine that are contributed to by parts
-		contained in the component_parts list. (example: glass and material amounts for
-		the autolathe)
-
-		Default definition handles power usage only (all parts contribute based on energy_rating).
-
-	assign_uid()               'game/machinery/machine.dm'
-		Called by machine to assign a value to the uid variable.
-
-	process()                  'game/machinery/machine.dm'
-		Called by the 'master_controller' once per game tick for each machine that is listed in the 'machines' list.
-
-
-	Compiled by Aygar
-*/
+/**
+ * 
+ * Overview:
+ * 	Used to create objects that need a per step proc call.  Default definition of 'New()'
+ * 	stores a reference to src machine in global 'machines list'.  Default definition
+ * 	of 'Del' removes reference to src machine in global 'machines list'.
+ * 
+ * Class Variables:
+ * 	use_power (num)
+ * 		current state of auto power use.
+ * 		Possible Values:
+ * 			0 -- no auto power use
+ * 			1 -- machine is using power at its idle power level
+ * 			2 -- machine is using power at its active power level
+ * 
+ * 	active_power_usage (num)
+ * 		Value for the amount of power to use when in active power mode
+ * 
+ * 	idle_power_usage (num)
+ * 		Value for the amount of power to use when in idle power mode
+ * 
+ * 	power_channel (num)
+ * 		What channel to draw from when drawing power for power mode
+ * 		Possible Values:
+ * 			AREA_USAGE_EQUIP:0 -- Equipment Channel
+ * 			AREA_USAGE_LIGHT:2 -- Lighting Channel
+ * 			AREA_USAGE_ENVIRON:3 -- Environment Channel
+ * 
+ * 	component_parts (list)
+ * 		A list of component parts of machine used by frame based machines.
+ * 
+ * 	panel_open (num)
+ * 		Whether the panel is open
+ * 
+ * 	uid (num)
+ * 		Unique id of machine across all machines.
+ * 
+ * 	gl_uid (global num)
+ * 		Next uid value in sequence
+ * 
+ * 	stat (bitflag)
+ * 		Machine status bit flags.
+ * 		Possible bit flags:
+ * 			BROKEN:1 -- Machine is broken
+ * 			NOPOWER:2 -- No power is being supplied to machine.
+ * 			POWEROFF:4 -- tbd
+ * 			MAINT:8 -- machine is currently under going maintenance.
+ * 			EMPED:16 -- temporary broken by EMP pulse
+ * 
+ * 	Class Procs:
+ * 		New()                     'game/machinery/machine.dm'
+ * 
+ * 		Destroy()                     'game/machinery/machine.dm'
+ * 
+ * 		powered(chan = AREA_USAGE_EQUIP)         'modules/power/power_usage.dm'
+ * 			Checks to see if area that contains the object has power available for power
+ * 			channel given in 'chan'.
+ * 
+ * 		use_power_oneoff(amount, chan=AREA_USAGE_EQUIP, autocalled)   'modules/power/power_usage.dm'
+ * 			Deducts 'amount' from the power channel 'chan' of the area that contains the object.
+ * 			This is not a continuous draw, but rather will be cleared after one APC update.
+ * 
+ * 		power_change()               'modules/power/power_usage.dm'
+ * 			Called by the area that contains the object when ever that area under goes a
+ * 			power state change (area runs out of power, or area channel is turned off).
+ * 
+ * 		RefreshParts()               'game/machinery/machine.dm'
+ * 			Called to refresh the variables in the machine that are contributed to by parts
+ * 			contained in the component_parts list. (example: glass and material amounts for
+ * 			the autolathe)
+ * 
+ * 			Default definition handles power usage only (all parts contribute based on energy_rating).
+ * 
+ * 		assign_uid()               'game/machinery/machine.dm'
+ * 			Called by machine to assign a value to the uid variable.
+ * 
+ * 		process()                  'game/machinery/machine.dm'
+ * 			Called by the 'master_controller' once per game tick for each machine that is listed in the 'machines' list.
+ * 
+ * 
+ * 	Compiled by Aygar
+ */
 
 /obj/machinery
 	name = "machinery"

--- a/code/game/machinery/mech_recharger.dm
+++ b/code/game/machinery/mech_recharger.dm
@@ -22,6 +22,10 @@
 		/obj/item/stock_parts/manipulator = 2
 	)
 
+	component_hint_cap = "Upgraded <b>capacitors</b> will increase charging rate."
+	component_hint_scan = "Upgraded <b>scanning modules</b> will increase both charging rate and repair speed."
+	component_hint_servo = "Upgraded <b>manipulators</b> will increase repair speed."
+
 /obj/machinery/mech_recharger/Initialize(mapload)
 	. = ..()
 
@@ -46,6 +50,7 @@
 
 /obj/machinery/mech_recharger/RefreshParts()
 	..()
+	
 	charge = 0
 	repair = -5
 

--- a/code/game/machinery/mecha_fabricator.dm
+++ b/code/game/machinery/mecha_fabricator.dm
@@ -44,6 +44,10 @@
 	///The timer id for the build callback, if we're building something
 	var/build_callback_timer
 
+	component_hint_bin = "Upgraded <b>matter bins</b> will increase material storage capacity."
+	component_hint_laser = "Upgraded <b>micro-lasers</b> will increase fabrication speed."
+	component_hint_servo = "Upgraded <b>manipulators</b> will improve material use efficiency."
+
 /obj/machinery/mecha_part_fabricator/Initialize()
 	. = ..()
 
@@ -73,6 +77,7 @@
 	..()
 
 /obj/machinery/mecha_part_fabricator/RefreshParts()
+	..()
 	res_max_amount = 0
 
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -136,8 +136,14 @@
 			D.master_matrix.apply_upgrades(D)
 
 /obj/machinery/recharge_station/get_examine_text(mob/user, distance, is_adjacent, infix, suffix)
+	desc = initial(desc)
+	desc += "<br>Uses a dedicated internal power cell to deliver <b>[charging_power]W</b> when in use."
+	desc += "<br>The charge meter reads: <b>[round(chargepercentage())]%</b>."
+	if(weld_rate)
+		desc += "<br>It is capable of repairing stationbounds' structural damage."
+	if(wire_rate)
+		desc += "<br>It is capable of repairing stationbounds' burn damage."
 	. = ..()
-	. += "The charge meter reads: [round(chargepercentage())]%."
 
 /obj/machinery/recharge_station/proc/chargepercentage()
 	if(!cell)
@@ -202,13 +208,6 @@
 	restore_power_passive = 5000 + 1000 * cap_rating
 	weld_rate = max(0, man_rating - 3)
 	wire_rate = max(0, man_rating - 5)
-
-	desc = initial(desc)
-	desc += " Uses a dedicated internal power cell to deliver [charging_power]W when in use."
-	if(weld_rate)
-		desc += "<br>It is capable of repairing stationbounds' structural damage."
-	if(wire_rate)
-		desc += "<br>It is capable of repairing stationbounds' burn damage."
 
 /obj/machinery/recharge_station/proc/build_overlays()
 	ClearOverlays()

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -45,6 +45,9 @@
 		/obj/item/stack/cable_coil{amount = 5}
 	)
 
+	component_hint_cap = "Upgraded <b>capacitors</b> will increase charging rate."
+	component_hint_servo = "Upgraded <b>manipulators</b> will make the recharging station also start to repair brute damage, then also burn damage, at increasing speed."
+
 /obj/machinery/recharge_station/Initialize()
 	. = ..()
 	update_icon()
@@ -182,6 +185,7 @@
 
 /obj/machinery/recharge_station/RefreshParts()
 	..()
+
 	var/man_rating = 0
 	var/cap_rating = 0
 

--- a/code/game/machinery/stasis_cage.dm
+++ b/code/game/machinery/stasis_cage.dm
@@ -36,6 +36,8 @@
 	 */
 	var/obj/item/cell/cell = null
 
+	component_hint_cap = "Upgraded <b>capacitors</b> will reduce power usage."
+
 
 /obj/machinery/stasis_cage/Initialize()
 	. = ..()
@@ -199,7 +201,6 @@
 
 
 /obj/machinery/stasis_cage/RefreshParts()
-	..()
 	var/charge_multiplier
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)
 		charge_multiplier += C.rating / 2

--- a/code/game/machinery/stasis_cage.dm
+++ b/code/game/machinery/stasis_cage.dm
@@ -38,6 +38,8 @@
 
 	component_hint_cap = "Upgraded <b>capacitors</b> will reduce power usage."
 
+	parts_power_mgmt = FALSE
+
 
 /obj/machinery/stasis_cage/Initialize()
 	. = ..()
@@ -201,6 +203,7 @@
 
 
 /obj/machinery/stasis_cage/RefreshParts()
+	..()
 	var/charge_multiplier
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)
 		charge_multiplier += C.rating / 2

--- a/code/game/objects/items/devices/debugger.dm
+++ b/code/game/objects/items/devices/debugger.dm
@@ -1,7 +1,8 @@
 // Used to resolve throwing vendors without going directly into wiring.
 /obj/item/device/debugger
 	name = "debugger"
-	desc = "Used to debug electronic equipment."
+	desc = "Used to debug electronic equipment, debuggers come with a retractable data cable that can be plugged into most machines."
+	desc_info = "The debugger can be used on vending machines to identify and resolve any viral infections, or on upgradeable machinery to identify the component parts it contains"
 	icon = 'icons/obj/hacktool.dmi'
 	icon_state = "hacktool-g"
 	obj_flags = OBJ_FLAG_CONDUCTABLE

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -31,6 +31,10 @@
 		/obj/item/stack/cable_coil{amount = 2}
 	)
 
+	component_hint_bin = "Upgraded <b>matter bins</b> will improve cooling efficiency and increase the volume of air it can cool at once."
+	component_hint_cap = "Upgraded <b>capacitors</b> will increase maximum power setting."
+	component_hint_servo = "Upgraded <b>manipulators</b> will improve cooling efficiency."
+
 /obj/machinery/atmospherics/unary/freezer/Initialize()
 	initialize_directions = dir
 	. = ..()
@@ -150,7 +154,6 @@
 
 //upgrading parts
 /obj/machinery/atmospherics/unary/freezer/RefreshParts()
-	..()
 	var/cap_rating = 0
 	var/manip_rating = 0
 	var/bin_rating = 0

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -35,6 +35,8 @@
 	component_hint_cap = "Upgraded <b>capacitors</b> will increase maximum power setting."
 	component_hint_servo = "Upgraded <b>manipulators</b> will improve cooling efficiency."
 
+	parts_power_mgmt = FALSE
+
 /obj/machinery/atmospherics/unary/freezer/Initialize()
 	initialize_directions = dir
 	. = ..()
@@ -154,6 +156,7 @@
 
 //upgrading parts
 /obj/machinery/atmospherics/unary/freezer/RefreshParts()
+	..()
 	var/cap_rating = 0
 	var/manip_rating = 0
 	var/bin_rating = 0

--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -30,6 +30,9 @@
 		/obj/item/stack/cable_coil{amount = 5}
 	)
 
+	component_hint_bin = "Upgraded <b>matter bins</b> will increase maximum temperature setting and the volume of air it can heat at once."
+	component_hint_cap = "Upgraded <b>capacitors</b> will increase maximum power setting and maximum temperature setting."
+
 /obj/machinery/atmospherics/unary/heater/Initialize()
 	initialize_directions = dir
 	. = ..()

--- a/code/modules/cooking/machinery/cooking_machines/_appliance.dm
+++ b/code/modules/cooking/machinery/cooking_machines/_appliance.dm
@@ -53,6 +53,9 @@
 	var/place_verb = "into"
 	var/combine_first = FALSE//If 1, this appliance will do combination cooking before checking recipes
 
+	component_hint_cap = "Upgraded <b>capacitors</b> will increase heating power."
+	component_hint_scan = "Upgraded <b>scanning modules</b> will increase heating power and improve power efficiency."
+
 /obj/machinery/appliance/Initialize()
 	. = ..()
 	if(length(output_options))
@@ -664,7 +667,6 @@
 	cooking_power = cooking_coeff
 
 /obj/machinery/appliance/RefreshParts()
-	..()
 	var/scan_rating = 0
 	var/cap_rating = 0
 

--- a/code/modules/cooking/machinery/cooking_machines/_appliance.dm
+++ b/code/modules/cooking/machinery/cooking_machines/_appliance.dm
@@ -27,6 +27,8 @@
 							/obj/item/stock_parts/scanning_module = 1,
 							/obj/item/stock_parts/matter_bin = 2)
 
+	parts_power_mgmt = FALSE
+
 	var/cooking_power = 0			// Effectiveness/speed at cooking
 	var/cooking_coeff = 0			// Part-based cooking power multiplier
 	var/heating_power = 1000		// Effectiveness at heating up; not used for mixers, should be equal to active_power_usage
@@ -667,6 +669,7 @@
 	cooking_power = cooking_coeff
 
 /obj/machinery/appliance/RefreshParts()
+	..()
 	var/scan_rating = 0
 	var/cap_rating = 0
 

--- a/code/modules/cooking/machinery/cooking_machines/grill.dm
+++ b/code/modules/cooking/machinery/cooking_machines/grill.dm
@@ -43,6 +43,7 @@
 	. = ..()
 
 /obj/machinery/appliance/cooker/grill/RefreshParts()
+	..()
 	cooking_coeff = 0.3 // we will always cook nice and slow
 
 /obj/machinery/appliance/cooker/grill/get_efficiency()

--- a/code/modules/cooking/machinery/cooking_machines/grill.dm
+++ b/code/modules/cooking/machinery/cooking_machines/grill.dm
@@ -43,7 +43,6 @@
 	. = ..()
 
 /obj/machinery/appliance/cooker/grill/RefreshParts()
-	..()
 	cooking_coeff = 0.3 // we will always cook nice and slow
 
 /obj/machinery/appliance/cooker/grill/get_efficiency()

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -62,6 +62,8 @@
 	component_hint_cap = "Upgraded <b>capacitors</b> will improve power efficiency."
 	component_hint_laser = "Upgraded <b>micro-lasers</b> will increase the amount of ore harvested."
 
+	parts_power_mgmt = FALSE
+
 	/// The list of ores currently held within the mining drill
 	var/list/stored_ores = list()
 
@@ -439,6 +441,7 @@
 	return
 
 /obj/machinery/mining/drill/RefreshParts()
+	..()
 	harvest_speed = 0
 	capacity = 0
 	charge_use = 25

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -58,6 +58,10 @@
 		/obj/item/cell/high
 	)
 
+	component_hint_bin = "Upgraded <b>matter bins</b> will increase ore capacity."
+	component_hint_cap = "Upgraded <b>capacitors</b> will improve power efficiency."
+	component_hint_laser = "Upgraded <b>micro-lasers</b> will increase the amount of ore harvested."
+
 	/// The list of ores currently held within the mining drill
 	var/list/stored_ores = list()
 
@@ -435,7 +439,6 @@
 	return
 
 /obj/machinery/mining/drill/RefreshParts()
-	..()
 	harvest_speed = 0
 	capacity = 0
 	charge_use = 25

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -36,6 +36,10 @@
 		/obj/item/stock_parts/console_screen
 	)
 
+	component_hint_cap = "Upgraded <b>capacitors</b> will increase the amount of ore smelted per second."
+	component_hint_laser = "Upgraded <b>micro-lasers</b> will increase the amount of ore smelted per second."
+	component_hint_scan = "Upgraded <b>scanning modules</b> will increase the amount of ore smelted per second."
+
 /obj/machinery/mineral/processing_unit_console/Initialize(mapload, d, populate_components)
 	. = ..()
 	var/mutable_appearance/screen_overlay = mutable_appearance(icon, "production_console-screen", plane = EFFECTS_ABOVE_LIGHTING_PLANE)

--- a/code/modules/mob/living/carbon/slime/slime_extractor.dm
+++ b/code/modules/mob/living/carbon/slime/slime_extractor.dm
@@ -19,6 +19,9 @@
 		/obj/item/stack/cable_coil{amount = 5}
 	)
 
+	component_hint_bin = "Upgraded <b>matter bins</b> will increase slime capacity."
+	component_hint_laser = "Upgraded <b>micro-lasers</b> will increase extraction speed."
+
 /obj/machinery/slime_extractor/get_examine_text(mob/user, distance, is_adjacent, infix, suffix)
 	. = ..()
 	. += FONT_SMALL(SPAN_NOTICE("It can hold <b>[slime_limit] slime\s</b> at a time."))

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -17,7 +17,10 @@
 		/obj/item/cell/high = 3
 	)
 
+	parts_power_mgmt = FALSE
+
 /obj/machinery/power/smes/batteryrack/RefreshParts()
+	..()
 	capacitors_amount = 0
 	cells_amount = 0
 

--- a/code/modules/power/crystal_agitator.dm
+++ b/code/modules/power/crystal_agitator.dm
@@ -26,6 +26,9 @@
 		/obj/item/circuitboard/crystal_agitator
 	)
 
+	component_hint_cap = "Upgraded <b>capacitors</b> will reduce active power usage."
+	component_hint_servo = "Upgraded <b>manipulators</b> will increase agitation speed."
+
 /obj/machinery/power/crystal_agitator/Initialize()
 	. = ..()
 	connect_to_network()

--- a/code/modules/power/crystal_agitator.dm
+++ b/code/modules/power/crystal_agitator.dm
@@ -29,6 +29,8 @@
 	component_hint_cap = "Upgraded <b>capacitors</b> will reduce active power usage."
 	component_hint_servo = "Upgraded <b>manipulators</b> will increase agitation speed."
 
+	parts_power_mgmt = FALSE
+
 /obj/machinery/power/crystal_agitator/Initialize()
 	. = ..()
 	connect_to_network()
@@ -90,6 +92,7 @@
 	last_agitation = world.time
 
 /obj/machinery/power/crystal_agitator/RefreshParts()
+	..()
 	for(var/obj/item/stock_parts/SP in component_parts)
 		if(ismanipulator(SP))
 			agitation_rate = initial(agitation_rate) - (SP.rating * 5)

--- a/code/modules/power/outlet.dm
+++ b/code/modules/power/outlet.dm
@@ -19,6 +19,8 @@
 
 	component_hint_cap = "Upgraded <b>capacitors</b> will increase the rate at which connected devices charge."
 
+	parts_power_mgmt = FALSE
+
 /obj/machinery/power/outlet/Initialize()
 	. = ..()
 	connect_to_network()
@@ -27,6 +29,7 @@
 	icon_state = panel_open ? "[initial(icon_state)]-open" : initial(icon_state)
 
 /obj/machinery/power/outlet/RefreshParts()
+	..()
 	var/part_level = 0
 	for(var/obj/item/stock_parts/SP in component_parts)
 		part_level += SP.rating

--- a/code/modules/power/outlet.dm
+++ b/code/modules/power/outlet.dm
@@ -17,6 +17,8 @@
 		/obj/item/circuitboard/outlet
 	)
 
+	component_hint_cap = "Upgraded <b>capacitors</b> will increase the rate at which connected devices charge."
+
 /obj/machinery/power/outlet/Initialize()
 	. = ..()
 	connect_to_network()

--- a/code/modules/power/portgen.dm
+++ b/code/modules/power/portgen.dm
@@ -15,6 +15,8 @@
 	var/portgen_lightcolour = "#000000"
 	var/datum/looping_sound/generator/soundloop
 
+	component_hint_cap = "Upgraded <b>capacitors</b> will increase maximum power output."
+
 /obj/machinery/power/portgen/Initialize()
 	. = ..()
 	soundloop = new(src, active)

--- a/code/modules/power/portgen.dm
+++ b/code/modules/power/portgen.dm
@@ -139,6 +139,8 @@
 		/obj/item/stock_parts/capacitor
 	)
 
+	parts_power_mgmt = FALSE
+
 /obj/machinery/power/portgen/basic/Initialize()
 	component_types += board_path
 	. = ..()
@@ -151,6 +153,7 @@
 	return ..()
 
 /obj/machinery/power/portgen/basic/RefreshParts()
+	..()
 	var/temp_rating = 0
 
 	for(var/obj/item/stock_parts/SP in component_parts)

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -26,6 +26,8 @@
 		/obj/item/circuitboard/rtg
 	)
 
+	component_hint_cap = "Upgraded <b>capacitors</b> will increase maximum power output."
+
 /obj/machinery/power/rtg/Initialize()
 	. = ..()
 	connect_to_network()

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -28,6 +28,8 @@
 
 	component_hint_cap = "Upgraded <b>capacitors</b> will increase maximum power output."
 
+	parts_power_mgmt = FALSE
+
 /obj/machinery/power/rtg/Initialize()
 	. = ..()
 	connect_to_network()
@@ -43,6 +45,7 @@
 	icon_state = panel_open ? "[initial(icon_state)]-open" : initial(icon_state)
 
 /obj/machinery/power/rtg/RefreshParts()
+	..()
 	var/part_level = 0
 	for(var/obj/item/stock_parts/SP in component_parts)
 		part_level += SP.rating

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -44,7 +44,14 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 	///The timer id for the build callback, if we're building something
 	var/build_callback_timer
 
+	component_hint_bin = "Upgraded <b>matter bins</b> will increase material storage capacity."
+	component_hint_cap = "Upgraded <b>capacitors</b> will reduce active power usage."
+	component_hint_laser = "Upgraded <b>micro-lasers</b> will increase data gathered from destructive analysis."
+	component_hint_scan = "Upgraded <b>scanning modules</b> will increase data gathered from destructive analysis."
+	component_hint_servo = "Upgraded <b>manipulators</b> will improve material use efficiency and increase fabrication speed."
+
 /obj/machinery/r_n_d/circuit_imprinter/RefreshParts()
+	..()
 	// Adjust reagent container volume to match combined volume of the inserted beakers
 	var/T = 0
 	for(var/obj/item/reagent_containers/glass/G in component_parts)

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -45,9 +45,6 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 	var/build_callback_timer
 
 	component_hint_bin = "Upgraded <b>matter bins</b> will increase material storage capacity."
-	component_hint_cap = "Upgraded <b>capacitors</b> will reduce active power usage."
-	component_hint_laser = "Upgraded <b>micro-lasers</b> will increase data gathered from destructive analysis."
-	component_hint_scan = "Upgraded <b>scanning modules</b> will increase data gathered from destructive analysis."
 	component_hint_servo = "Upgraded <b>manipulators</b> will improve material use efficiency and increase fabrication speed."
 
 /obj/machinery/r_n_d/circuit_imprinter/RefreshParts()

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -23,7 +23,12 @@ Note: Must be placed within 3 tiles of the R&D Console
 		/obj/item/stock_parts/micro_laser
 	)
 
+	component_hint_laser = "Upgraded <b>micro-lasers</b> will increase data gathered from destructive analysis."
+	component_hint_scan = "Upgraded <b>scanning modules</b> will increase data gathered from destructive analysis."
+	component_hint_servo = "Upgraded <b>manipulators</b> will increase data gathered from destructive analysis."
+
 /obj/machinery/r_n_d/destructive_analyzer/RefreshParts()
+	..()
 	var/T = 0
 
 	for(var/obj/item/stock_parts/S in component_parts)

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -35,6 +35,9 @@
 		/obj/item/reagent_containers/glass/beaker = 2
 	)
 
+	component_hint_bin = "Upgraded <b>matter bins</b> will increase material storage capacity."
+	component_hint_servo = "Upgraded <b>manipulators</b> will improve material use efficiency and increase fabrication speed."
+
 ///Returns the total of all the stored materials
 /obj/machinery/r_n_d/protolathe/proc/TotalMaterials()
 	var/t = 0
@@ -43,6 +46,7 @@
 	return t
 
 /obj/machinery/r_n_d/protolathe/RefreshParts()
+	..()
 	// Adjust reagent container volume to match combined volume of the inserted beakers
 	var/T = 0
 	for(var/obj/item/reagent_containers/glass/G in component_parts)

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -24,6 +24,8 @@
 
 	component_hint_scan = "Upgraded <b>scanning modules</b> will reduce active power usage."
 
+	parts_power_mgmt = FALSE
+
 /obj/machinery/r_n_d/server/Destroy()
 	for(var/obj/machinery/r_n_d/tech_processor/TP as anything in linked_processors)
 		TP.set_server(null)
@@ -31,6 +33,7 @@
 	return ..()
 
 /obj/machinery/r_n_d/server/RefreshParts()
+	..()
 	var/tot_rating = 0
 
 	for(var/obj/item/stock_parts/SP in component_parts)

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -22,6 +22,8 @@
 		/obj/item/stack/cable_coil = 2
 	)
 
+	component_hint_scan = "Upgraded <b>scanning modules</b> will reduce active power usage."
+
 /obj/machinery/r_n_d/server/Destroy()
 	for(var/obj/machinery/r_n_d/tech_processor/TP as anything in linked_processors)
 		TP.set_server(null)

--- a/code/modules/research/stockparts.dm
+++ b/code/modules/research/stockparts.dm
@@ -2,6 +2,27 @@
 #define STOCK_PART_ADVANCED 2
 #define STOCK_PART_SUPER 3
 
+/***
+ * Stock parts (as of 2025/06) are only able to be installed in machinery objects.
+ * 
+ * They improve the functionality of the machine in various ways, scaling with their rating. The
+ * impact any given part type has on a machine should be described in a var/hint_[parttype].
+ * 
+ * By default, higher-rated parts will also increase machine power usage- refer to energy_rating()
+ * to see the multiplier the total energy rating will apply to power usage.
+ * 
+ * By assigning a machinery the variable "parts_power_mgmt = FALSE", bespoke power usage code can 
+ * be applied (i.e. upgrades that reduce power usage). This should be modified in the future to
+ * accommodate more flexible and intuitive power draw changes due to stock parts, but was implemented
+ * this way by Bat just to accommodate existing machine upgrades. Future changes will entail a more
+ * in-depth balance pass.
+ * 
+ * Tcomms stock parts are somewhat weirder, not following the same 'rank' behavior as the standard
+ * cluster of ranked five. They are also no longer used exclusively in Tcomms machinery- for example,
+ * the Hull Shield Generator requires both standard and Tcomms stock parts. This should also be
+ * addressed in future.
+ */ 
+
 /obj/item/storage/bag/stockparts_box
 	name = "stock parts box"
 	desc = "A low-tech method of storing stock parts used in machinery."

--- a/code/modules/research/stockparts.dm
+++ b/code/modules/research/stockparts.dm
@@ -82,6 +82,17 @@
 	. = ..()
 	randpixel_xy()
 
+/obj/item/stock_parts/proc/energy_rating()
+	switch (rating)
+		if (STOCK_PART_BASIC)
+			return 1
+		if (STOCK_PART_ADVANCED)
+			return 3
+		if (STOCK_PART_SUPER)
+			return 5
+		else
+			return 0
+
 //Rank 1
 
 /obj/item/stock_parts/console_screen
@@ -112,7 +123,7 @@
 /obj/item/stock_parts/manipulator
 	name = "micro-manipulator"
 	parent_stock_name = "micro-manipulator"
-	desc = "A tiny little manipulator used in the construction of certain devices."
+	desc = "A tiny micrometer-scale manipulator used in the construction of certain devices."
 	icon_state = "micro_mani"
 	origin_tech = list(TECH_MATERIAL = 1, TECH_DATA = 1)
 	matter = list(DEFAULT_WALL_MATERIAL = 30)
@@ -141,7 +152,7 @@
 
 /obj/item/stock_parts/capacitor/adv
 	name = "advanced capacitor"
-	desc = "An advanced capacitor used in the construction of a variety of devices."
+	desc = "A compact, ultra-high resolution scanning module used in the construction of certain devices."
 	icon_state = "adv_capacitor"
 	origin_tech = list(TECH_POWER = 3)
 	rating = STOCK_PART_ADVANCED
@@ -157,6 +168,7 @@
 
 /obj/item/stock_parts/manipulator/nano
 	name = "nano-manipulator"
+	desc = "A tiny nanometer-scale manipulator used in the construction of certain devices."
 	icon_state = "nano_mani"
 	origin_tech = list(TECH_MATERIAL = 3, TECH_DATA = 2)
 	rating = STOCK_PART_ADVANCED
@@ -164,6 +176,7 @@
 
 /obj/item/stock_parts/micro_laser/high
 	name = "high-power micro-laser"
+	desc = "A tiny, high-powered laser used in certain devices."
 	icon_state = "high_micro_laser"
 	origin_tech = list(TECH_MAGNET = 3)
 	rating = STOCK_PART_ADVANCED
@@ -188,7 +201,7 @@
 
 /obj/item/stock_parts/scanning_module/phasic
 	name = "phasic scanning module"
-	desc = "A compact, high resolution phasic scanning module used in the construction of certain devices."
+	desc = "A compact, ultra-high resolution phasic scanning module used in the construction of certain devices."
 	icon_state = "super_scan_module"
 	origin_tech = list(TECH_MAGNET = 5)
 	rating = STOCK_PART_SUPER
@@ -196,6 +209,7 @@
 
 /obj/item/stock_parts/manipulator/pico
 	name = "pico-manipulator"
+	desc = "A tiny picometer-scale manipulator used in the construction of certain devices."
 	icon_state = "pico_mani"
 	origin_tech = list(TECH_MATERIAL = 5, TECH_DATA = 2)
 	rating = STOCK_PART_SUPER
@@ -203,6 +217,7 @@
 
 /obj/item/stock_parts/micro_laser/ultra
 	name = "ultra-high-power micro-laser"
+	desc = "A tiny, alarmingly high-powered laser used in certain devices."
 	icon_state = "ultra_high_micro_laser"
 	origin_tech = list(TECH_MAGNET = 5)
 	rating = STOCK_PART_SUPER
@@ -210,6 +225,7 @@
 
 /obj/item/stock_parts/matter_bin/super
 	name = "super matter bin"
+	desc = "A container for holding compressed matter awaiting re-construction. Fortunately, this is a super 'matter bin,' not a 'super matter' bin."
 	icon_state = "super_matter_bin"
 	origin_tech = list(TECH_MATERIAL = 5)
 	rating = STOCK_PART_SUPER

--- a/code/modules/research/tech_processor.dm
+++ b/code/modules/research/tech_processor.dm
@@ -18,6 +18,8 @@
 
 	var/heat_delay = 10
 
+	component_hint_scan = "Upgraded <b>scanning modules</b> will increase speed at which research calculations are made and reduce active power usage."
+
 /obj/machinery/r_n_d/tech_processor/Destroy()
 	set_server(null)
 	return ..()

--- a/code/modules/research/tech_processor.dm
+++ b/code/modules/research/tech_processor.dm
@@ -20,11 +20,14 @@
 
 	component_hint_scan = "Upgraded <b>scanning modules</b> will increase speed at which research calculations are made and reduce active power usage."
 
+	parts_power_mgmt = FALSE
+
 /obj/machinery/r_n_d/tech_processor/Destroy()
 	set_server(null)
 	return ..()
 
 /obj/machinery/r_n_d/tech_processor/RefreshParts()
+	..()
 	tech_rate = 0
 	for(var/obj/item/stock_parts/scanning_module/SM in component_parts)
 		tech_rate += SM.rating / 2

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -19,8 +19,10 @@
 	)
 
 	component_hint_cap = "Upgraded <b>capacitors</b> will improve the power efficiency of the telepad."
+	parts_power_mgmt = FALSE
 
 /obj/machinery/telepad/RefreshParts()
+	..()
 	var/E
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)
 		E += C.rating

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -18,6 +18,8 @@
 		/obj/item/stack/cable_coil{amount = 1}
 	)
 
+	component_hint_cap = "Upgraded <b>capacitors</b> will improve the power efficiency of the telepad."
+
 /obj/machinery/telepad/RefreshParts()
 	var/E
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)

--- a/html/changelogs/Batrachophreno-StockParts.yml
+++ b/html/changelogs/Batrachophreno-StockParts.yml
@@ -1,0 +1,63 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Batrachophreno
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Upgradeable objects now, on extended Examine (show more info), state what parts can be upgraded and what they do."
+  - qol: "Extended Examine text now formatted more cleanly and broken up by section (mechanics, upgrades, antag hooks, etc.)"
+  - refactor: "Minor refactor to get_examine_text() to accommodate the above and make room for future development."
+  - balance: "Machine stock parts now more consistently affect power draw (usually increases it, unless specified otherwise)."
+  - balance: "Antagonism extended descriptions now viewable by ghosts and Storytellers, not just active antags."
+  - rscadd: "Added missing descriptions or updated existing ones on several stock parts."


### PR DESCRIPTION
In preparation for future development, both A.) increased the power draw of upgraded machines in more predictable ways and B.) reformated Examine text output to handle displaying machines' upgradeable parts and what they do in a more user-friendly way.

A.) is important because it opens the door to adding upgrade components available for more machines.

B.) is important because not only do we need to communicate those sorts of mechanics in a clean, clear, consistent way, but it also opens the doors to being able to communicate more types of interaction mechanics similarly well (such as assembly/disassembly tips).

Examples of new Examine boxes:
![Screenshot 2025-06-26 102050](https://github.com/user-attachments/assets/d7aa8b4c-b35f-4477-a1a2-b2846e92e06c)
![Screenshot 2025-06-26 102140](https://github.com/user-attachments/assets/0abb0a4c-a373-4427-af47-cadd192dfdc7)
![Screenshot 2025-06-26 102109](https://github.com/user-attachments/assets/886e4298-8a60-4cbb-be69-3de4cc8254d5)
![Screenshot 2025-06-26 102030](https://github.com/user-attachments/assets/5752da8c-b567-4337-94d4-b2ac2ca7ac36)

Note- while updating, made get_examine_text() also give Antagonism text boxes to ghosts and storytellers, not just active Antags. This seemed like a no-brainer thing but can be split into a separate PR if requested.