### PR TITLE
M'sai hair fix

### DIFF
--- a/code/modules/mob/abstract/new_player/sprite_accessories.dm
+++ b/code/modules/mob/abstract/new_player/sprite_accessories.dm
@@ -3358,7 +3358,7 @@ Follow by example and make good judgement based on length which list to include 
 
 /datum/sprite_accessory/hair/msai_ears/msai_ears_bobcut_overeye
 	name = "M'sai Bobcut, overeye"
-	icon_state = "hair_bobcut_overeye"
+	icon_state = "msai_bobcut_overeye"
 	length = 2
 	chatname = "bobcut"
 
@@ -3617,7 +3617,7 @@ Follow by example and make good judgement based on length which list to include 
 
 /datum/sprite_accessory/hair/msai_ears/msai_ears_diagonal_bangs
 	name = "M'sai Diagonal Bangs"
-	icon_state = "hair_diagonal_bangs"
+	icon_state = "msai_diagonal_bangs"
 	length = 2
 	chatname = "bangs"
 

--- a/code/modules/mob/abstract/new_player/sprite_accessories.dm
+++ b/code/modules/mob/abstract/new_player/sprite_accessories.dm
@@ -3386,7 +3386,7 @@ Follow by example and make good judgement based on length which list to include 
 	length = 3
 	chatname = "curly mane"
 
-/datum/sprite_accessory/hair/msai_ears/msai_ears_curls
+/datum/sprite_accessory/hair/msai_ears/msai_ears_curlsalt
 	name = "M'sai Curly Alt"
 	icon_state = "msai_curlyalt"
 	length = 3

--- a/html/changelogs/ElorgRHG-m'sai-hair-fix.yml
+++ b/html/changelogs/ElorgRHG-m'sai-hair-fix.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: ElorgRHG
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes M'sai curly, and diagonal bangs hair styles not having sprites."

--- a/html/changelogs/ElorgRHG-m'sai-hair-fix.yml
+++ b/html/changelogs/ElorgRHG-m'sai-hair-fix.yml
@@ -11,3 +11,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - bugfix: "Fixes M'sai diagonal bangs, and overeye bobcut hair styles not having sprites."
+  - bugfix: "Fixes M'sai not having the curly alt hairstyle."

--- a/html/changelogs/ElorgRHG-m'sai-hair-fix.yml
+++ b/html/changelogs/ElorgRHG-m'sai-hair-fix.yml
@@ -10,4 +10,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "Fixes M'sai curly, and diagonal bangs hair styles not having sprites."
+  - bugfix: "Fixes M'sai diagonal bangs, and overeye bobcut hair styles not having sprites."

--- a/html/changelogs/ElorgRHG-m'sai-hair-fix.yml
+++ b/html/changelogs/ElorgRHG-m'sai-hair-fix.yml
@@ -11,4 +11,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - bugfix: "Fixes M'sai diagonal bangs, and overeye bobcut hair styles not having sprites."
-  - bugfix: "Fixes M'sai not having the curly alt hairstyle."
+  - bugfix: "Fixes M'sai not having the curly hairstyle, while having the alt variant of it."


### PR DESCRIPTION
From changelog:
>bugfix: "Fixes M'sai curly, and diagonal bangs hair styles not having sprites.
>bugfix: "Fixes M'sai not having the curly hairstyle, while having the alt variant of it.

`icon_state` did not correspond to the contents of the file.
both curly and curly alt had the same path, so only curlyalt worked