### PR TITLE
Red nightshade nerfs.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -170,9 +170,9 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /obj/item/proc/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)
 	var/power = force
 	if((user.mutations & HULK))
-		power *= 2
+		power *= 1.25
 	if(user.is_berserk())
-		power *= 1.5
+		power *= 1.1
 	if(ishuman(user))
 		var/mob/living/carbon/human/X = user
 		if(ishuman(target))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -502,8 +502,6 @@
 /mob/living/carbon/proc/can_feel_pain()
 	if (species && (species.flags & NO_PAIN))
 		return FALSE
-	if (is_berserk())
-		return FALSE
 	if ((mutations & HULK))
 		return FALSE
 	if (analgesic > 100)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -818,6 +818,7 @@
 		H.berserk_process()
 	M.make_jittery(20)
 	M.add_chemical_effect(CE_BERSERK, 1)
+	M.add_up_to_chemical_effect(CE_PAINKILLER, 60)
 	if(M.a_intent != I_HURT)
 		M.a_intent_change(I_HURT)
 	if(prob(3))

--- a/html/changelogs/mattatlas-longoverdue.yml
+++ b/html/changelogs/mattatlas-longoverdue.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Red Nightshade no longer totally negates all pain. It now applies a grace period of 60 pain."
+  - balance: "Red Nightshade no longer multiplies all melee damage by 1.25x. The multiplier has been reduced to 1.1x."


### PR DESCRIPTION
Red nightshade is an overly centralizing traitor/merc item because of its practically zero downsides when compares to its massive benefits, such as complete pain immunity and a whopping 1.25x damage multiplier on all melee damage (for comparison, on an energy sword that's 42 damage total, with 25 AP, meaning that its hits will penetrate EVERY armour in the game). This makes melee not only insanely strong but basically riskless in most situations, especially when combined with the esword's parry mechanic.

Red nightshade's pain immunity has been removed in favour of a painkiller effect of 75, more than mortaphenyl. The melee damage multiplier has been reduced to a more sensical 1.1x.

