### PR TITLE
Add Missing Mech Modules

### DIFF
--- a/code/modules/research/designs/mechfab/mechs/designs_exosuit_equipment.dm
+++ b/code/modules/research/designs/mechfab/mechs/designs_exosuit_equipment.dm
@@ -84,6 +84,18 @@
 	build_path = /obj/item/mecha_equipment/mounted_system/combat/grenadestinger
 	materials = list(DEFAULT_WALL_MATERIAL = 20000, MATERIAL_GOLD = 3000, MATERIAL_SILVER = 3000)
 
+/datum/design/item/mechfab/exosuit_equipment/tear
+	name = "Mounted Teargas Launcher"
+	req_tech = list(TECH_COMBAT = 3)
+	build_path = /obj/item/mecha_equipment/mounted_system/combat/grenadetear
+	materials = list(DEFAULT_WALL_MATERIAL = 20000, MATERIAL_GOLD = 3000, MATERIAL_SILVER = 3000)
+
+/datum/design/item/mechfab/exosuit_equipment/smoke
+	name = "Mounted Smoke Launcher"
+	req_tech = list(TECH_COMBAT = 2)
+	build_path = /obj/item/mecha_equipment/mounted_system/combat/grenadesmoke
+	materials = list(DEFAULT_WALL_MATERIAL = 20000, MATERIAL_GLASS = 10000)
+
 /datum/design/item/mechfab/exosuit_equipment/cleaner
 	name = "Mounted Cleaner Grenade Launcher"
 	req_tech = list(TECH_MATERIAL = 2)

--- a/html/changelogs/addmissingmechmodules.yml
+++ b/html/changelogs/addmissingmechmodules.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "Added missing recipes for mounted Teargas and Smoke grenade launchers to the mechatronic fabricator."


### PR DESCRIPTION
This PR adds back in missing recipes for the teargas and smoke exosuit grenade launchers, which were present in the game files, but not available to manufacture unlike their stinger and flashbang counterparts. Both of these launcher types previously weren't accessible anywhere in the game. 