### PR TITLE
Hydroponics tweaks #4

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -126,7 +126,7 @@
 	uniform = /obj/item/clothing/under/rank/hydroponics
 	head = /obj/item/clothing/head/bandana/hydro/nt
 	shoes = /obj/item/clothing/shoes/sneakers/black
-	suit_store = /obj/item/device/analyzer/plant_analyzer
+	belt = /obj/item/storage/belt/hydro/full
 
 	tab_pda = /obj/item/modular_computer/handheld/pda/civilian
 	wristbound = /obj/item/modular_computer/handheld/wristbound/preset/pda/civilian

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -570,7 +570,7 @@
 	max_w_class = WEIGHT_CLASS_BULKY
 	can_hold = list(
 		/obj/item/reagent_containers/glass,
-		/obj/item/grenade/chem_grenade, //weed killer grenades mostly, or water-pottassium if you grow the bannanas!
+		/obj/item/grenade/chem_grenade,
 		/obj/item/bee_smoker, //will this ever get used? Probally not.
 		/obj/item/plantspray/pests,
 		/obj/item/storage/bag/plants,
@@ -583,8 +583,19 @@
 		/obj/item/reagent_containers/spray, //includes if you ever wish to get a spraybottle full of other chemicals, Like water
 		/obj/item/device/analyzer/plant_analyzer,
 		/obj/item/clothing/gloves/botanic_leather,
-		/obj/item/device/radio
+		/obj/item/device/radio,
+		/obj/item/crowbar
 	)
+
+/obj/item/storage/belt/hydro/full
+	starts_with = list(
+		/obj/item/material/minihoe = 1,
+		/obj/item/material/hatchet = 1,
+		/obj/item/wirecutters/clippers = 1,
+		/obj/item/device/analyzer/plant_analyzer = 1,
+		/obj/item/storage/bag/plants = 1
+	)
+
 
 /obj/item/storage/belt/ninja //credits to BurgerBB
 	name = "advanced combat belt"

--- a/code/modules/hydroponics/seed_datums/adhomai.dm
+++ b/code/modules/hydroponics/seed_datums/adhomai.dm
@@ -134,10 +134,10 @@
 	seed_type = "nfrihi"
 
 /datum/seed/sugartree
-	name = "sugar tree"
-	seed_name = "sugar tree"
+	name = "sugartree"
+	seed_name = "sugartree"
 	display_name = "sugar trees"
-	product_desc = "the fruit of the Sugar Tree, native to Adhomai. It is sweet and commonly used in candies."
+	product_desc = "The fruit of the Sugar Tree, native to Adhomai. It is sweet and commonly used in candies."
 	product_desc_extended = "Sugar Tree, or Nm'shaan, are hardy snow bamboo invaluable for sugar production on the planet. They are unique in that on every stem it bears a single spherical fruit at the very top, surrounded by a white woolly rind. Short stems which end in thick-leafed fronds grow along the length of the 'trunk', giving it an appearance like Terran bamboo. The stalks tend to be as thick as one's thigh with very hard, protective woody shells around its vulnerable interior."
 	seed_noun = SEED_NOUN_SEEDS
 	mutants = null
@@ -150,13 +150,13 @@
 	set_trait(TRAIT_MATURATION, 9)
 	set_trait(TRAIT_PRODUCTION, 5)
 	set_trait(TRAIT_YIELD, 2)
-	set_trait(TRAIT_PRODUCT_ICON,"sugartree")
+	set_trait(TRAIT_PRODUCT_ICON,"nmshaan")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#fffdf7")
 	set_trait(TRAIT_PLANT_COLOUR,"#31331c")
-	set_trait(TRAIT_PLANT_ICON,"sugartree")
+	set_trait(TRAIT_PLANT_ICON,"nmshaan")
 	set_trait(TRAIT_IDEAL_HEAT, 253)
 	set_trait(TRAIT_WATER_CONSUMPTION, 4)
 	set_trait(TRAIT_IDEAL_LIGHT, 3)
 
 /obj/item/seeds/sugartree
-	seed_type = "sugar tree"
+	seed_type = "sugartree"

--- a/code/modules/hydroponics/seed_datums/adhomai.dm
+++ b/code/modules/hydroponics/seed_datums/adhomai.dm
@@ -159,4 +159,4 @@
 	set_trait(TRAIT_IDEAL_LIGHT, 3)
 
 /obj/item/seeds/sugartree
-	seed_type = "sugartree"
+	seed_type = "sugar tree"

