### PR TITLE
gear loadout price standardization

### DIFF
--- a/code/datums/uplink/gear loadout.dm
+++ b/code/datums/uplink/gear loadout.dm
@@ -150,13 +150,13 @@
 	name = "NanoTrasen Assets (Group)"
 	desc = "A crate containing gear for a group. The hardsuits are are only usable by humans and skrell."
 	path = /obj/structure/closet/crate/gear_loadout/nanotrasen
-	telecrystal_cost = 50
+	telecrystal_cost = 35
 
 /datum/uplink_item/item/gear_loadout/nanotrasen_single
 	name = "NanoTrasen Assets (Single)"
 	desc = "A crate containing gear for a single individual. The hardsuit is only usable by humans and skrell."
 	path = /obj/structure/closet/crate/gear_loadout/nanotrasen/single
-	telecrystal_cost = 15
+	telecrystal_cost = 10
 
 /datum/uplink_item/item/gear_loadout/hammertail
 	name = "Hammertail Smiths Assets (Group)"
@@ -184,19 +184,19 @@
 	name = "Imperial Army Assets (Group)"
 	desc = "A crate containing gear for a group."
 	path = /obj/structure/closet/crate/secure/gear_loadout/imperial_army
-	telecrystal_cost = 50
+	telecrystal_cost = 35
 
 /datum/uplink_item/item/gear_loadout/imperial_army_single
 	name = "Imperial Army Assets (Single)"
 	desc = "A crate containing gear for a single individual."
 	path = /obj/structure/closet/crate/secure/gear_loadout/imperial_army/single
-	telecrystal_cost = 15
+	telecrystal_cost = 10
 
 /datum/uplink_item/item/gear_loadout/tcaf
 	name = "Tau Ceti Armed Forces Assets (Group)"
 	desc = "A crate containing gear for a group."
 	path = /obj/structure/closet/crate/secure/gear_loadout/tcaf
-	telecrystal_cost = 50
+	telecrystal_cost = 35
 
 /datum/uplink_item/item/gear_loadout/tcaf_single
 	name = "Tau Ceti Armed Forces Assets (Single)"

--- a/html/changelogs/gearloadoutpricestandards.yml
+++ b/html/changelogs/gearloadoutpricestandards.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: UltraBigRat
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Lowers higher than usual prices of NT, Imperial army and TCAF gearloadouts."


### PR DESCRIPTION
* "Lowers higher than usual prices of NT, Imperial army and TCAF gearloadouts."

Some of the gear loadouts had higher than usual prices of 50 per group and 15 per single compared to the standard 35 and 10. Some of these like TCAF even were just straight up the same items as the single crate but at less bang per buck. 

Overall none of these kits are strong enough when compared to others, to justify a higher price that makes it hard for mercs to budget it for their gimmick. While the NT kit has a hardsuit, it should be noted it is an empty one that has online slowdown unlike other combat rigs, similar to the TCFL rigs.