### PR TITLE
Nerfs Door Rigged Mines

### DIFF
--- a/code/game/objects/items/weapons/landmines.dm
+++ b/code/game/objects/items/weapons/landmines.dm
@@ -219,7 +219,7 @@
  */
 /obj/item/landmine/frag/door_rigging
 	name = "door rigging landmine"
-	fragment_damage = 20
+	fragment_damage = 10
 
 	///The airlock that we are observing for when it opens, to explode
 	var/obj/machinery/door/airlock/door_rigged

--- a/code/modules/background/accent/human.dm
+++ b/code/modules/background/accent/human.dm
@@ -453,6 +453,6 @@
 
 /datum/accent/zhurong
 	name = ACCENT_DOMINIA_ZHURONG
-	description = "Zhurongese is a dialect of Vulgar Morozi found on the Core World of Zhurong, where it is spoken by the Secondaries who make up most of the skilled workers and supervisors who live there. While it mostly sticks to traditional Vulgar Morozi structures, its origin on one of the oldest colonies in the Empire and Zhurong itself being a more restricted world has led to this dialect being less influenced by the broader Spur. Scholars believe this dialect may be closer to pre-Imperial Vulgar Morozi than any other in the Empire."
+	description = "Zhurongese is a dialect of Vulgar Morozi found on the Core World of Zhurong, where it is spoken by the Secondaries who make up most of the planet’s skilled workers and supervisors. While it mostly sticks to traditional Vulgar Morozi structures, its origin on one of the Empire’s oldest colonies and Zhurong itself being a more restricted world has led to this dialect being less influenced by the broader Spur. Scholars believe this dialect may be closer to pre-Imperial Vulgar Morozi than any other in the Empire."
 	tag_icon = "zhurong"
 	text_tag = "ZHU"

--- a/code/modules/background/accent/human.dm
+++ b/code/modules/background/accent/human.dm
@@ -453,6 +453,6 @@
 
 /datum/accent/zhurong
 	name = ACCENT_DOMINIA_ZHURONG
-	description = "Zhurongese is a dialect of Vulgar Morozi found on the Core World of Zhurong, where it is spoken by the Secondaries who make up most of the planet’s skilled workers and supervisors. While it mostly sticks to traditional Vulgar Morozi structures, its origin on one of the Empire’s oldest colonies and Zhurong itself being a more restricted world has led to this dialect being less influenced by the broader Spur. Scholars believe this dialect may be closer to pre-Imperial Vulgar Morozi than any other in the Empire."
+	description = "Zhurongese is a dialect of Vulgar Morozi found on the Core World of Zhurong, where it is spoken by the Secondaries who make up most of the skilled workers and supervisors who live there. While it mostly sticks to traditional Vulgar Morozi structures, its origin on one of the oldest colonies in the Empire and Zhurong itself being a more restricted world has led to this dialect being less influenced by the broader Spur. Scholars believe this dialect may be closer to pre-Imperial Vulgar Morozi than any other in the Empire."
 	tag_icon = "zhurong"
 	text_tag = "ZHU"

--- a/html/changelogs/Fyni-MineNerf.yml
+++ b/html/changelogs/Fyni-MineNerf.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Nerfs door rigged mines."

--- a/html/changelogs/Fyni-MineNerf.yml
+++ b/html/changelogs/Fyni-MineNerf.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: Fyni
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True


### PR DESCRIPTION
Nerfs the door rigged mine. Currently, it all but instantly kill an unarmoured person who walks into this trap with no warning. This nerf puts it on par with normal land mines, which they used to do twice the damage of.