### PR TITLE
More Horizon area cleanups/polish

### DIFF
--- a/html/changelogs/bat-radshielding.yml
+++ b/html/changelogs/bat-radshielding.yml
@@ -10,8 +10,7 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - qol: "Radstorm shielding added to the following areas: ResDeck lifts,changing room, recovery ward, all AI rooms, self-destruct room, INDRA monitoring, SM monitoring, C-Goliath monitoring."
-  - balance: "Radstorm shielding removed from Gravity Generator."
+  - qol: "Radstorm shielding added to the following areas: ResDeck lifts,changing room, recovery ward, psych office, ALL washrooms, AI rooms, self-destruct room, INDRA monitoring, SM monitoring, C-Goliath monitoring."
   - qol: "In-game stairwell names clarified (I.E. the starboard-side stairwell updated from 'Stairwell' to 'Starboard Stairwell', etc.)"
   - qol: "Deck 1 recharging compartment renamed from 'Mech Bay' to 'Charge Bay'."
   - rscadd: "More areas given custom blurbs."

--- a/html/changelogs/bat-radshielding.yml
+++ b/html/changelogs/bat-radshielding.yml
@@ -1,0 +1,17 @@
+# Your name.
+author: Batrachophrenoboocosmomachia
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Radstorm shielding added to the following areas: ResDeck lifts,changing room, recovery ward, all AI rooms, self-destruct room, INDRA monitoring, SM monitoring, C-Goliath monitoring."
+  - balance: "Radstorm shielding removed from Gravity Generator."
+  - qol: "In-game stairwell names clarified (I.E. the starboard-side stairwell updated from 'Stairwell' to 'Starboard Stairwell', etc.)"
+  - qol: "Deck 1 recharging compartment renamed from 'Mech Bay' to 'Charge Bay'."
+  - rscadd: "More areas given custom blurbs."

--- a/html/changelogs/bat-radshielding.yml
+++ b/html/changelogs/bat-radshielding.yml
@@ -10,7 +10,7 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - qol: "Radstorm shielding added to the following areas: ResDeck lifts,changing room, recovery ward, psych office, ALL washrooms, AI rooms, self-destruct room, INDRA monitoring, SM monitoring, C-Goliath monitoring."
+  - qol: "Radstorm shielding added to the following areas: ResDeck lifts, changing room, recovery ward, psych office, ALL washrooms, AI rooms, self-destruct room, INDRA monitoring, SM monitoring, C-Goliath monitoring."
   - qol: "In-game stairwell names clarified (I.E. the starboard-side stairwell updated from 'Stairwell' to 'Starboard Stairwell', etc.)"
   - qol: "Deck 1 recharging compartment renamed from 'Mech Bay' to 'Charge Bay'."
-  - rscadd: "More areas given custom blurbs."
+  - rscadd: "More areas given custom blurbs (cheers to Stripes for the Commissary blurb!)"

--- a/maps/sccv_horizon/areas/horizon_areas_ai.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_ai.dm
@@ -13,6 +13,7 @@
 	ambience = AMBIENCE_AI
 	horizon_deck = 3
 	department = LOC_AI
+	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_HIDE_FROM_HOLOMAP
 	area_blurb = "Ticking, beeping, and buzzing. Great tides of invisible signal traffic across the electromagnetic spectrum, flowing in both directions. Otherwise, the silence and stillness of a tomb."
 
 /area/horizon/ai/chamber

--- a/maps/sccv_horizon/areas/horizon_areas_command.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_command.dm
@@ -92,6 +92,7 @@
 	name = "Command Bunker"
 	icon_state = "ai_foyer"
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_HIDE_FROM_HOLOMAP
+	area_blurb = "Heavily armored and internal, the Combat Information Center is the secondary nerve center of the ship; the responsibility of the place weighs heavily."
 
 /area/horizon/command/bridge/meeting_room
 	name = "Bridge Conference Room"
