### PR TITLE
Allows Neuter Pronouns for Appropriate Unathi Characters (Guwans)

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/unathi/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/unathi/unathi.dm
@@ -7,7 +7,7 @@
 	species_height = HEIGHT_CLASS_TALL
 	height_min = 175
 	height_max = 215
-	selectable_pronouns = list(NEUTER, MALER, FEMALE, PLURAL)
+	selectable_pronouns = list(NEUTER, MALE, FEMALE, PLURAL)
 	icobase = 'icons/mob/human_races/unathi/r_unathi.dmi'
 	deform = 'icons/mob/human_races/unathi/r_def_unathi.dmi'
 	preview_icon = 'icons/mob/human_races/unathi/unathi_preview.dmi'

--- a/code/modules/mob/living/carbon/human/species/station/unathi/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/unathi/unathi.dm
@@ -7,6 +7,7 @@
 	species_height = HEIGHT_CLASS_TALL
 	height_min = 175
 	height_max = 215
+	selectable_pronouns = list(NEUTER, MALER, FEMALE, PLURAL)
 	icobase = 'icons/mob/human_races/unathi/r_unathi.dmi'
 	deform = 'icons/mob/human_races/unathi/r_def_unathi.dmi'
 	preview_icon = 'icons/mob/human_races/unathi/unathi_preview.dmi'

--- a/html/changelogs/Evandorf-NeuterUnathi.yml
+++ b/html/changelogs/Evandorf-NeuterUnathi.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Evandorf
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Allows Unathi to choose neuter pronouns for appropriate characters; primarily guwan onship, but offship or antag guwandi are also applicable. If you have questions reach out to the lore team."

--- a/html/changelogs/Evandorf-NeuterUnathi.yml
+++ b/html/changelogs/Evandorf-NeuterUnathi.yml
@@ -55,4 +55,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Allows Unathi to choose neuter pronouns for appropriate characters; primarily guwan onship, but offship or antag guwandi are also applicable. If you have questions reach out to the lore team."
+  - rscadd: "Allows Unathi to choose neuter pronouns for appropriate characters; essentially just guwan, but if you have questions reach out to the lore team."


### PR DESCRIPTION
Guwans are stripped of status and gender at time of exile. This change allows players to choose these pronouns for those characters if they wish.