### PR TITLE
Misc bugfixes, COFFEE COUNTS AS A BUGFIX

### DIFF
--- a/code/controllers/subsystems/movement/movement_types.dm
+++ b/code/controllers/subsystems/movement/movement_types.dm
@@ -41,7 +41,13 @@
 /datum/move_loop/proc/setup(delay = 1, timeout = INFINITY)
 	if(!ismovable(moving) || !owner)
 		return FALSE
-
+	// Handle issue of delay 0 being passed for simplemobs.
+	if(istype(moving, /mob/living/simple_animal))
+		var/mob/living/simple_animal/moving_sa = moving
+		if(!delay && moving_sa.seek_speed)
+			delay = moving_sa.seek_speed
+		else
+			delay = 5
 	src.delay = max(delay, world.tick_lag) //Please...
 	src.lifetime = timeout
 	return TRUE

--- a/code/controllers/subsystems/throwing.dm
+++ b/code/controllers/subsystems/throwing.dm
@@ -202,8 +202,9 @@ SUBSYSTEM_DEF(throwing)
 	if(!thrownthing)
 		return
 	thrownthing.throwing = null
+	var/turf/thrownthing_turf = get_turf(thrownthing)
 	if (!hit)
-		for (var/atom/movable/obstacle as anything in get_turf(thrownthing)) //looking for our target on the turf we land on.
+		for (var/atom/movable/obstacle as anything in thrownthing_turf) //looking for our target on the turf we land on.
 			if (obstacle == target)
 				hit = TRUE
 				thrownthing.throw_impact(obstacle, src)
@@ -211,7 +212,7 @@ SUBSYSTEM_DEF(throwing)
 					return //deletion should already be handled by on_thrownthing_qdel()
 				break
 		if (!hit)
-			thrownthing.throw_impact(get_turf(thrownthing), src)  // we haven't hit something yet and we still must, let's hit the ground.
+			thrownthing.throw_impact(thrownthing_turf, src)  // we haven't hit something yet and we still must, let's hit the ground.
 			if(QDELETED(thrownthing)) //throw_impact can delete things, such as glasses smashing
 				return //deletion should already be handled by on_thrownthing_qdel()
 			thrownthing.newtonian_move(init_dir)
@@ -227,7 +228,7 @@ SUBSYSTEM_DEF(throwing)
 		callback.Invoke()
 
 	// Stopped on an open turf? Finish the job, gravity!
-	if(is_open(get_turf(thrownthing)))
+	if(thrownthing_turf.is_open())
 		ADD_FALLING_ATOM(thrownthing)
 
 	if(thrownthing)

--- a/code/controllers/subsystems/throwing.dm
+++ b/code/controllers/subsystems/throwing.dm
@@ -226,9 +226,9 @@ SUBSYSTEM_DEF(throwing)
 	if (callback)
 		callback.Invoke()
 
-	// if(!thrownthing.currently_z_moving) // I don't think you can zfall while thrown but hey, just in case.
-	// 	var/turf/T = get_turf(thrownthing)
-	// 	T?.zFall(thrownthing)
+	// Stopped on an open turf? Finish the job, gravity!
+	if(is_open(get_turf(thrownthing)))
+		ADD_FALLING_ATOM(thrownthing)
 
 	if(thrownthing)
 		SEND_SIGNAL(thrownthing, COMSIG_MOVABLE_THROW_LANDED, src)

--- a/html/changelogs/Bat-FallingGarbage.yml
+++ b/html/changelogs/Bat-FallingGarbage.yml
@@ -55,4 +55,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
+  - bugfix: "Simple mobs no longer allowed to move at hyper-speed when chasing targets."
   - bugfix: "Objects thrown onto Open Space turfs should more reliably drop down remaining Z-level (if there is gravity)."

--- a/html/changelogs/Bat-FallingGarbage.yml
+++ b/html/changelogs/Bat-FallingGarbage.yml
@@ -57,3 +57,7 @@ delete-after: True
 changes:
   - bugfix: "Simple mobs no longer allowed to move at hyper-speed when chasing targets."
   - bugfix: "Objects thrown onto Open Space turfs should more reliably drop down remaining Z-level (if there is gravity)."
+  - bugfix: "Area adjustments to fix D3 bunker turret controls."
+  - bugfix: "Fixed naming convention for scuttling device compartment."
+  - bugfix: "Replaced parent stairwell area with correct child."
+  - bugfix: "Replaces misleading AI shell exosuit charger with synthetic recharger."

--- a/html/changelogs/Bat-FallingGarbage.yml
+++ b/html/changelogs/Bat-FallingGarbage.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Batrachophrenoboocosmomachia
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Objects from D2 disposals ejection should more reliably drop the remaining Z-level."

--- a/html/changelogs/Bat-FallingGarbage.yml
+++ b/html/changelogs/Bat-FallingGarbage.yml
@@ -61,3 +61,4 @@ changes:
   - bugfix: "Fixed naming convention for scuttling device compartment."
   - bugfix: "Replaced parent stairwell area with correct child."
   - bugfix: "Replaces misleading AI shell exosuit charger with synthetic recharger."
+  - qol: "Replaces the Engi break room stripped-down soda dispenser with stripped-down coffee dispenser."

--- a/html/changelogs/Bat-FallingGarbage.yml
+++ b/html/changelogs/Bat-FallingGarbage.yml
@@ -55,4 +55,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "Objects from D2 disposals ejection should more reliably drop the remaining Z-level."
+  - bugfix: "Objects thrown onto Open Space turfs should more reliably drop down remaining Z-level (if there is gravity)."

--- a/maps/sccv_horizon/areas/horizon_areas_command.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_command.dm
@@ -119,7 +119,7 @@
 	area_flags = AREA_FLAG_RAD_SHIELDED
 
 /area/horizon/command/bridge/selfdestruct
-	name = "Command - Station Authentication Terminal Safe"
+	name = "Authentication Terminal Safe"
 	icon_state = "bridge"
 	area_flags = AREA_FLAG_HIDE_FROM_HOLOMAP
 

--- a/maps/sccv_horizon/areas/horizon_areas_engineering.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_engineering.dm
@@ -41,6 +41,7 @@
 	name = "Gravity Generator"
 	icon_state = "engine"
 	horizon_deck = 1
+	area_flags = AREA_FLAG_RAD_SHIELDED
 	area_blurb = "The air in here tastes like copper, sour sugar, and smoke; none of the angles seem right. That probably means everything is working."
 	area_blurb_category = "engi_breakroom"
 


### PR DESCRIPTION
Fixes https://github.com/Aurorastation/Aurora.3/issues/20799
Fixes https://github.com/Aurorastation/Aurora.3/issues/19718
Fixes https://github.com/Aurorastation/Aurora.3/issues/21001

changes:
  - bugfix: "Simple mobs no longer allowed to move at hyper-speed when chasing targets."
  - bugfix: "Objects thrown onto Open Space turfs should more reliably drop down remaining Z-level (if there is gravity)."
  - bugfix: "Area adjustments to fix D3 bunker turret controls."
  - bugfix: "Fixed naming convention for scuttling device compartment."
  - bugfix: "Replaced parent stairwell area with correct child."
  - bugfix: "Replaces misleading AI shell exosuit charger with synthetic recharger."
  - qol: "Replaces the Engi break room stripped-down soda dispenser with stripped-down coffee dispenser."