--- a/code/modules/hydroponics/seed_datums/adhomai.dm
+++ b/code/modules/hydroponics/seed_datums/adhomai.dm
@@ -134,8 +134,8 @@
 	seed_type = "nfrihi"
 
 /datum/seed/sugartree
-	name = "sugartree"
-	seed_name = "sugartree"
+	name = "sugar tree"
+	seed_name = "sugar tree"
 	display_name = "sugar trees"
 	product_desc = "The fruit of the Sugar Tree, native to Adhomai. It is sweet and commonly used in candies."
 	product_desc_extended = "Sugar Tree, or Nm'shaan, are hardy snow bamboo invaluable for sugar production on the planet. They are unique in that on every stem it bears a single spherical fruit at the very top, surrounded by a white woolly rind. Short stems which end in thick-leafed fronds grow along the length of the 'trunk', giving it an appearance like Terran bamboo. The stalks tend to be as thick as one's thigh with very hard, protective woody shells around its vulnerable interior."
@@ -159,4 +159,4 @@
 	set_trait(TRAIT_IDEAL_LIGHT, 3)
 
 /obj/item/seeds/sugartree
-	seed_type = "sugartree"
+	seed_type = "sugar tree"

--- a/code/modules/hydroponics/seed_datums/fruits.dm
+++ b/code/modules/hydroponics/seed_datums/fruits.dm
@@ -20,6 +20,7 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#3AF026")
 	set_trait(TRAIT_PLANT_ICON,"tree")
 	set_trait(TRAIT_FLESH_COLOUR,"#3AF026")
+	set_trait(TRAIT_IDEAL_HEAT, 304)
 
 /obj/item/seeds/limeseed
 	seed_type = "lime"
@@ -347,7 +348,7 @@
 	set_trait(TRAIT_PRODUCT_ICON,"treefruit")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#CCA935")
 	set_trait(TRAIT_PLANT_ICON,"tree2")
-	set_trait(TRAIT_IDEAL_HEAT, 298)
+	set_trait(TRAIT_IDEAL_HEAT, 304)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 
 /datum/seed/banana

--- a/code/modules/hydroponics/seed_datums/misc.dm
+++ b/code/modules/hydroponics/seed_datums/misc.dm
@@ -74,6 +74,7 @@
 	..()
 	set_trait(TRAIT_PRODUCT_COLOUR, "#0F6E56")
 	set_trait(TRAIT_PLANT_COLOUR, "#0D4836")
+	set_trait(TRAIT_IDEAL_HEAT, 284) // To fit with molluscs.
 
 /obj/item/seeds/seaweed
 	seed_type = "seaweed"

--- a/code/modules/hydroponics/seed_datums/nralakk.dm
+++ b/code/modules/hydroponics/seed_datums/nralakk.dm
@@ -90,7 +90,7 @@
 /obj/item/seeds/guamiseed
 	seed_type = "guami"
 
-/datum/seed/eki
+/datum/seed/mushroom/eki
 	name = "eki"
 	seed_name = "eki"
 	display_name = "eki"
@@ -98,7 +98,7 @@
 	chems = list(/singleton/reagent/nutriment = list(7, 11))
 	kitchen_tag = "eki"
 
-/datum/seed/eki/setup_traits()
+/datum/seed/mushroom/eki/setup_traits()
 	..()
 	set_trait(TRAIT_SPREAD, 1)
 	set_trait(TRAIT_MATURATION, 10)

--- a/code/modules/hydroponics/seed_datums/vegetables.dm
+++ b/code/modules/hydroponics/seed_datums/vegetables.dm
@@ -133,7 +133,7 @@
 	set_trait(TRAIT_PRODUCT_ICON,"eggplant")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#892694")
 	set_trait(TRAIT_PLANT_ICON,"bush4")
-	set_trait(TRAIT_IDEAL_HEAT, 298)
+	set_trait(TRAIT_IDEAL_HEAT, 304)
 	set_trait(TRAIT_IDEAL_LIGHT, 7)
 
 /obj/item/seeds/eggplantseed

--- a/code/modules/hydroponics/seed_packets.dm
+++ b/code/modules/hydroponics/seed_packets.dm
@@ -74,8 +74,7 @@ GLOBAL_LIST_EMPTY(plant_seed_sprites)
 	. = ..()
 	if(seed && !seed.roundstart)
 		. += "It's tagged as variety #[seed.uid]."
