### PR TITLE
Hydroponics Overhaul: the Atmos Update

### DIFF
--- a/code/__DEFINES/hydroponics.dm
+++ b/code/__DEFINES/hydroponics.dm
@@ -14,6 +14,19 @@
 #define GROWTH_BIOMASS			  "biomass"
 #define GROWTH_MOLD				  "mold"
 
+// The various standardised ideal heat values. They vary by increments of 10.
+#define IDEAL_HEAT_MOGHES 333
+#define IDEAL_HEAT_TROPICAL 303
+#define IDEAL_HEAT_TEMPERATE 293
+#define IDEAL_HEAT_COLD 283
+#define IDEAL_HEAT_ADHOMAI 255
+
+// The various standardised ideal light values. They vary by incrmeents of 2.
+#define IDEAL_LIGHT_MOGHES 9
+#define IDEAL_LIGHT_HIGH 7
+#define IDEAL_LIGHT_TEMPERATE 5
+#define IDEAL_LIGHT_DIM 3
+
 // Definitions for genes (trait groupings)
 #define GENE_BIOCHEMISTRY "biochemistry"
 #define GENE_HARDINESS "hardiness"

--- a/code/__DEFINES/hydroponics.dm
+++ b/code/__DEFINES/hydroponics.dm
@@ -22,7 +22,6 @@
 #define IDEAL_HEAT_ADHOMAI 255
 
 // The various standardised ideal light values. They vary by incrmeents of 2.
-#define IDEAL_LIGHT_MOGHES 9
 #define IDEAL_LIGHT_HIGH 7
 #define IDEAL_LIGHT_TEMPERATE 5
 #define IDEAL_LIGHT_DIM 3

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -584,7 +584,9 @@
 		/obj/item/device/analyzer/plant_analyzer,
 		/obj/item/clothing/gloves/botanic_leather,
 		/obj/item/device/radio,
-		/obj/item/crowbar
+		/obj/item/crowbar,
+		/obj/item/device/analyzer,
+		/obj/item/device/t_scanner,
 	)
 
 /obj/item/storage/belt/hydro/full

--- a/code/game/objects/random/misc.dm
+++ b/code/game/objects/random/misc.dm
@@ -232,7 +232,7 @@
 		/obj/item/storage/belt/champion = 11,
 		/obj/item/pen/invisible = 10,
 		/obj/item/grenade/fake = 7,
-		/obj/item/gun/energy/wand/toy = 7,
+		/obj/item/gun/energy/wand/toy =	 7,
 		/obj/item/device/binoculars = 11,
 		/obj/item/device/megaphone = 11,
 		/obj/item/eightball = 11,
@@ -616,3 +616,28 @@
 		/obj/item/toy/comic/magazine/horticulturetoday/issue6
 	)
 
+/obj/random/hydroponics
+	name = "random hydroponics item"
+	desc = "This is a hydroponics thing."
+	icon_state = "tech_supply"
+	spawnlist = list(
+		/obj/item/material/scythe/sickle = 1,
+		/obj/item/material/scythe = 1,
+		/obj/item/reagent_containers/glass/bottle/mutagen = 1,
+		/obj/item/gun/energy/floragun = 1,
+		/obj/item/reagent_containers/glass/fertilizer/rh = 1,
+		/obj/item/reagent_containers/glass/fertilizer/l4z = 1,
+		/obj/item/reagent_containers/glass/fertilizer/ez = 1,
+		/obj/item/crowbar = 1,
+		/obj/item/shovel = 1,
+		/obj/item/shovel/spade = 1,
+		/obj/item/wrench = 1,
+		/obj/random/condiment = 3,
+		/obj/random/kitchen_staples = 3,
+		/obj/random/smokable = 1,
+		/obj/random/seed = 3,
+		/obj/random/plushie = 1,
+		/obj/random/mre = 1,
+		/obj/random/med_stack = 1,
+		/obj/item/reagent_containers/glass/bottle/ammonia,
+	)

--- a/code/game/objects/structures/crates_lockers/closets/hazmat.dm
+++ b/code/game/objects/structures/crates_lockers/closets/hazmat.dm
@@ -20,6 +20,7 @@
 	new /obj/item/clothing/suit/hazmat/general(src)
 	new /obj/item/clothing/mask/gas/half(src)
 	new /obj/item/clothing/mask/gas/half(src)
+	new /obj/item/tank/oxygen(src)
 
 // Research
 /obj/structure/closet/hazmat/research

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -601,6 +601,7 @@
 	new /obj/item/beehive_assembly(src)
 	new /obj/item/bee_net(src)
 	new /obj/item/bee_smoker(src)
+	new /obj/item/crowbar(src)
 
 // Includes everything you need to run your own horticultural medicinal operation. Or something more nefarious, if you prefer.
 /obj/structure/closet/crate/hydroponics/herbalism

--- a/code/modules/hydroponics/beekeeping/bee_pack.dm
+++ b/code/modules/hydroponics/beekeeping/bee_pack.dm
@@ -5,6 +5,10 @@
 	icon_state = "bee_pack"
 	var/full = TRUE
 
+/obj/item/bee_pack/mechanics_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "Insert this into a beehive with an open lid to populate it with bees."
+
 /obj/item/bee_pack/Initialize()
 	. = ..()
 	AddOverlays("bee_pack-full")

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -4,6 +4,10 @@
 	icon = 'icons/obj/beekeeping.dmi'
 	icon_state = "beehive_assembly"
 
+/obj/item/beehive_assembly/assembly_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "Use this on any unoccupied turf to place a beehive where you are standing."
+
 /obj/item/beehive_assembly/attack_self(var/mob/user)
 	to_chat(user, SPAN_NOTICE("You start assembling \the [src]..."))
 	if(do_after(user, 30))
@@ -14,6 +18,7 @@
 
 /obj/machinery/beehive
 	name = "beehive"
+	desc = "They make honey in these, allegedly."
 	icon = 'icons/obj/beekeeping.dmi'
 	icon_state = "beehive"
 	density = TRUE
@@ -27,6 +32,17 @@
 	var/maxFrames = 5
 
 	var/list/owned_bee_swarms = list()
