### PR TITLE
Re-Introduction of Engineering Alt-Titles

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -86,6 +86,7 @@
 	supervisors = "the chief engineer"
 	selection_color = "#c67519"
 	economic_modifier = 5
+	alt_titles = list("Reactor Technician", "Maintenance Technician", "Shipboard Systems Engineer")
 
 	minimum_character_age = list(
 		SPECIES_HUMAN = 25,
@@ -160,6 +161,7 @@
 	supervisors = "the chief engineer"
 	selection_color = "#c67519"
 	economic_modifier = 5
+	alt_titles = list("Life Support Engineer", "Enviromental Systems Technician")
 
 	minimum_character_age = list(
 		SPECIES_HUMAN = 25,

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -283,7 +283,7 @@
 		var/list/choices = pref.GetValidTitles(job)
 		if(!LAZYLEN(choices))
 			return ..()// should never happen
-		var/choice = input("Choose a title for [job.title].", "Choose Title", pref.GetPlayerAltTitle(job)) as anything in choices|null
+		var/choice = input("Choose a title for [job.title]. Be aware that choosing an alternative title does not absolve you from the job's regular duties!", "Choose Title", pref.GetPlayerAltTitle(job)) as anything in choices|null
 		if(choice && CanUseTopic(user))
 			SetPlayerAltTitle(job, choice)
 			return TOPIC_REFRESH_UPDATE_PREVIEW


### PR DESCRIPTION
## About PR

This PR re-introduces alt-titles for the engineering department. Longer players may remember that a few years ago, many alt-titles were slashed because they created wrong OOC expectations. This PR aims to re-introduce these alt-titles while putting safety mechanism in place to prevent these wrong expecations.
First safety is a warning whenever someone selects (any) alt-title:
> <img width="297" height="111" alt="Screenshot 2025-08-14 201217" src="https://github.com/user-attachments/assets/7aa68c2f-3c24-474e-bbf6-08e23cff689c" />

Here you can see the alt-titles in question:
> <img width="769" height="30" alt="image" src="https://github.com/user-attachments/assets/deddc2b0-d7e7-401b-962a-1b1700d2658c" />
> <img width="634" height="44" alt="image" src="https://github.com/user-attachments/assets/7f0c1091-1171-4741-876f-e7b68b4fc5d3" />


Second safety will be a big red warning, similarly worded on the job guides (where applicable). Think of it similar with the warnings regarding origins and naming conventions.

The alt-titles I put in are not set in stone. I am expecting a maintainer discussion label of shame as well. Regardless a feedback thread has been created on the forums:
