### PR TITLE
Schlorrgo Egg Nerfs

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/schlorrgo.dm
+++ b/code/modules/mob/living/simple_animal/friendly/schlorrgo.dm
@@ -56,6 +56,8 @@
 
 	/// How many eggs the Schlorrgo is able to lay
 	var/eggs_left = 0
+	/// How many eggs the Schlorrgo has made. When it reaches max, schlorrgo will stop producing eggs.
+	var/eggs_total = 0
 	/// Bigger Schlorrgos can lay more eggs. Starts to increase after schlorrgo becomes fat. When set to 0, Schlorrgo will never lay eggs
 	var/max_eggs = 0
 
@@ -126,8 +128,9 @@
 
 /mob/living/simple_animal/schlorrgo/process_food()
 	..()
-	if(prob(4) && eggs_left < max_eggs && current_size >= FAT_SCHLORRGO) // Change to add egg when fat
+	if(prob(1) && eggs_total < max_eggs && current_size >= FAT_SCHLORRGO)
 		eggs_left += 1 // only +1 since this can proc often
+		eggs_total += 1
 	check_wideness_change()
 
 /mob/living/simple_animal/schlorrgo/proc/check_wideness_change()
@@ -186,7 +189,7 @@
 			icon_living = "schlorrgo_fat"
 			icon_dead = "schlorrgo_fat_dead"
 			holder_type = /obj/item/holder/schlorrgo/fat
-			max_eggs = 3
+			max_eggs = 10
 
 		if(FAT_SCHLORRGO)
 			if(!named)
@@ -214,7 +217,7 @@
 			a_intent = I_HURT
 			emote_sounds = list('sound/effects/creatures/schlorrgo_scream.ogg')
 			holder_type = null
-			max_eggs = 6
+			max_eggs = 20
 
 		if(WIDE_SCHLORRGO)
 			if(!named)
@@ -247,7 +250,7 @@
 			a_intent = I_HURT
 			emote_sounds = list('sound/effects/creatures/schlorrgo_scream.ogg')
 			holder_type = null
-			max_eggs = 9
+			max_eggs = 40
 
 	update_icon()
 

--- a/html/changelogs/Ben10083 - Schlorrgo_Eggs.yml
+++ b/html/changelogs/Ben10083 - Schlorrgo_Eggs.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Schlorrgos now have a max amount of eggs they will produce before they stop, to help prevent singularity."
+  - balance: "Schlorrgos egg making chance reduced."


### PR DESCRIPTION
- Schlorrgo egg making chance reduced from 4% to 1%
- Schlorrgos now have a max amount of eggs they can produce. With total max of 30 (and realistic max of 10-20 considering how hard it is to 'max' fat a schlorrgo)