### PR TITLE
The Bodega Update: remapping the commissary and library

### DIFF
--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -17,7 +17,6 @@
 	icon_state = "book-0"
 	anchored = 1
 	density = 1
-	opacity = 1
 	build_amt = 5
 
 /obj/structure/bookcase/Initialize()

--- a/html/changelogs/hazelmouse-bodega.yml
+++ b/html/changelogs/hazelmouse-bodega.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "The operations commissary has been moved to service, adjacent to the library, and now accomodates access both from operations and service staff. The library has also been remapped to accomodate this move."

--- a/html/changelogs/hazelmouse-bodega.yml
+++ b/html/changelogs/hazelmouse-bodega.yml
@@ -56,3 +56,5 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscadd: "The operations commissary has been moved to service, adjacent to the library, and now accomodates access both from operations and service staff. The library has also been remapped to accomodate this move."
+  - rscadd: "Bookcases no longer obstruct vision."
+  - rscadd: "Hydroponics now has a first-aid kit."

--- a/maps/sccv_horizon/code/sccv_horizon_areas.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_areas.dm
@@ -231,6 +231,9 @@
 /area/maintenance/hangar/port
 	name = "Port Hangar Maintenance"
 
+/area/maintenance/wing/cargo_compartment
+	name = "Auxiliary Cargo Maintenance"
+
 /area/maintenance/hangar/starboard
 	name = "Starboard Hangar Maintenance"
 


### PR DESCRIPTION
This PR remaps the operations commissary, moving it across to the service hallway where it can receive much more foot traffic than in its original position. Reflecting its new spot in service, and considering particularly how much a hydroponicist can contribute to the commissary, both service and operations staff now have access to it - although I personally anticipate this will remain primarily used by operations.

Adjacent vendors in the service hall have been moved into the commissary to encourage interaction, and hopefully to capture a little of that bodega feel - although I'm open for other ideas on how to capture the right atmosphere.

Because of the location, the library has necessarily also been remapped. It's now smaller, but my hope is that it uses the space it has more effectively. The old location of the commissary is now generic maintenance until someone finds a better use for it.

A few points:

- "Is this bad for librarians?" Hopefully not! It isn't a very popular job right now, and I don't expect this PR to change that, but I've gone into the remap with the intention of making the library a more appealing place to be in than before. The old library has a lot of dead space, particularly with its gigantic office, whereas this new design is intended to be a little more compact. Now featuring tinted windows if you want to get some mood lighting going on.
- "Why the move?" The current location of the commissary is within view of virtually no foot traffic period - operations generally is an extremely isolated department, and something like the commissary lives and dies in the playerbase according to how visible it is. Appropriately, this moves it to a more visible spot.

<img width="416" height="544" alt="image" src="https://github.com/user-attachments/assets/c470abfa-a01c-467c-8fff-58a308b0531c" />

<img width="480" height="256" alt="image" src="https://github.com/user-attachments/assets/aa32a756-2573-4746-bebf-9002e4f66cd9" />