+
+/obj/machinery/beehive/mechanics_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "Use a <b>crowbar</b> to open a beehive, and then retrieve the frames from inside with an open hand."
+	. += "You can populate a beehive using a <b>bee pack</b>, and review the status of the hive inside with a <b>plant analyzer</b>."
+	. += "While occupied by bees and within several turfs of a growing plant, bees will increase the health of the adjacent plant. This can be particularly \
+	useful if you're low on fertiliser and need to keep your crops alive!"
+
+/obj/machinery/beehive/disassembly_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "This can be dismantled with a <b>screwdriver</b>."
 
 /obj/machinery/beehive/feedback_hints(mob/user, distance, is_adjacent)
 	. += ..()

--- a/code/modules/hydroponics/beekeeping/honey_extractor.dm
+++ b/code/modules/hydroponics/beekeeping/honey_extractor.dm
@@ -14,6 +14,11 @@
 		. += SPAN_NOTICE("It's holding \the <b>[contained_frame]</b>.")
 	. += SPAN_NOTICE("It contains <b>[honey]</b> units of honey for collection.")
 
+/obj/machinery/honey_extractor/mechanics_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "Once filled honeycombs have been obtained, insert them into this device to process them into wax and honey. The honey can be retrieved from \
+	the extractor with any reagent container."
+
 /obj/machinery/honey_extractor/attackby(obj/item/attacking_item, mob/user)
 	if(contained_frame)
 		to_chat(user, SPAN_WARNING("\The [src] is currently spinning, wait until it's finished."))

--- a/code/modules/hydroponics/beekeeping/honey_frame.dm
+++ b/code/modules/hydroponics/beekeeping/honey_frame.dm
@@ -6,6 +6,10 @@
 	w_class = WEIGHT_CLASS_SMALL
 	var/honey = 0
 
+/obj/item/honey_frame/feedback_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += SPAN_NOTICE("This contains <b>[honey] units</b> units of honey.")
+
 /obj/item/honey_frame/filled
 	name = "filled beehive frame"
 	desc = "A frame for the beehive that has been filled with honeycombs."

--- a/code/modules/hydroponics/beekeeping/net.dm
+++ b/code/modules/hydroponics/beekeeping/net.dm
@@ -8,6 +8,10 @@
 	var/caught_bees = 0
 	var/feralbees
 
+/obj/item/bee_net/mechanics_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "This can be used to contain rogue bees, although beware overcrowding the net! If you do, the contained bees may all break out at once."
+
 /obj/item/bee_net/get_examine_text(mob/user, distance, is_adjacent, infix, suffix)
 	. = ..()
 	if(caught_bees)

--- a/code/modules/hydroponics/beekeeping/smoker.dm
+++ b/code/modules/hydroponics/beekeeping/smoker.dm
@@ -8,6 +8,10 @@
 	w_class = WEIGHT_CLASS_BULKY
 	var/max_fuel = 60
 
+/obj/item/bee_smoker/mechanics_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "Use this to pacify bees before extracting frames from a hive!"
+
 /obj/item/bee_smoker/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
 	. += "This device can be used to blind people in short range."

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -91,17 +91,17 @@
 	set_trait(TRAIT_TOXINS_TOLERANCE,     5)
 	set_trait(TRAIT_PEST_TOLERANCE,       5)
 	set_trait(TRAIT_WEED_TOLERANCE,       5)
-	set_trait(TRAIT_IDEAL_LIGHT,          5)
-	set_trait(TRAIT_HEAT_TOLERANCE,       20) // Plants will begin to die if they're twenty or more degrees from their ideal temperature.
+	set_trait(TRAIT_IDEAL_LIGHT,          IDEAL_LIGHT_TEMPERATE)
+	set_trait(TRAIT_HEAT_TOLERANCE,       12) // Plants will begin to die if they're twelve or more degrees from their ideal temperature.
 	set_trait(TRAIT_LOWKPA_TOLERANCE,     25) // Plants survive all the way down to a quarter of an atmosphere!
 	set_trait(TRAIT_ENDURANCE,            100)
 	set_trait(TRAIT_HIGHKPA_TOLERANCE,    200)
-	set_trait(TRAIT_IDEAL_HEAT,           293)
+	set_trait(TRAIT_IDEAL_HEAT,           IDEAL_HEAT_TEMPERATE)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.25)
 	set_trait(TRAIT_PLANT_COLOUR,         "#46B543")
 	set_trait(TRAIT_LARGE,                0)
 	set_trait(TRAIT_HEAT_PREFERENCE,      5) // By default, plants grow faster in a temperature within five degrees of their ideal.
-	set_trait(TRAIT_LIGHT_PREFERENCE,     2) // Similarly, they grow faster under lumens within two of their ideal.
+	set_trait(TRAIT_LIGHT_PREFERENCE,     1.5) // Similarly, they grow faster under lumens within 1.5 of their ideal.
 
 	setup_traits()
 

--- a/code/modules/hydroponics/seed_datums/adhomai.dm
+++ b/code/modules/hydroponics/seed_datums/adhomai.dm
@@ -20,7 +20,8 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#378C61")
 	set_trait(TRAIT_PLANT_COLOUR,"#378C61")
 	set_trait(TRAIT_PLANT_ICON,"tree5")
-	set_trait(TRAIT_IDEAL_HEAT, 278)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_ADHOMAI)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 
 /obj/item/seeds/shandseed
@@ -45,7 +46,8 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#4CC5C7")
 	set_trait(TRAIT_PLANT_COLOUR,"#4CC789")
 	set_trait(TRAIT_PLANT_ICON,"bush7")
-	set_trait(TRAIT_IDEAL_HEAT, 278)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_ADHOMAI)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 
 /obj/item/seeds/mtearseed
@@ -70,7 +72,8 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#87CEEB")
 	set_trait(TRAIT_PLANT_COLOUR,"#4D8F53")
 	set_trait(TRAIT_PLANT_ICON,"alien2")
-	set_trait(TRAIT_IDEAL_HEAT, 278)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_ADHOMAI)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
 	set_trait(TRAIT_WATER_CONSUMPTION, 8)
 
 /obj/item/seeds/earthenroot
