### PR TITLE
Adds the ability to wash kitchenware and glassware. No actual mechanical effects.

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -311,7 +311,7 @@
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "sink"
 	desc = "A sink used for washing one's hands and face."
-	desc_info = "Use HELP intent to fill a container in your hand from this, and use any other intent to empty the container into this. \
+	desc_info = "Use HELP intent to fill a container in your hand from this. Use DISARM intent to rinse an empty container. Use any other intent to empty the container into this. \
 	You can right-click this and change the amount transferred per use."
 	anchored = 1
 	var/busy = 0 	//Something's being washed at the moment

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -388,13 +388,12 @@
 			RG.reagents.add_reagent(/singleton/reagent/water, min(RG.volume - RG.reagents.total_volume, amount_per_transfer_from_this))
 			user.visible_message("<b>[user]</b> fills \a [RG] using \the [src].", SPAN_NOTICE("You fill \a [RG] using \the [src]."))
 			playsound(loc, 'sound/effects/sink.ogg', 75, 1)
-		if (usr.a_intent == I_DISARM)
+		if(user.a_intent == I_DISARM)
 			if(!RG.reagents.total_volume)
-				user.visible_message(SPAN_NOTICE("[usr] washes \a [RG] in \the [src]."))
-				playsound(loc, 'sound/effects/sink.ogg', 75, 1)
+				user.visible_message(SPAN_NOTICE("[user] washes \a [RG] in \the [src]."))
+				playsound(loc, 'sound/effects/sink.ogg', 75, TRUE)
 			else
-				to_chat(usr, SPAN_WARNING("\The [RG] still has something in it."))
-
+				to_chat(user, SPAN_WARNING("\The [RG] still has something in it."))
 		else
 			if(!RG.reagents.total_volume)
 				to_chat(usr, SPAN_WARNING("\The [RG] is already empty."))

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -391,7 +391,7 @@
 			return
 		if(user.a_intent == I_DISARM)
 			if(!RG.reagents.total_volume)
-				busy = 1
+				busy = TRUE
 				user.visible_message(SPAN_NOTICE("[user] starts washing \a [RG] in \the [src]."))
 				if(!do_after(user, 25, src))
 					playsound(loc, 'sound/effects/sink.ogg', 75, TRUE)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -395,9 +395,9 @@
 				user.visible_message(SPAN_NOTICE("[user] starts washing \a [RG] in \the [src]."))
 				if(!do_after(user, 25, src))
 					playsound(loc, 'sound/effects/sink.ogg', 75, TRUE)
-					busy = 0
+					busy = FALSE
 					return TRUE
-				busy = 0
+				busy = FALSE
 				user.visible_message(SPAN_NOTICE("[user] finishes washing \a [RG] in \the [src]."))
 			else
 				to_chat(user, SPAN_WARNING("\The [RG] still has something in it."))

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -388,6 +388,13 @@
 			RG.reagents.add_reagent(/singleton/reagent/water, min(RG.volume - RG.reagents.total_volume, amount_per_transfer_from_this))
 			user.visible_message("<b>[user]</b> fills \a [RG] using \the [src].", SPAN_NOTICE("You fill \a [RG] using \the [src]."))
 			playsound(loc, 'sound/effects/sink.ogg', 75, 1)
+		if (usr.a_intent == I_DISARM)
+			if(!RG.reagents.total_volume)
+				user.visible_message(SPAN_NOTICE("[usr] washes \a [RG] in \the [src]."))
+				playsound(loc, 'sound/effects/sink.ogg', 75, 1)
+			else
+				to_chat(usr, SPAN_WARNING("\The [RG] still has something in it."))
+
 		else
 			if(!RG.reagents.total_volume)
 				to_chat(usr, SPAN_WARNING("\The [RG] is already empty."))

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -388,12 +388,20 @@
 			RG.reagents.add_reagent(/singleton/reagent/water, min(RG.volume - RG.reagents.total_volume, amount_per_transfer_from_this))
 			user.visible_message("<b>[user]</b> fills \a [RG] using \the [src].", SPAN_NOTICE("You fill \a [RG] using \the [src]."))
 			playsound(loc, 'sound/effects/sink.ogg', 75, 1)
+			return
 		if(user.a_intent == I_DISARM)
 			if(!RG.reagents.total_volume)
-				user.visible_message(SPAN_NOTICE("[user] washes \a [RG] in \the [src]."))
-				playsound(loc, 'sound/effects/sink.ogg', 75, TRUE)
+				busy = 1
+				user.visible_message(SPAN_NOTICE("[user] starts washing \a [RG] in \the [src]."))
+				if(!do_after(user, 25, src))
+					playsound(loc, 'sound/effects/sink.ogg', 75, TRUE)
+					busy = 0
+					return TRUE
+				busy = 0
+				user.visible_message(SPAN_NOTICE("[user] finishes washing \a [RG] in \the [src]."))
 			else
 				to_chat(user, SPAN_WARNING("\The [RG] still has something in it."))
+				return
 		else
 			if(!RG.reagents.total_volume)
 				to_chat(usr, SPAN_WARNING("\The [RG] is already empty."))

--- a/html/changelogs/ASmallCuteCat - Wash the dishes.yml
+++ b/html/changelogs/ASmallCuteCat - Wash the dishes.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ASmallCuteCat
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "You can now wash dishes, cooking pots, and glassware! With the empty item in hand, left-click a sink with DISARM intent."


### PR DESCRIPTION
This PR gives you the ability to wash glassware (glasses, mugs, beakers, vials, etc) and kitchenware (pots and pans) at the sink.

With the empty item in hand, left-click a sink on DISARM intent.

There are no mechanical or gameplay changes. Items don't get dirty, you aren't required to wash anything after use, it's just a little text-only interaction meant for roleplay and nothing more. However, there's nothing stopping the Executive Officer from giving you the stink-eye if you don't wash the trays before putting them away!