### PR TITLE
Allows Queenless K'lax Vaurcae to select the Si'akh religion

### DIFF
--- a/code/modules/background/origins/origins/vaurca/klax.dm
+++ b/code/modules/background/origins/origins/vaurca/klax.dm
@@ -72,4 +72,4 @@
 	desc = " A broad descriptor for the unrepresented groups in the Hive. The Breeders of the factions once belonged to forgotten broods or were foreign rulers that fell into the domain of the K'lax. The Yiaa'mak'tzut diaspora and other rebellious K'lax are spread across Izweski territory, Biesel, and even Eridani."
 	possible_accents = list(ACCENT_KLAX, ACCENT_TTS)
 	possible_citizenships = list(CITIZENSHIP_IZWESKI, CITIZENSHIP_NONE)
-	possible_religions = list(RELIGION_PILOTDREAM, RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_OTHER, RELIGION_NONE)
+	possible_religions = list(RELIGION_PILOTDREAM, RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_SIAKH, RELIGION_OTHER, RELIGION_NONE)

--- a/html/changelogs/SimpleMaroon-siakhklax.yml
+++ b/html/changelogs/SimpleMaroon-siakhklax.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: SimpleMaroon
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Queenless K'lax Vaurcae can now select Si'akh as their religion. This is only meant for those of the Ssup'vihtal group!"


### PR DESCRIPTION
Requested by Lent23, current lore dev for Unathi, to be in line with the existence of the Ssup'vihtal Queenless group as shown [here](https://wiki.aurorastation.org/index.php?title=Si%27akh#The_Ssup%E2%80%99vihtal)