### PR TITLE
Himean Patrol Ship Tweaks + GPS

### DIFF
--- a/html/changelogs/Ben10083 - Himeo_Patrol_Tweaks.yml
+++ b/html/changelogs/Ben10083 - Himeo_Patrol_Tweaks.yml
@@ -1,0 +1,61 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds GPS units to Himean Patrol Ship."
+  - rscadd: "Slight remap of Himean Patrol Ship shuttle to provide exterior vents."
+  - qol: "Access requirements added to airlocks for Himean Patrol Ship."
+  - qol: "Adds proper access requirements to Himean Patrol Ship fireshutters and other equipment."

--- a/maps/away/ships/himeo/himeo_patrol_ship.dmm
+++ b/maps/away/ships/himeo/himeo_patrol_ship.dmm
@@ -389,6 +389,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/himeo_patrol_ship/deck_2_interstitial)
+"bR" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tcaf_shuttle";
+	name = "airlock_tcaf_shuttle";
+	req_one_access = list(204);
+	shuttle_tag = "TCAF Gunship"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/airlock_sensor/airlock_exterior{
+	pixel_x = -23;
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/large/airless,
+/area/space)
 "bS" = (
 /obj/structure/lattice/catwalk/indoor/grate/gunmetal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2939,6 +2957,23 @@
 /obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/full,
 /area/himeo_patrol_ship/eva)
+"ms" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tcaf_shuttle";
+	name = "airlock_tcaf_shuttle";
+	req_one_access = list(204);
+	shuttle_tag = "TCAF Gunship"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/reinforced/large/airless,
+/area/space)
 "mt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 10
@@ -3226,6 +3261,12 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/himeo_patrol_ship/deck_2_office)
+"nC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/wall/shuttle/dark/cardinal/coalition,
+/area/shuttle/himeo_patrol/central)
 "nF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4498,6 +4539,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/himeo_patrol_ship/deck_2_interstitial)
+"tx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/wall/shuttle/dark/cardinal/coalition,
+/area/shuttle/himeo_patrol/central)
 "tF" = (
 /obj/effect/floor_decal/corner/black{
 	dir = 9
@@ -5777,12 +5824,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/distribution)
-"yD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
-/turf/simulated/wall/shuttle/dark/cardinal/coalition,
-/area/shuttle/himeo_patrol/central)
 "yF" = (
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
@@ -9002,24 +9043,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_interstitial)
-"MH" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
-	master_tag = "airlock_tcaf_shuttle";
-	name = "airlock_tcaf_shuttle";
-	req_one_access = list(204);
-	shuttle_tag = "TCAF Gunship"
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/airlock_sensor/airlock_exterior{
-	pixel_x = -23;
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/large/airless,
-/area/space)
 "MI" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -9027,12 +9050,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/reinforced,
 /area/himeo_patrol_ship/ammunition)
-"MJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/turf/simulated/wall/shuttle/dark/cardinal/coalition,
-/area/shuttle/himeo_patrol/central)
 "MQ" = (
 /turf/simulated/floor/tiled/dark,
 /area/himeo_patrol_ship/deck_2_interstitial)
@@ -10512,23 +10529,6 @@
 	},
 /turf/simulated/floor,
 /area/himeo_patrol_ship/generator)
-"Sn" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
-	master_tag = "airlock_tcaf_shuttle";
-	name = "airlock_tcaf_shuttle";
-	req_one_access = list(204);
-	shuttle_tag = "TCAF Gunship"
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/turf/simulated/floor/reinforced/large/airless,
-/area/space)
 "So" = (
 /obj/machinery/computer/ship/engines/terminal{
 	dir = 4
@@ -11444,8 +11444,8 @@
 	req_one_access = list(253)
 	},
 /obj/machinery/door/airlock/external/himeo_patrol,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/himeo_patrol/central)
@@ -113816,7 +113816,7 @@ rs
 SP
 cF
 Xh
-Sn
+ms
 so
 UC
 GJ
@@ -114072,8 +114072,8 @@ GM
 zx
 Bk
 GM
-MJ
-yD
+nC
+tx
 so
 UC
 hn
@@ -115101,7 +115101,7 @@ Xh
 Xh
 Zk
 Xh
-MH
+bR
 so
 UC
 jf