@@ -97,9 +100,10 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#C4AE7A")
 	set_trait(TRAIT_PLANT_COLOUR,"#4D8F53")
 	set_trait(TRAIT_PLANT_ICON,"bush4")
-	set_trait(TRAIT_IDEAL_HEAT, 278)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_ADHOMAI)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
 
 /obj/item/seeds/dirtberries
 	seed_type = "dirtberries"
@@ -127,8 +131,8 @@
 	set_trait(TRAIT_PLANT_COLOUR,"#31331c")
 	set_trait(TRAIT_PLANT_ICON,"nfrihi")
 	set_trait(TRAIT_WATER_CONSUMPTION, 4)
-	set_trait(TRAIT_IDEAL_LIGHT, 3)
-	set_trait(TRAIT_IDEAL_HEAT, 253)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_ADHOMAI)
 
 /obj/item/seeds/blizzard
 	seed_type = "nfrihi"
@@ -154,9 +158,9 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#fffdf7")
 	set_trait(TRAIT_PLANT_COLOUR,"#31331c")
 	set_trait(TRAIT_PLANT_ICON,"nmshaan")
-	set_trait(TRAIT_IDEAL_HEAT, 253)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_ADHOMAI)
 	set_trait(TRAIT_WATER_CONSUMPTION, 4)
-	set_trait(TRAIT_IDEAL_LIGHT, 3)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
 
 /obj/item/seeds/sugartree
 	seed_type = "sugar tree"

--- a/code/modules/hydroponics/seed_datums/aquaculture.dm
+++ b/code/modules/hydroponics/seed_datums/aquaculture.dm
@@ -15,8 +15,8 @@
 	set_trait(TRAIT_PRODUCT_ICON,      "mollusc")
 	set_trait(TRAIT_PLANT_ICON,        "mollusc")
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
-	set_trait(TRAIT_IDEAL_HEAT,        284)
-	set_trait(TRAIT_LIGHT_TOLERANCE,   6)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_COLD)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
 	set_trait(TRAIT_PRODUCT_COLOUR,    "#aaabba")
 	set_trait(TRAIT_PLANT_COLOUR,      "#aaabba")
 
@@ -64,3 +64,19 @@
 
 /obj/item/seeds/clam/rasval
 	seed_type = "rasval clam"
+
+/datum/seed/grass/sea
+	name = "seaweed"
+	seed_name = "seaweed"
+	display_name = "seaweed"
+	kitchen_tag = "seaweed"
+
+/datum/seed/grass/sea/setup_traits()
+	..()
+	set_trait(TRAIT_PRODUCT_COLOUR, "#0F6E56")
+	set_trait(TRAIT_PLANT_COLOUR, "#0D4836")
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_COLD)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
+
+/obj/item/seeds/seaweed
+	seed_type = "seaweed"

--- a/code/modules/hydroponics/seed_datums/flowers.dm
+++ b/code/modules/hydroponics/seed_datums/flowers.dm
@@ -35,7 +35,6 @@
 	set_trait(TRAIT_PRODUCT_ICON,"flower3")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#B33715")
 	set_trait(TRAIT_PLANT_ICON,"flower3")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
 	set_trait(TRAIT_WATER_CONSUMPTION, 0.5)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 
@@ -53,7 +52,7 @@
 	set_trait(TRAIT_PRODUCT_ICON,"flower2")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#FFF700")
 	set_trait(TRAIT_PLANT_ICON,"flower2")
-	set_trait(TRAIT_IDEAL_LIGHT, 7)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 

--- a/code/modules/hydroponics/seed_datums/fruits.dm
+++ b/code/modules/hydroponics/seed_datums/fruits.dm
@@ -20,7 +20,8 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#3AF026")
 	set_trait(TRAIT_PLANT_ICON,"tree")
 	set_trait(TRAIT_FLESH_COLOUR,"#3AF026")
-	set_trait(TRAIT_IDEAL_HEAT, 304)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/limeseed
 	seed_type = "lime"
@@ -37,7 +38,6 @@
 	set_trait(TRAIT_PRODUCES_POWER,1)
 	set_trait(TRAIT_PRODUCT_COLOUR,"#F0E226")
 	set_trait(TRAIT_FLESH_COLOUR,"#F0E226")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
 
 /obj/item/seeds/lemonseed
 	seed_type = "lemon"
@@ -78,7 +78,8 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#BB6AC4")
 	set_trait(TRAIT_PLANT_COLOUR,"#378F2E")
 	set_trait(TRAIT_PLANT_ICON,"vine")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 
 /obj/item/seeds/grapeseed
@@ -294,7 +295,6 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#FF540A")
 	set_trait(TRAIT_PLANT_ICON,"tree2")
 	set_trait(TRAIT_FLESH_COLOUR,"#E8E39B")
-	set_trait(TRAIT_IDEAL_LIGHT, 4)
 
 /obj/item/seeds/appleseed
 	seed_type = "apple"
@@ -348,7 +348,8 @@
 	set_trait(TRAIT_PRODUCT_ICON,"treefruit")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#CCA935")
 	set_trait(TRAIT_PLANT_ICON,"tree2")
-	set_trait(TRAIT_IDEAL_HEAT, 304)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 
 /datum/seed/banana
@@ -369,8 +370,8 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#FFEC1F")
 	set_trait(TRAIT_PLANT_COLOUR,"#69AD50")
 	set_trait(TRAIT_PLANT_ICON,"tree4")
-	set_trait(TRAIT_IDEAL_HEAT, 304)
-	set_trait(TRAIT_IDEAL_LIGHT, 7)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 
 /obj/item/seeds/bananaseed
@@ -420,8 +421,8 @@
 	set_trait(TRAIT_PLANT_COLOUR,"#49be45")
 	set_trait(TRAIT_PLANT_ICON,"vine2")
 	set_trait(TRAIT_FLESH_COLOUR,"#ff5858")
-	set_trait(TRAIT_IDEAL_HEAT, 304)
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 
 /obj/item/seeds/watermelonseed
