### PR TITLE
Gives hardsuits to group loadouts that were missing them.

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/gear_loadout.dm
+++ b/code/game/objects/structures/crates_lockers/crates/gear_loadout.dm
@@ -178,7 +178,7 @@
 	new /obj/item/clothing/under/rank/sol/marine(src)
 	new /obj/item/clothing/under/rank/sol/marine(src)
 	new /obj/item/clothing/under/rank/sol/marine(src)
-	new /obj/item/rig/military(src)
+	new /obj/item/rig/military/fsf(src) // This is the balanced equipped version, the main one has a pulse rifle for some reason?
 	new /obj/item/clothing/head/helmet/space/void/sol(src)
 	new /obj/item/clothing/head/helmet/space/void/sol(src)
 	new /obj/item/clothing/head/helmet/space/void/sol(src)
@@ -580,6 +580,7 @@
 	new/obj/item/clothing/under/unathi/izweski(src)
 	new/obj/item/clothing/under/unathi/izweski(src)
 	new/obj/item/clothing/under/unathi/izweski/officer(src)
+	new /obj/item/rig/unathi/fancy/equipped(src) // Knights get this so why not they?
 	new /obj/item/clothing/head/helmet/space/void/hegemony(src)
 	new /obj/item/clothing/head/helmet/space/void/hegemony(src)
 	new /obj/item/clothing/head/helmet/space/void/hegemony(src)
@@ -693,6 +694,7 @@
 	new /obj/item/clothing/under/unathi(src)
 	new /obj/item/clothing/under/unathi(src)
 	new /obj/item/clothing/under/unathi(src)
+	new /obj/item/rig/merc(src) // Courtesy of Hammertail
 	new /obj/item/clothing/head/helmet/space/void/unathi_pirate(src)
 	new /obj/item/clothing/suit/space/void/unathi_pirate(src)
 	new /obj/item/clothing/head/helmet/space/void/unathi_pirate(src)
@@ -845,6 +847,7 @@
 		new /obj/item/gun/projectile/automatic/rifle/sts35(src)
 		new /obj/item/ammo_magazine/c762(src)
 	new /obj/item/storage/box/species_modkit(src) //species modkits for switching on the fly
+	new /obj/item/rig/merc(src) // Im pretty sure they invented this thing.
 
 /obj/structure/closet/crate/secure/gear_loadout/hammertail/single/fill()
 	new /obj/item/clothing/under/syndicate/hammertail(src) //1 outfit
@@ -909,7 +912,7 @@
 	new /obj/item/clothing/head/helmet/space/void/kala(src)
 	new /obj/item/clothing/shoes/jackboots/kala(src)
 
-/obj/structure/closet/crate/secure/gear_loadout/imperial_army/fill()
+/obj/structure/closet/crate/secure/gear_loadout/imperial_army/fill() // Was told the Jinxiang is only for the marines, so no rig
 	new /obj/item/gun/projectile/automatic/rifle/dominia(src)
 	new /obj/item/ammo_magazine/a556(src)
 	new /obj/item/ammo_magazine/a556(src)
@@ -977,6 +980,7 @@
 	new /obj/item/clothing/shoes/jackboots/toeless(src)
 	new /obj/item/clothing/shoes/jackboots/toeless(src)
 	new /obj/item/clothing/shoes/jackboots/toeless(src)
+	new /obj/item/rig/combat/legionnaire/equipped(src)
 	new /obj/item/clothing/gloves/tcaf(src)
 	new /obj/item/clothing/gloves/tcaf(src)
 	new /obj/item/clothing/gloves/tcaf(src)

--- a/html/changelogs/loadouthardsuits.yml
+++ b/html/changelogs/loadouthardsuits.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: UltraBigRat
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Gave faction hardsuits to group gear loadouts that were missing them."
+  - balance: "Solarian loadout hardsuit now gets modules like the others."


### PR DESCRIPTION
* Alot of newer group loadouts were missing their factions hardsuit, despite that being the standard for most of them, so this gives those to the faction loadouts that had appropriate ones. 
* Also gave the Solarian hardsuit loadout a version with modules since it was an empty version unlike the other hardsuits previously. Used the fsf module set for that since their regular equipped version had a pulse rifle module for some reason, suit itself should still be the same.