### PR TITLE
Fix phazon mech trampling itself

### DIFF
--- a/code/modules/heavy_vehicle/mech_interaction.dm
+++ b/code/modules/heavy_vehicle/mech_interaction.dm
@@ -556,6 +556,8 @@ GLOBAL_DATUM_INIT(mech_state, /datum/ui_state/default, new())
 		return
 	if(!isliving(H))
 		return
+	if(src == H)
+		return
 
 	if(legs?.trample_damage)
 		if(ishuman(H))

--- a/html/changelogs/AlaunusLux-fix-phazon-mech-trample-self.yml
+++ b/html/changelogs/AlaunusLux-fix-phazon-mech-trample-self.yml
@@ -1,0 +1,6 @@
+author: AlaunusLux
+
+delete-after: True
+
+changes:
+  - bugfix: "Mechs will no longer trample themselves when using a Phazon Bluespace Transmission System."


### PR DESCRIPTION
Observed in the jockey round earlier (cAO-dL7N) that a phazonned mech was trampling and destroying itself. 

I couldn't reproduce on the dev map with a modified `/mob/living/heavy_vehicle/premade/random`, but could in the jockey antag area with daemon mech parts. In game they were still trampling themselves once out of phazon mode, but I was unable to replicate that. This fix should handle that case, still.

Also observed the phazonned mech being attackable, though I'm not sure that's strictly a bug so I'm leaving it alone in favor of fixing the biggest issue at the moment.