### PR TITLE
Remove false positive 'fire alarm in area' text from atmos alerts

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1,5 +1,5 @@
 ////////////////////////////////////////
-//CONTAINS: Air Alarms and Fire Alarms//
+//CONTAINS: Air Alarms//
 ////////////////////////////////////////
 
 #define AALARM_MODE_SCRUBBING	1
@@ -706,7 +706,6 @@ pixel_x = 10;
 	data["total_danger"] = danger_level
 	data["environment"] = environment_data
 	data["atmos_alarm"] = alarm_area.atmosalm
-	data["fire_alarm"] = alarm_area.fire != null
 	data["target_temperature"] = "[target_temperature - T0C]C"
 
 /obj/machinery/alarm/proc/populate_controls(var/list/data)
@@ -1046,8 +1045,6 @@ Just a object used in constructing air alarms
 	desc = "Looks like a circuit. Probably is."
 	w_class = WEIGHT_CLASS_SMALL
 	matter = list(DEFAULT_WALL_MATERIAL = 50, MATERIAL_GLASS = 50)
-
-// Fire Alarms moved to firealarm.dm
 
 #undef AALARM_MODE_SCRUBBING
 #undef AALARM_MODE_REPLACEMENT

--- a/html/changelogs/Batrachophreno-FalseFireAlarm.yml
+++ b/html/changelogs/Batrachophreno-FalseFireAlarm.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Batrachophrenoboocosmomachia
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Remove orphaned fire alarm code from air alarms."

--- a/nano/templates/air_alarm.tmpl
+++ b/nano/templates/air_alarm.tmpl
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 Title: Air Alarm
 Used In File(s): \code\game\machinery\alarm.dm
 
@@ -19,7 +19,7 @@ Used In File(s): \code\game\machinery\alarm.dm
 <H1>Air Status</H1>
 {{if data.has_environment}}
 	{{for data.environment}}
-		{{:value.name}}: 
+		{{:value.name}}:
 		{{if value.danger_level == 2}}
 			<span class='bad'>
 		{{else value.danger_level == 1}}
@@ -38,7 +38,7 @@ Used In File(s): \code\game\machinery\alarm.dm
 			<span class='good'>Optimal
 		{{/if}}
 		</span><br>
-    Area Status: {{if data.atmos_alarm}}<span class='bad'>Atmosphere alert in area</span>{{else data.fire_alarm}}<span class='bad'>Fire alarm in area</span>{{else}}No alerts{{/if}}
+    Area Status: {{if data.atmos_alarm}}<span class='bad'>Atmosphere alert in area</span>{{else}}No alerts{{/if}}
 {{else}}
 	<span class='bad'>Warning: Cannot obtain air sample for analysis.</span>
 {{/if}}
@@ -59,7 +59,7 @@ Used In File(s): \code\game\machinery\alarm.dm
                 <tr>
                     <td>
                         <div class="item">
-                            <div class="itemContent" style="width: 100%;">	
+                            <div class="itemContent" style="width: 100%;">
                                 {{:helper.link('Off',	null, { 'rcon' : 1}, data.remote_connection && !data.remote_access ? (data.rcon == 1 ? 'yellowButton' : 'disabled') : null, data.rcon == 1 ? 'selected' : null)}}
                                 {{:helper.link('Auto',	null, { 'rcon' : 2}, data.remote_connection && !data.remote_access ? (data.rcon == 2 ? 'yellowButton' : 'disabled') : null, data.rcon == 2 ? 'selected' : null)}}
                                 {{:helper.link('On',	null, { 'rcon' : 3}, data.remote_connection && !data.remote_access ? (data.rcon == 3 ? 'yellowButton' : 'disabled') : null, data.rcon == 3 ? 'selected' : null)}}
@@ -148,7 +148,7 @@ Used In File(s): \code\game\machinery\alarm.dm
 					{{:helper.link(helper.fixed(value.external,2), null, { 'id_tag' : value.id_tag, 'command' : 'set_external_pressure'})}}
 					{{:helper.link('Reset', null, { 'id_tag' : value.id_tag, 'command' : 'reset_external_pressure'})}}
 				</div>
-			</div>			
+			</div>
 			<HR>
 		{{empty}}
 			No vents connected.
@@ -209,9 +209,8 @@ Used In File(s): \code\game\machinery\alarm.dm
 						{{:helper.link(settingsValue.selected >= 0 ? helper.fixed(settingsValue.selected, 2) : "Off", null, { 'command' : 'set_threshold', 'env' : settingsValue.env, 'var' : settingsValue.val })}}
 					</td>
 				{{/for}}
-			</tr>			
+			</tr>
 		{{/for}}
 		<table>
     {{/if}}
 {{/if}}
- 


### PR DESCRIPTION
Orphaned code from when fire alarms were migrated to their own machinery obj. Handled.