### PR TITLE
Gun Sound Reminder

### DIFF
--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -1,12 +1,12 @@
 /* A reminder for all new additions:
 Gun reload sounds under insert_sound have different kinds of usable sounds, depending on the gun and material of the gun. The actual reload sound is tied to the magazine, because of how the game handles guns.
 There are the following options (to be found under code/game/sound):
-metal_slide_reload - for all pistols or SMGs that have a metal slide.
-polymer_slide_reload - for all pistols or SMGs that are mostly made out of polymer material.
-rifle_slide_reload - for all bigger magazine-fed rifle type weapons that rack a charging handle after reloading.
-revolver_reload - for guns that have a drum you reload bullet by bullet and can be spun.
-shotgun_reload - for all tube-fed guns that are reloaded shell by shell.
-heavy_machine_gun_reload - for all heavy duty guns, that rack a charging handle when reloaded and/or have multi stage reloads.
+"metal_slide_reload" - for all pistols or SMGs that have a metal slide.
+"polymer_slide_reload" - for all pistols or SMGs that are mostly made out of polymer material.
+"rifle_slide_reload" - for all bigger magazine-fed rifle type weapons that rack a charging handle after reloading.
+"revolver_reload" - for guns that have a drum you reload bullet by bullet and can be spun.
+"shotgun_reload" - for all tube-fed guns that are reloaded shell by shell.
+"heavy_machine_gun_reload" - for all heavy duty guns, that rack a charging handle when reloaded and/or have multi stage reloads.
 
 If nothing is chosen, reload sounds revert to the default, which is metal_slide_reload.*/
 

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -1,3 +1,15 @@
+/* A reminder for all new additions:
+Gun reload sounds under insert_sound have different kinds of usable sounds, depending on the gun and material of the gun. The actual reload sound is tied to the magazine, because of how the game handles guns.
+There are the following options (to be found under code/game/sound):
+metal_slide_reload - for all pistols or SMGs that have a metal slide.
+polymer_slide_reload - for all pistols or SMGs that are mostly made out of polymer material.
+rifle_slide_reload - for all bigger magazine-fed rifle type weapons that rack a charging handle after reloading.
+revolver_reload - for guns that have a drum you reload bullet by bullet and can be spun.
+shotgun_reload - for all tube-fed guns that are reloaded shell by shell.
+heavy_machine_gun_reload - for all heavy duty guns, that rack a charging handle when reloaded and/or have multi stage reloads.
+
+If nothing is chosen, reload sounds revert to the default, which is metal_slide_reload.*/
+
 // Revolvos //
 /obj/item/ammo_magazine/a357
 	name = "speed loader (.357)"

--- a/html/changelogs/KingOfThePing - larp_reminder.yml
+++ b/html/changelogs/KingOfThePing - larp_reminder.yml
@@ -1,0 +1,6 @@
+author: KingOfThePing
+
+delete-after: True
+
+changes:
+  - rscadd: "Added a reminder header to the gun reload sounds .dm to remind people that there are a variety of sounds available."


### PR DESCRIPTION
## About PR

In preparation for more new gun sounds, this PR simply adds a header to the boxes.dm, which handles reload sounds for all types of guns to remind contributors about the existence of the different types of sounds and when they could/should be used.
The way the game handles reloads the sounds are tied to the magazines. While testing something completely unrelated I noticed that a lot guns recently added use the standard reload sound, instead of a maybe more appropriate one. 

No player facing changes.
