### PR TITLE
Fixes mobs ignoring their speed value

### DIFF
--- a/code/controllers/subsystems/movement/movement_types.dm
+++ b/code/controllers/subsystems/movement/movement_types.dm
@@ -45,6 +45,7 @@
 	if(istype(moving, /mob/living/simple_animal))
 		var/mob/living/simple_animal/moving_sa = moving
 		if(!moving_sa.speed)
+			moving_sa.speed = 5
 			delay = 5
 	src.delay = max(delay, world.tick_lag) //Please...
 	src.lifetime = timeout

--- a/code/controllers/subsystems/movement/movement_types.dm
+++ b/code/controllers/subsystems/movement/movement_types.dm
@@ -44,9 +44,7 @@
 	// Handle issue of delay 0 being passed for simplemobs.
 	if(istype(moving, /mob/living/simple_animal))
 		var/mob/living/simple_animal/moving_sa = moving
-		if(!delay && moving_sa.seek_speed)
-			delay = moving_sa.seek_speed
-		else
+		if(!moving_sa.speed)
 			delay = 5
 	src.delay = max(delay, world.tick_lag) //Please...
 	src.lifetime = timeout

--- a/html/changelogs/kano-dot-speed-fix.yml
+++ b/html/changelogs/kano-dot-speed-fix.yml
@@ -1,0 +1,6 @@
+author: Kano
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed mobs ignoring their speed value."


### PR DESCRIPTION
## About PR

the `delay` value in use here gets assigned with mob's `speed` var (I am positive on this, though movement code is a relic I can't fully comprehend). If the mob calling this proc had an initial delay value, this check used to ignore it and assigned a fix number. This PR makes it so if `speed` is null or 0, then they're assigned with the fix number.