--- a/maps/away/ships/himeo/himeo_patrol_ship.dmm
+++ b/maps/away/ships/himeo/himeo_patrol_ship.dmm
@@ -538,7 +538,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/messhall)
@@ -795,7 +798,10 @@
 "dy" = (
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/engineering)
@@ -950,10 +956,12 @@
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/access_button{
 	pixel_x = 28;
-	pixel_y = -8;
+	pixel_y = -6;
 	req_access = list(253)
 	},
-/obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship,
+/obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /turf/simulated/floor/plating,
@@ -1292,7 +1300,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/starboard_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/starboard_dock{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_interstitial)
 "fe" = (
@@ -1560,7 +1570,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/himeo_patrol_ship/thruster_starboard)
@@ -1792,7 +1805,9 @@
 /area/himeo_patrol_ship/thruster_aft)
 "hF" = (
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/port_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/port_dock{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol{
 	dir = 4
 	},
@@ -1816,10 +1831,30 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/bridge)
+"hK" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tcaf_shuttle";
+	name = "airlock_tcaf_shuttle";
+	req_one_access = list(204);
+	shuttle_tag = "TCAF Gunship"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/reinforced/large/airless,
+/area/space)
 "hL" = (
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/himeo_patrol/central)
@@ -2213,7 +2248,9 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/port_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/port_dock{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_interstitial)
 "jk" = (
@@ -2281,7 +2318,9 @@
 /area/himeo_patrol_ship/engineering)
 "jE" = (
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol_ship/shuttle_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol_ship/shuttle_dock{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol,
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_fore)
@@ -2532,7 +2571,9 @@
 	icon_state = "4-8"
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol_ship/shuttle_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol_ship/shuttle_dock{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_fore)
 "kO" = (
@@ -2542,7 +2583,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/barracks)
@@ -2556,7 +2600,11 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, docking arm"
 	},
