### PR TITLE
All hardsuits remove Offworlder slowdown

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/human/human_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/human/human_subspecies.dm
@@ -74,8 +74,8 @@
 		if((l_leg.status & ORGAN_ROBOT) && (r_leg.status & ORGAN_ROBOT))
 			return
 
-		if(istype(H.back, /obj/item/rig/light/offworlder))
-			var/obj/item/rig/light/offworlder/rig = H.back
+		if(istype(H.back, /obj/item/rig))
+			var/obj/item/rig/rig = H.back
 			if(!rig.offline)
 				return
 

--- a/html/changelogs/CometBlaze-slendersweep.yml
+++ b/html/changelogs/CometBlaze-slendersweep.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Offworlder slowdown is now removed by all hardsuits instead of just the exostellar skeleton."


### PR DESCRIPTION
Currently, picking the exostellar skeleton as an offworlder means you can't use a hardsuit since only the ESS removes the slowdown. This fixes that by extending that property to all other hardsuits with the logic that if they're strong enough to splint a miner's leg and let let them walk around, they're strong enough to help noodleman with their back pain.
