### PR TITLE
Nightshade injectors now cost TC

### DIFF
--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -61,7 +61,7 @@
 
 /datum/uplink_item/item/medical/berserk_injectors
 	name = "Box of Berserk Injectors"
-	telecrystal_cost = 3
+	telecrystal_cost = 4
 	path = /obj/item/storage/box/syndie_kit/berserk_injectors
 	desc = "Comes with 2x autoinjectors filled with Red Nightshade - used to induce a berserk state lasting ~2.5 minutes per injector. You cannot use advanced tools (guns/computer consoles/etc.) while berserk. Using both injectors will increase time berserk, but will lead to liver failure."
 

--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -61,7 +61,7 @@
 
 /datum/uplink_item/item/medical/berserk_injectors
 	name = "Box of Berserk Injectors"
-	bluecrystal_cost = 4
+	telecrystal_cost = 3
 	path = /obj/item/storage/box/syndie_kit/berserk_injectors
 	desc = "Comes with 2x autoinjectors filled with Red Nightshade - used to induce a berserk state lasting ~2.5 minutes per injector. You cannot use advanced tools (guns/computer consoles/etc.) while berserk. Using both injectors will increase time berserk, but will lead to liver failure."
 

--- a/html/changelogs/nightshade-tc.yml
+++ b/html/changelogs/nightshade-tc.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: UltraBigRat
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Changes berserk injector cost from 4 BC to 3 TC."


### PR DESCRIPTION
* Berserk injector cost changes from 4 bluecrystals to 3 telecrystals.
Bluecrystals tend to be for defensive, support, utility or roleplay items. Red Nightshade is for the most part a combat item. So this changes its cost to be in TC, slightly lowering it to match the higher value currency being used, since it is in the end also still a limited use item that damages your organs.
