### PR TITLE
Atmos Alarm Control computer program search fix and UI refactor

### DIFF
--- a/code/__DEFINES/ship_locations.dm
+++ b/code/__DEFINES/ship_locations.dm
@@ -29,6 +29,7 @@
 #define LOC_PUBLIC		"Public"
 #define LOC_CREW		"Crew Areas"
 #define LOC_ENGINEERING	"Engineering"
+#define LOC_HANGAR		"Hangar"
 #define LOC_HOLODECK	"Holodeck"
 #define LOC_MAINTENANCE	"Maintenance"
 #define LOC_MEDICAL		"Medical"
@@ -55,7 +56,6 @@
 
 /// Operations Subdepartments
 #define SUBLOC_MINING		"Mining"
-#define SUBLOC_HANGAR		"Hangar"
 #define SUBLOC_MACHINING	"Machining"
 
 /// Science Subdepartments

--- a/code/datums/wires/alarm.dm
+++ b/code/datums/wires/alarm.dm
@@ -15,7 +15,7 @@
 	if(!..())
 		return FALSE
 	var/obj/machinery/alarm/A = holder
-	if(A.wiresexposed && A.buildstage == 2)
+	if(A.panel_open && A.buildstage == 2)
 		return TRUE
 
 /datum/wires/alarm/get_status()

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -21,7 +21,7 @@
 	if(!..())
 		return FALSE
 	var/obj/machinery/power/apc/A = holder
-	return A?.wiresexposed
+	return A?.panel_open
 
 /datum/wires/apc/on_pulse(wire)
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -113,18 +113,19 @@ pixel_x = 10;
 	z_flags = ZMM_MANGLE_PLANES
 
 	var/alarm_id = null
-	var/breach_detection = 1 // Whether to use automatic breach detection or not
 	var/frequency = 1439
+	/// Whether to use automatic breach detection or not
+	var/breach_detection = 1
 	//var/skipprocess = 0 //Experimenting
 	var/alarm_frequency = 1437
 	var/remote_control = 0
 	var/rcon_setting = 2
 	var/rcon_time = 0
 	var/locked = 1
-	var/wiresexposed = 0 // If it's been screwdrivered open.
 	var/aidisabled = 0
 	var/shorted = 0
-	var/highpower = 0	// if true, power usage & temperature regulation power is increased
+	/// If true, power usage & temperature regulation power is increased
+	var/highpower = FALSE
 
 	var/datum/wires/alarm/wires
 
@@ -132,7 +133,12 @@ pixel_x = 10;
 	var/screen = AALARM_SCREEN_MAIN
 	var/area_uid
 	var/area/alarm_area
-	var/buildstage = 2 //2 is built, 1 is building, 0 is frame.
+	/// Display name
+	var/alarm_area_name
+	/// FULL area name- only used internally in the TGUI for searches, and cached here. Dumb I know but it works.
+	var/alarm_area_name_full
+	/// 2 is built, 1 is building, 0 is frame.
+	var/buildstage = 2
 
 	var/target_temperature = T0C+20
 	var/regulating_temperature = 0
@@ -140,7 +146,8 @@ pixel_x = 10;
 	var/datum/radio_frequency/radio_connection
 
 	var/list/TLV = list()
-	var/list/trace_gas = list(GAS_N2O) //list of other gases that this air alarm is able to detect
+	/// List of other gases that this air alarm is able to detect
+	var/list/trace_gas = list(GAS_N2O)
 
 	var/danger_level = 0
 	var/pressure_dangerlevel = 0
@@ -331,7 +338,7 @@ pixel_x = 10;
 		if(dir)
 			src.set_dir(dir)
 		buildstage = 0
-		wiresexposed = 1
+		panel_open = 1
 
 		update_icon()
 		set_pixel_offsets()
@@ -354,13 +361,15 @@ pixel_x = 10;
 
 /obj/machinery/alarm/proc/first_run()
 	alarm_area = get_area(src)
