### PR TITLE
Liberty's Cradle Sector Improvements

### DIFF
--- a/code/modules/background/space_sectors/coalition/coalition.dm
+++ b/code/modules/background/space_sectors/coalition/coalition.dm
@@ -53,10 +53,47 @@
 	description = "The beating heart of the modern Coalition of Colonies, Liberty’s Cradle is home to many of the Coalition’s most developed and influential worlds. In contrast to the Solarian stereotype of the frontier as a decivilized wasteland populated by roving bands of pirates and petty warlords, Liberty’s Cradle is a prosperous and safe region which has a higher standard of living than much of the former Middle and Outer Ring possessed prior to the Solarian Collapse of 2462. Post-Collapse the area has continued to prosper and, now that it dwells far behind the Coalition-controlled Weeping Stars, is more secure than it has ever been before."
 	skybox_icon = "arusha"//placeholder
 	scheduled_port_visits = null
-//	cargo_price_coef = TBD
+	cargo_price_coef = list(
+		"arisi" = 1.2,
+		"bishop" = 0.8,
+		"blam" = 1.2,
+		"eckharts" = 1.2,
+		"einstein" = 0.8,
+		"getmore" = 0.8,
+		"hephaestus" = 1.1,
+		"iac" = 1.2,
+		"idris" = 0.8,
+		"molinaris" = 1.2,
+		"nanotrasen" = 0.8,
+		"orion" = 0.8,
+		"virgo" = 1.2,
+		"vysoka" = 1.2,
+		"xion" = 1.1,
+		"zavodskoi" = 0.8,
+		"zeng_hu" = 0.7,
+		"zharkov" = 1.2,
+		"zora" = 1.2,
+		)
 	starlight_color = "#2d9647"
 	starlight_power = 2
 	starlight_range = 5
+
+
+/datum/space_sector/libertys_cradle/xanu
+	name = SECTOR_XANU
+	description = "Located in the eastern Orion Spur. The Xanu system is home to the Xanu Prime, colonised in 2185, which has grown into the current capital of the Coalition of Colonies, a decentralised government that won its independence from the Solarian Alliance after the Interstellar War."
+	skybox_icon = "arusha" //placeholder
+	possible_exoplanets = list(/obj/effect/overmap/visitable/sector/exoplanet/barren/asteroid, /obj/effect/overmap/visitable/sector/exoplanet/barren/asteroid/ice)
+	guaranteed_exoplanets = list(/obj/effect/overmap/visitable/sector/exoplanet/xanu)
+
+	ports_of_call = list("Pataliputra")
+	scheduled_port_visits = list("Saturday", "Sunday")
+	starlight_range = 2
+
+	lobby_tracks = list(
+		'sound/music/regional/xanu/xanu_rock_1.ogg',
+		'sound/music/regional/xanu/xanu_rock_2.ogg'
+	)
 
 /datum/space_sector/burzsia
 	name = SECTOR_BURZSIA
@@ -133,20 +170,4 @@
 		"75.4 PBA" = 'texts/lore_radio/konyang/75.4_PBA.txt',
 		"77.7 SoulFM" = 'texts/lore_radio/konyang/77.7_SoulFM.txt',
 		"78.1 RealFM" = 'texts/lore_radio/konyang/78.1_RealFM.txt'
-	)
-
-/datum/space_sector/xanu
-	name = SECTOR_XANU
-	description = "Located in the eastern Orion Spur. The Xanu system is home to the Xanu Prime, colonised in 2185, which has grown into the current capital of the Coalition of Colonies, a decentralised government that won its independence from the Solarian Alliance after the Interstellar War."
-	skybox_icon = "arusha" //placeholder
-	possible_exoplanets = list(/obj/effect/overmap/visitable/sector/exoplanet/barren/asteroid, /obj/effect/overmap/visitable/sector/exoplanet/barren/asteroid/ice)
-	guaranteed_exoplanets = list(/obj/effect/overmap/visitable/sector/exoplanet/xanu)
-
-	ports_of_call = list("Pataliputra")
-	scheduled_port_visits = list("Saturday", "Sunday")
-	starlight_range = 2
-
-	lobby_tracks = list(
-		'sound/music/regional/xanu/xanu_rock_1.ogg',
-		'sound/music/regional/xanu/xanu_rock_2.ogg'
 	)

--- a/code/modules/background/space_sectors/coalition/coalition.dm
+++ b/code/modules/background/space_sectors/coalition/coalition.dm
@@ -52,6 +52,7 @@
 	name = SECTOR_LIBERTYS_CRADLE
 	description = "The beating heart of the modern Coalition of Colonies, Liberty’s Cradle is home to many of the Coalition’s most developed and influential worlds. In contrast to the Solarian stereotype of the frontier as a decivilized wasteland populated by roving bands of pirates and petty warlords, Liberty’s Cradle is a prosperous and safe region which has a higher standard of living than much of the former Middle and Outer Ring possessed prior to the Solarian Collapse of 2462. Post-Collapse the area has continued to prosper and, now that it dwells far behind the Coalition-controlled Weeping Stars, is more secure than it has ever been before."
 	skybox_icon = "arusha"//placeholder
+	scheduled_port_visits = null
 //	cargo_price_coef = TBD
 	starlight_color = "#2d9647"
 	starlight_power = 2

--- a/html/changelogs/Ben10083 - Lib_Cradle_Sector.yml
+++ b/html/changelogs/Ben10083 - Lib_Cradle_Sector.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Updates sector variables for Liberty's Cradle, in accordance with lore plans."

--- a/html/changelogs/Ben10083 - Lib_Cradle_Sector.yml
+++ b/html/changelogs/Ben10083 - Lib_Cradle_Sector.yml
@@ -55,4 +55,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - balance: "Updates sector variables for Liberty's Cradle, in accordance with lore plans."
+  - balance: "Updates sector variables for Liberty's Cradle, in accordance with lore."
+  - refactor: "Xanu how is a child of the Liberty's Cradle sector datum. inheriting values such as cargo prices."

--- a/html/changelogs/Ben10083 - Lib_Cradle_Sector.yml
+++ b/html/changelogs/Ben10083 - Lib_Cradle_Sector.yml
@@ -56,4 +56,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - balance: "Updates sector variables for Liberty's Cradle, in accordance with lore."
-  - refactor: "Xanu how is a child of the Liberty's Cradle sector datum. inheriting values such as cargo prices."
+  - refactor: "Xanu is now a child of the Liberty's Cradle sector datum. inheriting values such as cargo prices."


### PR DESCRIPTION
- Adds cargo price coefficent for all suppliers with help from lore (for most it is +20% if non-megacorp, -20% if megacorp)
- Refactors Xanu to be child of Liberty's Cradle, this should be what is done for the other major systems in the region
- Removes port of call days for liberty's cradle