### PR TITLE
Repositions mercs in the gamemode vote list

### DIFF
--- a/code/datums/votes/round_type.dm
+++ b/code/datums/votes/round_type.dm
@@ -15,6 +15,7 @@
 	//Put Odyssey and Secret as the first options
 	default_choices.Add("Odyssey")
 	default_choices.Add("Secret")
+	default_choices.Add("Mercenary")
 
 	//Sort the gamemodes
 	for(var/votable_mode_name in GLOB.config.votable_modes)

--- a/html/changelogs/Mercstothetop.yml
+++ b/html/changelogs/Mercstothetop.yml
@@ -55,4 +55,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Placed Mercs between Odyssey and Secret in the gamemode vote."
+  - rscadd: "Placed Mercs after Odyssey and Secret in the gamemode vote."

--- a/html/changelogs/Mercstothetop.yml
+++ b/html/changelogs/Mercstothetop.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: UltraBigRat
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Placed Mercs between Odyssey and Secret in the gamemode vote."


### PR DESCRIPTION
* Puts Mercs by Odyssey and Secret in the gamemode vote.
Mercs are our main and most developed highpop gamemode besides maybe Odyssey, and are what people tend to expect when voting secret in highpop. But they never get voted themselves in the gamemode vote because they're deep in the middle of the gamemode list with a bunch of unpopular gamemodes.

This puts them near the top so they can be seen and voted for.


Before:
<img width="505" height="600" alt="Screenshot 2025-08-12 163304" src="https://github.com/user-attachments/assets/3ff5f304-a891-4c03-a67e-9b2d63c9ff8f" />

After:
<img width="477" height="600" alt="image" src="https://github.com/user-attachments/assets/1d134325-75f9-487c-9560-1d6ed583a157" />
