### PR TITLE
Banner fixes

### DIFF
--- a/code/game/objects/structures/flags_banners.dm
+++ b/code/game/objects/structures/flags_banners.dm
@@ -31,6 +31,10 @@
 	///Boolean, if we've been torn down
 	var/ripped = FALSE
 
+	///Default offset value. Used in accurately locating the turf we're standing on.
+	var/offset_constant = 32
+	///Boolean, set to TRUE if someone is folding the banner.
+	var/currently_folding = FALSE
 	var/ripped_outline_state = "flag_ripped"
 	var/flag_path
 	var/flag_size
@@ -79,7 +83,7 @@
 		flag_icon = new(icon, icon_state)
 		shading_icon = new('icons/obj/structure/flags.dmi', "flag")
 		flag_icon.Blend(shading_icon, ICON_MULTIPLY)
-		var/turf/T = get_step(loc, dir)
+		var/turf/T = locate(x + src.pixel_x / offset_constant, y + src.pixel_y / offset_constant, z)
 		if(iswall(T))
 			icon = flag_icon
 			return
@@ -151,14 +155,12 @@
 	if(use_check_and_message(user))
 		return
 
-
-	for(var/obj/A in get_turf(user.loc))
-		if(istype(A, /obj/structure/bed))
-			to_chat(user, SPAN_DANGER("There is already a [A.name] here."))
-			return
-		if(A.density)
-			to_chat(user, SPAN_DANGER("There is already something here."))
-			return
+	for(var/obj/A in get_step(user.loc, user.dir))
+		if(!iswall(A) && !istype(A, /obj/structure/table) && !istype(A, /obj/structure/window_frame) && !istype(A, /obj/structure/window))
+			if(A.density || istype(A, /obj/structure/bed))
+				to_chat(user, SPAN_WARNING("You can't place this here, [A.name] blocking the way!"))
+				return
+		continue
 
 	if(isfloor(user.loc))
 		user.visible_message(SPAN_NOTICE("\The [user] deploys \the [src] on \the [get_turf(loc)]."), SPAN_NOTICE("You deploy \the [src] on \the [get_turf(loc)]."))
@@ -226,9 +228,15 @@
 		if(I_HELP)
 			examinate(user, src)
 		if(I_DISARM)
+			if(currently_folding)
+				to_chat(user, SPAN_WARNING("You are already folding up \the [src]."))
+				return
+			currently_folding = TRUE
 			user.visible_message(SPAN_NOTICE("\The [user] begins to carefully fold up \the [src]."), SPAN_NOTICE("You begin to carefully fold up \the [src]."))
 			if(do_after(user, 50))
 				unfasten(user)
+			else
+				currently_folding = FALSE
 		if(I_GRAB)
 			user.visible_message(SPAN_NOTICE("\The [user] salutes \the [src]."), SPAN_NOTICE("You salute \the [src]."))
 		if(I_HURT)

--- a/code/game/objects/structures/flags_banners.dm
+++ b/code/game/objects/structures/flags_banners.dm
@@ -155,7 +155,7 @@
 	if(use_check_and_message(user))
 		return
 
-	for(var/obj/A in get_step(user.loc, user.dir))
+	for(var/obj/A in get_step(get_turf(user),, user.dir))
 		if(!iswall(A) && !istype(A, /obj/structure/table) && !istype(A, /obj/structure/window_frame) && !istype(A, /obj/structure/window))
 			if(A.density || istype(A, /obj/structure/bed))
 				to_chat(user, SPAN_WARNING("You can't place this here, [A.name] is blocking the way!"))

--- a/code/game/objects/structures/flags_banners.dm
+++ b/code/game/objects/structures/flags_banners.dm
@@ -158,7 +158,7 @@
 	for(var/obj/A in get_step(user.loc, user.dir))
 		if(!iswall(A) && !istype(A, /obj/structure/table) && !istype(A, /obj/structure/window_frame) && !istype(A, /obj/structure/window))
 			if(A.density || istype(A, /obj/structure/bed))
-				to_chat(user, SPAN_WARNING("You can't place this here, [A.name] blocking the way!"))
+				to_chat(user, SPAN_WARNING("You can't place this here, [A.name] is blocking the way!"))
 				return
 		continue
 

--- a/code/game/objects/structures/flags_banners.dm
+++ b/code/game/objects/structures/flags_banners.dm
@@ -155,7 +155,7 @@
 	if(use_check_and_message(user))
 		return
 
-	for(var/obj/A in get_step(get_turf(user),, user.dir))
+	for(var/obj/A in get_step(get_turf(user), user.dir))
 		if(!iswall(A) && !istype(A, /obj/structure/table) && !istype(A, /obj/structure/window_frame) && !istype(A, /obj/structure/window))
 			if(A.density || istype(A, /obj/structure/bed))
 				to_chat(user, SPAN_WARNING("You can't place this here, [A.name] is blocking the way!"))

--- a/html/changelogs/kano-dot-saner-flag-stands.yml
+++ b/html/changelogs/kano-dot-saner-flag-stands.yml
@@ -1,0 +1,6 @@
+author: Kano
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed the following issues: banners appearing with their stand when put on walls in mapping, being unable to place it when standing on furniture or dense objects, banner duplication."


### PR DESCRIPTION
## About PR

- Uses `locate()` instead of `get_step()` when determining banner's location, while considering the set offset value (normally either 32 or -32) to have an accurate result. This resolves banners having stands while placed on walls after Init.

- Instead of checking where the user is standing, the banners now checks the position it'll be placed upon, and whether this position has dense objects except the ones that is fine to be placed upon. Resolves #18068 

- Prevents banner duplication, resolves #18620

I am sorry for the shitcode in advance