-/obj/effect/map_effect/window_spawner/full/shuttle/raider,
+/obj/effect/map_effect/window_spawner/full/shuttle/raider{
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_fore)
 "kY" = (
@@ -2582,7 +2630,9 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/starboard_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/starboard_dock{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol{
 	dir = 4
 	},
@@ -3093,7 +3143,9 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/fore_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/fore_dock{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol{
 	dir = 4
 	},
@@ -3378,7 +3430,9 @@
 /area/shuttle/himeo_patrol/central)
 "oh" = (
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/starboard_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/starboard_dock{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol{
 	dir = 4
 	},
@@ -3700,7 +3754,9 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = 23
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/fore,
+/obj/effect/map_effect/marker/airlock/himeo_patrol/fore{
+	req_one_access = list(253)
+	},
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/messhall)
@@ -3741,6 +3797,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/himeo_patrol_ship/eva)
+"ql" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tcaf_shuttle";
+	name = "airlock_tcaf_shuttle";
+	req_one_access = list(204);
+	shuttle_tag = "TCAF Gunship"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/airlock_sensor/airlock_exterior{
+	pixel_x = -23;
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/large/airless,
+/area/space)
 "qm" = (
 /obj/structure/table/reinforced/steel,
 /obj/machinery/light/colored/decayed/dimmed{
@@ -3822,7 +3896,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/eva)
@@ -3970,7 +4047,9 @@
 "rq" = (
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/starboard_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/starboard_dock{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol{
 	dir = 4
 	},
@@ -4079,6 +4158,22 @@
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide,
 /obj/structure/extinguisher_cabinet/south,
+/obj/item/device/gps{
+	gps_prefix = "HPG";
+	gpstag = "HPG0"
+	},
+/obj/item/device/gps{
+	gps_prefix = "HPG";
+	gpstag = "HPG0"
+	},
+/obj/item/device/gps{
+	gps_prefix = "HPG";
+	gpstag = "HPG0"
+	},
+/obj/item/device/gps{
+	gps_prefix = "HPG";
+	gpstag = "HPG0"
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/eva)
 "rV" = (
@@ -4245,7 +4340,10 @@
 "sC" = (
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/infirmary)
@@ -4334,6 +4432,12 @@
 /obj/machinery/light/colored/decayed/dimmed{
 	dir = 8
 	},
+/obj/item/device/gps/stationary{
+	gps_prefix = "HPG";
+	gpstag = "HPGSHUTTLE";
+	pixel_x = -24;
+	pixel_y = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/himeo_patrol/central)
 "tc" = (
@@ -4396,6 +4500,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/himeo_patrol_ship/generator)
+"to" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/wall/shuttle/dark/cardinal/coalition,
+/area/shuttle/himeo_patrol/central)
 "tq" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -4413,7 +4523,9 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/fore_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/fore_dock{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_fore)
 "tw" = (
@@ -4977,7 +5089,9 @@
 	dir = 4;
 	pixel_x = 8
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/fore,
+/obj/effect/map_effect/marker/airlock/himeo_patrol/fore{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol{
 	dir = 4
 	},
@@ -5035,7 +5149,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/fore,
+/obj/effect/map_effect/marker/airlock/himeo_patrol/fore{
+	req_one_access = list(253)
+	},
 /obj/machinery/light/small/emergency,
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
@@ -5378,7 +5494,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/eva)
@@ -5490,6 +5609,12 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
+/obj/item/device/gps/stationary{
+	gps_prefix = "HPG";
+	gpstag = "HPGPATROL";
+	pixel_y = 28;
+	pixel_x = -6
+	},
 /turf/simulated/floor/tiled/gunmetal,
 /area/himeo_patrol_ship/bridge)
 "xU" = (
@@ -5571,7 +5696,9 @@
 	pixel_x = 8;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/port_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/port_dock{
+	req_one_access = list(253)
+	},
 /obj/effect/shuttle_landmark/himeo_patrol/dock4{
 	dir = 8
 	},
@@ -5703,7 +5830,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol_ship/shuttle_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol_ship/shuttle_dock{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_fore)
 "yJ" = (
@@ -5734,7 +5863,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/engineering)
@@ -5827,7 +5959,9 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/port_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/port_dock{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol{
 	dir = 4
 	},
@@ -5936,7 +6070,9 @@
 /area/himeo_patrol_ship/bridge)
 "zx" = (
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol_ship/shuttle_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol_ship/shuttle_dock{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol{
 	dir = 4
 	},
@@ -5947,7 +6083,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock/himeo_patrol/deck_2/starboard,
+/obj/effect/map_effect/marker/airlock/himeo_patrol/deck_2/starboard{
+	req_one_access = list(253)
+	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	pixel_y = -23;
 	dir = 1
@@ -6181,6 +6319,12 @@
 	},
 /turf/space,
 /area/space)
+"AB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/wall/shuttle/dark/cardinal/coalition,
+/area/shuttle/himeo_patrol/central)
 "AF" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/railing/mapped{
@@ -6282,7 +6426,11 @@
 	id = "himeo_military_decktwo_ffore_blast";
 	name = "Fore Checkpoint Blast Door"
 	},
-/obj/effect/map_effect/window_spawner/full/shuttle/raider,
+/obj/effect/map_effect/window_spawner/full/shuttle/raider{
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/himeo_patrol_ship/deck_2_checkpoint)
 "Ba" = (
@@ -6373,7 +6521,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol_ship/shuttle_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol_ship/shuttle_dock{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol{
 	dir = 4
 	},
@@ -6531,14 +6681,19 @@
 /turf/simulated/floor,
 /area/himeo_patrol_ship/autocannon)
 "BN" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/structure/bed/handrail{
 	dir = 8
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship,
+/obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship{
+	req_one_access = list(253)
+	},
+/obj/effect/map_effect/marker_helper/airlock/out,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/himeo_patrol/central)
 "BO" = (
@@ -6682,7 +6837,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/distribution)
@@ -7192,7 +7350,11 @@
 /turf/simulated/wall/shuttle/raider,
 /area/himeo_patrol_ship/thruster_aft)
 "EB" = (
-/obj/effect/map_effect/window_spawner/full/shuttle/raider,
+/obj/effect/map_effect/window_spawner/full/shuttle/raider{
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_fore)
 "EC" = (
@@ -7225,7 +7387,9 @@
 "EK" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/starboard_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/starboard_dock{
+	req_one_access = list(253)
+	},
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_interstitial)
@@ -7324,7 +7488,9 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/aft_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/aft_dock{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_interstitial)
 "Ff" = (
@@ -7498,7 +7664,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/himeo_patrol_ship/thruster_port)
@@ -7548,7 +7717,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/bridge)
@@ -7586,7 +7758,9 @@
 	pixel_x = 32;
 	pixel_y = 8
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/fore,
+/obj/effect/map_effect/marker/airlock/himeo_patrol/fore{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol,
 /turf/simulated/floor/tiled/full,
 /area/himeo_patrol_ship/messhall)
@@ -7597,7 +7771,9 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol_ship/shuttle_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol_ship/shuttle_dock{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_fore)
 "Gc" = (
@@ -7911,7 +8087,9 @@
 	pixel_x = -24;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/port_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/port_dock{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol{
 	dir = 4
 	},
@@ -7946,7 +8124,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/infirmary)
@@ -7957,10 +8138,10 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship,
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 4
+/obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship{
+	req_one_access = list(253)
 	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /turf/simulated/floor/plating,
 /area/shuttle/himeo_patrol/central)
 "Ik" = (
@@ -8028,7 +8209,9 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol_ship/shuttle_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol_ship/shuttle_dock{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_fore)
 "ID" = (
@@ -8255,7 +8438,11 @@
 /area/himeo_patrol_ship/hydroponics)
 "JD" = (
 /obj/effect/map_effect/map_helper/ruler_tiles_3,
-/obj/effect/map_effect/window_spawner/full/shuttle/raider,
+/obj/effect/map_effect/window_spawner/full/shuttle/raider{
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_fore)
 "JJ" = (
@@ -8309,7 +8496,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/distribution)
@@ -8442,7 +8632,9 @@
 	dir = 6
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/fore_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/fore_dock{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_fore)
 "KC" = (
@@ -8584,6 +8776,9 @@
 /obj/effect/floor_decal/industrial/outline_door/red{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/gunmetal,
 /area/shuttle/himeo_patrol/central)
 "Ls" = (
@@ -8680,7 +8875,9 @@
 	req_access = list(222);
 	pixel_y = -8
 	},
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/fore_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/fore_dock{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol,
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_fore)
@@ -8794,7 +8991,9 @@
 	req_access = list(253);
 	pixel_y = -8
 	},
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol_ship/shuttle_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol_ship/shuttle_dock{
+	req_one_access = list(253)
+	},
 /obj/effect/shuttle_landmark/himeo_patrol_shuttle/dock{
 	dir = 1
 	},
@@ -8979,7 +9178,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/barracks)
@@ -9164,7 +9366,11 @@
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_fore)
 "Oa" = (
-/obj/effect/map_effect/window_spawner/full/shuttle/raider,
+/obj/effect/map_effect/window_spawner/full/shuttle/raider{
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/himeo_patrol_ship/deck_2_checkpoint)
 "Oe" = (
@@ -9279,7 +9485,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/armoury)
@@ -9344,7 +9553,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/armoury)
@@ -9355,7 +9567,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/infirmary)
@@ -9497,9 +9712,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux,
 /turf/simulated/floor/tiled/gunmetal,
 /area/shuttle/himeo_patrol/central)
 "Pr" = (
@@ -9770,7 +9983,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/hydroponics)
@@ -9862,7 +10078,9 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/port_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/port_dock{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_interstitial)
 "QG" = (
@@ -9905,7 +10123,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/himeo_patrol_ship/thruster_port)
@@ -10016,7 +10237,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/fore_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/fore_dock{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_fore)
 "Rs" = (
@@ -10049,10 +10272,10 @@
 	pixel_x = -23;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 5
+/obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship{
+	req_one_access = list(253)
 	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /turf/simulated/floor/plating,
 /area/shuttle/himeo_patrol/central)
 "RA" = (
@@ -10237,7 +10460,9 @@
 /turf/simulated/wall/shuttle/raider,
 /area/himeo_patrol_ship/hydroponics)
 "Sb" = (
-/obj/effect/map_effect/marker/airlock/himeo_patrol/fore,
+/obj/effect/map_effect/marker/airlock/himeo_patrol/fore{
+	req_one_access = list(253)
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux,
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
@@ -10503,7 +10728,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/deck_2/starboard,
+/obj/effect/map_effect/marker/airlock/himeo_patrol/deck_2/starboard{
+	req_one_access = list(253)
+	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/access_button{
 	pixel_y = -24;
@@ -10555,7 +10782,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/bridge)
@@ -10652,7 +10882,9 @@
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/starboard_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/starboard_dock{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_interstitial)
 "TA" = (
@@ -10776,7 +11008,11 @@
 /turf/simulated/floor/tiled/gunmetal,
 /area/himeo_patrol_ship/engineering)
 "TX" = (
-/obj/effect/map_effect/window_spawner/full/shuttle/raider,
+/obj/effect/map_effect/window_spawner/full/shuttle/raider{
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /turf/simulated/floor/plating,
 /area/space)
 "TZ" = (
@@ -10799,7 +11035,9 @@
 "Ub" = (
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/fore_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/fore_dock{
+	req_one_access = list(253)
+	},
 /obj/effect/shuttle_landmark/himeo_patrol/dock2{
 	dir = 1
 	},
@@ -10853,7 +11091,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 5
 	},
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/starboard_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/starboard_dock{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_interstitial)
 "Uq" = (
@@ -10873,7 +11113,11 @@
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/aft)
 "Ut" = (
-/obj/effect/map_effect/window_spawner/full/shuttle/raider,
+/obj/effect/map_effect/window_spawner/full/shuttle/raider{
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_storage)
 "Ux" = (
@@ -10954,12 +11198,17 @@
 /turf/simulated/floor/tiled/gunmetal,
 /area/himeo_patrol_ship)
 "UK" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship,
+/obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship{
+	req_one_access = list(253)
+	},
+/obj/effect/map_effect/marker_helper/airlock/out,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/himeo_patrol/central)
 "UO" = (
@@ -10969,7 +11218,9 @@
 	pixel_x = -8;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/starboard_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/starboard_dock{
+	req_one_access = list(253)
+	},
 /obj/effect/shuttle_landmark/himeo_patrol/dock1{
 	dir = 4
 	},
@@ -10991,7 +11242,9 @@
 	req_access = list(253)
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/fore_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/fore_dock{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol{
 	dir = 4
 	},
@@ -11183,8 +11436,13 @@
 	pixel_y = 8;
 	req_access = list(253)
 	},
-/obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship,
+/obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/himeo_patrol/central)
 "Vs" = (
@@ -11246,7 +11504,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/hydroponics)
@@ -11279,7 +11540,11 @@
 /turf/simulated/floor/carpet/red,
 /area/himeo_patrol_ship/barracks)
 "VR" = (
-/obj/effect/map_effect/window_spawner/full/shuttle/raider,
+/obj/effect/map_effect/window_spawner/full/shuttle/raider{
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_interstitial)
 "VS" = (
@@ -11544,8 +11809,13 @@
 	icon_state = "1-2"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship,
+/obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/himeo_patrol/central)
 "Xm" = (
@@ -11558,7 +11828,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship)
@@ -11827,7 +12100,9 @@
 /obj/structure/sign/vacuum{
 	pixel_y = 32
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/starboard,
+/obj/effect/map_effect/marker/airlock/himeo_patrol/starboard{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/aft)
 "YN" = (
@@ -11848,7 +12123,9 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/port_dock,
+/obj/effect/map_effect/marker/airlock/docking/himeo_patrol/port_dock{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_interstitial)
 "YS" = (
@@ -11905,7 +12182,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#6C7364";
-	frame_color = "#6C7364"
+	frame_color = "#6C7364";
+	req_one_access = list(253);
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship)
@@ -11990,7 +12270,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/deck_2/starboard,
+/obj/effect/map_effect/marker/airlock/himeo_patrol/deck_2/starboard{
+	req_one_access = list(253)
+	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/access_button{
 	pixel_y = 28;
@@ -12058,7 +12340,9 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock/himeo_patrol/fore,
+/obj/effect/map_effect/marker/airlock/himeo_patrol/fore{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/messhall)
 "ZI" = (
@@ -12129,8 +12413,11 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship,
+/obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship{
+	req_one_access = list(253)
+	},
 /obj/machinery/door/airlock/external/himeo_patrol,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /turf/simulated/floor/plating,
 /area/shuttle/himeo_patrol/central)
 "ZY" = (
@@ -113525,7 +113812,7 @@ rs
 SP
 cF
 Xh
-Xh
+hK
 so
 UC
 GJ
@@ -113781,8 +114068,8 @@ GM
 zx
 Bk
 GM
-so
-so
+AB
+to
 so
 UC
 hn
@@ -114810,7 +115097,7 @@ Xh
 Xh
 Zk
 Xh
-Xh
+ql
 so
 UC
 jf

--- a/maps/away/ships/himeo/himeo_patrol_ship.dmm
+++ b/maps/away/ships/himeo/himeo_patrol_ship.dmm
@@ -1838,23 +1838,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/bridge)
-"hK" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
-	master_tag = "airlock_tcaf_shuttle";
-	name = "airlock_tcaf_shuttle";
-	req_one_access = list(204);
-	shuttle_tag = "TCAF Gunship"
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/turf/simulated/floor/reinforced/large/airless,
-/area/space)
 "hL" = (
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/himeo_patrol/central)
@@ -3710,7 +3693,9 @@
 /turf/simulated/wall/shuttle/raider,
 /area/himeo_patrol_ship/barracks)
 "px" = (
-/obj/machinery/door/window/southleft,
+/obj/machinery/door/window/southleft{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/tiled/gunmetal/full,
 /area/shuttle/himeo_patrol/central)
 "pE" = (
@@ -3797,24 +3782,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/himeo_patrol_ship/eva)
-"ql" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
-	master_tag = "airlock_tcaf_shuttle";
-	name = "airlock_tcaf_shuttle";
-	req_one_access = list(204);
-	shuttle_tag = "TCAF Gunship"
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/airlock_sensor/airlock_exterior{
-	pixel_x = -23;
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/large/airless,
-/area/space)
 "qm" = (
 /obj/structure/table/reinforced/steel,
 /obj/machinery/light/colored/decayed/dimmed{
@@ -4500,12 +4467,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/himeo_patrol_ship/generator)
-"to" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
-/turf/simulated/wall/shuttle/dark/cardinal/coalition,
-/area/shuttle/himeo_patrol/central)
 "tq" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -5816,6 +5777,12 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/distribution)
+"yD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/wall/shuttle/dark/cardinal/coalition,
+/area/shuttle/himeo_patrol/central)
 "yF" = (
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
@@ -6319,12 +6286,6 @@
 	},
 /turf/space,
 /area/space)
-"AB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/turf/simulated/wall/shuttle/dark/cardinal/coalition,
-/area/shuttle/himeo_patrol/central)
 "AF" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/railing/mapped{
@@ -9041,6 +9002,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/deck_2_interstitial)
+"MH" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tcaf_shuttle";
+	name = "airlock_tcaf_shuttle";
+	req_one_access = list(204);
+	shuttle_tag = "TCAF Gunship"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/airlock_sensor/airlock_exterior{
+	pixel_x = -23;
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/large/airless,
+/area/space)
 "MI" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -9048,6 +9027,12 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/reinforced,
 /area/himeo_patrol_ship/ammunition)
+"MJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/wall/shuttle/dark/cardinal/coalition,
+/area/shuttle/himeo_patrol/central)
 "MQ" = (
 /turf/simulated/floor/tiled/dark,
 /area/himeo_patrol_ship/deck_2_interstitial)
@@ -10015,7 +10000,9 @@
 /turf/simulated/floor,
 /area/himeo_patrol_ship/blaster)
 "Qt" = (
-/obj/machinery/door/window/southright,
+/obj/machinery/door/window/southright{
+	req_one_access = list(253)
+	},
 /turf/simulated/floor/tiled/gunmetal/full,
 /area/shuttle/himeo_patrol/central)
 "Qu" = (
@@ -10525,6 +10512,23 @@
 	},
 /turf/simulated/floor,
 /area/himeo_patrol_ship/generator)
+"Sn" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tcaf_shuttle";
+	name = "airlock_tcaf_shuttle";
+	req_one_access = list(204);
+	shuttle_tag = "TCAF Gunship"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/reinforced/large/airless,
+/area/space)
 "So" = (
 /obj/machinery/computer/ship/engines/terminal{
 	dir = 4
@@ -113812,7 +113816,7 @@ rs
 SP
 cF
 Xh
-hK
+Sn
 so
 UC
 GJ
@@ -114068,8 +114072,8 @@ GM
 zx
 Bk
 GM
-AB
-to
+MJ
+yD
 so
 UC
 hn
@@ -115097,7 +115101,7 @@ Xh
 Xh
 Zk
 Xh
-ql
+MH
 so
 UC
 jf

--- a/maps/away/ships/himeo/himeo_patrol_ship.dmm
+++ b/maps/away/ships/himeo/himeo_patrol_ship.dmm
@@ -389,24 +389,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/himeo_patrol_ship/deck_2_interstitial)
-"bR" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
-	master_tag = "airlock_tcaf_shuttle";
-	name = "airlock_tcaf_shuttle";
-	req_one_access = list(204);
-	shuttle_tag = "TCAF Gunship"
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/airlock_sensor/airlock_exterior{
-	pixel_x = -23;
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/large/airless,
-/area/space)
 "bS" = (
 /obj/structure/lattice/catwalk/indoor/grate/gunmetal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -549,6 +531,12 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/gunmetal,
 /area/himeo_patrol_ship/engineering)
+"cx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/wall/shuttle/dark/cardinal/coalition,
+/area/shuttle/himeo_patrol/central)
 "cz" = (
 /obj/machinery/door/blast/regular/open{
 	name = "Emergency Lockdown Shutter";
@@ -1961,6 +1949,23 @@
 	},
 /turf/simulated/floor/tiled/gunmetal,
 /area/himeo_patrol_ship)
+"ih" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tcaf_shuttle";
+	name = "airlock_tcaf_shuttle";
+	req_one_access = list(204);
+	shuttle_tag = "TCAF Gunship"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/reinforced/large/airless,
+/area/space)
 "ij" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -2818,6 +2823,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/himeo_patrol_ship/deck_2_interstitial)
+"lS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/wall/shuttle/dark/cardinal/coalition,
+/area/shuttle/himeo_patrol/central)
 "lV" = (
 /obj/random/dirt_75,
 /obj/effect/floor_decal/industrial/outline_door/red{
@@ -2957,23 +2968,6 @@
 /obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/full,
 /area/himeo_patrol_ship/eva)
-"ms" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
-	master_tag = "airlock_tcaf_shuttle";
-	name = "airlock_tcaf_shuttle";
-	req_one_access = list(204);
-	shuttle_tag = "TCAF Gunship"
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/turf/simulated/floor/reinforced/large/airless,
-/area/space)
 "mt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 10
@@ -3261,12 +3255,6 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/himeo_patrol_ship/deck_2_office)
-"nC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/turf/simulated/wall/shuttle/dark/cardinal/coalition,
-/area/shuttle/himeo_patrol/central)
 "nF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3617,7 +3605,6 @@
 /obj/item/clothing/head/bandana/engineering,
 /obj/item/clothing/head/beret/engineering,
 /obj/item/clothing/head/softcap/engineering,
