### PR TITLE
Medical cargo list tweaks.

### DIFF
--- a/code/modules/cargo/items/medical.dm
+++ b/code/modules/cargo/items/medical.dm
@@ -116,7 +116,7 @@
 
 /singleton/cargo_item/bloodpack_ominus
 	category = "medical"
-	name = "O- blood pack (x1)"
+	name = "O- blood pack (x2)"
 	supplier = "zeng_hu"
 	description = "A blood pack filled with universally-compatible O- Blood."
 	price = 800
@@ -126,7 +126,7 @@
 	access = ACCESS_MEDICAL
 	container_type = "freezer"
 	groupable = TRUE
-	spawn_amount = 1
+	spawn_amount = 2
 
 /singleton/cargo_item/bloodpack_sbs
 	category = "medical"
@@ -156,53 +156,53 @@
 	groupable = TRUE
 	spawn_amount = 1
 
-/singleton/cargo_item/dexplus_autoinjector
+/singleton/cargo_item/dexplus_vial
 	category = "medical"
-	name = "dexalin plus autoinjector"
+	name = "dexalin plus vial"
 	supplier = "nanotrasen"
-	description = "An autoinjector designed to treat oxygen deprivation."
-	price = 550
+	description = "A vial that comes with 15 units of Dexalin Plus, an advanced chemical used to rapidly oxygenate blood cells."
+	price = 900
 	items = list(
-		/obj/item/reagent_containers/hypospray/autoinjector/oxygen
+		/obj/item/reagent_containers/glass/beaker/vial/dexalin_plus
 	)
 	access = 0
 	container_type = "crate"
 	groupable = TRUE
 	spawn_amount = 1
 
-/singleton/cargo_item/peridaxonautoinjector
+/singleton/cargo_item/peridaxon_vial
 	category = "medical"
-	name = "peridaxon autoinjector"
+	name = "peridaxon vial"
 	supplier = "nanotrasen"
-	description = "An autoinjector designed to treat broad-spectrum organ damage."
-	price = 725
+	description = "A vial that comes with 15 units of Peridaxon, an advanced organ regenerative compound."
+	price = 1300
 	items = list(
-		/obj/item/reagent_containers/hypospray/autoinjector/peridaxon
+		/obj/item/reagent_containers/glass/beaker/vial/peridaxon
 	)
 	access = ACCESS_MEDICAL
 	container_type = "crate"
 	groupable = TRUE
 	spawn_amount = 1
 
-/singleton/cargo_item/pneumalin_inhaler
+/singleton/cargo_item/pneumalin_inhalers
 	category = "medical"
-	name = "pneumalin autoinhaler"
+	name = "pneumalin autoinhaler kit (x3)"
 	supplier = "nanotrasen"
-	description = "An autoinhaler used to treat lung damage."
-	price = 450
+	description = "A kit of autoinhalers used to treat lung damage."
+	price = 750
 	items = list(
 		/obj/item/reagent_containers/inhaler/pneumalin
 	)
 	access = ACCESS_MEDICAL
 	container_type = "crate"
 	groupable = TRUE
-	spawn_amount = 1
+	spawn_amount = 3
 
 /singleton/cargo_item/bodybags
 	category = "medical"
-	name = "body bags boxes (x3)"
+	name = "body bag boxes (x3)"
 	supplier = "nanotrasen"