@@ -121,11 +122,12 @@
 /area/horizon/command/bridge/selfdestruct
 	name = "Authentication Terminal Safe"
 	icon_state = "bridge"
-	area_flags = AREA_FLAG_HIDE_FROM_HOLOMAP
+	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_HIDE_FROM_HOLOMAP
+	area_blurb = "The air veritably throbs with doom."
 
 /area/horizon/command/bridge/controlroom
 	name = "Bridge Control Room"
-	area_blurb = "The full expanse of space lies beyond a thick pane of reinforced glass, all that protects you from a cold and painful death. The computers hum, showing various displays and holographic signs. The sight would be overwhelming if you are not used to such an environment. Even at full power, the sensors fail to map even a fraction of the dots of light making up the cosmic filament."
+	area_blurb = "The full expanse of space lies beyond a thick pane of reinforced glass, all that protects you from a cold and painful death. The computers hum, showing various displays and holographic signs. The sight would be overwhelming to one unused to such an environment. Even at full power, the sensors fail to map even a fraction of the dots of light making up the cosmic filament."
 	area_blurb_category = "bridge"
 	area_flags = AREA_FLAG_RAD_SHIELDED
 

--- a/maps/sccv_horizon/areas/horizon_areas_crew.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_crew.dm
@@ -240,9 +240,11 @@
 	horizon_deck = 1
 	area_blurb = "A discrete compartment frequented by the ship's many synthetics and IPCs."
 
+// Rad shielded because common afk area.
 /area/horizon/crew/washroom
 	name = "Horizon - Washroom (PARENT AREA - DON'T USE)"
 	icon_state = "washroom"
+	area_flags = AREA_FLAG_RAD_SHIELDED
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 
 /area/horizon/crew/washroom/deck_2

--- a/maps/sccv_horizon/areas/horizon_areas_crew.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_crew.dm
@@ -95,15 +95,15 @@
 	location_ew = LOC_STARBOARD
 
 /area/horizon/stairwell/starboard/deck_1
-	name = "Stairwell"
+	name = "Starboard Stairwell"
 	horizon_deck = 1
 
 /area/horizon/stairwell/starboard/deck_2
-	name = "Stairwell"
+	name = "Starboard Stairwell"
 	horizon_deck = 2
 
 /area/horizon/stairwell/starboard/deck_3
-	name = "Stairwell"
+	name = "Starboard Stairwell"
 	horizon_deck = 3
 
 // Starboard Stairwell (Security/Cafe)
@@ -112,11 +112,11 @@
 	location_ew = LOC_PORT
 
 /area/horizon/stairwell/port/deck_2
-	name = "Stairwell"
+	name = "Port Stairwell"
 	horizon_deck = 2
 
 /area/horizon/stairwell/port/deck_3
-	name = "Stairwell"
+	name = "Port Stairwell"
 	horizon_deck = 3
 
 // Bridge Stairwell (Captain/Kitchen/Hydro)
@@ -129,11 +129,11 @@
 	location_ns = LOC_FORE_FAR
 
 /area/horizon/stairwell/bridge/deck_2
-	name = "Stairwell"
+	name = "Bridge Stairwell"
 	horizon_deck = 2
 
 /area/horizon/stairwell/bridge/deck_3
-	name = "Stairwell"
+	name = "Bridge Stairwell"
 	horizon_deck = 3
 
 // Engineering Stairwell (Engineering/Atmos)
@@ -145,12 +145,12 @@
 	location_ns = LOC_AFT
 
 /area/horizon/stairwell/engineering/deck_1
-	name = "Stairwell"
+	name = "Engineering Stairwell"
 	horizon_deck = 1
 	area_blurb = "The exterior stowage tanks are visible from the window, hunched like patient stones."
 
 /area/horizon/stairwell/engineering/deck_2
-	name = "Stairwell"
+	name = "Engineering Stairwell"
 	horizon_deck = 2
 	area_blurb = "Filled with the sounds of machinery and an atmosphere of meaningful, directed purpose."
 
