### PR TITLE
Fixes that silicons can open unpowered windoors from a distance

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -220,6 +220,9 @@
 
 	if(allowed(user))
 		if(!operable())
+			if (!user.Adjacent(src))
+				to_chat(user, SPAN_WARNING("\The [src] is unpowered."))
+				return TRUE
 			if(!do_after(user, 1 SECOND, src))
 				return TRUE
 			visible_message("\The [user] [density ? "pushes" : "pulls"] \the [src] [density ? "open" : "closed"].")

--- a/html/changelogs/WindoorDistanceFix.yml
+++ b/html/changelogs/WindoorDistanceFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Silicons can no longer open unpowered windoors from a distance."


### PR DESCRIPTION
Fixes https://github.com/Aurorastation/Aurora.3/issues/20850

This adds a check so that silicons can't open unpowered windoors from a distance. It shouldn't pop up for humans, since that already requires them to be adjacent before it lets them interact with it.