-	description = "This box contains body bags."
+	description = "A kit of three boxes of body bags."
 	price = 35
 	items = list(
 		/obj/item/storage/box/bodybags
@@ -210,7 +210,7 @@
 	access = 0
 	container_type = "crate"
 	groupable = TRUE
-	spawn_amount = 1
+	spawn_amount = 3
 
 /singleton/cargo_item/injectors_box
 	category = "medical"
@@ -282,14 +282,14 @@
 	groupable = TRUE
 	spawn_amount = 1
 
-/singleton/cargo_item/dermaline_bottle
+/singleton/cargo_item/kelotane_bottle
 	category = "medical"
-	name = "dermaline bottle"
+	name = "kelotane bottle"
 	supplier = "nanotrasen"
-	description = "A bottle of dermaline, a medicine used to treat severe burns."
+	description = "A bottle of kelotane, a medicine used to treat severe burns."
 	price = 250
 	items = list(
-		/obj/item/reagent_containers/glass/bottle/dermaline
+		/obj/item/reagent_containers/glass/bottle/kelotane
 	)
 	access = 0
 	container_type = "crate"
@@ -324,11 +324,25 @@
 	groupable = TRUE
 	spawn_amount = 1
 
+/singleton/cargo_item/arithrazine_vial
+	category = "medical"
+	name = "arithrazine vial"
+	supplier = "nanotrasen"
+	description = "A bottle containing Arithrazine, a potent anti-radiation medication."
+	price = 750
+	items = list(
+		/obj/item/reagent_containers/glass/beaker/vial/arithrazine
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
 /singleton/cargo_item/inaprovaline_bottle
 	category = "medical"
 	name = "inaprovaline bottle"
 	supplier = "nanotrasen"
-	description = "A bottle of inaprovaline, a broad-spectrum stimulant and cardiac stabilizer."
+	description = "A bottle of inaprovaline, a broad-spectrum stabilizer.."
 	price = 205
 	items = list(
 		/obj/item/reagent_containers/glass/bottle/inaprovaline
@@ -360,6 +374,20 @@
 	price = 455
 	items = list(
 		/obj/item/reagent_containers/glass/bottle/mortaphenyl
+	)
+	access = ACCESS_MEDICAL
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
+/singleton/cargo_item/thetamycin_bottle
+	category = "medical"
+	name = "thetamycin bottle"
+	supplier = "nanotrasen"
+	description = "A bottle of thetamycin, a broad-spectrum antibiotic."
+	price = 350
+	items = list(
+		/obj/item/reagent_containers/glass/bottle/thetamycin
 	)
 	access = ACCESS_MEDICAL
 	container_type = "crate"

--- a/code/modules/cargo/items/medical.dm
+++ b/code/modules/cargo/items/medical.dm
@@ -342,7 +342,7 @@
 	category = "medical"
 	name = "inaprovaline bottle"
 	supplier = "nanotrasen"
-	description = "A bottle of inaprovaline, a broad-spectrum stabilizer.."
+	description = "A bottle of inaprovaline, a broad-spectrum stabilizer."
 	price = 205
 	items = list(
 		/obj/item/reagent_containers/glass/bottle/inaprovaline

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -202,6 +202,21 @@
 	amount_per_transfer_from_this = 5
 	reagents_to_add = list(/singleton/reagent/antibodies = 60)
 
+/obj/item/reagent_containers/glass/beaker/vial/dexalin_plus
+	name = "dexalin plus vial"
+	desc = "A small vial of Dexalin Plus, a potent medication that aids in the re-oxygenating of blood cells."
+	reagents_to_add = list(/singleton/reagent/dexalin/plus = 15)
+
+/obj/item/reagent_containers/glass/beaker/vial/peridaxon
+	name = "peridaxon vial"
+	desc = "A small vial of Peridaxon, an advanced organ regenerative compound."
+	reagents_to_add = list(/singleton/reagent/peridaxon = 15)
+
+/obj/item/reagent_containers/glass/beaker/vial/arithrazine
+	name = "arithrazine vial"
+	desc = "A small vial of Arithrazine, a potent anti-radiation medication."
+	reagents_to_add = list(/singleton/reagent/arithrazine = 15)
+
 /obj/item/reagent_containers/glass/beaker/medcup
 	name = "medicine cup"
 	desc = "A glass medicine cup. Like a shot glass for medicine."

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -198,6 +198,12 @@
 	icon_state = "bottle-1"
 	reagents_to_add = list(/singleton/reagent/butazoline = 60)
 
+/obj/item/reagent_containers/glass/bottle/kelotane
+	name = "kelotane bottle"
+	desc = "A small bottle. Contains kelotane - treats burnt tissues."
+	icon_state = "bottle-2"
+	reagents_to_add = list(/singleton/reagent/kelotane = 60)
+
 /obj/item/reagent_containers/glass/bottle/dermaline
 	name = "dermaline bottle"
 	desc = "A small bottle. Contains dermaline - treats burnt tissues."

--- a/html/changelogs/mattatlas-cargotweaksformed.yml
+++ b/html/changelogs/mattatlas-cargotweaksformed.yml
@@ -1,0 +1,62 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "The Dexalin Plus and Peridaxon autoinjectors in the medical cargo category are now vials that come with 15 units."
+  - rscadd: "Added Arithrazine and Thetamycin to the medical cargo category."
+  - rscadd: "O- blood bags in the medical cargo category now come in a pair of two, rather than just one."
+  - rscadd: "Changed the Dermaline crate to a Kelotane crate instead."
+  - bugfix: "The three body bag boxes crate now actually comes with three body bag boxes."


### PR DESCRIPTION
- The Dexalin Plus and Peridaxon autoinjectors in the medical cargo category are now vials that come with 15 units.
- Added Arithrazine and Thetamycin to the medical cargo category.
- O- blood bags in the medical cargo category now come in a pair of two, rather than just one.
- Changed the Dermaline crate to a Kelotane crate instead.
- The three body bag boxes crate now actually comes with three body bag boxes.
