### PR TITLE
Mechfab Rebalancing: Material Scarcity Edition

### DIFF
--- a/code/modules/heavy_vehicle/premade/hoverpod.dm
+++ b/code/modules/heavy_vehicle/premade/hoverpod.dm
@@ -8,7 +8,7 @@
 	max_damage = 150
 	move_delay = 5
 	turn_delay = 2
-	power_use = 2000
+	power_use = 2500
 	trample_damage = 0
 	hover = TRUE
 
@@ -17,7 +17,7 @@
 	exosuit_desc_string = "light thrusters"
 	desc = "A set of fragile hover-thrusters. This variant seems to sacrifice vast structural integrity for... more speed."
 	icon_state = "light-hoverlegs"
-	max_damage = 40
+	max_damage = 75
 	move_delay = 2
 	turn_delay = 2
-	power_use = 725
+	power_use = 2000

--- a/code/modules/research/designs/mechfab/hardsuit/rigs.dm
+++ b/code/modules/research/designs/mechfab/hardsuit/rigs.dm
@@ -11,9 +11,9 @@
 	build_path = /obj/item/rig_assembly/ce
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3, TECH_MAGNET = 3, TECH_POWER = 4)
 	materials = list(
-		MATERIAL_ALUMINIUM = 15000,
+		MATERIAL_ALUMINIUM = 12500,
 		MATERIAL_GLASS = 12500,
-		DEFAULT_WALL_MATERIAL = 10000,
+		DEFAULT_WALL_MATERIAL = 7000,
 		MATERIAL_SILVER = 5500,
 		MATERIAL_GOLD = 5500,
 		MATERIAL_PHORON = 7550,
@@ -24,7 +24,7 @@
 	name = "EVA Suit Control Module Assembly"
 	desc = "An assembly for light rig that is desiged for repairs and maintenance to the outside of habitats and vessels."
 	build_path = /obj/item/rig_assembly/eva
-	materials = list(MATERIAL_ALUMINIUM = 15000, MATERIAL_GLASS = 12500, DEFAULT_WALL_MATERIAL = 10000, MATERIAL_LEAD = 5500)
+	materials = list(MATERIAL_ALUMINIUM = 12500, MATERIAL_GLASS = 12500, DEFAULT_WALL_MATERIAL = 7000, MATERIAL_LEAD = 5500)
 
 /datum/design/rig/eva/pilot
 	name = "pilot Suit Control Module Assembly"
@@ -36,26 +36,26 @@
 	name = "Industrial Suit Control Module Assembly"
 	desc = "An assembly for a heavy, powerful rig used by construction crews and mining corporations."
 	build_path = /obj/item/rig_assembly/industrial
-	materials = list(DEFAULT_WALL_MATERIAL = 25000, MATERIAL_GLASS = 12500, MATERIAL_PLASTEEL = 3500, MATERIAL_LEAD = 3500)
+	materials = list(DEFAULT_WALL_MATERIAL = 23000, MATERIAL_GLASS = 12500, MATERIAL_PLASTEEL = 3500, MATERIAL_LEAD = 3500)
 
 /datum/design/rig/hazmat
 	name = "AMI Control Module Assembly"
 	desc = "An assembly for Anomalous Material Interaction hardsuit that protects against the strangest energies the universe can throw at it."
 	build_path = /obj/item/rig_assembly/hazmat
-	materials = list(DEFAULT_WALL_MATERIAL = 25000, MATERIAL_GLASS = 25000, MATERIAL_SILVER = 5500, MATERIAL_GOLD = 5500, MATERIAL_PHORON = 7550, MATERIAL_LEAD = 5500)
+	materials = list(DEFAULT_WALL_MATERIAL = 19500, MATERIAL_GLASS = 25000, MATERIAL_SILVER = 5500, MATERIAL_GOLD = 5500, MATERIAL_PHORON = 7550, MATERIAL_LEAD = 5500)
 
 /datum/design/rig/medical
 	name = "Rescue Suit Control Module Assembly"
 	desc = "An assembly for a durable suit designed for medical rescue in high risk areas."
 	build_path = /obj/item/rig_assembly/medical
-	materials = list(MATERIAL_ALUMINIUM = 15000, MATERIAL_GLASS = 12500, MATERIAL_SILVER = 5500, MATERIAL_GOLD = 3500, MATERIAL_PHORON = 7550, MATERIAL_LEAD = 2500)
+	materials = list(MATERIAL_ALUMINIUM = 14000, MATERIAL_GLASS = 12500, DEFAULT_WALL_MATERIAL = 8500, MATERIAL_SILVER = 5500, MATERIAL_GOLD = 3500, MATERIAL_PHORON = 7550, MATERIAL_LEAD = 2500)
 
 /datum/design/rig/hazard
 	name = "Hazard Hardsuit Control Module"
 	desc = "An assembly for a security hardsuit designed for prolonged EVA in dangerous environments."
 	build_path = /obj/item/rig_assembly/combat/hazard
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3, TECH_MAGNET = 3, TECH_POWER = 3, TECH_COMBAT = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 30000, MATERIAL_GLASS = 12500, MATERIAL_SILVER = 3500, MATERIAL_GOLD = 5500, MATERIAL_LEAD = 3500)
+	materials = list(DEFAULT_WALL_MATERIAL = 26500, MATERIAL_GLASS = 12500, MATERIAL_SILVER = 3500, MATERIAL_GOLD = 5500, MATERIAL_LEAD = 3500)
 
 /datum/design/rig/combat
 	name = "Combat Hardsuit Control Module Assembly"