@@ -469,7 +470,8 @@
 	set_trait(TRAIT_PRODUCT_ICON,"bean2")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#be9109")
 	set_trait(TRAIT_PLANT_ICON,"bush2")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/coffeeseed
 	seed_type = "coffee"
@@ -491,7 +493,8 @@
 	set_trait(TRAIT_PRODUCT_ICON,"bean2")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#be9109")
 	set_trait(TRAIT_PLANT_ICON,"bush2")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/richcoffeeseed
 	seed_type = "richcoffee"

--- a/code/modules/hydroponics/seed_datums/grains.dm
+++ b/code/modules/hydroponics/seed_datums/grains.dm
@@ -15,7 +15,6 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#DBD37D")
 	set_trait(TRAIT_PLANT_COLOUR,"#BFAF82")
 	set_trait(TRAIT_PLANT_ICON,"stalk2")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 
 /obj/item/seeds/wheatseed
@@ -39,8 +38,8 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#FFF23B")
 	set_trait(TRAIT_PLANT_COLOUR,"#87C969")
 	set_trait(TRAIT_PLANT_ICON,"corn")
-	set_trait(TRAIT_IDEAL_HEAT, 298)
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 
 /obj/item/seeds/cornseed
@@ -64,6 +63,8 @@
 	set_trait(TRAIT_PLANT_COLOUR,"#8ED17D")
 	set_trait(TRAIT_PLANT_ICON,"stalk2")
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 
 /obj/item/seeds/riceseed

--- a/code/modules/hydroponics/seed_datums/herbs.dm
+++ b/code/modules/hydroponics/seed_datums/herbs.dm
@@ -16,11 +16,10 @@
 	set_trait(TRAIT_PRODUCT_ICON,"herb")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#4dd298")
 	set_trait(TRAIT_PLANT_ICON,"herb")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
 
 /obj/item/seeds/mintseed
 	seed_type = "mint"
-
 
 /datum/seed/tea
 	name = "tea"
@@ -38,7 +37,7 @@
 	set_trait(TRAIT_PRODUCT_ICON,"herb")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#4fd24d")
 	set_trait(TRAIT_PLANT_ICON,"herb")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
 
 /obj/item/seeds/teaseed
 	seed_type = "tea"
@@ -58,7 +57,7 @@
 	set_trait(TRAIT_PRODUCT_ICON,"herb")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#0E1F0E")
 	set_trait(TRAIT_PLANT_ICON,"herb")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
 
 /obj/item/seeds/sencha
 	seed_type = "sencha"
@@ -78,7 +77,7 @@
 	set_trait(TRAIT_PRODUCT_ICON,"herb")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#5C6447")
 	set_trait(TRAIT_PLANT_ICON,"herb")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
 
 /obj/item/seeds/tieguanyin
 	seed_type = "tieguanyin"
@@ -98,7 +97,7 @@
 	set_trait(TRAIT_PRODUCT_ICON,"herb")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#534337")
 	set_trait(TRAIT_PLANT_ICON,"herb")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
 
 /obj/item/seeds/jaekseol
 	seed_type = "jaekseol"
@@ -119,7 +118,7 @@
 	set_trait(TRAIT_PRODUCT_ICON, "herb")
 	set_trait(TRAIT_PRODUCT_COLOUR, "#056608")
 	set_trait(TRAIT_PLANT_ICON, "herb")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
 
 /obj/item/seeds/cocaseed
 	seed_type = "coca"

--- a/code/modules/hydroponics/seed_datums/misc.dm
+++ b/code/modules/hydroponics/seed_datums/misc.dm
@@ -35,7 +35,8 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#B4D6BD")
 	set_trait(TRAIT_PLANT_COLOUR,"#6BBD68")
 	set_trait(TRAIT_PLANT_ICON,"stalk3")
-	set_trait(TRAIT_IDEAL_HEAT, 304)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/sugarcaneseed
 	seed_type = "sugarcane"
@@ -63,21 +64,6 @@
 
 /obj/item/seeds/grassseed
 	seed_type = "grass"
-
-/datum/seed/grass/sea
-	name = "seaweed"
-	seed_name = "seaweed"
-	display_name = "seaweed"
-	kitchen_tag = "seaweed"
-
-/datum/seed/grass/sea/setup_traits()
-	..()
-	set_trait(TRAIT_PRODUCT_COLOUR, "#0F6E56")
-	set_trait(TRAIT_PLANT_COLOUR, "#0D4836")
-	set_trait(TRAIT_IDEAL_HEAT, 284) // To fit with molluscs.
-
-/obj/item/seeds/seaweed
-	seed_type = "seaweed"
 
 /datum/seed/grass/moss
 	name = "moss"
@@ -110,7 +96,8 @@
 	set_trait(TRAIT_PRODUCT_ICON,"nuts")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#4d4d4d")
 	set_trait(TRAIT_PLANT_ICON,"vine2")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/peppercornseed
 	seed_type = "peppercorn"

--- a/code/modules/hydroponics/seed_datums/mushrooms.dm
+++ b/code/modules/hydroponics/seed_datums/mushrooms.dm
@@ -25,8 +25,8 @@
 	set_trait(TRAIT_PLANT_COLOUR,"#D9C94E")
 	set_trait(TRAIT_PLANT_ICON,"mushroom")
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
-	set_trait(TRAIT_IDEAL_HEAT, 282)
-	set_trait(TRAIT_LIGHT_TOLERANCE, 6)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_COLD)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
 
 /datum/seed/koisspore
 	name = "koisspore"
@@ -49,7 +49,6 @@
 	set_trait(TRAIT_YIELD,3)
 	set_trait(TRAIT_POTENCY,60)
 	set_trait(TRAIT_BIOLUM,1)
-	set_trait(TRAIT_IDEAL_LIGHT,5)
 	set_trait(TRAIT_REQUIRES_NUTRIENTS,0)
 	set_trait(TRAIT_REQUIRES_WATER,0)
 	set_trait(TRAIT_LIGHT_TOLERANCE,10)
@@ -75,7 +74,6 @@
 	set_trait(TRAIT_BIOLUM_PWR,-1.5)
 	set_trait(TRAIT_POTENCY,80)
 	set_trait(TRAIT_ENDURANCE,75)