-/obj/item/device/gps/engineering,
 /obj/item/device/magnetic_lock/engineering,
 /obj/item/clothing/suit/storage/hooded/wintercoat/engineering,
 /obj/effect/floor_decal/corner/orange{
@@ -4440,12 +4427,6 @@
 /obj/machinery/light/colored/decayed/dimmed{
 	dir = 8
 	},
-/obj/item/device/gps/stationary{
-	gps_prefix = "HPG";
-	gpstag = "HPGSHUTTLE";
-	pixel_x = -24;
-	pixel_y = 2
-	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/himeo_patrol/central)
 "tc" = (
@@ -4539,12 +4520,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/himeo_patrol_ship/deck_2_interstitial)
-"tx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
-/turf/simulated/wall/shuttle/dark/cardinal/coalition,
-/area/shuttle/himeo_patrol/central)
 "tF" = (
 /obj/effect/floor_decal/corner/black{
 	dir = 9
@@ -6575,6 +6550,12 @@
 /obj/random/dirt_75,
 /obj/structure/fuel_port/hydrogen{
 	pixel_y = 32
+	},
+/obj/item/device/gps/stationary{
+	gps_prefix = "HPG";
+	gpstag = "HPGSHUTTLE";
+	pixel_x = -24;
+	pixel_y = 2
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/himeo_patrol/central)
@@ -10164,6 +10145,24 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/himeo_patrol_ship/blaster)
+"QZ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tcaf_shuttle";
+	name = "airlock_tcaf_shuttle";
+	req_one_access = list(204);
+	shuttle_tag = "TCAF Gunship"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/airlock_sensor/airlock_exterior{
+	pixel_x = -23;
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/large/airless,
+/area/space)
 "Ra" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -113816,7 +113815,7 @@ rs
 SP
 cF
 Xh
-ms
+ih
 so
 UC
 GJ
@@ -114072,8 +114071,8 @@ GM
 zx
 Bk
 GM
-nC
-tx
+lS
+cx
 so
 UC
 hn
@@ -115101,7 +115100,7 @@ Xh
 Xh
 Zk
 Xh
-bR
+QZ
 so
 UC
 jf

--- a/maps/away/ships/himeo/himeo_patrol_ship_submaps.dmm
+++ b/maps/away/ships/himeo/himeo_patrol_ship_submaps.dmm
@@ -5,7 +5,10 @@
 "am" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
-/obj/machinery/alarm/south,
+/obj/machinery/alarm/south{
+	req_access = list(253);
+	req_one_access = null
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	level = 2
@@ -16,7 +19,24 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/trash_pile,
 /obj/random/dirt_75,
-/obj/machinery/alarm/south,
+/obj/machinery/alarm/south{
+	req_access = list(253);
+	req_one_access = null
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/template_noop)
+"az" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/loot,
+/obj/random/dirt_75,
+/obj/machinery/alarm/south{
+	req_one_access = null;
+	req_access = list(253)
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	level = 2
@@ -36,7 +56,9 @@
 /turf/simulated/floor/carpet/rubber,
 /area/template_noop)
 "aH" = (
-/obj/machinery/power/apc/north,
+/obj/machinery/power/apc/north{
+	req_access = list(253)
+	},
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
@@ -165,7 +187,10 @@
 /area/template_noop)
 "iO" = (
 /obj/random/dirt_75,
-/obj/machinery/alarm/east,
+/obj/machinery/alarm/east{
+	req_one_access = null;
+	req_access = list(253)
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/template_noop)
 "jn" = (
@@ -215,7 +240,10 @@
 "la" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/machinery/alarm/east,
+/obj/machinery/alarm/east{
+	req_one_access = null;
+	req_access = list(253)
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/template_noop)
 "lJ" = (
@@ -232,7 +260,10 @@
 "mx" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack/no_cargo,
-/obj/machinery/alarm/south,
+/obj/machinery/alarm/south{
+	req_one_access = null;
+	req_access = list(253)
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	level = 2
@@ -260,7 +291,9 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/north,
+/obj/machinery/power/apc/north{
+	req_access = list(253)
+	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack/no_cargo,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -301,7 +334,10 @@
 "qm" = (
 /obj/structure/closet/crate/loot,
 /obj/random/dirt_75,
-/obj/machinery/alarm/south,
+/obj/machinery/alarm/south{
+	req_access = list(253);
+	req_one_access = null
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	level = 2
@@ -362,7 +398,10 @@
 /obj/effect/floor_decal/spline/plain/red{
 	dir = 6
 	},
-/obj/machinery/alarm/east,
+/obj/machinery/alarm/east{
+	req_one_access = null;
+	req_access = list(253)
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/template_noop)
 "vm" = (
@@ -484,7 +523,9 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/north,
+/obj/machinery/power/apc/north{
+	req_access = list(253)
+	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -772,7 +813,9 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/north,
+/obj/machinery/power/apc/north{
+	req_access = list(253)
+	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate/loot,
 /obj/random/dirt_75,
@@ -812,7 +855,10 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate/loot,
 /obj/random/dirt_75,
-/obj/machinery/alarm/south,
+/obj/machinery/alarm/south{
+	req_access = list(253);
+	req_one_access = null
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	level = 2
@@ -857,7 +903,9 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/north,
+/obj/machinery/power/apc/north{
+	req_access = list(253)
+	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate/trashcart,
 /obj/random/junk,
@@ -886,7 +934,10 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/template_noop)
 "Ya" = (
-/obj/machinery/alarm/east,
+/obj/machinery/alarm/east{
+	req_one_access = null;
+	req_access = list(253)
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/template_noop)
 "Yf" = (
@@ -1269,7 +1320,7 @@ am
 mg
 zU
 gR
-Tc
+az
 mg
 PI
 gR


### PR DESCRIPTION
Does various things for the Himean Patrol Ships such as:

- Access requirements for APCs and Air alarms
- Exterior windows spawn with firedoor + grille
- Access requirements for airlocks
- Adds GPS units + stationary units
- Slight Remap to shuttle airlock to allow for exterior cycling of air
<details>
<img width="383" height="232" alt="image" src="https://github.com/user-attachments/assets/511d1f20-a141-4203-8db1-87619707e8fb" />
</details>