--- a/code/modules/research/designs/mechfab/hardsuit/rigs.dm
+++ b/code/modules/research/designs/mechfab/hardsuit/rigs.dm
@@ -10,12 +10,21 @@
 	desc = "An assembly frame for an advanced voidsuit that protects against hazardous, low pressure environments."
 	build_path = /obj/item/rig_assembly/ce
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3, TECH_MAGNET = 3, TECH_POWER = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 25000, MATERIAL_GLASS = 12500, MATERIAL_SILVER = 5500, MATERIAL_GOLD = 5500, MATERIAL_PHORON = 7550)
+	materials = list(
+		MATERIAL_ALUMINIUM = 15000,
+		MATERIAL_GLASS = 12500,
+		DEFAULT_WALL_MATERIAL = 10000,
+		MATERIAL_SILVER = 5500,
+		MATERIAL_GOLD = 5500,
+		MATERIAL_PHORON = 7550,
+		MATERIAL_LEAD = 5500,
+	)
 
 /datum/design/rig/eva
 	name = "EVA Suit Control Module Assembly"
 	desc = "An assembly for light rig that is desiged for repairs and maintenance to the outside of habitats and vessels."
 	build_path = /obj/item/rig_assembly/eva
+	materials = list(MATERIAL_ALUMINIUM = 15000, MATERIAL_GLASS = 12500, DEFAULT_WALL_MATERIAL = 10000, MATERIAL_LEAD = 5500)
 
 /datum/design/rig/eva/pilot
 	name = "pilot Suit Control Module Assembly"
@@ -27,25 +36,26 @@
 	name = "Industrial Suit Control Module Assembly"
 	desc = "An assembly for a heavy, powerful rig used by construction crews and mining corporations."
 	build_path = /obj/item/rig_assembly/industrial
+	materials = list(DEFAULT_WALL_MATERIAL = 25000, MATERIAL_GLASS = 12500, MATERIAL_PLASTEEL = 3500, MATERIAL_LEAD = 3500)
 
 /datum/design/rig/hazmat
 	name = "AMI Control Module Assembly"
 	desc = "An assembly for Anomalous Material Interaction hardsuit that protects against the strangest energies the universe can throw at it."
 	build_path = /obj/item/rig_assembly/hazmat
-	materials = list(DEFAULT_WALL_MATERIAL = 25000, MATERIAL_GLASS = 25000, MATERIAL_SILVER = 5500, MATERIAL_GOLD = 5500, MATERIAL_PHORON = 7550)
+	materials = list(DEFAULT_WALL_MATERIAL = 25000, MATERIAL_GLASS = 25000, MATERIAL_SILVER = 5500, MATERIAL_GOLD = 5500, MATERIAL_PHORON = 7550, MATERIAL_LEAD = 5500)
 
 /datum/design/rig/medical
 	name = "Rescue Suit Control Module Assembly"
 	desc = "An assembly for a durable suit designed for medical rescue in high risk areas."
 	build_path = /obj/item/rig_assembly/medical