-	set_trait(TRAIT_IDEAL_LIGHT,0)
 	set_trait(TRAIT_BIOLUM_COLOUR,"#FFFFFF")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#31004A")
 	set_trait(TRAIT_PLANT_COLOUR,"#31004A")

--- a/code/modules/hydroponics/seed_datums/mushrooms.dm
+++ b/code/modules/hydroponics/seed_datums/mushrooms.dm
@@ -26,7 +26,6 @@
 	set_trait(TRAIT_PLANT_ICON,"mushroom")
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_COLD)
-	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
 
 /datum/seed/koisspore
 	name = "koisspore"

--- a/code/modules/hydroponics/seed_datums/nralakk.dm
+++ b/code/modules/hydroponics/seed_datums/nralakk.dm
@@ -17,7 +17,6 @@
 	set_trait(TRAIT_PRODUCT_ICON,"leaves")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#00e0e0")
 	set_trait(TRAIT_PLANT_ICON,"bush8")
-	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
 	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/dynseed
@@ -40,7 +39,6 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#61E2EC")
 	set_trait(TRAIT_PLANT_ICON,"wumpavines")
 	set_trait(TRAIT_WATER_CONSUMPTION, 10)
-	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
 	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/wulumunushaseed
@@ -65,7 +63,6 @@
 	set_trait(TRAIT_FLESH_COLOUR, "#9FE4B0")
 	set_trait(TRAIT_PLANT_ICON,"mushroom9")
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
-	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
 	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/qlortseed
@@ -92,7 +89,6 @@
 	set_trait(TRAIT_PLANT_COLOUR,"#4790DA")
 	set_trait(TRAIT_PLANT_ICON,"alien1")
 	set_trait(TRAIT_WATER_CONSUMPTION, 10)
-	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
 	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/guamiseed
@@ -118,8 +114,6 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#F1EAD9")
 	set_trait(TRAIT_PLANT_COLOUR,"#F1EAD9")
 	set_trait(TRAIT_PLANT_ICON,"mushroom6")
-	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
-	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/eki
 	seed_type = "eki"
@@ -145,7 +139,6 @@
 	set_trait(TRAIT_PLANT_ICON,"bush")
 	set_trait(TRAIT_WATER_CONSUMPTION, 10)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
-	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
 	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/ylpha
@@ -173,7 +166,6 @@
 	set_trait(TRAIT_BIOLUM_COLOUR,"#990033")
 	set_trait(TRAIT_SPREAD,1)
 	set_trait(TRAIT_WATER_CONSUMPTION, 10)
-	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
 	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/fjylozyn

--- a/code/modules/hydroponics/seed_datums/nralakk.dm
+++ b/code/modules/hydroponics/seed_datums/nralakk.dm
@@ -17,6 +17,8 @@
 	set_trait(TRAIT_PRODUCT_ICON,"leaves")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#00e0e0")
 	set_trait(TRAIT_PLANT_ICON,"bush8")
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/dynseed
 	seed_type = "dyn"
@@ -38,6 +40,8 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#61E2EC")
 	set_trait(TRAIT_PLANT_ICON,"wumpavines")
 	set_trait(TRAIT_WATER_CONSUMPTION, 10)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/wulumunushaseed
 	seed_type = "wulumunusha"
@@ -61,6 +65,8 @@
 	set_trait(TRAIT_FLESH_COLOUR, "#9FE4B0")
 	set_trait(TRAIT_PLANT_ICON,"mushroom9")
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/qlortseed
 	seed_type = "qlort"
@@ -86,6 +92,8 @@
 	set_trait(TRAIT_PLANT_COLOUR,"#4790DA")
 	set_trait(TRAIT_PLANT_ICON,"alien1")
 	set_trait(TRAIT_WATER_CONSUMPTION, 10)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/guamiseed
 	seed_type = "guami"
@@ -110,6 +118,8 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#F1EAD9")
 	set_trait(TRAIT_PLANT_COLOUR,"#F1EAD9")
 	set_trait(TRAIT_PLANT_ICON,"mushroom6")
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/eki
 	seed_type = "eki"
@@ -135,6 +145,8 @@
 	set_trait(TRAIT_PLANT_ICON,"bush")
 	set_trait(TRAIT_WATER_CONSUMPTION, 10)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/ylpha
 	seed_type = "ylpha"
@@ -161,6 +173,8 @@
 	set_trait(TRAIT_BIOLUM_COLOUR,"#990033")
 	set_trait(TRAIT_SPREAD,1)
 	set_trait(TRAIT_WATER_CONSUMPTION, 10)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_DIM)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/fjylozyn
 	seed_type = "fjylozyn"

--- a/code/modules/hydroponics/seed_datums/smokables.dm
+++ b/code/modules/hydroponics/seed_datums/smokables.dm
@@ -17,8 +17,8 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#749733")
 	set_trait(TRAIT_PLANT_COLOUR,"#749733")
 	set_trait(TRAIT_PLANT_ICON,"vine2")
-	set_trait(TRAIT_IDEAL_HEAT, 304)
-	set_trait(TRAIT_IDEAL_LIGHT, 7)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 
@@ -83,7 +83,8 @@
 	set_trait(TRAIT_PRODUCT_ICON,"ambrosia")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#9FAD55")
 	set_trait(TRAIT_PLANT_ICON,"ambrosia")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/ambrosiavulgarisseed
 	seed_type = "ambrosia"
@@ -125,7 +126,8 @@
 	set_trait(TRAIT_PRODUCT_COLOUR, "#ad5555")
 	set_trait(TRAIT_PLANT_COLOUR, "#ffa2a2")
 	set_trait(TRAIT_PLANT_ICON, "flower")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/oracleseed
 	seed_type = "oracle"

--- a/code/modules/hydroponics/seed_datums/tomato.dm
+++ b/code/modules/hydroponics/seed_datums/tomato.dm
@@ -20,7 +20,6 @@
 	set_trait(TRAIT_PRODUCT_ICON,"tomato")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#D10000")
 	set_trait(TRAIT_PLANT_ICON,"bush3")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.25)
 

