### PR TITLE
Moved aluminium, added lead @Machinist 2 (For Real)

### DIFF
--- a/html/changelogs/FlyBrokenWings-AluminiumLeadMachinists.yml
+++ b/html/changelogs/FlyBrokenWings-AluminiumLeadMachinists.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: FlyBrokenWings
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -55,5 +55,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
-  - rscdel: "Killed innocent kittens."
+  - rscadd: "Gave the Machinists 10 lead and 2 stacks of Aluminium."
+  - rscdel: "Snapped Engineering's 2 stacks of Aluminium into dust. The world is in balance. (They weren't using it.)"

--- a/html/changelogs/FlyBrokenWings-AluminiumLeadMachinists.yml
+++ b/html/changelogs/FlyBrokenWings-AluminiumLeadMachinists.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
+  - rscdel: "Killed innocent kittens."


### PR DESCRIPTION
Still learning GitHub. And I managed to nearly do a big bad by doing everything else I was working on the same branch. But hey, it's fixed. 

>
Moved aluminium, added lead.
By request of TCJ. Moves the 2 stacks of aluminium engineering kept bringing to the machinists to the machinists and adds 10 sheets of lead into their starting material box. TCJ didn't expect the lead requirements to be so hard to fill some rounds.

<img width="374" height="399" alt="image" src="https://github.com/user-attachments/assets/c57ebe99-4608-475c-a886-89752bcbe059" />