-	materials = list(DEFAULT_WALL_MATERIAL = 25000, MATERIAL_GLASS = 12500, MATERIAL_SILVER = 5500, MATERIAL_GOLD = 3500, MATERIAL_PHORON = 7550)
+	materials = list(MATERIAL_ALUMINIUM = 15000, MATERIAL_GLASS = 12500, MATERIAL_SILVER = 5500, MATERIAL_GOLD = 3500, MATERIAL_PHORON = 7550, MATERIAL_LEAD = 2500)
 
 /datum/design/rig/hazard
 	name = "Hazard Hardsuit Control Module"
 	desc = "An assembly for a security hardsuit designed for prolonged EVA in dangerous environments."
 	build_path = /obj/item/rig_assembly/combat/hazard
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3, TECH_MAGNET = 3, TECH_POWER = 3, TECH_COMBAT = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 30000, MATERIAL_GLASS = 12500, MATERIAL_SILVER = 3500, MATERIAL_GOLD = 5500)
+	materials = list(DEFAULT_WALL_MATERIAL = 30000, MATERIAL_GLASS = 12500, MATERIAL_SILVER = 3500, MATERIAL_GOLD = 5500, MATERIAL_LEAD = 3500)
 
 /datum/design/rig/combat
 	name = "Combat Hardsuit Control Module Assembly"

--- a/code/modules/research/designs/mechfab/mechs/designs_exosuits.dm
+++ b/code/modules/research/designs/mechfab/mechs/designs_exosuits.dm
@@ -16,21 +16,22 @@
 	build_path = /obj/item/robot_parts/robot_component/armor/mech/radproof
 	time = 50 SECONDS
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 12500)
+	// Steel for equivalent armor, but lead for its radiation shielding
+	materials = list(DEFAULT_WALL_MATERIAL = 6000, MATERIAL_LEAD = 7500)
 
 /datum/design/item/mechfab/exosuit/em_armor
 	name = "EM-shielded Exosuit Armor"
 	build_path = /obj/item/robot_parts/robot_component/armor/mech/em
 	time = 50 SECONDS
 	req_tech = list(TECH_MATERIAL = 2, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 12500, MATERIAL_SILVER = 1000)
+	materials = list(DEFAULT_WALL_MATERIAL = 12500, MATERIAL_LEAD = 2500, MATERIAL_SILVER = 1000)
 
 /datum/design/item/mechfab/exosuit/combat_armor
 	name = "Combat Exosuit Armor"
 	build_path = /obj/item/robot_parts/robot_component/armor/mech/combat
 	time = 50 SECONDS
 	req_tech = list(TECH_MATERIAL = 4, TECH_COMBAT = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 20000, MATERIAL_DIAMOND = 5000)
+	materials = list(DEFAULT_WALL_MATERIAL = 10000, MATERIAL_PLASTEEL = 10000, MATERIAL_DIAMOND = 5000)
 
 /datum/design/item/mechfab/exosuit/actuator
 	name = "Actuator"
@@ -64,28 +65,28 @@
 
 /datum/design/item/mechfab/exosuit/combat_head
 	name = "Combat Exosuit Sensors"
-	time = 30 SECONDS
+	time = 90 SECONDS
 	materials = list(DEFAULT_WALL_MATERIAL = 10000, MATERIAL_GOLD = 10500, MATERIAL_SILVER = 10000)
 	build_path = /obj/item/mech_component/sensors/combat
 	req_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 3)
 
 /datum/design/item/mechfab/exosuit/combat_torso
 	name = "Combat Exosuit Chassis"
-	time = 60 SECONDS
+	time = 180 SECONDS
 	materials = list(DEFAULT_WALL_MATERIAL = 45000, MATERIAL_GOLD = 10500, MATERIAL_SILVER = 10000)
 	build_path = /obj/item/mech_component/chassis/combat
 	req_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 3)
 
 /datum/design/item/mechfab/exosuit/combat_arms
 	name = "Combat Exosuit Manipulators"
-	time = 30 SECONDS
+	time = 90 SECONDS
 	materials = list(DEFAULT_WALL_MATERIAL = 15000, MATERIAL_GOLD = 10500, MATERIAL_SILVER = 10000)
 	build_path = /obj/item/mech_component/manipulators/combat
 	req_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 3)
 
 /datum/design/item/mechfab/exosuit/combat_legs
 	name = "Combat Exosuit Motivators"
-	time = 30 SECONDS
+	time = 90 SECONDS
 	materials = list(DEFAULT_WALL_MATERIAL = 15000, MATERIAL_GOLD = 10500, MATERIAL_SILVER = 10000)
 	build_path = /obj/item/mech_component/propulsion/combat
 	req_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 3)
@@ -93,111 +94,112 @@
 /datum/design/item/mechfab/exosuit/ripley_head
 	name = "Powerloader Sensors"
 	build_path = /obj/item/mech_component/sensors/ripley