--- a/code/modules/hydroponics/seed_datums/unathi.dm
+++ b/code/modules/hydroponics/seed_datums/unathi.dm
@@ -20,7 +20,7 @@
 	set_trait(TRAIT_PLANT_ICON,"tree3")
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_MOGHES)
-	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_MOGHES)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
 
 /obj/item/seeds/xuiziseed
 	seed_type = "xuizi"
@@ -47,7 +47,7 @@
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_MOGHES)
-	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_MOGHES)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
 
 /obj/item/seeds/sarezhiseed
 	seed_type = "sarezhi"
@@ -73,7 +73,7 @@
 	set_trait(TRAIT_PLANT_COLOUR,"#6d9c6b")
 	set_trait(TRAIT_PLANT_ICON,"algae")
 	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_MOGHES)
-	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_MOGHES)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 
@@ -98,7 +98,7 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#866523")
 	set_trait(TRAIT_PLANT_ICON,"tree")
 	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_MOGHES)
-	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_MOGHES)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
 
 /obj/item/seeds/aghrasshseed
 	seed_type = "aghrassh"
@@ -124,7 +124,7 @@
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_MOGHES)
-	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_MOGHES)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
 
 /obj/item/seeds/sthberryseed
 	seed_type = "sthberry"
@@ -144,7 +144,7 @@
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_MOGHES)
-	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_MOGHES)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
 
 /obj/item/seeds/serkiflowerseed
 	seed_type = "serkiflower"

--- a/code/modules/hydroponics/seed_datums/unathi.dm
+++ b/code/modules/hydroponics/seed_datums/unathi.dm
@@ -19,6 +19,8 @@
 	set_trait(TRAIT_PLANT_COLOUR,"#4D8F53")
 	set_trait(TRAIT_PLANT_ICON,"tree3")
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_MOGHES)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_MOGHES)
 
 /obj/item/seeds/xuiziseed
 	seed_type = "xuizi"
@@ -44,6 +46,8 @@
 	set_trait(TRAIT_PLANT_ICON,"bush")
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_MOGHES)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_MOGHES)
 
 /obj/item/seeds/sarezhiseed
 	seed_type = "sarezhi"
@@ -68,7 +72,8 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#e93e1c")
 	set_trait(TRAIT_PLANT_COLOUR,"#6d9c6b")
 	set_trait(TRAIT_PLANT_ICON,"algae")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_MOGHES)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_MOGHES)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 
@@ -92,6 +97,8 @@
 	set_trait(TRAIT_PRODUCT_ICON,"nuts")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#866523")
 	set_trait(TRAIT_PLANT_ICON,"tree")
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_MOGHES)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_MOGHES)
 
 /obj/item/seeds/aghrasshseed
 	seed_type = "aghrassh"
@@ -116,6 +123,8 @@
 	set_trait(TRAIT_PLANT_ICON,"bush")
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_MOGHES)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_MOGHES)
 
 /obj/item/seeds/sthberryseed
 	seed_type = "sthberry"
@@ -134,6 +143,8 @@
 	set_trait(TRAIT_IDEAL_LIGHT, 7)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_MOGHES)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_MOGHES)
 
 /obj/item/seeds/serkiflowerseed
 	seed_type = "serkiflower"

--- a/code/modules/hydroponics/seed_datums/vegetables.dm
+++ b/code/modules/hydroponics/seed_datums/vegetables.dm
@@ -202,6 +202,8 @@
 	set_trait(TRAIT_PRODUCT_ICON,"bean")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#EBE7C0")
 	set_trait(TRAIT_PLANT_ICON,"stalk")
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/soyaseed
 	seed_type = "soybean"

--- a/code/modules/hydroponics/seed_datums/vegetables.dm
+++ b/code/modules/hydroponics/seed_datums/vegetables.dm
@@ -19,8 +19,8 @@
 	set_trait(TRAIT_PRODUCT_ICON,"chili")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#ED3300")
 	set_trait(TRAIT_PLANT_ICON,"bush2")
-	set_trait(TRAIT_IDEAL_HEAT, 304)
-	set_trait(TRAIT_IDEAL_LIGHT, 7)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/chiliseed
 	seed_type = "chili"
@@ -61,8 +61,8 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#ff922d")
 	set_trait(TRAIT_PLANT_COLOUR,"#35d65d")
 	set_trait(TRAIT_PLANT_ICON,"bush2")
-	set_trait(TRAIT_IDEAL_HEAT, 293)
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 	set_trait(TRAIT_WATER_CONSUMPTION, 5)
 
 /obj/item/seeds/bellpepperseed
@@ -133,8 +133,8 @@
 	set_trait(TRAIT_PRODUCT_ICON,"eggplant")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#892694")
 	set_trait(TRAIT_PLANT_ICON,"bush4")
-	set_trait(TRAIT_IDEAL_HEAT, 304)
-	set_trait(TRAIT_IDEAL_LIGHT, 7)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/eggplantseed
 	seed_type = "eggplant"
@@ -179,7 +179,8 @@
 	set_trait(TRAIT_PRODUCT_ICON,"nuts")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#F2B369")
 	set_trait(TRAIT_PLANT_ICON,"bush2")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_IDEAL_LIGHT, IDEAL_LIGHT_HIGH)
+	set_trait(TRAIT_IDEAL_HEAT, IDEAL_HEAT_TROPICAL)
 
 /obj/item/seeds/peanutseed
 	seed_type = "peanut"
@@ -245,7 +246,6 @@
 	set_trait(TRAIT_PRODUCT_ICON, "bean")
 	set_trait(TRAIT_PRODUCT_COLOUR, "#70b74a")
 	set_trait(TRAIT_PLANT_ICON, "bush2")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
 
 /obj/item/seeds/peaseed
 	seed_type = "peas"
@@ -272,7 +272,6 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#84BD82")
 	set_trait(TRAIT_PLANT_COLOUR,"#6D9C6B")
 	set_trait(TRAIT_PLANT_ICON,"vine2")
-	set_trait(TRAIT_IDEAL_LIGHT, 6)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
 	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
 

--- a/code/modules/hydroponics/seed_packets.dm
+++ b/code/modules/hydroponics/seed_packets.dm
@@ -70,11 +70,24 @@ GLOBAL_LIST_EMPTY(plant_seed_sprites)
 		sm.Blend(so, ICON_OVERLAY)
 		return sm
 
