### PR TITLE
Repairing damaged walls now clears the dark 'damaged state' overlay

### DIFF
--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -103,6 +103,8 @@
 		damage_image = damage_overlays[overlay]
 		overlays_to_add += damage_image
 
+	// Remove the existing damage overlay entirely and replace it with the newly-calculated one.
+	CutOverlays(damage_overlays)
 	AddOverlays(overlays_to_add)
 	UNSETEMPTY(reinforcement_images)
 	QUEUE_SMOOTH(src)
@@ -115,5 +117,5 @@
 	for(var/i = 1; i <= damage_overlays.len; i++)
 		var/image/img = image(icon = 'icons/turf/walls.dmi', icon_state = "overlay_damage")
 		img.blend_mode = BLEND_MULTIPLY
-		img.alpha = (i * alpha_inc) - 1
+		img.alpha = (i * alpha_inc * 2) - i
 		damage_overlays[i] = img

--- a/html/changelogs/Batrachophreno-WallDmgRepairFix.yml
+++ b/html/changelogs/Batrachophreno-WallDmgRepairFix.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FabianK3, Batrachophrenoboocosmomachia
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Repairing damage to a wall now clears the dark 'damaged state' overlay."
+


### PR DESCRIPTION
All credit for actual bugfix here to FabianK3 who did all the sleuthing and actually found the root issue.

I changed the alpha blending formula to make the damage overlay a bit darker; it still won't be as dark as it used to be, since it used to be Multiple Overlays stacked atop one another instead of just the one as intended, but the modified formula handles both minimal and maximal damage states adequately.