@@ -168,8 +168,10 @@
 /area/horizon/crew/resdeck/living_quarters_lift
 	name = "Living Quarters Lift"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
+	area_flags = AREA_FLAG_RAD_SHIELDED
 	horizon_deck = 1
 	subdepartment = SUBLOC_RESDECK
+	area_blurb = "This compartment is a primary access point between the Operations Decks and the Residential Decks of the SCCV Horizon."
 
 /// Fitness Center (legacy)
 /area/horizon/crew/fitness
@@ -180,15 +182,19 @@
 /area/horizon/crew/fitness/gym
 	name = "Gym"
 	icon_state = "fitness_gym"
+	area_blurb = "It smells like sweat and sterilizing agents. Get pumped!"
 
+// This area contains the Cryo pods. Spawn area = rad shielding.
 /area/horizon/crew/fitness/changing
 	name = "Changing Room"
+	area_flags = AREA_FLAG_RAD_SHIELDED
 	icon_state = "fitness_changingroom"
 
 /area/horizon/crew/fitness/showers
 	name = "Showers"
 	icon_state = "showers"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
+	area_blurb = "Kept cleaner than most communal showers on ResDeck 3."
 
 /// Representative and Consular offices.
 // Yeah yeah I know, they're technically not 'Crew,' but they're also not Command...
@@ -229,9 +235,10 @@
 	horizon_deck = 3
 
 /area/horizon/crew/chargebay
-	name = "Mech Bay"
+	name = "Charge Bay"
 	icon_state = "mechbay"
 	horizon_deck = 1
+	area_blurb = "A discrete compartment frequented by the ship's many synthetics and IPCs."
 
 /area/horizon/crew/washroom
 	name = "Horizon - Washroom (PARENT AREA - DON'T USE)"

--- a/maps/sccv_horizon/areas/horizon_areas_engineering.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_engineering.dm
@@ -41,6 +41,7 @@
 	name = "Gravity Generator"
 	icon_state = "engine"
 	horizon_deck = 1
+	area_flags = AREA_FLAG_RAD_SHIELDED
 	area_blurb = "The air in here tastes like copper, sour sugar, and smoke; none of the angles seem right. That probably means everything is working."
 	area_blurb_category = "engi_breakroom"
 

--- a/maps/sccv_horizon/areas/horizon_areas_engineering.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_engineering.dm
@@ -41,7 +41,6 @@
 	name = "Gravity Generator"
 	icon_state = "engine"
 	horizon_deck = 1
-	area_flags = AREA_FLAG_RAD_SHIELDED
 	area_blurb = "The air in here tastes like copper, sour sugar, and smoke; none of the angles seem right. That probably means everything is working."
 	area_blurb_category = "engi_breakroom"
 
@@ -69,6 +68,7 @@
 
 /area/horizon/engineering/bluespace_drive/monitoring
 	name = "Bluespace Drive Monitoring"
+	area_flags = AREA_FLAG_RAD_SHIELDED
 	icon_state = "engineering"
 	horizon_deck = 1
 
@@ -170,6 +170,7 @@
 /area/horizon/engineering/reactor/supermatter/monitoring
 	name = "Supermatter Reactor Monitoring"
 	icon_state = "engine_monitoring"
+	area_flags = AREA_FLAG_RAD_SHIELDED
 	area_blurb = "This compartment provides a fairly convincing illusion of safety and control."
 
 /area/horizon/engineering/reactor/supermatter/waste
@@ -195,6 +196,7 @@
 /area/horizon/engineering/reactor/indra/monitoring
 	name = "INDRA Reactor Monitoring"
 	icon_state = "engine_monitoring"
+	area_flags = AREA_FLAG_RAD_SHIELDED
 	area_blurb = "Where atoms are consigned to be smashed and the pretty lights beheld."
 
 /area/horizon/engineering/reactor/indra/office