+/obj/item/seeds/mechanics_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "All plants have preferential heat and light values. They will grow faster if close to these values, and may even begin to stop growing and die if \
+	they are too far away from them. Use hydroponics trays to get plants within their optimal values!"
+	. += "Plants can be mutated with any mutagen, altering their genes in a random way. Do this with caution as the results may be hazardous!"
+
 /obj/item/seeds/get_examine_text(mob/user, distance, is_adjacent, infix, suffix)
 	. = ..()
+
 	if(seed && !seed.roundstart)
 		. += "It's tagged as variety #[seed.uid]."
-	. += "This has an ideal temperature of <b>[seed.get_trait(TRAIT_IDEAL_HEAT)] kelvin</b> and light level of <b>[seed.get_trait(TRAIT_IDEAL_LIGHT)] lumens.</b>"
+
+	var/lower_heat_tolerance = seed.get_trait(TRAIT_IDEAL_HEAT) - seed.get_trait(TRAIT_HEAT_PREFERENCE)
+	var/higher_heat_tolerance = seed.get_trait(TRAIT_IDEAL_HEAT) + seed.get_trait(TRAIT_HEAT_PREFERENCE)
+	var/lower_light_tolerance = seed.get_trait(TRAIT_IDEAL_LIGHT) - seed.get_trait(TRAIT_LIGHT_PREFERENCE)
+	var/higher_light_tolerance = seed.get_trait(TRAIT_IDEAL_LIGHT) + seed.get_trait(TRAIT_LIGHT_PREFERENCE)
+
+	. += SPAN_NOTICE("This grows optimally between <b>[lower_heat_tolerance] and [higher_heat_tolerance] kelvin</b>, and between <b>[lower_light_tolerance] and [higher_light_tolerance] lumens.</b>")
 
 /obj/item/seeds/cutting
 	name = SEED_NOUN_CUTTINGS

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -180,7 +180,7 @@
 	else
 		. += "This is a soil plot, and therefore lacks many of the features of hydroponics trays. You will need to ensure that the surrounding atmosphere \
 		lighting of the plot matches the preferences of the plant you are trying to grow, or else it may grow slowly or not at all."
-	. += "If a plant matures while not within within both their heat and light preferences, their yields will be reduced."
+	. += "If a plant matures while not within within both their heat and light preferences, its yield will be reduced."
 
 /obj/machinery/portable_atmospherics/hydroponics/AltClick()
 	if (istype(usr, /mob/living/carbon/alien/diona))//A diona alt+clicking feeds the plant

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -175,10 +175,12 @@
 		. += "Improper lighting can be lethal to plants! If your surrounding lighting is inappropriate, you can lower the lid and set a tray light level \
 		using <b>Control + Left Click</b> with an open hand."
 		. += "When the lid is lowered, and if wrenched to a connector, hydroponics trays adopt the temperature of the gas inside the connector. Use this to \
-		change the temperature at which a tray is growing to conform to a plant's heat preferences."
+		change the temperature at which a tray is growing to conform to a plant's heat preferences. Note that if you do this while the connector contains \
+		vacuum, it will cause the temperature of the interior of the tray to reduce drastically in temperature and kill whatever is growing there."
 	else
 		. += "This is a soil plot, and therefore lacks many of the features of hydroponics trays. You will need to ensure that the surrounding atmosphere \
 		lighting of the plot matches the preferences of the plant you are trying to grow, or else it may grow slowly or not at all."
+	. += "If a plant matures while not within within both their heat and light preferences, their yields will be reduced."
 
 /obj/machinery/portable_atmospherics/hydroponics/AltClick()
 	if (istype(usr, /mob/living/carbon/alien/diona))//A diona alt+clicking feeds the plant
@@ -759,7 +761,7 @@
 
 		. += "The tray's sensor suite is reporting [light_string] and a temperature of <b>[environment.temperature]K</b>."
 
-		if(seed)
+		if(seed && !dead)
 			// These record whether the tray is outside its tolerances, outside its preferences, or inside its preferences.
 			// These are the only three possible states.
 			var/heat_status
@@ -770,14 +772,14 @@
 			else if(seed.check_heat_preferences(environment))
 				heat_status = SPAN_GOOD("within its heat preferences, accelerating growth")
 			else
-				heat_status = SPAN_NOTICE("outside its heat preferences, slowing growth")
+				heat_status = SPAN_NOTICE("outside its heat preferences, slowing growth and reducing yield")
 
 			if(seed.check_light_tolerances(light_available))
 				light_status = SPAN_BAD("outside its light tolerances, totally preventing growth")
 			else if(seed.check_light_preferences(light_available))
 				light_status = SPAN_GOOD("within its light preferences, accelerating growth")
 			else
-				light_status = SPAN_NOTICE("outside its light preferences, slowing growth")
+				light_status = SPAN_NOTICE("outside its light preferences, slowing growtha and reducing yield")
 
 			// Tells the user if they're messing things up or not.
 			. += SPAN_NOTICE("Sensors report that this tray is [heat_status], and [light_status].")

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -779,7 +779,7 @@
 			else if(seed.check_light_preferences(light_available))
 				light_status = SPAN_GOOD("within its light preferences, accelerating growth")
 			else
-				light_status = SPAN_NOTICE("outside its light preferences, slowing growtha and reducing yield")
+				light_status = SPAN_NOTICE("outside its light preferences, slowing growth and reducing yield")
 
 			// Tells the user if they're messing things up or not.
 			. += SPAN_NOTICE("Sensors report that this tray is [heat_status], and [light_status].")

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -180,7 +180,7 @@
 	else
 		. += "This is a soil plot, and therefore lacks many of the features of hydroponics trays. You will need to ensure that the surrounding atmosphere \
 		lighting of the plot matches the preferences of the plant you are trying to grow, or else it may grow slowly or not at all."
