### PR TITLE
Zoom for Screenshots and More

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1023,3 +1023,12 @@ GLOBAL_LIST_INIT(localhost_addresses, list(
 /// This grabs the DPI of the user per their skin
 /client/proc/acquire_dpi()
 	window_scaling = text2num(winget(src, null, "dpi"))
+
+/mob/verb/set_icon_size()
+	set name = "Set View Zoom"
+	set desc = "Lets you zoom in."
+	set category = "OOC"
+
+	var/list/zoom_options = list("Default" = 0, "Low" = 3, "Medium" = 6, "High" = 10, "Extreme" = 15)
+	var/selected_zoom = tgui_input_list(usr, "Please select a zoom level for your view.", "Set View Zoom", zoom_options, zoom_options[1])
+	winset(src, "mapwindow.map", "zoom=[zoom_options[selected_zoom]]")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1024,7 +1024,7 @@ GLOBAL_LIST_INIT(localhost_addresses, list(
 /client/proc/acquire_dpi()
 	window_scaling = text2num(winget(src, null, "dpi"))
 
-/mob/verb/set_icon_size()
+/client/verb/set_icon_size()
 	set name = "Set View Zoom"
 	set desc = "Lets you zoom in."
 	set category = "OOC"

--- a/html/changelogs/geeves-zoom_for_screenies.yml
+++ b/html/changelogs/geeves-zoom_for_screenies.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Added the option to set your view zoom in the OOC tab. Use this for screenshots or cheating at melee fights."


### PR DESCRIPTION
* Added the option to set your view zoom in the OOC tab. Use this for screenshots or cheating at melee fights.

<img width="131" height="152" alt="image" src="https://github.com/user-attachments/assets/ddc5df8d-843d-4c12-af17-add78dfb310f" />
<img width="1919" height="983" alt="image" src="https://github.com/user-attachments/assets/b308321c-a1c7-4457-a38f-e9f582fe88d4" />