-	var/area_display_name = get_area_display_name(alarm_area)
+	// Just directional indicators, if any
+	alarm_area_name = get_area_display_name(alarm_area, FALSE, FALSE, FALSE, TRUE)
+	alarm_area_name_full = get_area_display_name(alarm_area)
 	area_uid = alarm_area.uid
 	if (name == "alarm")
 		if (highpower)
-			name = "[area_display_name] High-Power Air Alarm"
+			name = "[alarm_area_name] High-Power Air Alarm"
 		else
-			name = "[area_display_name] Air Alarm"
+			name = "[alarm_area_name] Air Alarm"
 
 	if(!wires)
 		wires = new(src)
@@ -515,7 +524,7 @@ pixel_x = 10;
 	ClearOverlays()
 	icon_state = "alarmp"
 
-	if(wiresexposed)
+	if(panel_open)
 		icon_state = "alarmx"
 
 	if((stat & (NOPOWER|BROKEN)) || shorted)
@@ -631,10 +640,9 @@ pixel_x = 10;
 		return
 
 	var/datum/signal/alert_signal = new
-	var/area_display_name = get_area_display_name(alarm_area)
 	alert_signal.source = src
 	alert_signal.transmission_method = TRANSMISSION_RADIO
-	alert_signal.data["zone"] = area_display_name
+	alert_signal.data["zone"] = alarm_area_name
 	alert_signal.data["type"] = "Atmospheric"
 
 	if(alert_level==2)
@@ -659,7 +667,7 @@ pixel_x = 10;
 
 /obj/machinery/alarm/interact(mob/user)
 	ui_interact(user)
-	if (wiresexposed)
+	if (panel_open)
 		wires.interact(user)
 
 /obj/machinery/alarm/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, var/master_ui = null, var/datum/ui_state/state = GLOB.default_state)
@@ -961,12 +969,12 @@ pixel_x = 10;
 	switch(buildstage)
 		if(2)
 			if(attacking_item.isscrewdriver())  // Opening that Air Alarm up.
-				wiresexposed = !wiresexposed
-				to_chat(user, SPAN_NOTICE("You [wiresexposed ? "open" : "close"] the maintenance panel."))
+				panel_open = !panel_open
+				to_chat(user, SPAN_NOTICE("You [panel_open ? "open" : "close"] the maintenance panel."))
 				update_icon()
 				return TRUE
 
-			if (wiresexposed && attacking_item.iswirecutter())
+			if (panel_open && attacking_item.iswirecutter())
 				user.visible_message(SPAN_WARNING("[user] has cut the wires inside \the [src]!"), "You cut the wires inside \the [src].")
 				playsound(src.loc, 'sound/items/Wirecutter.ogg', 50, 1)
 				new/obj/item/stack/cable_coil(get_turf(src), 5)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -14,7 +14,6 @@
 	active_power_usage = 6
 	power_channel = AREA_USAGE_ENVIRON
 	var/last_process = 0
-	var/wiresexposed = 0
 	var/buildstage = 2 // 2 = complete, 1 = no wires,  0 = circuit gone
 	var/seclevel
 	///looping sound datum for our fire alarm siren.
@@ -27,7 +26,7 @@
 		if(dir)
 			src.set_dir(dir)
 		buildstage = 0
-		wiresexposed = 1
+		panel_open = 1
 
 		update_icon()
 		set_pixel_offsets()
@@ -59,7 +58,7 @@
 /obj/machinery/firealarm/update_icon()
 	ClearOverlays()
 
-	if(wiresexposed)
+	if(panel_open)
 		switch(buildstage)
 			if(2)
 				AddOverlays("fire_b2")
@@ -111,13 +110,13 @@
 		return TRUE
 
 	if (attacking_item.isscrewdriver() && buildstage == 2)
-		if(!wiresexposed)
+		if(!panel_open)
 			set_light(0)
-		wiresexposed = !wiresexposed
+		panel_open = !panel_open
 		update_icon()
 		return TRUE
 
-	if(wiresexposed)
+	if(panel_open)
 		set_light(0)
 		switch(buildstage)
 			if(2)

