### PR TITLE
Aluminium And Lead Cargo Mats

### DIFF
--- a/code/modules/cargo/items/engineering.dm
+++ b/code/modules/cargo/items/engineering.dm
@@ -1,3 +1,17 @@
+/singleton/cargo_item/aluminiumsheets
+	category = "engineering"
+	name = "aluminium sheets"
+	supplier = "hephaestus"
+	description = "50 sheets of aluminium."
+	price = 75
+	items = list(
+		/obj/item/stack/material/aluminium/full
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
 /singleton/cargo_item/glasssheets
 	category = "engineering"
 	name = "glass sheets"
@@ -10,6 +24,20 @@
 	access = 0
 	container_type = "crate"
 	groupable = TRUE
+
+/singleton/cargo_item/leadsheets
+	category = "engineering"
+	name = "lead sheets"
+	supplier = "hephaestus"
+	description = "50 sheets of lead."
+	price = 105
+	items = list(
+		/obj/item/stack/material/lead/full
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
 
 /singleton/cargo_item/plasteelsheets
 	category = "engineering"

--- a/html/changelogs/hellfirejag-aluminiumandleadcargo.yml
+++ b/html/changelogs/hellfirejag-aluminiumandleadcargo.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "Added aluminium and lead to the materials that can be ordered via Operations."


### PR DESCRIPTION
This PR adds the ability for Operations to order sheets of aluminium and lead sheets, ostensibly for the machine shop which now requires them for a decent number of things. They're both very common materials that aren't necessarily unique to mining(In fact aluminium is by far the most commonly mined material of them all), so this is mainly to act as a sanity check for rounds where there's no shaft miners to obtain these common materials. Or to pad out the shop when answering cargo bounties.

One may argue I should add gold and silver too, but to be honest I don't think I should because they're both something you can obtain via engineering from the INDRA, so there's not really a need to be able to order them. Aluminium and lead on the other hand are more feast or famine.

I've tested this PR and verified that it works. 
<img width="610" height="250" alt="image" src="https://github.com/user-attachments/assets/edf21eaf-ddce-4b89-adf6-7381ea9913ff" />