-	time = 15 SECONDS
+	time = 45 SECONDS
 	materials = list(DEFAULT_WALL_MATERIAL = 3500)
 
 /datum/design/item/mechfab/exosuit/ripley_torso
 	name = "Powerloader Chassis"
 	build_path = /obj/item/mech_component/chassis/ripley
-	time = 35 SECONDS
+	time = 105 SECONDS
 	materials = list(DEFAULT_WALL_MATERIAL = 15000)
 
 /datum/design/item/mechfab/exosuit/ripley_arms
 	name = "Powerloader Manipulators"
 	build_path = /obj/item/mech_component/manipulators/ripley
-	time = 25 SECONDS
+	time = 75 SECONDS
 	materials = list(DEFAULT_WALL_MATERIAL = 4500)
 
 /datum/design/item/mechfab/exosuit/ripley_legs
 	name = "Powerloader Motivators"
 	build_path = /obj/item/mech_component/propulsion/ripley
-	time = 25 SECONDS
+	time = 75 SECONDS
 	materials = list(DEFAULT_WALL_MATERIAL = 4500)
 
 /datum/design/item/mechfab/exosuit/light_head
 	name = "Light Exosuit Sensors"
-	time = 20 SECONDS
-	materials = list(DEFAULT_WALL_MATERIAL = 6500)
+	time = 60 SECONDS
+	materials = list(MATERIAL_ALUMINIUM = 3500, DEFAULT_WALL_MATERIAL = 3000)
 	build_path = /obj/item/mech_component/sensors/light
 	req_tech = list(TECH_MATERIAL = 1)
 
 /datum/design/item/mechfab/exosuit/light_torso
 	name = "Light Exosuit Chassis"
-	time = 30 SECONDS
-	materials = list(DEFAULT_WALL_MATERIAL = 25000)
+	time = 90 SECONDS
+	materials = list(MATERIAL_ALUMINIUM = 15000, DEFAULT_WALL_MATERIAL = 10000)
 	build_path = /obj/item/mech_component/chassis/light
 	req_tech = list(TECH_MATERIAL = 1)
 
 /datum/design/item/mechfab/exosuit/light_arms
 	name = "Light Exosuit Manipulators"
-	time = 20 SECONDS
-	materials = list(DEFAULT_WALL_MATERIAL = 10000)
+	time = 60 SECONDS
+	materials = list(MATERIAL_ALUMINIUM = 6500, DEFAULT_WALL_MATERIAL = 3500)
 	build_path = /obj/item/mech_component/manipulators/light
 	req_tech = list(TECH_MATERIAL = 1)
 
 /datum/design/item/mechfab/exosuit/light_legs
 	name = "Light Exosuit Motivators"
-	time = 25 SECONDS
-	materials = list(DEFAULT_WALL_MATERIAL = 10000)
+	time = 75 SECONDS
+	materials = list(MATERIAL_ALUMINIUM = 6500, DEFAULT_WALL_MATERIAL = 3500)
 	build_path = /obj/item/mech_component/propulsion/light
 	req_tech = list(TECH_MATERIAL = 1)
 
 /datum/design/item/mechfab/exosuit/heavy_head
 	name = "Heavy Exosuit Sensors"
-	time = 35 SECONDS
+	time = 105 SECONDS
 	materials = list(DEFAULT_WALL_MATERIAL = 12000, MATERIAL_URANIUM = 7000, MATERIAL_SILVER = 7000, MATERIAL_GOLD = 7000)
 	build_path = /obj/item/mech_component/sensors/heavy
 	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 4)
 
 /datum/design/item/mechfab/exosuit/heavy_torso
 	name = "Heavy Exosuit Chassis"
-	time = 75 SECONDS
+	time = 225 SECONDS
 	materials = list(DEFAULT_WALL_MATERIAL = 70000, MATERIAL_URANIUM = 10000, MATERIAL_SILVER = 10000, MATERIAL_GOLD = 10000)
 	build_path = /obj/item/mech_component/chassis/heavy
 	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 4)
 
 /datum/design/item/mechfab/exosuit/heavy_arms
 	name = "Heavy Exosuit Manipulators"
-	time = 35 SECONDS
+	time = 105 SECONDS
 	materials = list(DEFAULT_WALL_MATERIAL = 20000, MATERIAL_URANIUM = 5000, MATERIAL_SILVER = 5000, MATERIAL_GOLD = 5000)
 	build_path = /obj/item/mech_component/manipulators/heavy
 	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 4)
 
 /datum/design/item/mechfab/exosuit/heavy_legs
 	name = "Heavy Exosuit Motivators"
