### PR TITLE
Adds the Expeditionary radio frequency as a default channel

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -91,7 +91,8 @@ var/list/reverseradiochannels = list(
 	"[AI_FREQ]"		= "AI Private",
 	"[ENT_FREQ]"	= "Entertainment",
 	"[MED_I_FREQ]"	= "Medical (I)",
-	"[SEC_I_FREQ]"	= "Security (I)"
+	"[SEC_I_FREQ]"	= "Security (I)",
+	"[EXP_FREQ]"	= "Expeditionary",
 )
 
 // The assoc variants are separate lists because they need the keys to be strings, but some code expects numbers.

--- a/code/game/objects/items/devices/radio/_radio_defines.dm
+++ b/code/game/objects/items/devices/radio/_radio_defines.dm
@@ -10,6 +10,7 @@
 #define CHANNEL_SERVICE "Service"
 #define CHANNEL_AI_PRIVATE "AI Private"
 #define CHANNEL_PENAL "Penal"
+#define CHANNEL_EXPED "Expeditionary"
 
 #define CHANNEL_RESPONSE_TEAM "Response Team"
 
@@ -42,5 +43,6 @@ var/global/list/ALL_RADIO_CHANNELS = list(
 	CHANNEL_NINJA = TRUE,
 	CHANNEL_BLUESPACE = TRUE,
 	CHANNEL_BURGLAR = TRUE,
-	CHANNEL_JOCKEY = TRUE
+	CHANNEL_JOCKEY = TRUE,
+	CHANNEL_EXPED = TRUE,
 )

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -10,7 +10,7 @@
 	var/translate_hivenet = FALSE
 	var/syndie = FALSE // Signifies that it de-crypts Syndicate transmissions
 	var/independent = FALSE // Signifies that it lets you talk on the spicy channel
