### PR TITLE
More area display name updates

### DIFF
--- a/code/modules/alarm/alarm.dm
+++ b/code/modules/alarm/alarm.dm
@@ -85,7 +85,7 @@
 
 /datum/alarm/proc/alarm_name()
 	if(!origin)
-		return last_name
+		return get_area_display_name(last_area)
 
 	last_name = origin.get_alarm_name()
 	return last_name
@@ -137,13 +137,18 @@
 	return display_name
 
 /area/get_alarm_name()
-	return name
+	var/display_name = get_area_display_name(src)
+	return display_name
 
 /mob/get_alarm_name()
-	return name
+	var/area/A = get_area(src)
+	var/display_name = get_area_display_name(A)
+	return display_name
 
 /atom/proc/get_source_name()
-	return name
+	var/area/A = get_area(src)
+	var/display_name = get_area_display_name(A)
+	return display_name
 
 /obj/machinery/camera/get_source_name()
 	return c_tag

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -11,6 +11,7 @@
 	endWhen = 11
 	no_fake = 1
 	var/area/chosen_area
+	var/location_name
 	var/event_name = "Slime Leak"
 	var/chosen_mob = INFESTATION_SLIMES
 	var/chosen_verb = "have leaked into"
@@ -145,7 +146,8 @@
 			to_chat(H, SPAN_CULT("Suddenly, an anomalous pinging makes itself known in your internals. It rises to a shrill high, setting your mind on edge, and it then disappears just as abruptly..."))
 
 /datum/event/infestation/announce()
-	command_announcement.Announce("[chosen_scan_type] indicate that [chosen_mob] [chosen_verb] [chosen_area]. Clear them out before this starts to affect productivity.", event_name, new_sound = 'sound/AI/vermin.ogg', zlevels = affecting_z)
+	location_name = get_area_display_name(chosen_area)
+	command_announcement.Announce("[chosen_scan_type] indicate that [chosen_mob] [chosen_verb] [location_name]. Clear them out before this starts to affect productivity.", event_name, new_sound = 'sound/AI/vermin.ogg', zlevels = affecting_z)
 
 
 #undef INFESTATION_RATS

--- a/html/changelogs/Bat-eventareanames.yml
+++ b/html/changelogs/Bat-eventareanames.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Batrachophrenoboocosmomachia
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Alarm Monitoring app now correctly provides full area names."
+  - bugfix: "Infestation event announcement now correctly provides full area name."
+  - bugfix: "Supply Drop event announcement now correctly provides full area name."


### PR DESCRIPTION
More locations where full area display name was not being used.

changes:
  - bugfix: "Alarm Monitoring app now correctly provides full area names."
  - bugfix: "Infestation event announcement now correctly provides full area name."
  - bugfix: "Supply Drop event announcement now correctly provides full area name."