### PR TITLE
Power Monitoring APC name sorting

### DIFF
--- a/html/changelogs/batrachophreno-TguiSorting.yml
+++ b/html/changelogs/batrachophreno-TguiSorting.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Batrachophrenoboocosmomachia
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "APCs in the Power Monitor app now listed in alphabetical order."
+  - code_imp: "es-toolkit 1.39.3 added to TGUI dependencies for sorting funcs."

--- a/tgui/packages/tgui/interfaces/PowerMonitor.tsx
+++ b/tgui/packages/tgui/interfaces/PowerMonitor.tsx
@@ -2,6 +2,7 @@ import { BooleanLike } from '../../common/react';
 import { useBackend } from '../backend';
 import { Box, Button, LabeledList, NoticeBox, Section, Table } from '../components';
 import { NtosWindow } from '../layouts';
+import { sortBy } from 'es-toolkit';
 
 export type PowerData = {
   all_sensors: Sensor[];
@@ -73,6 +74,10 @@ export const ShowMasterList = (props, context) => {
 
 export const SensorMonitoring = (props, context) => {
   const { act, data } = useBackend<PowerData>(context);
+  const { apc_data = [] } = data.focus;
+  const apcs_sorted: APCData[] = sortBy(apc_data, [
+    (APCData: APCData) => APCData.name,
+  ]);
 
   return (
     <Section
@@ -108,8 +113,8 @@ export const SensorMonitoring = (props, context) => {
             <Table.Cell>Cell Status</Table.Cell>
             <Table.Cell>APC Load</Table.Cell>
           </Table.Row>
-          {data.focus.apc_data && data.focus.apc_data.length ? (
-            data.focus.apc_data.map((apc) => (
+          {apcs_sorted && apcs_sorted.length ? (
+            apcs_sorted.map((apc) => (
               <Table.Row key={apc.name}>
                 <Table.Cell>{apc.name}</Table.Cell>
                 <Table.Cell>{apc.s_equipment}</Table.Cell>

--- a/tgui/packages/tgui/package.json
+++ b/tgui/packages/tgui/package.json
@@ -8,6 +8,7 @@
     "common": "workspace:*",
     "dateformat": "^4.5.1",
     "dompurify": "^2.5.4",
+    "es-toolkit": "^1.39.3",
     "highlight.js": "^11.5.1",
     "inferno": "^7.4.8",
     "inferno-vnode-flags": "^7.4.8",


### PR DESCRIPTION
This in anticipation of the areas-cleanup PR, which is going to make naming conventions for every area more consistent.

  - qol: "APCs in the Power Monitor app now listed in alphabetical order."
  - code_imp: "es-toolkit 1.39.3 added to TGUI dependencies for sorting funcs."