### PR TITLE
Removes an l from soll_officer

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/sol_gear.dm
+++ b/code/game/objects/structures/crates_lockers/closets/sol_gear.dm
@@ -131,12 +131,12 @@
 	new /obj/item/clothing/shoes/laceup(src)
 	new /obj/item/clothing/shoes/laceup(src)
 
-/obj/structure/closet/secure_closet/soll_officer
+/obj/structure/closet/secure_closet/sol_officer
 	name = "sol alliance officer locker"
 	req_access = list(ACCESS_CAPTAIN)
 	icon_state = "cap"
 
-/obj/structure/closet/secure_closet/soll_officer/fill()
+/obj/structure/closet/secure_closet/sol_officer/fill()
 	..()
 	if(prob(50))
 		new /obj/item/storage/backpack/captain(src)

--- a/html/changelogs/Tag103-marines-cant-spell-amirite.yml
+++ b/html/changelogs/Tag103-marines-cant-spell-amirite.yml
@@ -3,4 +3,4 @@ author: Tag103
 delete-after: True
 
 changes:
-  - refactor: "Changed the name used in the code for the sol alliance officer locker from 'soll_officer' to 'sol_officer'."
+  - refactor: "Part of the name used in the code for the sol alliance officer locker has been changed from 'soll_officer' to 'sol_officer'."

--- a/html/changelogs/Tag103-marines-cant-spell-amirite.yml
+++ b/html/changelogs/Tag103-marines-cant-spell-amirite.yml
@@ -1,0 +1,6 @@
+author: Tag103
+
+delete-after: True
+
+changes:
+  - refactor: "Changed the name used in the code for the sol alliance officer locker from 'soll_officer' to 'sol_officer'."

--- a/maps/random_ruins/exoplanets/ouerea/ouerea_sol_base.dmm
+++ b/maps/random_ruins/exoplanets/ouerea/ouerea_sol_base.dmm
@@ -907,7 +907,9 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/structure/closet/secure_closet/sol_officer,
+/obj/structure/closet/secure_closet/sol_officer{
+	req_access = list(203)
+	},
 /turf/simulated/floor/exoplanet/tiled,
 /area/ouerea_sol)
 "Uw" = (

--- a/maps/random_ruins/exoplanets/ouerea/ouerea_sol_base.dmm
+++ b/maps/random_ruins/exoplanets/ouerea/ouerea_sol_base.dmm
@@ -898,9 +898,6 @@
 /turf/simulated/floor/exoplanet/tiled,
 /area/ouerea_sol)
 "Up" = (
-/obj/structure/closet/secure_closet/soll_officer{
-	req_access = list(203)
-	},
 /obj/item/clothing/under/rank/sol/service,
 /obj/item/melee/energy/sword/knife/sol,
 /obj/item/gun/projectile/pistol/sol,
@@ -910,6 +907,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/structure/closet/secure_closet/sol_officer,
 /turf/simulated/floor/exoplanet/tiled,
 /area/ouerea_sol)
 "Uw" = (


### PR DESCRIPTION
Changes part of the name used in the code for sol alliance officer lockers from "soll_officer" to "sol_officer".

There is probably a joke somewhere in here involving the phrase "taking the L".