### PR TITLE
Ringer Animation Fix

### DIFF
--- a/code/game/machinery/ringer.dm
+++ b/code/game/machinery/ringer.dm
@@ -204,7 +204,7 @@ pixel_x = 8;
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 
-	flick(src, "ringer_on")
+	flick("ringer_on", src)
 
 	if(use_power)
 		use_power_oneoff(active_power_usage)

--- a/html/changelogs/SleepyGemmy-ringer_animation.yml
+++ b/html/changelogs/SleepyGemmy-ringer_animation.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed ringer buttons not animating when pressed."


### PR DESCRIPTION
turns out the ringer button was supposed to be animated when pressed all this time. the values in the code were reversed.