-	time = 35 SECONDS
+	time = 105 SECONDS
 	materials = list(DEFAULT_WALL_MATERIAL = 20000, MATERIAL_URANIUM = 5000, MATERIAL_SILVER = 5000, MATERIAL_GOLD = 5000)
 	build_path = /obj/item/mech_component/propulsion/heavy
 	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 4)
 
 /datum/design/item/mechfab/exosuit/spider
 	name = "Quadruped Motivators"
-	time = 20 SECONDS
+	time = 60 SECONDS
 	materials = list(DEFAULT_WALL_MATERIAL = 12000)
 	build_path = /obj/item/mech_component/propulsion/spider
-	req_tech = list(TECH_ENGINEERING = 2)
 
 /datum/design/item/mechfab/exosuit/spider/heavy
 	name = "Industrial Quadruped Motivators"
-	time = 35 SECONDS
+	time = 105 SECONDS
 	materials = list(DEFAULT_WALL_MATERIAL = 25000)
 	build_path = /obj/item/mech_component/propulsion/spider/heavy
-	req_tech = list(TECH_ENGINEERING = 4)
 
 /datum/design/item/mechfab/exosuit/hover_legs
 	name = "Heavy Hoverthrusters"
-	time = 35 SECONDS
-	materials = list(DEFAULT_WALL_MATERIAL = 14000)
+	time = 105 SECONDS
+	// Significantly heavier armor than light hoverthrusters, gold, silver, and phoron are for the ion engines.
+	materials = list(DEFAULT_WALL_MATERIAL = 15000, MATERIAL_ALUMINIUM = 7500, MATERIAL_GOLD = 2500, MATERIAL_SILVER = 2500, MATERIAL_PHORON = 2500)
 	build_path = /obj/item/mech_component/propulsion/hover
 
 /datum/design/item/mechfab/exosuit/hover_legs/light
 	name = "Light Hoverthrusters"
-	time = 25 SECONDS
-	materials = list(DEFAULT_WALL_MATERIAL = 7500)
+	time = 75 SECONDS
+	// Harder to obtain materials than other leg types, though not unobtainable by any means. You can get them roundstart by partnering up with engineering.
+	// The cost is kind of intentionally set to discourage "Light hoverthruster meta", there is otherwise no actual reason to ever make anything else.
+	materials = list(MATERIAL_ALUMINIUM = 15000, MATERIAL_GOLD = 4500, MATERIAL_SILVER = 4500, MATERIAL_PHORON = 4500)
 	build_path = /obj/item/mech_component/propulsion/hover/light
 
 /datum/design/item/mechfab/exosuit/track
 	name = "Armored Treads"
-	time = 35 SECONDS
+	time = 105 SECONDS
 	materials = list(DEFAULT_WALL_MATERIAL = 25000)
 	build_path = /obj/item/mech_component/propulsion/tracks

--- a/html/changelogs/hellfirejag-mechfab_rebalance.yml
+++ b/html/changelogs/hellfirejag-mechfab_rebalance.yml
@@ -1,0 +1,7 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - balance: "Many mech recipes now require new materials such as Aluminium or Lead, and have had their build time tripled. Hoverthrusters of both kinds now require rare materials."
+  - balance: "Light hoverthrusters are somewhat less fragile (from 45 to 75 health), while their power consumption has been significantly increased. Heavy hoverthrusters also now draw more power."
+  - balance: "Most hardsuits now require new materials such as Aluminium or Lead."
+  - balance: "To help encourage more experimenting with mech parts, quad-legged mechs no longer require research to build."


### PR DESCRIPTION
This PR significantly rebalances the construction costs and times of the "Mech" side of the machine shop in order to break up the "Light mech hoverthruster meta" that has been severely prevalent. In general steel usage for many things is going down, in exchange for using aluminium by the same amount. Lead is being introduced as the material to use for "Anything that gives you radiation protection", and most hardsuits and some mech armors now call for its use. 

The biggest thing to be rebalanced are the Hoverthrusters. Imagine my surprise when I discover that not only were the hoverthrusters insanely cheap, they also had the lowest power draw of any mech chassis in the game, which meant that if you used them with the self-recharging power cells, you essentially had infinite power and full flight. Hoverthrusters of both kinds are being changed to require rare materials. So I significantly increased the power draw for hoverthrusters(For god's sake they let the mech fly at high speed, they're the exact opposite of low power). As a small concession, the health for the light thrusters is increased slightly. 

Finally, to help encourage more experimenting with lesser-used mech chassis, I removed the tech requirements for the quadruped chassis, allowing Machinists to experiment with trying out different, "Less ideal" mech designs. 