### PR TITLE
Renames the Positronic Brain Implant

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -280,7 +280,7 @@ GLOBAL_LIST_INIT(valid_bloodtypes, list(
 				if(BP_EYES)
 					out += "<li>- Retinal Overlayed [capitalize_first_letters(parse_zone(organ_name))]</li>"
 				if(BP_BRAIN)
-					out += "<li>- Positronic-Implanted [capitalize_first_letters(parse_zone(organ_name))]</li>"
+					out += "<li>- Pseudoneuron-Assisted [capitalize_first_letters(parse_zone(organ_name))]</li>"
 				else
 					out += "<li>- Mechanically Assisted [capitalize_first_letters(parse_zone(organ_name))]</li>"
 		else if(status == ORGAN_PREF_REMOVED)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -390,7 +390,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 		if(BP_EYES)
 			name = "retinal overlayed [initial(name)]"
 		if(BP_BRAIN)
-			name = "positronic-implanted [initial(name)]"
+			name = "pseudoneuron-assisted [initial(name)]"
 		else
 			name = "mechanically assisted [initial(name)]"
 	icon_state = initial(icon_state)

--- a/html/changelogs/cometblaze-posibrain.yml
+++ b/html/changelogs/cometblaze-posibrain.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: CometBlaze
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Renamed the positronic-implanted brain to pseudoneuron-assisted brain."


### PR DESCRIPTION
Changes the Positronic-Implanted Brain to Pseudoneuron-Assisted Brain. The current name causes confusion and creates a link to IPCs that synthlore does not want. This shouldn't affect the concepts that can currently be explored by the implant as is.
This was discussed with and approved by NM.
