### PR TITLE
Severely nerfs binoculars in viewsize and time to use.

### DIFF
--- a/code/controllers/subsystems/persistence.dm
+++ b/code/controllers/subsystems/persistence.dm
@@ -28,7 +28,7 @@ SUBSYSTEM_DEF(persistence)
 
 			// Retrieve all persistent data that is not expired
 			var/list/persistent_data = database_get_active_entries()
-			log_subsystem_persistence("Init: Retrieved [persistent_data.len] entries for instancing this round.")
+v			log_subsystem_persistence("Init: Retrieved [persistent_data.len] entries for instancing this round.")
 
 			// Instantiate all remaining entries based of their type
 			// Assign persistence related vars found in /obj, apply content and add to live tracking list.

--- a/code/datums/callback.dm
+++ b/code/datums/callback.dm
@@ -155,7 +155,7 @@
 	// 	return WrapAdminProcCall(object, delegate, calling_arguments)
 	if (object == GLOBAL_PROC)
 		return call(delegate)(arglist(calling_arguments))
-	return call(object, delegate)(arglist(calling_arguments))
+ 	return call(object, delegate)(arglist(calling_arguments))
 
 /**
 	Helper datum for the select callbacks proc

--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -13,14 +13,16 @@
 	throw_range = 15
 	throw_speed = 3
 
-	var/tileoffset = 14
+	var/tileoffset = 7
 	var/viewsize = 7
 
 /obj/item/device/binoculars/attack_self(mob/user)
-	zoom(user,tileoffset,viewsize, show_zoom_message = FALSE)
+	if(do_after(user, 1.5 SECONDS))
+		user.visible_message(SPAN_NOTICE("[user] looks into the binoculars."), SPAN_NOTICE("You look through the binoculars."))
+		zoom(user, tileoffset, viewsize, show_zoom_message = FALSE)
 
 /obj/item/device/binoculars/high_power
 	name = "high power binoculars"
 	desc = "A pair of high power binoculars."
 	icon_state = "binoculars_high"
-	tileoffset = 14*3
+	tileoffset = 8

--- a/html/changelogs/mattatlas-binodeath.yml
+++ b/html/changelogs/mattatlas-binodeath.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Binoculars have been severely nerfed in view offset."
+  - balance: "Binoculars now have a 1.5 second windup."


### PR DESCRIPTION
Binoculars are an excessively centralizing item that has essentially zero downsides (!) while giving you near omniscience of three screens' worth of information. This is particularly broken when used in the hands of ship crew, who have access to up to 3 at roundstart (including warehouse spawns).

They are now far less strong.