-	var/list/channels = list(CHANNEL_COMMON = TRUE, CHANNEL_ENTERTAINMENT = TRUE)
+	var/list/channels = list(CHANNEL_COMMON = TRUE, CHANNEL_ENTERTAINMENT = TRUE, CHANNEL_EXPED = TRUE)
 	var/list/additional_channels = list()
 
 /obj/item/device/encryptionkey/attackby(obj/item/attacking_item, mob/user)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -3,6 +3,7 @@
 var/global/list/default_internal_channels = list(
 	num2text(PUB_FREQ) = list(),
 	num2text(ENT_FREQ) = list(),
+	num2text(EXP_FREQ) = list(),
 	num2text(AI_FREQ)  = list(ACCESS_EQUIPMENT),
 	num2text(ERT_FREQ) = list(ACCESS_CENT_SPECOPS),
 	num2text(COMM_FREQ)= list(ACCESS_HEADS),
@@ -633,7 +634,7 @@ var/global/list/default_interrogation_channels = list(
 	return
 
 /obj/item/device/radio/borg/proc/recalculateChannels()
-	channels = list(CHANNEL_COMMON = TRUE, CHANNEL_ENTERTAINMENT = TRUE)
+	channels = list(CHANNEL_COMMON = TRUE, CHANNEL_ENTERTAINMENT = TRUE, CHANNEL_EXPED = TRUE)
 	syndie = FALSE
 
 	if(isrobot(loc))

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -24,6 +24,7 @@ var/list/department_radio_keys = list(
 		":v" = "Service",		".v" = "Service",
 		":p" = "AI Private",	".p" = "AI Private",
 		":z" = "Entertainment",".z" = "Entertainment",
+		":d" = "Expeditionary",".d" = "Expeditionary",
 
 		":R" = "right ear",	".R" = "right ear",
 		":L" = "left ear",	".L" = "left ear",
@@ -49,6 +50,7 @@ var/list/department_radio_keys = list(
 		":V" = "Service",		".V" = "Service",
 		":P" = "AI Private",	".P" = "AI Private",
 		":Z" = "Entertainment",".Z" = "Entertainment",
+		":D" = "Expeditionary",".D" = "Expeditionary",
 
 		//kinda localization -- rastaf0
 		//same keys as above, but on russian keyboard layout. This file uses cp1251 as encoding.

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -63,6 +63,7 @@ em						{font-style: normal;font-weight: bold;}
 .entradio				{color: #bd893c;}
 .hailradio				{color: #7331c4;}
 .shipradio				{color: #738465;}
+.expradio				{color: #FFEEB5;}
 
 .secradio				{color: #A30000;}
 .penradio				{color: #DB1270;}

--- a/html/changelogs/nauticall-exped_channel.yml
+++ b/html/changelogs/nauticall-exped_channel.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: nauticall
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added the Expeditionary radio frequency to all radios that come with Common (and Entertainment) frequencies as a default radio channel."
+  - rscadd: "The Expeditionary radio channel is now accessible in-radio via the shortcut key 'D', e.g. ':d' or '.d'."
+  - qol: "Expeditionary radio channel changed to custard yellow for easier visibility."

--- a/nano/templates/radio_basic.tmpl
+++ b/nano/templates/radio_basic.tmpl
@@ -20,7 +20,7 @@ Used In File(s): /code/game/objects/item/devices/radio/radio.dm
 		.sciradio				{color: #c03bc0;}
 		.supradio				{color: #c09141;}
 		.srvradio				{color: #7fc732;}
-    .expradio       {color: #5a3975;}
+    	.expradio       		{color: #ffeeB5;}
 
 		.channelList			{overflow: clip;}
 	</style>

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -461,7 +461,7 @@ em {
   color: #7fc732;
 }
 .expradio {
-  color: #5a3975;
+  color: #ffeeb5;
 }
 
 /* Miscellaneous */

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -475,7 +475,7 @@ em {
   color: #6eaa2c;
 }
 .expradio {
-  color: #5a3975;
+  color: #d6bc67;
 }
 
 /* Miscellaneous */

--- a/tgui/packages/tgui-say/constants.ts
+++ b/tgui/packages/tgui-say/constants.ts
@@ -34,4 +34,5 @@ export const RADIO_PREFIXES = {
   ':f ': 'Uncom',
   ':q ': 'Pen',
   ':t ': 'Merc',
+  ':d ': 'Exped',
 } as const;

--- a/tgui/packages/tgui-say/styles/colors.scss
+++ b/tgui/packages/tgui-say/styles/colors.scss
@@ -33,6 +33,7 @@ $supply: #c09141;
 $hail: #8b4cd8;
 $ent: #cfcfcf;
 $cling: #376340;
+$exped: #d6bc67;
 
 $_channel_map: (
   'Say': $say,
@@ -56,6 +57,7 @@ $_channel_map: (
   'Hail': $hail,
   'Ent': $ent,
   'Cling': $cling,
+  'Exped': $exped,
 );
 
 $channel_keys: map.keys($_channel_map) !default;


### PR DESCRIPTION
- Added the Expeditionary radio frequency to all radios that come with Common (and Entertainment) frequencies as a default radio channel.
- The Expeditionary radio channel is now accessible in-radio via the shortcut key 'D', e.g. `:d` or `.d`.
- Expeditionary radio channel changed to custard yellow for easier visibility.

Should make expeditions (and Odysseys) a whole lot easier by allowing everyone to access the Expeditionary channel in their headset, no radio or frequency tweaking necessary.

Color was also changed to a sort of custard yellow, since its old color was very hard to see for a lot of people.

![image](https://github.com/user-attachments/assets/1e9b3da1-c9d9-4073-9072-d2b41b55388b)
![image](https://github.com/user-attachments/assets/6b2e454d-aa88-4c44-8bae-4bcd635152e0)
![image](https://github.com/user-attachments/assets/b1f52ef6-7525-405f-a8f6-aa9809bdbee7)
![image](https://github.com/user-attachments/assets/31e6a423-4842-43e9-9179-196168146168)
![image](https://github.com/user-attachments/assets/5be773aa-36ac-4de8-bb94-f9cca5a27ccd)
