### PR TITLE
Add Datums For Falcata Boards

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig_construction.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_construction.dm
@@ -166,7 +166,6 @@
 	rig_type = /obj/item/rig/light/falcata
 	board_type = /obj/item/circuitboard/rig_assembly/combat/falcata
 	target_board_type = /obj/item/circuitboard/rig_assembly/combat/targeting/falcata
-	origin_tech = list(TECH_COMBAT = 1)
 
 ////////////////////////
 ////ILLEGAL ASSEMBLY////

--- a/code/modules/research/designs/circuit/hardsuit_circuits.dm
+++ b/code/modules/research/designs/circuit/hardsuit_circuits.dm
@@ -65,9 +65,9 @@
 	build_path = /obj/item/circuitboard/rig_assembly/illegal/targeting/hacker
 
 /datum/design/circuit/hardsuit/falcata
-	name = "Combat Hardsuit Central Circuit Board"
+	name = "Falcata Exoskeleton Central Circuit Board"
 	build_path = /obj/item/circuitboard/rig_assembly/combat/falcata
 
 /datum/design/circuit/hardsuit/falcata_target
-	name = "Combat Hardsuit Control And Targeting Board"
+	name = "Falcata Exoskeleton Control And Targeting Board"
 	build_path = /obj/item/circuitboard/rig_assembly/combat/targeting/falcata

--- a/code/modules/research/designs/circuit/hardsuit_circuits.dm
+++ b/code/modules/research/designs/circuit/hardsuit_circuits.dm
@@ -63,3 +63,11 @@
 	name = "Cybersuit Hardsuit Control And Targeting Board"
 	req_tech = list(TECH_DATA = 6, TECH_COMBAT = 3, TECH_ILLEGAL = 3)
 	build_path = /obj/item/circuitboard/rig_assembly/illegal/targeting/hacker
+
+/datum/design/circuit/hardsuit/falcata
+	name = "Combat Hardsuit Central Circuit Board"
+	build_path = /obj/item/circuitboard/rig_assembly/combat/falcata
+
+/datum/design/circuit/hardsuit/falcata_target
+	name = "Combat Hardsuit Control And Targeting Board"
+	build_path = /obj/item/circuitboard/rig_assembly/combat/targeting/falcata

--- a/code/modules/research/designs/mechfab/hardsuit/rigs.dm
+++ b/code/modules/research/designs/mechfab/hardsuit/rigs.dm
@@ -64,6 +64,7 @@
 /datum/design/rig/falcata
 	name = "Falcata Exoskeleton Control Module Assembly"
 	desc = "An assembly for a security exoskeleton. Though offering no vacuum protection, the Falcata serves as a lightweight platform for bearing security hardsuit modules."
+	build_path = /obj/item/rig_assembly/combat/falcata
 	materials = list(
 		DEFAULT_WALL_MATERIAL = 12500,
 		MATERIAL_ALUMINIUM = 12500,

--- a/html/changelogs/Hellfirejag-falcata-missing-stuff.yml
+++ b/html/changelogs/Hellfirejag-falcata-missing-stuff.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "Added missing recipes needed to make a falcata exoskeleton."


### PR DESCRIPTION
The one thing I forgot. Agony. 
This PR adds in the missing circuit board datums for the falcata exoskeleton. This is what not having a fully functional dev environment does to a man.