### PR TITLE
Galatean Mind Blanker

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -3072,6 +3072,7 @@
 #include "code\modules\organs\subtypes\augment\augments\language_processor.dm"
 #include "code\modules\organs\subtypes\augment\augments\lighter.dm"
 #include "code\modules\organs\subtypes\augment\augments\memory_inhibitor.dm"
+#include "code\modules\organs\subtypes\augment\augments\mind_blanker.dm"
 #include "code\modules\organs\subtypes\augment\augments\pen.dm"
 #include "code\modules\organs\subtypes\augment\augments\phalanx_facial_plate.dm"
 #include "code\modules\organs\subtypes\augment\augments\psi_receiver.dm"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -64,4 +64,9 @@
 // tgui signals
 #define COMSIG_TGUI_CLOSE "tgui_close"
 
+// Psionics signals
+/// Raised on the target of a "mind-affecting" psionic power.
+#define COMSIG_PSI_MIND_POWER "psi_block_check"
+	#define COMSIG_PSI_MIND_POWER_CANCELLED (1<<0)
+
 /*******Component Specific Signals*******/

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -172,6 +172,8 @@
 #define BP_AUG_LIGHTER         "retractable lighter"
 #define BP_AUG_MAGBOOT         "integrated mag-claws"
 #define BP_AUG_MEMORY          "memory inhibitor"
+#define BP_AUG_MIND_BLANKER	   "mind blanker"
+#define BP_AUG_MIND_BLANKER_L  "lethal mind blanker"
 #define BP_AUG_PEN             "retractable combipen"
 #define BP_AUG_PSI             "psionic receiver"
 #define BP_AUG_RADIO           "integrated radio"

--- a/code/modules/client/preference_setup/loadout/items/augments.dm
+++ b/code/modules/client/preference_setup/loadout/items/augments.dm
@@ -299,3 +299,18 @@
 	faction = "Private Military Contracting Group"
 	cost = 4
 	allowed_roles = list("Physician", "Surgeon", "Pharmacist", "Paramedic", "Psychiatrist", "Medical Intern", "Medical Personnel", "Security Officer", "Warden", "Security Cadet", "Investigator", "Security Personnel", "Corporate Liaison", "Assistant", "Off-Duty Crew Member", "Corporate Reporter", "Bridge Crew")
+
+/datum/gear/augment/mind_blanker
+	display_name = "Galatean Mind Blanker"
+	description = "A small, discrete organ attached near the base of the brainstem. Any attempt to read the mind of an individual with this augment installed will fail, as will attempts at psychic brainwashing."
+	path = /obj/item/organ/internal/augment/mind_blanker
+	origin_restriction = list(/singleton/origin_item/origin/galatea)
+	cost = 4
+
+/datum/gear/augment/mind_blanker_lethal
+	display_name = "Galatean Mind Blanker (Lethal)"
+	description = "Available only to higher-up MfAS agents and members of the Galatean government. This enhanced variant of a mind blanker introduces a psionic trap which inflicts severe neural damage on anyone attempting to read the user's mind."
+	path = /obj/item/organ/internal/augment/mind_blanker_lethal
+	origin_restriction = list(/singleton/origin_item/origin/galatea)
+	cost = 6
+	allowed_roles = list("Consular")

--- a/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
+++ b/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
@@ -55,5 +55,5 @@
 		var/mob/living/victim = caster
 		victim.adjustBrainLoss(20)
 		victim.confused += 20
-		to_chat(victim, SPAN_DANGER("Agony lances through my mind as [src]'s mind clamps down upon me."))
+		to_chat(victim, SPAN_DANGER("Agony lances through my mind as [src]'s mind clamps down upon me!"))
 	return COMSIG_PSI_MIND_POWER_CANCELLED

--- a/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
+++ b/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
@@ -4,6 +4,7 @@
 		+ "Any attempt to read the mind of an individual with this augment installed will fail, as will attempts at psychic brainwashing."
 	organ_tag = BP_AUG_MIND_BLANKER
 	parent_organ = BP_HEAD
+	robotic = 0
 
 /obj/item/organ/internal/augment/mind_blanker/Initialize()
 	. = ..()
@@ -31,6 +32,7 @@
 		+ "This enhanced variant of a mind blanker includes a psionic trap which inflicts severe neural damage on anyone attempting to read the user's mind."
 	organ_tag = BP_AUG_MIND_BLANKER_L
 	parent_organ = BP_HEAD
