### PR TITLE
Actual Fixes For Organs

### DIFF
--- a/code/controllers/subsystems/mob.dm
+++ b/code/controllers/subsystems/mob.dm
@@ -83,7 +83,7 @@ SUBSYSTEM_DEF(mobs)
 	//of course, if we haven't resumed, this comparison would be useless, hence we skip it
 	var/list/currentrun = resumed ? (src.currentrun &= (GLOB.mob_list + processing)) : src.currentrun
 
-	var/seconds_per_tick = wait / (1 SECONDS)
+	var/seconds_per_tick = (1 SECONDS) / wait
 
 	while(length(currentrun))
 		var/datum/thing = currentrun[length(currentrun)]

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -185,6 +185,10 @@
 	if(!owner.should_have_organ(BP_HEART))
 		return ..()
 
+	// Adjust the rate of brain healing and damage over time if the owner is in stasis.
+	if(owner.stasis_value > 0)
+		seconds_per_tick /= owner.stasis_value
+
 	// No heart? You are going to have a very bad time. Not 100% lethal because heart transplants should be a thing.
 	var/blood_volume = owner.get_blood_oxygenation()
 	if(blood_volume < BLOOD_VOLUME_SURVIVE)
@@ -204,9 +208,9 @@
 	switch(blood_volume)
 		if(BLOOD_VOLUME_SAFE to INFINITY)
 			if(can_heal && owner.chem_effects[CE_BRAIN_REGEN])
-				damage = max(damage - brain_regen_amount, 0) * safe_damage_modifier
+				damage -= min(damage, brain_regen_amount * safe_damage_modifier)
 			else if(can_heal)
-				damage = max(damage - brain_damage_amount, 0) * safe_damage_modifier
+				damage -= min(damage, brain_damage_amount * safe_damage_modifier)
 		if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)
 			owner.notify_message(SPAN_WARNING("You feel a bit [pick("lightheaded","dizzy","pale")]..."), rand(20 SECONDS, 40 SECONDS), key = "blood_volume_okay")
 			dammod = owner.chem_effects[CE_STABLE] ? okay_stabilized_mod : okay_unstable_mod

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -46,7 +46,7 @@
 	var/filter_effect_from_critical_toxin = 2
 
 	/// Modifier on how efficiently this liver eliminates booze.
-	var/booze_filtering_modifier = 1
+	var/booze_filtering_modifier = 0.03
 
 	/// How much the liver being bruised contributes to filter effect.
 	var/filter_effect_from_bruise = 1
@@ -55,7 +55,7 @@
 	var/filter_effect_from_broken = 2
 
 	/// Modifier on how efficiently this liver eliminates booze while blackout drunk.
-	var/blackout_booze_filtering_modifier = 0.5
+	var/blackout_booze_filtering_modifier = 0.015
 
 	/// Message to play in chat to a liver-haver when they have an infection.
 	var/infection_level_one_warning = "Your skin itches."
@@ -168,5 +168,5 @@
 	base_filter_strength = 1.5
 	base_filter_effect = 5
 	toxin_critical_mass = 90
-	booze_filtering_modifier = 100 // "Impossible to get drunk", this should make it impossible. :)
-	blackout_booze_filtering_modifier = 1
+	booze_filtering_modifier = 0.5 // "Impossible to get drunk", this should make it impossible. :)
+	blackout_booze_filtering_modifier = 0.25

--- a/html/changelogs/hellfirejag-moblifefixes.yml
+++ b/html/changelogs/hellfirejag-moblifefixes.yml
@@ -1,0 +1,6 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed mobs having an unintended high time delta. Things like organs should no longer work several dozen times faster than expected."
+  - bugfix: "You can now actually get drunk again(The unexpectedly high time delta was the culprit here)."
+  - rscadd: "Stasis sources(Such as cryogenics, stasis bags, and stasis beds) now decrease the rate at which brain damage is both healed and accumulated. Thus, they now properly buy time for medics."


### PR DESCRIPTION
So after a long time spent digging really deep into the code, and going over numbers passing into this with a fine comb, I discovered that this entire time, Mobs were being affected by a bug that was largely unnoticed for over a year due to mobs not doing anything that would directly interact with said bug. Right up until I started refactoring organs.

Seconds_per_tick that was being passed to mobs was actually ticks_per_second, it was inverted for mobs and only for mobs, everything else worked just fine with time deltas. But when I started making organs use time deltas, I got blindsided by organs doing nonsensical things that seemingly did not match up with what my models were predicting. Case in point, livers. 

So you can now get drunk again with this PR. I've actually gone around and tested this PR too.
<img width="527" height="114" alt="image" src="https://github.com/user-attachments/assets/a9f92233-fe2a-406d-9ddd-104c069bbc3d" />

<img width="601" height="165" alt="image" src="https://github.com/user-attachments/assets/6f6877f3-edd2-441b-9ea2-a29d816558ee" />

And verifying in a dev environment that brain math is now sensible again:
<img width="1474" height="814" alt="image" src="https://github.com/user-attachments/assets/07634d23-bfaa-477e-a64f-322bb0a3f3ec" />