-	. += "If a plant matures while not within within both their heat and light preferences, its yield will be reduced."
+	. += "If a plant matures while not within within both its heat and light preferences, its yield will be reduced."
 
 /obj/machinery/portable_atmospherics/hydroponics/AltClick()
 	if (istype(usr, /mob/living/carbon/alien/diona))//A diona alt+clicking feeds the plant

--- a/code/modules/hydroponics/trays/tray_process.dm
+++ b/code/modules/hydroponics/trays/tray_process.dm
@@ -136,8 +136,22 @@
 	// When the plant dies, weeds thrive and pests die off.
 	check_health()
 
+	// Handle light requirements for upcoming logic.
+	var/light_supplied
+	if(!closed_system)
+		if (TURF_IS_DYNAMICALLY_LIT(T))
+			light_supplied = T.get_lumcount(0, 3) * 10
+		else
+			light_supplied = 5
+	else
+		light_supplied = tray_light
+
 	// If enough time (in cycles, not ticks) has passed since the plant was harvested, we're ready to harvest again.
 	if((age > seed.get_trait(TRAIT_MATURATION)) && ((age - lastproduce) > seed.get_trait(TRAIT_PRODUCTION)) && (!harvest && !dead))
+		// If the plant matures while not at its heat and light preferences, the yield modifier is cut in half.
+		// Better grow your plants better next time.
+		if(!(seed.check_light_preferences(light_supplied) && seed.check_heat_preferences(environment)))
+			yield_mod * 0.5
 		harvest = 1
 		lastproduce = age
 		if(seed.get_trait(TRAIT_SPOROUS) && !closed_system)

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -2,9 +2,9 @@
 	name = "soil"
 	desc = "A mound of earth. You could plant some seeds here."
 	icon_state = "soil"
-	density = 0
+	density = FALSE
 	use_power = POWER_USE_OFF
-	mechanical = 0
+	mechanical = FALSE
 	tray_light = 0
 	/// Water level begins at zero.
 	waterlevel = 0

--- a/code/modules/hydroponics/trays/tray_update_icons.dm
+++ b/code/modules/hydroponics/trays/tray_update_icons.dm
@@ -69,11 +69,14 @@
 		if(stasis)
 			AddOverlays("stasis")
 
+	// Apply density and opacity if a large plant is growing in the plot. Exempt mechanical trays from density alterations, since they're always dense.
 	if(seed && seed.get_trait(TRAIT_LARGE))
-		density = TRUE
+		if(!mechanical)
+			density = TRUE
 		opacity = TRUE
 	else
-		density = FALSE
+		if(!mechanical)
+			density = FALSE
 		opacity = FALSE
 
 	// Update bioluminescence.

--- a/html/changelogs/hazelmouse-hydrooverhaul.yml
+++ b/html/changelogs/hazelmouse-hydrooverhaul.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Makes the plant job better."

--- a/maps/sccv_horizon/areas/horizon_areas_service.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_service.dm
@@ -15,6 +15,11 @@
 	name = "Hydroponics"
 	horizon_deck = 1
 
+/area/horizon/service/hydroponics/hazard
+	name = "Hydroponics - Hazardous Specimens Unit"
+	horizon_deck = 1
+	area_blurb = "Harsh, discordant lighting bears down upon you in the cramped confines of your surroundings. The air is stale. You should probably wear a suit in here."
+
 /area/horizon/service/hydroponics/garden
 	name = "Public Garden"
 	icon_state = "garden"


### PR DESCRIPTION
### What does this achieve?

This overhauls hydroponics to integrate atmospherics mechanics more heavily, with the hope of establishing the foundations of much more significant mechanical depth to what has been a very shallow job for a very long time.

Currently, this is limited to the preferences and tolerances system - hydroponics is now comprised of five 'reservoirs' of segmented portions of the pipe system connected to trays, with a gas heater and cooler to change temperature across the entire system, and you can cut off each reservoir with valves to separate it from the rest and maintain its current temperature.

Five tiers, each with a trait, have been implemented for the different heat ideals of different plants. Plants from Adhomai and Moghes are the most environmentally extreme, and cannot be grown outside of drastically low and high temperatures respectively, limiting them to hydroponics proper, whereas colder and warmer terrestrial plants can be grown at room temperature but will grow much slower than if they were within their preferences. **This means there will be plants that outright cannot be grown in the garden.**

With this, hydroponics becomes an atmos puzzle. If you need to grow nothing but mushrooms you'll probably send every tray cold, but if you need a diversity of different temperature ranges you'll have to fine-tune your setup and routine to have everything within their preferences. Once you're done growing mushrooms off one reservoir, you may turn the heat in it up so you can grow citrus, etc etc. 

This also solves several bugs and makes a lot of QoL changes, the full changelog will list everything.

<img width="910" height="293" alt="image" src="https://github.com/user-attachments/assets/8a0b0dbe-5119-4f7c-9a1a-ee94b0789da2" />

<img width="921" height="158" alt="image" src="https://github.com/user-attachments/assets/ce53bddf-577f-4fc2-a9a6-35090f9060fa" />

### What about the mapping?

Atmos has been integrated into every hydroponics tray in the mapping changes, rather than only on D1 like at present, to support the new mechanics. I've moved as much stuff up to D2 as I could fit, in the interest of getting players to the more visible and socially viable spot rather than hiding in their basement. D1 is now exclusively intended as a storage area, laboratory, and now has an expanded Hazardous Specimens unit.

### To-do before review

- [ ] Ensure that every offship with exotic crops (Adhomai, Moghes, etc) can actually grow their stuff.
- [ ] Ensure that chefs can still do alien-specific menus without a hydroponicist, now that they can't necessarily grow their stuff in the garden - loadout produce box, maybe?
- [ ] Review whether every alien crop can still grow on its respective in-game exoplanet - Adhomai might be okay?
- [ ] Resolve the unintuitive interaction of an atmos connected tray going to 0K if the lid is closed while its connector is at vacuum.
- [ ] Make sure the yield_mod interactions aren't explosive.

### Known issues

1. Yes, the examine on hydroponics trays is huge. In the long-term, IMO this should probably be a TGUI.
2. The TGUI on seed storage units is clunky, this is also on the to-do list for the future.
3. The logic for calculating growth is bad, it's very RNG-skewed. Another thing for later.