+	robotic = 0
 
 /obj/item/organ/internal/augment/mind_blanker_lethal/Initialize()
 	. = ..()

--- a/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
+++ b/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
@@ -5,6 +5,25 @@
 	organ_tag = BP_AUG_MIND_BLANKER
 	parent_organ = BP_HEAD
 
+/obj/item/organ/internal/augment/mind_blanker/Initialize()
+	. = ..()
+	if(owner)
+		RegisterSignal(owner, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power))
+
+/obj/item/organ/internal/augment/mind_blanker/replaced()
+	. = ..()
+	if(owner)
+		RegisterSignal(owner, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power))
+
+/obj/item/organ/internal/augment/mind_blanker/removed()
+	. = ..()
+	if(owner)
+		UnregisterSignal(owner, COMSIG_PSI_MIND_POWER)
+
+/obj/item/organ/internal/augment/mind_blanker/proc/cancel_power(mob/caster)
+	SIGNAL_HANDLER
+	return COMSIG_PSI_MIND_POWER_CANCELLED
+
 /obj/item/organ/internal/augment/mind_blanker_lethal
 	name = "lethal mind blanker"
 	desc = "A small, discrete organ attached near the base of the brainstem." \
@@ -12,3 +31,27 @@
 		+ "This enhanced variant of a mind blanker includes a psionic trap which inflicts severe neural damage on anyone attempting to read the user's mind."
 	organ_tag = BP_AUG_MIND_BLANKER_L
 	parent_organ = BP_HEAD
+
+/obj/item/organ/internal/augment/mind_blanker_lethal/Initialize()
+	. = ..()
+	if(owner)
+		RegisterSignal(owner, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power_lethal))
+
+/obj/item/organ/internal/augment/mind_blanker_lethal/replaced()
+	. = ..()
+	if(owner)
+		RegisterSignal(owner, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power_lethal))
+
+/obj/item/organ/internal/augment/mind_blanker_lethal/removed()
+	. = ..()
+	if(owner)
+		UnregisterSignal(owner, COMSIG_PSI_MIND_POWER)
+
+/obj/item/organ/internal/augment/mind_blanker_lethal/proc/cancel_power_lethal(var/mob/caster)
+	SIGNAL_HANDLER
+	if(isliving(caster))
+		var/mob/living/victim = caster
+		victim.adjustBrainLoss(20)
+		victim.confused += 20
+		to_chat(victim, SPAN_DANGER("Agony lances through my mind as [src]'s mind clamps down upon me."))
+	return COMSIG_PSI_MIND_POWER_CANCELLED

--- a/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
+++ b/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
@@ -1,0 +1,14 @@
+/obj/item/organ/internal/augment/mind_blanker
+	name = "mind blanker"
+	desc = "A small, discrete organ attached near the base of the brainstem." \
+		+ "Any attempt to read the mind of an individual with this augment installed will fail, as will attempts at psychic brainwashing."
+	organ_tag = BP_AUG_MIND_BLANKER
+	parent_organ = BP_HEAD
+
+/obj/item/organ/internal/augment/mind_blanker_lethal
+	name = "lethal mind blanker"
+	desc = "A small, discrete organ attached near the base of the brainstem." \
+		+ "Available only to higher-up MfAS agents and members of the Galatean government." \
+		+ "This enhanced variant of a mind blanker includes a psionic trap which inflicts severe neural damage on anyone attempting to read the user's mind."
+	organ_tag = BP_AUG_MIND_BLANKER_L
+	parent_organ = BP_HEAD

--- a/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
+++ b/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
@@ -49,7 +49,7 @@
 	if(owner)
 		UnregisterSignal(owner, COMSIG_PSI_MIND_POWER)
 
-/obj/item/organ/internal/augment/mind_blanker_lethal/proc/cancel_power_lethal(var/mob/caster)
+/obj/item/organ/internal/augment/mind_blanker_lethal/proc/cancel_power_lethal(mob/caster)
 	SIGNAL_HANDLER
 	if(isliving(caster))
 		var/mob/living/victim = caster

--- a/code/modules/psionics/abilities/assay.dm
+++ b/code/modules/psionics/abilities/assay.dm
@@ -53,7 +53,7 @@
 		to_chat(user, SPAN_WARNING("Psionic power does not flow through a dead person."))
 		return
 
