### PR TITLE
Experiment: increase lobby roundstart time.

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -1,4 +1,4 @@
-#define LOBBY_TIME 180
+#define LOBBY_TIME 150
 
 #define SETUP_OK 0
 #define SETUP_REVOTE 1
@@ -450,7 +450,7 @@ var/datum/controller/subsystem/ticker/SSticker
 		LAZYINITLIST(ready_player_jobs)
 
 		if (dynamic_time <= GLOB.config.vote_autogamemode_timeleft)
-			pregame_timeleft = GLOB.config.vote_autogamemode_timeleft + 10
+			pregame_timeleft = GLOB.config.vote_autogamemode_timeleft + 60
 			LOG_DEBUG("SSticker: dynamic set pregame time [dynamic_time]s was less than or equal to configured autogamemode vote time [GLOB.config.vote_autogamemode_timeleft]s, clamping.")
 		else
 			pregame_timeleft = dynamic_time

--- a/html/changelogs/mattatlas-higherlobbytime.yml
+++ b/html/changelogs/mattatlas-higherlobbytime.yml
@@ -1,0 +1,58 @@
+m################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - experiment: "Increased the lobby roundstart time."

--- a/html/changelogs/mattatlas-higherlobbytime.yml
+++ b/html/changelogs/mattatlas-higherlobbytime.yml
@@ -1,4 +1,4 @@
-m################################
+################################
 # Example Changelog File
 #
 # Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.


### PR DESCRIPTION
Increases the lobby roundstart time by 50 seconds. The thinking behind this is to see if readies globally increase by virtue of adding more time to the roundstart timer, be it because people have more time to think about what to play, or because of other reasons.