### PR TITLE
Fixes Exploitable Formatting

### DIFF
--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -206,8 +206,7 @@ Then check if it's true, if true return. This will stop the normal menu appearin
 				tgui_data["exploit"] = list()  // Setting this to equal L.fields passes it's variables that are lists as reference instead of value.
 												// We trade off being able to automatically add shit for more control over what gets passed to json
 												// and if it's sanitized for html.
-				tgui_data["exploit"]["tgui_exploit_record"] = html_encode(L.exploit_record) // Change stuff into html
-				tgui_data["exploit"]["tgui_exploit_record"] = replacetext(tgui_data["exploit"]["tgui_exploit_record"], "\n", "<br>") // change line breaks into <br>
+				tgui_data["exploit"]["tgui_exploit_record"] = html_decode(L.exploit_record) // this user input is already sanitized and encoded when saved to the DB, we can just decode it and slap it into a span
 				tgui_data["exploit"]["name"] = html_encode(L.name)
 				tgui_data["exploit"]["sex"] = html_encode(L.sex)
 				tgui_data["exploit"]["age"] = html_encode(L.age)

--- a/html/changelogs/geeves-exploitable_formatting.yml
+++ b/html/changelogs/geeves-exploitable_formatting.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed exploitables not formatting correctly."

--- a/tgui/packages/tgui/interfaces/Uplink.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink.tsx
@@ -334,9 +334,11 @@ const ExploitRecordSection = function (act: any, data: UplinkData) {
           </LabeledList.Item>
           <LabeledList.Item label="Acquired Information" />
         </LabeledList>
-        {exploit.tgui_exploit_record
-          ? exploit.tgui_exploit_record
-          : 'No additional information acquired.'}
+        <span style="white-space: pre-line;">
+          {exploit.tgui_exploit_record
+            ? exploit.tgui_exploit_record
+            : 'No additional information acquired.'}
+        </span>
       </Section>
     );
   } else {

--- a/tgui/packages/tgui/interfaces/Uplink.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink.tsx
@@ -334,7 +334,10 @@ const ExploitRecordSection = function (act: any, data: UplinkData) {
           </LabeledList.Item>
           <LabeledList.Item label="Acquired Information" />
         </LabeledList>
-        <span style="white-space: pre-line;">
+        <span
+          style={{
+            'white-space': 'pre-line',
+          }}>
           {exploit.tgui_exploit_record
             ? exploit.tgui_exploit_record
             : 'No additional information acquired.'}


### PR DESCRIPTION
* Fixed exploitables not formatting correctly.

Before:
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/91546d9a-2dde-483e-a144-e6b3ca691c2f" />

After:
<img width="720" height="573" alt="image" src="https://github.com/user-attachments/assets/676b4154-d0fa-4a9f-8cf7-7583c1d5aef4" />
