### PR TITLE
Fixes grabbed mobs being lowered after being buckled to a bed

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -199,6 +199,9 @@
 /obj/item/grab/proc/adjust_position()
 	if(!affecting)
 		return
+	var/buckled_to_bed = affecting.buckled_to ? istype(affecting.buckled_to, /obj/structure/bed/roller) : FALSE
+	if(buckled_to_bed)
+		return
 	if(affecting.buckled_to && affecting.buckled_to != assailant)
 		animate(affecting, pixel_x = affecting.get_standard_pixel_x(), pixel_y = affecting.get_standard_pixel_y(), 4, 1, LINEAR_EASING)
 		return
@@ -415,9 +418,10 @@
 			affecting.update_canmove()
 			affecting.anchored = FALSE
 		UnregisterSignal(assailant, COMSIG_MOVABLE_MOVED)
-
-	animate(affecting, pixel_x = affecting.get_standard_pixel_x(), pixel_y = affecting.get_standard_pixel_y(), 4, 1, LINEAR_EASING)
-	affecting.layer = initial(affecting.layer)
+	var/buckled_to_bed = affecting.buckled_to ? istype(affecting.buckled_to, /obj/structure/bed/roller) : FALSE
+	if(!buckled_to_bed)
+		animate(affecting, pixel_x = affecting.get_standard_pixel_x(), pixel_y = affecting.get_standard_pixel_y(), 4, 1, LINEAR_EASING)
+		affecting.layer = initial(affecting.layer)
 	if(affecting)
 		ADD_FALLING_ATOM(affecting) // Makes the grabbee check if they can fall.
 		affecting.grabbed_by -= src

--- a/html/changelogs/AlaunusLux-fix-grabbed-bed-buckle.yml
+++ b/html/changelogs/AlaunusLux-fix-grabbed-bed-buckle.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: AlaunusLux
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Buckling a grabbed mob to a bed will no longer cause the mob to lower after buckling."


### PR DESCRIPTION
Stops the lowering animation from triggering if the mob is buckled to a roller bed while grabbed, screenshot shows live functionality with the bed extended but the patient laying over the legs of the bed.

<img width="119" height="118" alt="image" src="https://github.com/user-attachments/assets/b34fe654-9692-4771-bcca-6633068a9d8b" />
