### PR TITLE
Stops the Solarian submachine gun from inheriting the description of the submachine gun

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -85,6 +85,7 @@
 /obj/item/gun/projectile/automatic/c20r/sol
 	name = "solarian submachine gun"
 	desc = "Designed by Zavodskoi as a scaled-down version of their M469, the M470-L is a personal defense weapon intended for use by second-line personnel from all branches of the Solarian military, such as support troops and Navy crewmen."
+	desc_extended = null
 	icon = 'icons/obj/guns/sol_smg.dmi'
 	icon_state = "vityaz"
 	item_state = "vityaz"

--- a/html/changelogs/Tag103-contract-bids.yml
+++ b/html/changelogs/Tag103-contract-bids.yml
@@ -1,0 +1,6 @@
+author: Tag103
+
+delete-after: True
+
+changes:
+  - bugfix: "The Solarian submachine gun no longer inherits the extended description intended for the submachine gun, which it is a subtype of."


### PR DESCRIPTION
Makes the Solarian submachine gun have no extended description, rather than inheriting the extended description of the submachine gun, which is Solarian, but isn't the Solarian submachine gun.