-	var/psi_blocked = target.is_psi_blocked()
+	var/psi_blocked = target.is_psi_blocked(src, TRUE)
 	if(psi_blocked)
 		to_chat(user, psi_blocked)
 		return

--- a/code/modules/psionics/abilities/assay.dm
+++ b/code/modules/psionics/abilities/assay.dm
@@ -53,7 +53,7 @@
 		to_chat(user, SPAN_WARNING("Psionic power does not flow through a dead person."))
 		return
 
-	var/psi_blocked = target.is_psi_blocked(src, TRUE)
+	var/psi_blocked = target.is_psi_blocked(user)
 	if(psi_blocked)
 		to_chat(user, psi_blocked)
 		return

--- a/code/modules/psionics/abilities/commune.dm
+++ b/code/modules/psionics/abilities/commune.dm
@@ -36,7 +36,7 @@
 		to_chat(user, SPAN_WARNING("Not even a psion of your level can speak to the dead."))
 		return
 
-	var/psi_blocked = target.is_psi_blocked(src, TRUE)
+	var/psi_blocked = target.is_psi_blocked(user)
 	if(psi_blocked)
 		to_chat(user, psi_blocked)
 		return

--- a/code/modules/psionics/abilities/commune.dm
+++ b/code/modules/psionics/abilities/commune.dm
@@ -36,7 +36,7 @@
 		to_chat(user, SPAN_WARNING("Not even a psion of your level can speak to the dead."))
 		return
 
-	var/psi_blocked = target.is_psi_blocked()
+	var/psi_blocked = target.is_psi_blocked(src, TRUE)
 	if(psi_blocked)
 		to_chat(user, psi_blocked)
 		return

--- a/code/modules/psionics/abilities/emotional_suggestion.dm
+++ b/code/modules/psionics/abilities/emotional_suggestion.dm
@@ -35,7 +35,7 @@
 		to_chat(user, SPAN_WARNING("Not even a psion of your level can suggest to the dead."))
 		return
 
-	var/psi_blocked = target.is_psi_blocked()
+	var/psi_blocked = target.is_psi_blocked(src, TRUE)
 	if(psi_blocked)
 		to_chat(user, psi_blocked)
 		return

--- a/code/modules/psionics/abilities/emotional_suggestion.dm
+++ b/code/modules/psionics/abilities/emotional_suggestion.dm
@@ -35,7 +35,7 @@
 		to_chat(user, SPAN_WARNING("Not even a psion of your level can suggest to the dead."))
 		return
 
-	var/psi_blocked = target.is_psi_blocked(src, TRUE)
+	var/psi_blocked = target.is_psi_blocked(user)
 	if(psi_blocked)
 		to_chat(user, psi_blocked)
 		return

--- a/code/modules/psionics/abilities/nlom_eyes.dm
+++ b/code/modules/psionics/abilities/nlom_eyes.dm
@@ -41,7 +41,7 @@
 	for(var/mob/living/L in GLOB.mob_list)
 		if(L == user)
 			continue
-		if(!L.is_psi_blocked(src, FALSE))
+		if(!L.is_psi_blocked(user))
 			continue
 		if(GET_Z(L) != GET_Z(user))
 			continue

--- a/code/modules/psionics/abilities/nlom_eyes.dm
+++ b/code/modules/psionics/abilities/nlom_eyes.dm
@@ -41,7 +41,7 @@
 	for(var/mob/living/L in GLOB.mob_list)
 		if(L == user)
 			continue
-		if(!L.is_psi_blocked())
+		if(!L.is_psi_blocked(src, FALSE))
 			continue
 		if(GET_Z(L) != GET_Z(user))
 			continue

--- a/code/modules/psionics/abilities/psi_search.dm
+++ b/code/modules/psionics/abilities/psi_search.dm
@@ -30,7 +30,7 @@
 		for(var/mob/living/carbon/human/H in GLOB.human_mob_list)
 			if(H == L)
 				continue
-			if((GET_Z(H) == GET_Z(L)) && !H.is_psi_blocked(src, FALSE))
+			if((GET_Z(H) == GET_Z(L)) && !H.is_psi_blocked(user))
 				if(HAS_TRAIT(H, TRAIT_PSIONIC_SUPPRESSION))
 					continue
 				level_humans |= H