--- a/maps/sccv_horizon/areas/horizon_areas_medical.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_medical.dm
@@ -69,8 +69,10 @@
 	icon_state = "exam_room"
 	horizon_deck = 2
 
+// Contains a player spawn area = rad-shielded
 /area/horizon/medical/ward
 	name = "Recovery Ward"
+	area_flags = AREA_FLAG_RAD_SHIELDED
 	icon_state = "patients"
 	horizon_deck = 3
 

--- a/maps/sccv_horizon/areas/horizon_areas_medical.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_medical.dm
@@ -110,6 +110,7 @@
 /area/horizon/medical/washroom
 	name = "Washroom"
 	horizon_deck = 3
+	area_flags = AREA_FLAG_RAD_SHIELDED
 
 /area/horizon/medical/hallway
 	name = "Atrium"

--- a/maps/sccv_horizon/areas/horizon_areas_medical.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_medical.dm
@@ -6,8 +6,6 @@
 	area_blurb_category = "mecical"
 	department = LOC_MEDICAL
 
-//Medbay is a large area, these additional areas help level out APC load.
-
 /area/horizon/medical/paramedic
 	name = "Paramedic Equipment Storage"
 	icon_state = "medbay"
@@ -47,7 +45,6 @@
 	name = "Intensive Care Unit"
 	icon_state = "cryo"
 	area_blurb = "The sounds of pumps and cooling equipment can be heard within the room."
-	area_blurb_category = "icu"
 	horizon_deck = 2
 
 /area/horizon/medical/main_storage

--- a/maps/sccv_horizon/areas/horizon_areas_medical.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_medical.dm
@@ -19,9 +19,11 @@
 	ambience = list('sound/ambience/signal.ogg')
 	horizon_deck = 2
 
+// Rad-shielded because its annoying as fuck
 /area/horizon/medical/psych
 	name = "Psych Office"
 	icon_state = "medbay3"
+	area_flags = AREA_FLAG_RAD_SHIELDED
 	area_blurb = "Featuring wood floors and soft carpets, this room has a warmer feeling compared to the sterility of the rest of the medical department."
 	area_blurb_category = "psych"
 	horizon_deck = 2

--- a/maps/sccv_horizon/areas/horizon_areas_operations.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_operations.dm
@@ -5,7 +5,7 @@
 	ambience = AMBIENCE_ENGINEERING
 	holomap_color = HOLOMAP_AREACOLOR_OPERATIONS
 	department = LOC_OPERATIONS
-	area_blurb = "While mighty Cargonia may never reign supreme, the halls of Operations ever resound with the clamor of pallets and materiel and rustling paper."
+	area_blurb = "The halls of Operations ever resound with the clamor of pallets and materiel and rustling paper."
 
 /area/horizon/operations/warehouse
 	name = "Warehouse"
@@ -54,6 +54,7 @@
 /area/horizon/operations/commissary
 	name = "Commissary"
 	horizon_deck = 2
+	area_blurb = "Even here, all the way out into the depths of space, retail work is found. The commissary room is eerily bare when not run— with empty shelves being such a rarity in the 25th century for most worlds, seeing them here is almost unnatural. Where are your treats?"
 
 /area/horizon/operations/secure_ammunition_storage
 	name = "Secure Ammunitions Storage"

--- a/maps/sccv_horizon/areas/horizon_areas_operations.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_operations.dm
@@ -5,7 +5,7 @@
 	ambience = AMBIENCE_ENGINEERING
 	holomap_color = HOLOMAP_AREACOLOR_OPERATIONS
 	department = LOC_OPERATIONS
-	area_blurb = "While mighty 'Cargonia' may never reign like in the feverish dreams of so many hangar techs, the halls of Operations today continue to resound with the clamor of pallets and materiel and rustling paper."
+	area_blurb = "While mighty Cargonia may never reign supreme, the halls of Operations ever resound with the clamor of pallets and materiel and rustling paper."
 
 /area/horizon/operations/warehouse
 	name = "Warehouse"