-	. += "The packet reads that this has an ideal temperature of <b>[seed.get_trait(TRAIT_IDEAL_HEAT)] kelvin.</b>"
-	. += "The packet reads that this has an ideal light level of <b>[seed.get_trait(TRAIT_IDEAL_LIGHT)] lumens.</b>"
+	. += "This has an ideal temperature of <b>[seed.get_trait(TRAIT_IDEAL_HEAT)] kelvin</b> and light level of <b>[seed.get_trait(TRAIT_IDEAL_LIGHT)] lumens.</b>"
 
 /obj/item/seeds/cutting
 	name = SEED_NOUN_CUTTINGS

--- a/code/modules/hydroponics/seed_packets.dm
+++ b/code/modules/hydroponics/seed_packets.dm
@@ -16,13 +16,13 @@ GLOBAL_LIST_EMPTY(plant_seed_sprites)
 	update_seed()
 	. = ..()
 
-//Grabs the appropriate seed datum from the global list.
+/// Grabs the appropriate seed datum from the global list.
 /obj/item/seeds/proc/update_seed()
 	if(!seed && seed_type && !isnull(SSplants.seeds) && SSplants.seeds[seed_type])
 		seed = SSplants.seeds[seed_type]
 	update_appearance()
 
-//Updates strings and icon appropriately based on seed datum.
+/// Updates strings and icon appropriately based on seed datum.
 /obj/item/seeds/proc/update_appearance(var/ret_image = FALSE)
 	if(!seed)
 		return
@@ -74,6 +74,8 @@ GLOBAL_LIST_EMPTY(plant_seed_sprites)
 	. = ..()
 	if(seed && !seed.roundstart)
 		. += "It's tagged as variety #[seed.uid]."
+	. += "The packet reads that this has an ideal temperature of <b>[seed.get_trait(TRAIT_IDEAL_HEAT)] kelvin.</b>"
+	. += "The packet reads that this has an ideal light level of <b>[seed.get_trait(TRAIT_IDEAL_LIGHT)] lumens.</b>"
 
 /obj/item/seeds/cutting
 	name = SEED_NOUN_CUTTINGS

--- a/code/modules/hydroponics/seed_storage.dm
+++ b/code/modules/hydroponics/seed_storage.dm
@@ -296,6 +296,7 @@
 		/obj/item/seeds/cocoapodseed = 3,
 		/obj/item/seeds/coffeeseed = 3,
 		/obj/item/seeds/cornseed = 3,
+		/obj/item/seeds/cranberryseed = 2,
 		/obj/item/seeds/dirtberries = 2,
 		/obj/item/seeds/dynseed = 3,
 		/obj/item/seeds/earthenroot = 2,
@@ -354,8 +355,7 @@
 		/obj/item/seeds/whitebeetseed = 3,
 		/obj/item/seeds/wulumunushaseed = 2,
 		/obj/item/seeds/xuiziseed = 3,
-		/obj/item/seeds/ylpha = 2,
-		/obj/item/seeds/cranberryseed = 2,
+		/obj/item/seeds/ylpha = 2
 	)
 
 /obj/machinery/seed_storage/garden/hydroponics

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -448,7 +448,7 @@
 		tray_light = new_light
 		user.visible_message(SPAN_NOTICE("\The [user] sets \the [src] to a light level of [tray_light] lumens."),
 		SPAN_NOTICE("You set the \the [src] to a light level of [tray_light] lumens."))
-		playsound(src, /singleton/sound_category/button_sound, 25, TRUE)
+		playsound(src, /singleton/sound_category/button_sound, 50, TRUE)
 
 /obj/machinery/portable_atmospherics/hydroponics/CtrlClick(var/mob/user)
 	if(usr.incapacitated())
@@ -686,7 +686,7 @@
 			update_use_power(POWER_USE_ACTIVE)
 			stasis = TRUE
 
-		playsound(src, /singleton/sound_category/button_sound, 25, TRUE)
+		playsound(src, /singleton/sound_category/button_sound, 50, TRUE)
 		update_icon()
 		return
 
@@ -764,6 +764,6 @@
 	else
 		density = TRUE
 	closed_system = !closed_system
-	playsound(src, 'sound/items/pickup/device.ogg', 25, TRUE)
+	playsound(src, 'sound/items/pickup/device.ogg', 50, TRUE)
 	to_chat(user, "You [closed_system ? "close" : "open"] the tray's lid.")
 	update_icon()

--- a/code/modules/hydroponics/trays/tray_process.dm
+++ b/code/modules/hydroponics/trays/tray_process.dm
@@ -81,43 +81,52 @@
 	if(!environment && istype(T)) environment = T.return_air()
 	if(!environment) return
 
+	// This carries the product of the handle_enviroment proc, so we can use it for multiple things.
+	var/environmental_damage
+
 	// Seed datum handles gasses, light and pressure relevant to whether the plant should be damaged.
 	if(mechanical && closed_system)