--- a/code/modules/psionics/abilities/psi_search.dm
+++ b/code/modules/psionics/abilities/psi_search.dm
@@ -30,7 +30,7 @@
 		for(var/mob/living/carbon/human/H in GLOB.human_mob_list)
 			if(H == L)
 				continue
-			if((GET_Z(H) == GET_Z(L)) && !H.is_psi_blocked())
+			if((GET_Z(H) == GET_Z(L)) && !H.is_psi_blocked(src, FALSE))
 				if(HAS_TRAIT(H, TRAIT_PSIONIC_SUPPRESSION))
 					continue
 				level_humans |= H

--- a/code/modules/psionics/abilities/read_mind.dm
+++ b/code/modules/psionics/abilities/read_mind.dm
@@ -33,7 +33,7 @@
 		to_chat(user, SPAN_WARNING("Not even a psion of your level can speak to the dead."))
 		return
 
-	var/psi_blocked = target.is_psi_blocked()
+	var/psi_blocked = target.is_psi_blocked(src, TRUE)
 	if(psi_blocked)
 		to_chat(user, psi_blocked)
 		return

--- a/code/modules/psionics/abilities/read_mind.dm
+++ b/code/modules/psionics/abilities/read_mind.dm
@@ -33,7 +33,7 @@
 		to_chat(user, SPAN_WARNING("Not even a psion of your level can speak to the dead."))
 		return
 
-	var/psi_blocked = target.is_psi_blocked(src, TRUE)
+	var/psi_blocked = target.is_psi_blocked(user)
 	if(psi_blocked)
 		to_chat(user, psi_blocked)
 		return

--- a/code/modules/psionics/mob/mob_helpers.dm
+++ b/code/modules/psionics/mob/mob_helpers.dm
@@ -5,11 +5,11 @@
 	var/obj/item/organ/internal/augment/psi/psiaug = internal_organs_by_name[BP_AUG_PSI]
 	return psiaug && !psiaug.is_broken()
 
-/mob/living/proc/is_psi_blocked()
+/mob/living/proc/is_psi_blocked(var/mob/caster, feedback)
 	return !has_psionics()
 
-/mob/living/carbon/is_psi_blocked()
-	if(HAS_TRAIT(src, TRAIT_PSIONICALLY_DEAF) && !has_psi_aug())
+/mob/living/carbon/is_psi_blocked(var/mob/caster, feedback)
+	if((HAS_TRAIT(src, TRAIT_PSIONICALLY_DEAF) && !has_psi_aug()) || has_mind_blanker(caster, feedback))
 		return SPAN_WARNING("[src]'s mind is inaccessible, like hitting a brick wall.")
 	for (var/obj/item/implant/mindshield/I in src)
 		if (I.implanted)
@@ -24,8 +24,24 @@
 		return FALSE
 	return TRUE
 
-/mob/living/proc/is_psi_pingable()
-	return !is_psi_blocked()
+/mob/living/proc/is_psi_pingable(var/mob/caster, feedback)
+	return !is_psi_blocked(caster, feedback)
 
-/mob/living/simple_animal/is_psi_pingable()
+/mob/living/simple_animal/is_psi_pingable(var/mob/caster, feedback)
 	return psi_pingable
+
+/mob/living/proc/has_mind_blanker(var/mob/caster, feedback)
+	return FALSE
+
+/mob/living/carbon/has_mind_blanker(var/mob/caster, feedback)
+	var/obj/item/organ/internal/augment/mind_blanker/trap = internal_organs_by_name[BP_AUG_MIND_BLANKER_L]
+	if (trap && !trap.is_broken())
+		if (feedback && isliving(caster))
+			var/mob/living/victim = caster
+			victim.adjustBrainLoss(20)
+			victim.confused += 20
+			to_chat(victim, SPAN_DANGER("Agony lances through my mind as [src]'s mind clamps down upon me."))
+		return TRUE
+
+	var/obj/item/organ/internal/augment/mind_blanker/mindblanker = internal_organs_by_name[BP_AUG_MIND_BLANKER]
+	return mindblanker && !mindblanker.is_broken()

--- a/code/modules/psionics/mob/mob_helpers.dm
+++ b/code/modules/psionics/mob/mob_helpers.dm
@@ -9,7 +9,7 @@
 	return !has_psionics()
 
 /mob/living/carbon/is_psi_blocked(mob/user)
