### PR TITLE
Fixes shuttles not being able to dock with Horizon's docking arms

### DIFF
--- a/html/changelogs/kano-dot-docking-fix.yml
+++ b/html/changelogs/kano-dot-docking-fix.yml
@@ -1,0 +1,6 @@
+author: Kano
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed shuttles not being able to dock with Horizon's docking arms."


### PR DESCRIPTION
Changes `/horizon/exterior` areas outside deck 3 docking arms back to `/area/space`. This was causing `check_collision()` to prevent listing the affected landmarks in the available docking points.

Fixes #21083

## Images

<img width="5120" height="3104" alt="image" src="https://github.com/user-attachments/assets/c7fc0f15-906a-409e-bf2c-1107759ec8b9" />