-		health -= seed.handle_environment(T,environment,tray_light)
+		environmental_damage = seed.handle_environment(T,environment,tray_light)
 	else
-		health -= seed.handle_environment(T,environment)
+		environmental_damage = seed.handle_environment(T,environment)
+
+	// Reduce health by however much handle_environent returned.
+	health -= environmental_damage
 
 	// If we're attached to a pipenet, then we should let the pipenet know we might have modified some gasses
 	if (closed_system && connected_port)
 		update_connected_network()
 
-	// By standard, the probability of growth is only 15%. This rises if growing conditions are within their preferences.
-	// This is intended to motivate the use of atmospheric equipment to more viably grow plants with irregular preferences.
-	// You *can* grow plants outside of their preferences without them dying so long as it's within their tolerance, but it'll be pretty slow.
-	var/probability_of_growth = 15
+	// We only let the plant grow if they're within their light, heat, and pressure tolerances - i.e. they've taken no damage in this process.
+	// We calculate this off the environmental_damage variable. If it's greater than 0, the plant has taken damage and shouldn't grow.
+	if(environmental_damage == 0)
+		// By standard, the probability of growth is only 15%. This rises if growing conditions are within their preferences.
+		// This is intended to motivate the use of atmospheric equipment to more viably grow plants with irregular preferences.
+		// You *can* grow plants outside of their preferences without them dying so long as it's within their tolerance, but it'll be pretty slow.
+		var/probability_of_growth = 15
 
-	// Are we within the preference zone for temperature? If so, add 15% to the chance of growth.
-	if(abs(environment.temperature - seed.get_trait(TRAIT_IDEAL_HEAT)) < seed.get_trait(TRAIT_HEAT_PREFERENCE))
-		probability_of_growth += 15
+		// Are we within the preference zone for temperature? If so, add 15% to the chance of growth.
+		if(abs(environment.temperature - seed.get_trait(TRAIT_IDEAL_HEAT)) < seed.get_trait(TRAIT_HEAT_PREFERENCE))
+			probability_of_growth += 15
 
-	// The light value we'll be using here.
-	var/actual_light
+		// The light value we'll be using here.
+		var/actual_light
 
-	// What kind of lighting are we under? If the lid isn't on and the turf isn't dynamically lit, default to 5 lumens.
-	if(closed_system && mechanical)
-		actual_light = tray_light
-	else if(TURF_IS_DYNAMICALLY_LIT(T))
-		actual_light = T.get_lumcount(0, 3) * 10
-	else
-		actual_light = 5
+		// What kind of lighting are we under? If the lid isn't on and the turf isn't dynamically lit, default to 5 lumens.
+		if(closed_system && mechanical)
+			actual_light = tray_light
+		else if(TURF_IS_DYNAMICALLY_LIT(T))
+			actual_light = T.get_lumcount(0, 3) * 10
+		else
+			actual_light = 5
 
-	// If we're within the preference zone for light, add another 5% to the chance for growth.
-	if(abs(actual_light - seed.get_trait(TRAIT_IDEAL_LIGHT)) < seed.get_trait(TRAIT_LIGHT_PREFERENCE))
-		probability_of_growth += 5
+		// If we're within the preference zone for light, add another 5% to the chance for growth.
+		if(abs(actual_light - seed.get_trait(TRAIT_IDEAL_LIGHT)) < seed.get_trait(TRAIT_LIGHT_PREFERENCE))
+			probability_of_growth += 5
 
-	// Roll the dice on advancing plant age, per a probability defined by the previous two checks. At minimum, 15% - at maximum, 35%.
-	// TODO: Move to seed datum?
-	if(prob(probability_of_growth)) age += 1 * HYDRO_SPEED_MULTIPLIER
+		// Roll the dice on advancing plant age, per a probability defined by the previous two checks. At minimum, 15% - at maximum, 35%.
+		// TODO: Move to seed datum?
+		if(prob(probability_of_growth)) age += 1 * HYDRO_SPEED_MULTIPLIER
 
 	// Toxin levels beyond the plant's tolerance cause damage, but
 	// toxins are sucked up each tick and slowly reduce over time.

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -13,6 +13,7 @@
 	/// Retains the ability for soil to grow weeds, as it should.
 	maxWeedLevel = 10
 
+/// TODO: Really need to just merge this with its parent proc, this is all duplicated.
 /obj/machinery/portable_atmospherics/hydroponics/soil/attackby(obj/item/attacking_item, mob/user)
 	//A special case for if the container has only water, for manual watering with buckets
 	if (istype(attacking_item, /obj/item/reagent_containers))
