### PR TITLE
Allows it/its pronouns to be selected to species with default selectable pronouns (humans, tajara)

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -19,7 +19,7 @@
 	var/age_max = 85
 	var/economic_modifier = 0
 	var/list/default_genders = list(MALE, FEMALE)
-	var/list/selectable_pronouns = list(MALE, FEMALE, PLURAL)
+	var/list/selectable_pronouns = list(MALE, FEMALE, PLURAL, NEUTER)
 
 	// Icon/appearance vars.
 	var/canvas_icon = 'icons/mob/base_32.dmi'                  // Used to blend parts and icons onto this, to avoid clipping issues.

--- a/html/changelogs/hollyhock-neuter-pronouns.yml
+++ b/html/changelogs/hollyhock-neuter-pronouns.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Hollyhock
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Adds neuter (it/its) pronouns as selectable by default, opening them up to humans, unathi, and tajara."


### PR DESCRIPTION
* This PR will add "neuter" (it/its) pronouns as an option in species.dm.

This will open up the it/its selection to humans and tajara. It does not touch any species directly, but it would make [this pr](https://github.com/Aurorastation/Aurora.3/pull/21250) obsolete if not merged, as unathi would be able to select "neuter". It will also make it/its pronouns available to skrell when [this pr](https://github.com/Aurorastation/Aurora.3/pull/21243) is merged, something directly approved by skrell lore.

Thank you!