### PR TITLE
Fix move-down(wards) hotkey defs

### DIFF
--- a/html/changelogs/bat-movedownhotkeyfix.yml
+++ b/html/changelogs/bat-movedownhotkeyfix.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Batrachophrenoboocosmomachia
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Update move-down hotkey defs missed after verb renamed to Move-Downwards."

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -97,7 +97,7 @@ Hotkey-Mode: (hotkey-mode must be on)
 \td = right
 \tw = up
 \t, = move-upwards
-\t. = move-down
+\t. = move-downwards
 \tq = drop
 \te = equip
 \tr = throw

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -220,13 +220,13 @@ macro "borghotkeymode"
 		command = "Move-Upwards"
 	elem
 		name = "CTRL+Southeast"
-		command = "Move-Down"
+		command = "Move-Downwards"
 	elem
 		name = ","
 		command = "Move-Upwards"
 	elem
 		name = "."
-		command = "Move-Down"
+		command = "Move-Downwards"
 
 
 macro "macro"
@@ -403,13 +403,13 @@ macro "macro"
 		command = "Move-Upwards"
 	elem
 		name = "CTRL+Southeast"
-		command = "Move-Down"
+		command = "Move-Downwards"
 	elem
 		name = ","
 		command = "Move-Upwards"
 	elem
 		name = "."
-		command = "Move-Down"
+		command = "Move-Downwards"
   elem
     name = "R"
     command = "throw_intent_toggle"
@@ -649,13 +649,13 @@ macro "hotkeymode"
 		command = "Move-Upwards"
 	elem
 		name = "CTRL+Southeast"
-		command = "Move-Down"
+		command = "Move-Downwards"
 	elem
 		name = ","
 		command = "move-upwards"
 	elem
 		name = "."
-		command = "Move-Down"
+		command = "Move-Downwards"
   elem
     name = "R"
     command = "throw_intent_toggle"
@@ -829,13 +829,13 @@ macro "borgmacro"
 		command = "Move-Upwards"
 	elem
 		name = "CTRL+Southeast"
-		command = "Move-Down"
+		command = "Move-Downwards"
 	elem
 		name = ","
 		command = "Move-Upwards"
 	elem
 		name = "."
-		command = "Move-Down"
+		command = "Move-Downwards"
 
 
 menu "menu"


### PR DESCRIPTION
Fixes https://github.com/Aurorastation/Aurora.3/issues/21163

Wasn't aware of the hotkey definitions also needing updated when I changed the name to match 'Move Upwards'! My bad.