-	var/cancelled = SEND_SIGNAL(user, COMSIG_PSI_MIND_POWER)
+	var/cancelled = SEND_SIGNAL(src, COMSIG_PSI_MIND_POWER)
 	if (cancelled & COMSIG_PSI_MIND_POWER_CANCELLED)
 		return SPAN_WARNING("[src]'s mind is inaccessible, like hitting a brick wall.")
 	if(HAS_TRAIT(src, TRAIT_PSIONICALLY_DEAF) && !has_psi_aug())

--- a/code/modules/psionics/mob/mob_helpers.dm
+++ b/code/modules/psionics/mob/mob_helpers.dm
@@ -9,11 +9,10 @@
 	return !has_psionics()
 
 /mob/living/carbon/is_psi_blocked(mob/user)
-	var/cancelled = SEND_SIGNAL(src, COMSIG_PSI_MIND_POWER)
-	if (cancelled & COMSIG_PSI_MIND_POWER_CANCELLED)
+	var/cancelled = SEND_SIGNAL(src, COMSIG_PSI_MIND_POWER, user)
+	if((cancelled & COMSIG_PSI_MIND_POWER_CANCELLED) && !has_zona_bovinae() && !has_psi_aug())
 		return SPAN_WARNING("[src]'s mind is inaccessible, like hitting a brick wall.")
-	if(HAS_TRAIT(src, TRAIT_PSIONICALLY_DEAF) && !has_psi_aug())
-		return SPAN_WARNING("[src]'s mind is inaccessible, like hitting a brick wall.")
+
 	for (var/obj/item/implant/mindshield/I in src)
 		if (I.implanted)
 			return SPAN_WARNING("[src]'s mind is inaccessible, like hitting a brick wall.")

--- a/code/modules/psionics/mob/mob_helpers.dm
+++ b/code/modules/psionics/mob/mob_helpers.dm
@@ -5,11 +5,14 @@
 	var/obj/item/organ/internal/augment/psi/psiaug = internal_organs_by_name[BP_AUG_PSI]
 	return psiaug && !psiaug.is_broken()
 
-/mob/living/proc/is_psi_blocked(var/mob/caster, feedback)
+/mob/living/proc/is_psi_blocked(mob/user)
 	return !has_psionics()
 
-/mob/living/carbon/is_psi_blocked(var/mob/caster, feedback)
-	if((HAS_TRAIT(src, TRAIT_PSIONICALLY_DEAF) && !has_psi_aug()) || has_mind_blanker(caster, feedback))
+/mob/living/carbon/is_psi_blocked(mob/user)
+	var/cancelled = SEND_SIGNAL(user, COMSIG_PSI_MIND_POWER)
+	if (cancelled & COMSIG_PSI_MIND_POWER_CANCELLED)
+		return SPAN_WARNING("[src]'s mind is inaccessible, like hitting a brick wall.")
+	if(HAS_TRAIT(src, TRAIT_PSIONICALLY_DEAF) && !has_psi_aug())
 		return SPAN_WARNING("[src]'s mind is inaccessible, like hitting a brick wall.")
 	for (var/obj/item/implant/mindshield/I in src)
 		if (I.implanted)
@@ -24,24 +27,8 @@
 		return FALSE
 	return TRUE
 
-/mob/living/proc/is_psi_pingable(var/mob/caster, feedback)
-	return !is_psi_blocked(caster, feedback)
+/mob/living/proc/is_psi_pingable()
+	return !is_psi_blocked()
 
-/mob/living/simple_animal/is_psi_pingable(var/mob/caster, feedback)
+/mob/living/simple_animal/is_psi_pingable()
 	return psi_pingable
-
-/mob/living/proc/has_mind_blanker(var/mob/caster, feedback)
-	return FALSE
-
-/mob/living/carbon/has_mind_blanker(var/mob/caster, feedback)
-	var/obj/item/organ/internal/augment/mind_blanker/trap = internal_organs_by_name[BP_AUG_MIND_BLANKER_L]
-	if (trap && !trap.is_broken())
-		if (feedback && isliving(caster))
-			var/mob/living/victim = caster
-			victim.adjustBrainLoss(20)
-			victim.confused += 20
-			to_chat(victim, SPAN_DANGER("Agony lances through my mind as [src]'s mind clamps down upon me."))
-		return TRUE
-
-	var/obj/item/organ/internal/augment/mind_blanker/mindblanker = internal_organs_by_name[BP_AUG_MIND_BLANKER]
-	return mindblanker && !mindblanker.is_broken()

