### PR TITLE
add missing pilot suit assembly

### DIFF
--- a/code/modules/research/designs/mechfab/hardsuit/rigs.dm
+++ b/code/modules/research/designs/mechfab/hardsuit/rigs.dm
@@ -17,6 +17,11 @@
 	desc = "An assembly for light rig that is desiged for repairs and maintenance to the outside of habitats and vessels."
 	build_path = /obj/item/rig_assembly/eva
 
+/datum/design/rig/eva/pilot
+	name = "pilot Suit Control Module Assembly"
+	desc = "An assembly for a light hardsuit that is designed for pilots."
+	build_path = /obj/item/rig_assembly/eva/pilot
+
 /datum/design/rig/industrial
 	name = "Industrial Suit Control Module Assembly"
 	desc = "An assembly for a heavy, powerful rig used by construction crews and mining corporations."

--- a/html/changelogs/addmissingpilotsuit.yml
+++ b/html/changelogs/addmissingpilotsuit.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Hellfirejag
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a missing construction recipe for pilot hardsuits to the mechatronic fabricator"


### PR DESCRIPTION
This PR adds in the missing construction recipe for the pilot hardsuit assembly, which wasn't present in the mechatronic fabricator. 

There was already a recipe in the circuit imprinter for the pilot suit central control board here:
<img width="491" height="267" alt="image" src="https://github.com/user-attachments/assets/aaeed072-75e5-4c94-a98e-9e1839939e06" />

However, no such assembly existed in the exosuit fabricator: 
<img width="508" height="329" alt="image" src="https://github.com/user-attachments/assets/21eca010-8a09-4848-843f-e9b1aab0546e" />

And while the code implied it was possible to make a pilot suit by using the pilot circuit board on an EVA suit assembly, it would instead make an EVA suit. 
<img width="315" height="183" alt="image" src="https://github.com/user-attachments/assets/167889a4-f04a-4415-a3eb-77988f546649" />

So this PR adds the ability to make the pilot hardsuit assemblies directly, allowing for the pilot suit to be made using the circuit board that already existed as a roundstart hardsuit option.