### PR TITLE
Various player greimorian fixes and changes

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -177,11 +177,12 @@
 	if(!isturf(loc)) // This is going to stop you from telekinesing from inside a closet, but I don't shed many tears for that
 		return
 
+	var/mob/living/simple_animal/simple_mob = istype(src, /mob/living/simple_animal) ? src : null
 	//Atoms on turfs (not on your person)
 	// A is a turf or is on a turf, or in something on a turf (pen in a box); but not something in something on a turf (pen in a box in a backpack)
 	sdepth = A.storage_depth_turf()
 	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= 1))
-		if(A.Adjacent(src) || (W && W.attack_can_reach(src, A, W.reach)) ) // see adjacent.dm
+		if(A.Adjacent(src) || (W && W.attack_can_reach(src, A, W.reach)) || (simple_mob && simple_mob.attack_can_reach(src, A, simple_mob.melee_reach))) // see adjacent.dm
 			if(W)
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
 				var/resolved = W.resolve_attackby(A,src, params)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -174,7 +174,7 @@
 			add_logs(src, A, attacktext)
 	setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	var/damage = rand(melee_damage_lower, melee_damage_upper)
-	if(A.attack_generic(src, damage, attacktext, environment_smash, armor_penetration, attack_flags) && loc && attack_sound)
+	if(A.attack_generic(src, damage, attacktext, armor_penetration, attack_flags) && loc && attack_sound)
 		playsound(loc, attack_sound, 50, 1, 1)
 
 /mob/living/CtrlClickOn(var/atom/A)

--- a/code/modules/mob/abstract/ghost/observer/observer.dm
+++ b/code/modules/mob/abstract/ghost/observer/observer.dm
@@ -201,7 +201,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost, you won't be able to play this round for another [GLOB.config.respawn_delay] minutes! You can't change your mind so choose wisely!)", "Are you sure you want to ghost?", "Ghost", "Stay in body")
 		if(response != "Ghost")
 			return
-		resting = 1
+		if(!istype(usr, /mob/living/simple_animal/hostile/giant_spider/nurse/spider_queen))
+			resting = 1
 		var/turf/location = get_turf(src)
 		message_admins("[key_name_admin(usr)] has ghosted. (<A href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[location.x];Y=[location.y];Z=[location.z]'>JMP</a>)")
 		log_game("[key_name_admin(usr)] has ghosted.")

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -420,6 +420,10 @@
 	set desc = "Lay a clutch of eggs to make new spiderlings. This will cost one food point."
 	set category = "Greimorian"
 
+	if(fed <= 0)
+		to_chat(src, SPAN_WARNING("You do not have the nutrients to do this. Try cocooning a corpse!"))
+		return
+
 	var/obj/effect/spider/eggcluster/E = locate() in get_turf(src)
 	if(!E && fed > 0)
 		src.visible_message("\The [src] begins to lay a cluster of eggs.")
@@ -435,6 +439,9 @@
 	set desc = "Lay a greimorian servant, which can be player-controlled. This will cost one food point."
 	set category = "Greimorian"
 
+	if(fed <= 0)
+		to_chat(src, SPAN_WARNING("You do not have the nutrients to do this. Try cocooning a corpse!"))
+		return
 
 	var/obj/effect/spider/eggcluster/E = locate() in get_turf(src)
 	if(!E && fed > 0)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -86,6 +86,7 @@
 	speed = -2
 	poison_type = /singleton/reagent/soporific
 	fed = 1
+	see_invisible = SEE_INVISIBLE_NOLIGHTING
 	var/playable = TRUE
 	sample_data = list("Genetic markers identified as being linked with stem cell differentiaton", "Cellular structures indicative of high offspring production", "Tissue sample contains high neural cell content")
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -166,6 +166,8 @@
 	get_light_and_color(parent)
 	add_language(LANGUAGE_GREIMORIAN)
 	add_language(LANGUAGE_GREIMORIAN_HIVEMIND)
