### PR TITLE
Fixes saving characters with multiple long-name languages.

### DIFF
--- a/SQL/migrate-2023/V012__increase_tag_size.sql
+++ b/SQL/migrate-2023/V012__increase_tag_size.sql
@@ -2,4 +2,4 @@
 -- Increases IPC tag size to 20
 --
 
-ALTER TABLE `ss13_characters_ipc_tags` MODIFY COLUMN `serial_number` VARCHAR(20);
+ALTER TABLE `ss13_characters` MODIFY COLUMN `language` VARCHAR(75);

--- a/html/changelogs/mattatlas-sqllanguagefix.yml
+++ b/html/changelogs/mattatlas-sqllanguagefix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Trying to save a character with many languages should no longer create an error and abort the whole SQL saving procedure."


### PR DESCRIPTION
This is a bug that affects characters with multiple long language names:
`language":"Elyran+Standard=&Sol+Common=&Encoded+Audio+Language="`
This exceeds the limit of 50 characters for the language column, thus bricking the saving.

The limit has been changed to 75 characters.