### PR TITLE
Tweaks package spawning logic for off-ships

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -188,6 +188,7 @@
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_living.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_main.dm"
 #include "code\__DEFINES\dcs\signals\signals_object\signals_object.dm"
+#include "code\__DEFINES\dcs\signals\signals_ghostrole.dm"
 #include "code\__HELPERS\_global_objects.dm"
 #include "code\__HELPERS\_lists.dm"
 #include "code\__HELPERS\area_movement.dm"

--- a/code/__DEFINES/dcs/signals/signals_ghostrole.dm
+++ b/code/__DEFINES/dcs/signals/signals_ghostrole.dm
@@ -1,0 +1,2 @@
+/// Called when a ghostrole is taken by a player in a hidden `overmap/visitable` for the first time : `/datum/ghostspawner/proc/post_spawn(mob/user)`
+#define COMSIG_GHOSTROLE_TAKEN "ghostrole_taken"

--- a/code/modules/ghostroles/spawner/base.dm
+++ b/code/modules/ghostroles/spawner/base.dm
@@ -224,6 +224,7 @@
 			sector.y = sector.start_y
 			sector.z = SSatlas.current_map.overmap_z
 			sector.invisible_until_ghostrole_spawn = FALSE
+			SEND_SIGNAL(sector, COMSIG_GHOSTROLE_TAKEN)
 	return TRUE
 
 //Proc to check if a specific user can edit this spawner (open/close/...)

--- a/maps/_common/mapsystem/map.dm
+++ b/maps/_common/mapsystem/map.dm
@@ -131,6 +131,7 @@
 
 	var/allow_borgs_to_leave = FALSE //this controls if borgs can leave the station or ship without exploding
 	var/area/warehouse_basearea //this controls where the cargospawner tries to populate warehouse items
+	var/area/warehouse_packagearea // used to handle spawnpoints for the packages that spawned after Initialize. See: `receptacle.dm`.
 
 	/**
 	 * A list of the shuttles on this map, used by the Shuttle Manifest program to populate itself.

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -159,6 +159,7 @@
 	allow_borgs_to_leave = TRUE
 
 	warehouse_basearea = /area/operations/storage
+	warehouse_packagearea = /area/operations/package_conveyors
 
 	shuttle_manifests = list(
 		"SCCV Canary" = list("color" = "blue", "icon" = "binoculars"),

--- a/maps/sccv_horizon/code/sccv_horizon_areas.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_areas.dm
@@ -175,6 +175,10 @@
 	area_blurb = "Scuff marks scar the floor from the movement of many crates and stored goods."
 	area_blurb_category = "ops_warehouse"
 
+/area/operations/package_conveyors
+	name = "Operations Package Conveyors"
+	icon_state = "dark128"
+
 /area/operations/lower/machinist
 	name = "Machinist Workshop"
 	icon_state = "machinist_workshop"


### PR DESCRIPTION
## About PR

Instead of spawning packages designated for hidden off-ships in the round-start, it's now handled after a player takes the ghostrole and makes the ship visible in overmap. Operations is also notified about the new packages ready for delivery.

The new packages now will spawn at the small area dedicated for them.

## Images

<img width="665" height="531" alt="image1" src="https://github.com/user-attachments/assets/7879972f-afcc-4cdf-a924-f49d28b8cae6" />

<img width="416" height="512" alt="image2" src="https://github.com/user-attachments/assets/6fa88eb6-ff5a-48bb-a664-fc253ee41643" />

<img width="891" height="42" alt="image3" src="https://github.com/user-attachments/assets/59633a9b-a32f-40ea-98b8-4a38fd0d31ac" />