--- a/code/modules/modular_computers/file_system/programs/engineering/atmoscontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/atmoscontrol.dm
@@ -60,7 +60,11 @@
 	var/alarms = list()
 	for(var/obj/machinery/alarm/alarm in monitored_alarms)
 		alarms += list(list(
-			"name" = sanitize(alarm.name),
+			"deck" = alarm.alarm_area.horizon_deck,
+			"dept" = alarm.alarm_area.department,
+			"subdept" = alarm.alarm_area.subdepartment,
+			"name" = alarm.alarm_area_name,
+			"searchname" = alarm.alarm_area_name_full,
 			"ref"= "[REF(alarm)]",
 			"danger" = max(alarm.danger_level, alarm.alarm_area.atmosalm)
 		))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -111,7 +111,6 @@ ABSTRACT_TYPE(/obj/machinery/power/apc)
 	var/lastused_total = 0
 	var/main_status = 0
 	var/mob/living/silicon/ai/hacker = null // Malfunction var. If set AI hacked the APC and has full control.
-	var/wiresexposed = FALSE
 	powernet = 0		// set so that APCs aren't found as powernet nodes //Hackish, Horrible, was like this before I changed it :c
 	var/autoflag = AUTOFLAG_OFF
 	var/has_electronics = HAS_ELECTRONICS_NONE
@@ -414,7 +413,7 @@ ABSTRACT_TYPE(/obj/machinery/power/apc)
 			update_state |= UPDATE_OPENED2
 	else if (emagged || failure_timer || (hacker && (hacker.system_override || prob(20))))
 		update_state |= UPDATE_BLUESCREEN
-	else if(wiresexposed)
+	else if(panel_open)
 		update_state |= UPDATE_WIREEXP
 	if(update_state <= 1)
 		update_state |= UPDATE_ALLGOOD
@@ -574,8 +573,8 @@ ABSTRACT_TYPE(/obj/machinery/power/apc)
 					return
 				update_icon()
 		else
-			wiresexposed = !wiresexposed
-			to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"]")
+			panel_open = !panel_open
+			to_chat(user, "The wires have been [panel_open ? "exposed" : "unexposed"]")
 			update_icon()
 
 	// ID CARD: Attempt to unlock the interface if you have sufficient access.
@@ -584,7 +583,7 @@ ABSTRACT_TYPE(/obj/machinery/power/apc)
 			to_chat(user, "The interface is broken.")
 		else if(opened != COVER_CLOSED)
 			to_chat(user, "You must close the cover to swipe an ID card.")
-		else if(wiresexposed)
+		else if(panel_open)
 			to_chat(user, "You must close the wiring panel to swipe an ID card.")
 		else if(stat & (BROKEN|MAINT))
 			to_chat(user, "Nothing happens.")
@@ -783,7 +782,7 @@ ABSTRACT_TYPE(/obj/machinery/power/apc)
 		else
 			if (issilicon(user))
 				return attack_hand(user)