@@ -61,6 +61,7 @@
 	ambience = AMBIENCE_FOREBODING
 	holomap_color = HOLOMAP_AREACOLOR_OPERATIONS
 	horizon_deck = 2
+	area_blurb = "Armor-piercing, bunker-busting, high-explosive... Don't sneeze!"
 
 /// OPERATIONS_AREAS - HANGAR_AREAS
 /area/horizon/hangar
@@ -106,7 +107,7 @@
 /area/horizon/operations/machinist/surgicalbay
 	name = "Machinist Surgical Bay"
 	icon_state = "machinist_workshop"
-	area_blurb = "The scent of sterilized equipment fill the air in this surgical bay."
+	area_blurb = "Back in the workshop's surgical bay, the sharp-edged odor of sterilized equipment predominates."
 	area_blurb_category = "robotics"
 	horizon_deck = 2
 
@@ -116,7 +117,7 @@
 	icon_state = "outpost_mine_main"
 	ambience = AMBIENCE_EXPOUTPOST
 	subdepartment = SUBLOC_MINING
-	area_blurb = "Even louder and noisier and rowdier than the rest of Operations, which is saying something."
+	area_blurb = "Even louder and noisier and rowdier than the rest of Operations, which is really saying something."
 
 /area/horizon/operations/mining_main/eva
 	name = "Mining EVA Storage"

--- a/maps/sccv_horizon/areas/horizon_areas_security.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_security.dm
@@ -30,6 +30,7 @@
 	name = "Washroom"
 	icon_state = "security"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
+	area_flags = AREA_FLAG_RAD_SHIELDED
 	horizon_deck = 2
 
 /area/horizon/security/brig

--- a/maps/sccv_horizon/areas/horizon_areas_service.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_service.dm
@@ -52,12 +52,11 @@
 	name = "Bar"
 	icon_state = "bar"
 	horizon_deck = 2
-	area_blurb = "A place whose atmosphere morphs with every shift to the tastes of the presiding bartenders. If bulkhead walls could talk."
+	area_blurb = "The Horizon's signature watering hole. The ever-rotating roster of bartenders and mixers enforces no certainties here. If bulkhead walls could talk."
 
 /area/horizon/service/bar/backroom
 	name = "Bar - Backroom"
 	area_flags = AREA_FLAG_RAD_SHIELDED
-	area_blurb = "A place whose atmosphere morphs with every shift to the tastes of the presiding bartenders. If bulkhead walls could talk, times three back here."
 
 // Dining Hall
 /area/horizon/service/dining_hall


### PR DESCRIPTION
More area tuning following the refactor/remap of all Horizon's areas. Primary change is expansion of rad shielding (protection from storms only):
- All areas which contain a player spawning area (resdecks, changing room [cryo], recovery ward [cryo] are now rad shielded.
- Washrooms, because they're used for AFK, have all been rad shielded.
- CIC was already rad shielded, so expanded that to the rest of that sector (AI areas and scuttling device) for logic's sake.
- The 'monitoring rooms' for the various high-energy appliances on the ship (reactors and BS drive) for logic's sake- they're where you hunker down to be protected from rads, so it stands to reason they're rad shielded.

changes:
  - qol: "Radstorm shielding added to the following areas: ResDeck lifts, changing room, recovery ward, psych office, ALL washrooms, AI rooms, self-destruct room, INDRA monitoring, SM monitoring, C-Goliath monitoring."
  - qol: "In-game stairwell names clarified (I.E. the starboard-side stairwell updated from 'Stairwell' to 'Starboard Stairwell', etc.)"
  - qol: "Deck 1 recharging compartment renamed from 'Mech Bay' to 'Charge Bay'."
  - rscadd: "More areas given custom blurbs (cheers to Stripes for the Commissary blurb!)"