--- a/code/modules/research/xenoarchaeology/artifact/artifact_crystal_madness.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_crystal_madness.dm
@@ -30,7 +30,7 @@
 	// get mobs
 	var/list/affected_mobs = list()
 	for(var/mob/living/carbon/human/mob_in_range in get_hearers_in_LOS(world.view, src))
-		if((!mob_in_range.is_psi_blocked(src, FALSE)) && (mob_in_range.has_psionics() || mob_in_range.has_psi_aug() || mob_in_range.has_zona_bovinae()))
+		if((!mob_in_range.is_psi_blocked(src)) && (mob_in_range.has_psionics() || mob_in_range.has_psi_aug() || mob_in_range.has_zona_bovinae()))
 			affected_mobs += mob_in_range
 
 	// set up timer for delayed effects

--- a/code/modules/research/xenoarchaeology/artifact/artifact_crystal_madness.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_crystal_madness.dm
@@ -30,7 +30,7 @@
 	// get mobs
 	var/list/affected_mobs = list()
 	for(var/mob/living/carbon/human/mob_in_range in get_hearers_in_LOS(world.view, src))
-		if((!mob_in_range.is_psi_blocked()) && (mob_in_range.has_psionics() || mob_in_range.has_psi_aug() || mob_in_range.has_zona_bovinae()))
+		if((!mob_in_range.is_psi_blocked(src, FALSE)) && (mob_in_range.has_psionics() || mob_in_range.has_psi_aug() || mob_in_range.has_zona_bovinae()))
 			affected_mobs += mob_in_range
 
 	// set up timer for delayed effects

--- a/code/modules/shareddream/dream_entry.dm
+++ b/code/modules/shareddream/dream_entry.dm
@@ -33,7 +33,7 @@ GLOBAL_LIST_EMPTY_TYPED(dream_entries, /turf)
 					G = l_hand
 				if(G)
 					var/mob/living/carbon/human/victim = G.affecting
-					if(ishuman(victim) && !isSynthetic(victim) && victim.is_psi_pingable(src, TRUE))
+					if(ishuman(victim) && !isSynthetic(victim) && victim.is_psi_pingable(srom_puller))
 						to_chat(bg, SPAN_NOTICE("You have taken [victim] to the Srom with you."))
 						victim.srom_pulled_by = WEAKREF(src)
 						srom_pulling = WEAKREF(victim)

--- a/code/modules/shareddream/dream_entry.dm
+++ b/code/modules/shareddream/dream_entry.dm
@@ -33,7 +33,7 @@ GLOBAL_LIST_EMPTY_TYPED(dream_entries, /turf)
 					G = l_hand
 				if(G)
 					var/mob/living/carbon/human/victim = G.affecting
-					if(ishuman(victim) && !isSynthetic(victim) && victim.is_psi_pingable())
+					if(ishuman(victim) && !isSynthetic(victim) && victim.is_psi_pingable(src, TRUE))
 						to_chat(bg, SPAN_NOTICE("You have taken [victim] to the Srom with you."))
 						victim.srom_pulled_by = WEAKREF(src)
 						srom_pulling = WEAKREF(victim)

--- a/html/changelogs/hellfirejag-galatean_mind_blanker.yml
+++ b/html/changelogs/hellfirejag-galatean_mind_blanker.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "Added two variants of mind blanker bioaugs as loadout options for Galatean characters."


### PR DESCRIPTION
This PR adds a pair of new "BioAugs" as loadout options for Galatean characters, called Mind Blanker. They come in two variants, and both are available exclusively to Galateans. The basic version of the mind blanker makes its user immune to mind-affecting psionic powers. 

The advanced version of it inflicts lethal biofeedback on any psychic that attempts to enter the user's mind, while also providing the user with the same protection as the basic version. The advanced version is more expensive, and is exclusively available to Galatean Consulars. 

This PR was requested by Human Lore for their "Galatean Bioaugments" list.
<img width="739" height="334" alt="image" src="https://github.com/user-attachments/assets/8dd0e65c-2834-4949-8a03-8966f22eeca4" />