-			if (opened == COVER_CLOSED && wiresexposed && \
+			if (opened == COVER_CLOSED && panel_open && \
 				attacking_item.ismultitool() || \
 				attacking_item.iswirecutter() || istype(attacking_item, /obj/item/device/assembly/signaler))
 				return attack_hand(user)
@@ -801,7 +800,7 @@ ABSTRACT_TYPE(/obj/machinery/power/apc)
 	if(!(emagged || hacker))		// trying to unlock with an emag card
 		if(opened != COVER_CLOSED)
 			to_chat(user, "You must close the cover to swipe an ID card.")
-		else if(wiresexposed)
+		else if(panel_open)
 			to_chat(user, "You must close the panel first")
 		else if(stat & (BROKEN|MAINT))
 			to_chat(user, "Nothing happens.")
@@ -873,12 +872,12 @@ ABSTRACT_TYPE(/obj/machinery/power/apc)
 
 			var/allcut = wires.is_all_cut()
 
-			if(beenhit >= pick(3, 4) && !wiresexposed)
-				wiresexposed = TRUE
+			if(beenhit >= pick(3, 4) && !panel_open)
+				panel_open = TRUE
 				update_icon()
 				visible_message(SPAN_WARNING("The [name]'s cover flies open, exposing the wires!"))
 
-			else if(wiresexposed && !allcut)
+			else if(panel_open && !allcut)
 				wires.cut_all()
 				update_icon()
 				visible_message(SPAN_WARNING("The [name]'s wires are shredded!"))
@@ -907,7 +906,7 @@ ABSTRACT_TYPE(/obj/machinery/power/apc)
 	if(!user)
 		return
 
-	if(wiresexposed && !isAI(user))
+	if(panel_open && !isAI(user))
 		wires.interact(user)
 
 	return ui_interact(user)

--- a/html/changelogs/Batrachophreno-AtmosControlBugfix.yml
+++ b/html/changelogs/Batrachophreno-AtmosControlBugfix.yml
@@ -1,0 +1,64 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Batrachophreno
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - code_imp: "Updated alarms to use parent 'panel_open' var instead of child 'wiresexposed' var."
+  - code_imp: "Filled missing area metadata for a few cases, corrected engi SM SMES area parentage."
+  - qol: "Refactored Atmos control app to use grid-based UI using new area metadata."
+  - bugfix: "Atmos control app search no longer crashes on init (no defined search term given)."
+  - bugfix: "Atmos control app search field now returns correct/full results based on area name, deck, and department."
+  - bugfix: "Removed several manually defined air alarm 'name' fields from map."
+  - bugfix: "Fixed swapped ops and aux hangar descriptions."

--- a/html/changelogs/Batrachophreno-AtmosControlBugfix.yml
+++ b/html/changelogs/Batrachophreno-AtmosControlBugfix.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: Batrachophreno
+author: Batrachophrenoboocosmomachia
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/maps/sccv_horizon/areas/horizon_areas_command.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_command.dm
@@ -19,19 +19,19 @@
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 
 /area/horizon/command/heads/captain
-	name = "Command - Captain's Office"
+	name = "Captain's Office"
 	icon_state = "captain"
 	sound_environment = SOUND_AREA_MEDIUM_SOFTFLOOR
 	area_blurb = "The most daunting office on the entire ship. Except for CCIA's. Theirs is still a little scarier."
 	horizon_deck = 3
 
 /area/horizon/command/heads/xo
-	name = "Command - Executive Officer's Office"
+	name = "Executive Officer's Office"
 	area_blurb = "No one really knows what goes on in here, but Ian usually seems pretty happy so it's got that going for it.."
 	horizon_deck = 3
 
 /area/horizon/command/heads/hos
-	name = "Security - Head of Security's Office"
+	name = "Head of Security's Office"
 	icon_state = "head_quarters"
 	area_flags = AREA_FLAG_HIDE_FROM_HOLOMAP
 	ambience = AMBIENCE_HIGHSEC
@@ -39,25 +39,25 @@
 	horizon_deck = 2
 
 /area/horizon/command/heads/rd
-	name = "Research - RD's Office"
+	name = "RD's Office"
 	icon_state = "head_quarters"
 	area_blurb = "There are nagging subtle scents of ink, chemicals, ozone, machine oil, alien blood, and a dozen more in the air here that the scrubbers seem simply incapable of finally purging."
 	horizon_deck = 2
 
 /area/horizon/command/heads/chief
-	name = "Engineering - CE's Office"
+	name = "CE's Office"
 	icon_state = "head_quarters"
 	area_blurb = "This office can't seem to decide if it smells like welding fumes or expensive cologne. Several bulkhead walls are covered in buttons and toggles that exude an air of dangerous importance."
 	horizon_deck = 2
 
 /area/horizon/command/heads/cmo
-	name = "Medical - CMO's Office"
+	name = "CMO's Office"
 	icon_state = "head_quarters"
 	area_blurb = "There's a peculiar serenity to this office completely at odds with the often frenetic atmosphere of the rest of Medical. Maybe it's the cat."
 	horizon_deck = 3
 
 /area/horizon/command/heads/om
-	name = "Operations - OM's Office"
+	name = "OM's Office"
 	icon_state = "head_quarters"
 	area_blurb = "Just stepping through the threshold imparts the nagging feeling that there's someone  out there that owes you money."
 	horizon_deck = 2

--- a/maps/sccv_horizon/areas/horizon_areas_engineering.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_engineering.dm
@@ -58,7 +58,7 @@
 	horizon_deck = 1
 
 /area/horizon/engineering/aft_airlock
-	name = "Aft Service Airlock"
+	name = "Aft Stowage Airlock"
 	horizon_deck = 2
 
 /area/horizon/engineering/bluespace_drive
@@ -160,7 +160,7 @@
 	name = "Supermatter Reactor Chamber"
 	area_blurb = "The air throbs with subdued lethality. Phoronic science breaks the laws of thermodynamics in this chamber, and the laws of thermodynamics seem angry."
 
-/area/horizon/engineering/smes
+/area/horizon/engineering/reactor/supermatter/smes
 	name = "Supermatter Reactor SMES"
 	icon_state = "engine_smes"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED

--- a/maps/sccv_horizon/areas/horizon_areas_holodeck.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_holodeck.dm
@@ -5,6 +5,7 @@
 	holomap_color = HOLOMAP_AREACOLOR_CIVILIAN
 	horizon_deck = 3
 	area_blurb = "One of the SCCV Horizon's very expensive holodecks."
+	department = LOC_CREW
 
 /area/horizon/holodeck_control/beta
 	name = "Holodeck Beta"
@@ -19,6 +20,7 @@
 	holomap_color = HOLOMAP_AREACOLOR_CIVILIAN
 	horizon_deck = 3
 	area_blurb = "One of the SCCV Horizon's very expensive holodecks."
+	department = LOC_CREW
 
 /area/horizon/holodeck/alphadeck
 	name = "Holodeck Alpha"

--- a/maps/sccv_horizon/areas/horizon_areas_operations.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_operations.dm
@@ -65,7 +65,7 @@
 	sound_environment = SOUND_ENVIRONMENT_HANGAR
 	holomap_color = HOLOMAP_AREACOLOR_HANGAR
 	horizon_deck = 1
-	subdepartment = SUBLOC_HANGAR
+	department = LOC_HANGAR
 
 /area/horizon/hangar/control
 	name = "Hangar Control Room"
@@ -81,12 +81,12 @@
 
 /area/horizon/hangar/operations
 	name = "Starboard Auxiliary Hangar"
-	area_blurb = "A big, open room, home to two of the SCCV Horizon's shuttles, the Quark and the Canary."
+	area_blurb = "A big, open room, home to the SCCV Horizon's mining shuttle, the Spark."
 	area_blurb_category = "hanger"
 
 /area/horizon/hangar/auxiliary
 	name = "Port Auxiliary Hangar"
-	area_blurb = "A big, open room, home to the SCCV Horizon's mining shuttle, the Spark."
+	area_blurb = "A big, open room, home to two of the SCCV Horizon's shuttles, the Quark and the Canary."
 	area_blurb_category = "hanger"
 
 /// OPERATIONS_AREAS - MACHINIST_AREAS
@@ -130,6 +130,7 @@
 	area_flags = AREA_FLAG_HIDE_FROM_HOLOMAP
 	horizon_deck = 3
 	area_blurb = "One of the SCCV Horizon's daunting weapons bays."
+	department = LOC_COMMAND
 
 /area/horizon/weapons/grauwolf
 	name = "Grauwolf Weapon System"
@@ -139,6 +140,7 @@
 	area_flags = AREA_FLAG_HIDE_FROM_HOLOMAP
 	horizon_deck = 2
 	area_blurb = "One of the SCCV Horizon's daunting weapons bays."
+	department = LOC_COMMAND
 
 /// STORAGE_AREAS
 /area/horizon/storage
@@ -170,6 +172,6 @@
 	name = "Secure Storage"
 	icon_state = "storage"
 	horizon_deck = 2
-	holomap_color = HOLOMAP_AREACOLOR_CIVILIAN
+	area_flags = AREA_FLAG_HIDE_FROM_HOLOMAP
 	department = LOC_COMMAND
 	area_blurb = "A place not to be visited unless things are going either horribly wrong or horribly right."

--- a/maps/sccv_horizon/areas/horizon_areas_shuttle.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_shuttle.dm
@@ -6,6 +6,7 @@
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 	area_flags = AREA_FLAG_RAD_SHIELDED
 	horizon_deck = 1
+	department = LOC_SHUTTLE
 	area_blurb = "A shuttle compartment: compact and rigidly functional."
 
 /area/horizon/shuttle/intrepid

--- a/tgui/packages/tgui/interfaces/AtmosAlarmControl.tsx
+++ b/tgui/packages/tgui/interfaces/AtmosAlarmControl.tsx
@@ -1,6 +1,6 @@
 import { BooleanLike } from '../../common/react';
 import { useBackend, useLocalState } from '../backend';
-import { Button, Input, NoticeBox, Section } from '../components';
+import { Button, Input, NoticeBox, Section, Table } from '../components';
 import { NtosWindow } from '../layouts';
 
 export type AlarmData = {
@@ -8,7 +8,10 @@ export type AlarmData = {
 };
 
 type Alarm = {
+  deck: number;
+  dept: string;
   name: string;
+  searchname: string;
   ref: string;
   danger: BooleanLike;
 };
@@ -30,7 +33,7 @@ export const AtmosAlarmControl = (props, context) => {
             <Input
               autoFocus
               autoSelect
-              placeholder="Search by name"
+              placeholder="Search"
               width="40vw"
               maxLength={512}
               onInput={(e, value) => {
@@ -39,23 +42,40 @@ export const AtmosAlarmControl = (props, context) => {
               value={searchTerm}
             />
           }>
-          {data.alarms && data.alarms.length ? (
-            data.alarms
-              .filter(
-                (a) =>
-                  a.name.toLowerCase().indexOf(searchTerm.toLowerCase()) > -1
-              )
-              .map((alarm) => (
-                <Button
-                  key={alarm.name}
-                  content={alarm.name}
-                  color={alarm.danger ? 'red' : ''}
-                  onClick={() => act('alarm', { alarm: alarm.ref })}
-                />
-              ))
-          ) : (
-            <NoticeBox>No alarms detected.</NoticeBox>
-          )}
+          <Table>
+            <Table.Row header>
+              <Table.Cell>Deck</Table.Cell>
+              <Table.Cell>Department</Table.Cell>
+              <Table.Cell>Area</Table.Cell>
+            </Table.Row>
+            {data.alarms && data.alarms.length ? (
+              data.alarms
+                // Search still doesn't work properly. While it correctly handles name searches now, it still won't search by dept or deck.
+                .filter(
+                  (alarm) =>
+                    alarm.searchname
+                      ?.toLowerCase()
+                      .indexOf(searchTerm.toLowerCase()) > -1
+                )
+                .sort((a, b) => a.dept?.localeCompare(b?.dept))
+                .map((alarm) => (
+                  <Table.Row key={alarm.ref}>
+                    <Table.Cell>{alarm.deck}</Table.Cell>
+                    <Table.Cell>{alarm.dept}</Table.Cell>
+                    <Table.Cell>
+                      <Button
+                        key={alarm.name}
+                        content={alarm.name}
+                        color={alarm.danger ? 'red' : 'green'}
+                        onClick={() => act('alarm', { alarm: alarm.ref })}
+                      />
+                    </Table.Cell>
+                  </Table.Row>
+                ))
+            ) : (
+              <NoticeBox>No alarms detected.</NoticeBox>
+            )}
+          </Table>
         </Section>
       </NtosWindow.Content>
     </NtosWindow>


### PR DESCRIPTION
Scope creeped PR. Fixes a breaking bug in the Atmos Alarm Control application introduced after areas-cleanup PR, but also refactors it into a grid-based interface that actually allows you to reliably search alarms by name, department, and deck # (possible now with all the area metadata we have to play with).

Also does behind-the-scenes cleanup of alarm panel code in general, a few area def problems, and some manually defined air alarm names on the map.