### PR TITLE
Tajara and Unathi mobs now display properly on UIs

### DIFF
--- a/code/datums/late_choices.dm
+++ b/code/datums/late_choices.dm
@@ -57,7 +57,7 @@
 	for(var/mutable_appearance/I in mannequin.overlays)
 		if(I.plane == EMISSIVE_PLANE)
 			mannequin.overlays -= I
-	character_image = getFlatIcon(mannequin, SOUTH)
+	character_image = getFlatIcon(mannequin, SOUTH, no_anim = TRUE)
 
 /datum/late_choices/ui_data(mob/user)
 	var/list/data = list()

--- a/code/datums/records.dm
+++ b/code/datums/records.dm
@@ -147,11 +147,11 @@
 	..()
 	if (!H)
 		var/mob/living/carbon/human/dummy/mannequin/dummy = SSmobs.get_mannequin("New record")
-		photo_front = getFlatIcon(dummy, SOUTH)
-		photo_side = getFlatIcon(dummy, WEST)
+		photo_front = getFlatIcon(dummy, SOUTH, no_anim = TRUE)
+		photo_side = getFlatIcon(dummy, WEST, no_anim = TRUE)
 	else
-		photo_front = getFlatIcon(H, SOUTH)
-		photo_side = getFlatIcon(H, WEST)
+		photo_front = getFlatIcon(H, SOUTH, no_anim = TRUE)
+		photo_side = getFlatIcon(H, WEST, no_anim = TRUE)
 	if(!nid)
 		nid = generate_record_id()
 	id = nid

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -188,9 +188,9 @@
 		chat_user.username = chat_user.generateUsernameIdCard(src)
 
 /obj/item/card/id/proc/set_id_photo(var/mob/M)
-	front = getFlatIcon(M, SOUTH)
+	front = getFlatIcon(M, SOUTH, no_anim = TRUE)
 	front.Scale(128, 128)
-	side = getFlatIcon(M, WEST)
+	side = getFlatIcon(M, WEST, no_anim = TRUE)
 	side.Scale(128, 128)
 
 /mob/proc/set_id_info(var/obj/item/card/id/id_card)

--- a/html/changelogs/Ben10083 - Icon_Fixes.yml
+++ b/html/changelogs/Ben10083 - Icon_Fixes.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Tajara, Unathi and other mobs with animated parts should now be properly shown in records and other UI."


### PR DESCRIPTION
Fixes https://github.com/Aurorastation/Aurora.3/issues/16943

Adds missing parameter to getFlatIcon() calls by UIs to properly display Tajara and Unathi mobs on UIs such as records and late join

<details>

**Before Fix** 
<img width="321" height="239" alt="image" src="https://github.com/user-attachments/assets/19382e23-10ba-4a89-bfb7-bf700c931aca" />
<img width="251" height="127" alt="image" src="https://github.com/user-attachments/assets/1f4527ba-a455-4f0a-b546-59e0fc783ea4" />

**After Fix**
<img width="321" height="275" alt="image" src="https://github.com/user-attachments/assets/408a4f16-41f4-4ee4-8198-f6eb02a68469" />
<img width="1648" height="458" alt="image" src="https://github.com/user-attachments/assets/dedb0ecd-6fa5-4d77-8fc0-f8b2853268d8" />
</details>