+	remove_language(LANGUAGE_TCB)
+	default_language = GLOB.all_languages[LANGUAGE_GREIMORIAN]
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/servant/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/spider_queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/spider_queen.dm
@@ -26,6 +26,7 @@
 	health = 1000
 	melee_damage_lower = 35
 	melee_damage_upper = 40
+	melee_reach = 2
 	armor_penetration = 30
 	resist_mod = 15 // LOL good luck pal
 	heat_damage_per_tick = 20

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -116,6 +116,7 @@
 	//LETTING SIMPLE ANIMALS ATTACK? WHAT COULD GO WRONG. Defaults to zero so Ian can still be cuddly
 	var/melee_damage_lower = 0
 	var/melee_damage_upper = 0
+	var/melee_reach = 1
 	var/armor_penetration = 0
 	var/attack_flags = 0
 	var/attacktext = "attacked"
@@ -1078,6 +1079,17 @@
 /mob/living/simple_animal/proc/derez()
 	visible_message(SPAN_NOTICE("\The [src] fades away!"))
 	qdel(src)
+
+//Taken from /obj/item/proc/attack_can_reach
+/mob/living/simple_animal/proc/attack_can_reach(var/atom/us, var/atom/them, var/range)
+	if(us.Adjacent(them))
+		return TRUE // Already adjacent.
+	else if(range <= 1)
+		return FALSE
+	if(AStar(get_turf(us), get_turf(them), /turf/proc/AdjacentTurfsRanged, /turf/proc/Distance, max_nodes=25, max_node_depth=range))
+		return TRUE
+	return FALSE
+
 
 #undef BLOOD_NONE
 #undef BLOOD_LIGHT

--- a/html/changelogs/AlaunusLux-various-greimorian-fixes.yml
+++ b/html/changelogs/AlaunusLux-various-greimorian-fixes.yml
@@ -1,0 +1,63 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: AlaunusLux
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Greimorian servants can now see in the dark."
+  - qol: "Greimorians attempting to lay eggs or a servant now get feedback if it fails."
+  - experiment: "Gives Greimorian Queens a melee attack reach of two tiles."
+  - bugfix: "Greimorian servants can no longer speak Tau Ceti Basic."
+  - bugfix: "Player controlled simple mob attacks now properly pass armor penetration and other variables."
+  - bugfix: "Fixes Greimorian Queen icon state being set to resting if the controlling player ghosts."


### PR DESCRIPTION
Most of these are self explanatory. Servants should be able to see in the dark. They should not speak TCB. The user should get feedback if a skill fails. The icon state shouldn't be set to resting if the simple mob AI will take back over (which it does).

The first big change here is removing `environment_smash` from the `attack_generic` proc. As far as I can tell, this variable is almost entirely deprecated. I only saw one check relying on it, in `/obj/structure/closet/statue/attack_generic(var/mob/user, damage, attacktext, environment_smash)`, but when I tried to spawn one it was invisible, so I assume that is also something that is mostly deprecated. As such, I removed the variable from the function call, lining its arguments back up with what the function is expecting. Maybe I should've done named arguments here, but given that there's only that one function that expects it, I just removed it.

The second big change is giving the Greimorian Queen reach on its melee attacks. I was mostly trying to fix the case where the queen can't attack a mob to its north, due to the mob being covered by the queen's icon. Attacking two tiles away looks fine when the queen is facing north, but facing south it looks not great. Directly East and West are usually okay, though it depends exactly which tile is being attacked. 

Maybe the sprite just needs to be adjusted when facing North/South to be more in the middle of the tiles it's taking up. That would fix a lot of it, but either way I'm still interested in testing a two tile reach for the queen, if possible. 

I did also duplicate a function, which I'm not a fan of. Perhaps `attack_can_reach` should be made more generic. Let me know the best place to do that, if so.

I'm not completely sold on adding the reach in its current form: Aside from the top center 3 and the two furthest east and west, it reaches way too far without good visual feedback that it can/is doing so, especially the bottom ones and corners. 

https://github.com/user-attachments/assets/a2b95cee-fe2d-4bc6-bf43-2e5b6e2e8f86