@@ -24,6 +25,7 @@
 					RC.reagents.remove_reagent(/singleton/reagent/water, amountToRemove, 1)
 					waterlevel += amountToRemove
 					user.visible_message("[user] pours [amountToRemove]u of water into the soil."," You pour [amountToRemove]u of water into the soil.")
+					playsound(src, /singleton/sound_category/generic_pour_sound, 25, 1)
 				else
 					to_chat(user, "The soil is saturated with water already.")
 				return 1

--- a/html/changelogs/hazelmouse-hydrostuff.yml
+++ b/html/changelogs/hazelmouse-hydrostuff.yml
@@ -61,5 +61,6 @@ changes:
   - rscadd: "Tweaked the preferential values of a few plants for consistency."
   - rscadd: "Eki is now, codewise, a mushroom."
   - rscadd: "Soil plots now produce noise when watered."
+  - rscadd: "Hydrobelts can now contain crowbars."
   - rscadd: "Slightly increased the volume of a few sound effects for hydroponics trays."
   - bugfix: "Sugar tree seeds now appear corectly in seed storage machines."

--- a/html/changelogs/hazelmouse-hydrostuff.yml
+++ b/html/changelogs/hazelmouse-hydrostuff.yml
@@ -60,4 +60,6 @@ changes:
   - rscadd: "Hydroponicists now spawn with filled hydrobelts, similarly to engineers and machinists."
   - rscadd: "Tweaked the preferential values of a few plants for consistency."
   - rscadd: "Eki is now, codewise, a mushroom."
+  - rscadd: "Soil plots now produce noise when watered."
+  - rscadd: "Slightly increased the volume of a few sound effects for hydroponics trays.""
   - bugfix: "Sugar tree seeds now appear corectly in seed storage machines."

--- a/html/changelogs/hazelmouse-hydrostuff.yml
+++ b/html/changelogs/hazelmouse-hydrostuff.yml
@@ -61,5 +61,5 @@ changes:
   - rscadd: "Tweaked the preferential values of a few plants for consistency."
   - rscadd: "Eki is now, codewise, a mushroom."
   - rscadd: "Soil plots now produce noise when watered."
-  - rscadd: "Slightly increased the volume of a few sound effects for hydroponics trays.""
+  - rscadd: "Slightly increased the volume of a few sound effects for hydroponics trays."
   - bugfix: "Sugar tree seeds now appear corectly in seed storage machines."

--- a/html/changelogs/hazelmouse-hydrostuff.yml
+++ b/html/changelogs/hazelmouse-hydrostuff.yml
@@ -1,0 +1,61 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Hydroponicists now spawn with filled hydrobelts, similarly to engineers and machinists."
+  - rscadd: "Tweaked the preferential values of a few plants for consistency."
+  - rscadd: "Eki is now, codewise, a mushroom."
+  - bugfix: "Sugar tree seeds now appear corectly in seed storage machines."

--- a/html/changelogs/hazelmouse-hydrostuff.yml
+++ b/html/changelogs/hazelmouse-hydrostuff.yml
@@ -55,6 +55,8 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
+  - rscadd: "When plants grown in hydroponics or the garden go outside of their tolerances, they will now cease to grow in addition to taking damage. If you notice plants failing to grow for a long time, you may be running afoul of their light or heat tolerances!"
+  - rscadd: "Seed packets now show their temperature and light tolerances on examine."
   - rscadd: "Hydroponicists now spawn with filled hydrobelts, similarly to engineers and machinists."
   - rscadd: "Tweaked the preferential values of a few plants for consistency."
   - rscadd: "Eki is now, codewise, a mushroom."


### PR DESCRIPTION
See changelog for the full list, several little QoL things coming off https://github.com/Aurorastation/Aurora.3/pull/20890.

The most notable mechanical change is that, if outside of their light of heat tolerances (or otherwise afoul whatsoever of the handle_environment proc), plants will stop growing. This is to avoid the awkward interaction of a plant being grown at completely improper temperatures or light levels still managing to mature before it dies.

Makes hydroponicists spawn with full belts at roundstart. Engineers do and machinists do, it just cuts down on a little roundstart begrudgery.

Includes light and heat preferences on seed packets!
<img width="633" height="118" alt="image" src="https://github.com/user-attachments/assets/4ac4b728-072a-4510-bb52-c9e5ed76c6a5" />

Coming up next will be extended descriptions explaining the mechanics somewhere visible to players, once https://github.com/Aurorastation/Aurora.3/pull/20923 is in.