### PR TITLE
adds missing za

### DIFF
--- a/code/modules/cargo/items/hospitality.dm
+++ b/code/modules/cargo/items/hospitality.dm
@@ -842,6 +842,20 @@
 	groupable = TRUE
 	spawn_amount = 1
 
+/singleton/cargo_item/pizzabox_pepperoni
+	category = "hospitality"
+	name = "pizza box, pepperoni"
+	supplier = "orion"
+	description = "Traditional Orion Express Pizza, delivered across the galaxy piping hot and ready to eat."
+	price = 10
+	items = list(
+		/obj/item/pizzabox/pepperoni
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
 /singleton/cargo_item/pizzabox_random
 	category = "hospitality"
 	name = "pizza box, random"


### PR DESCRIPTION
I added this before cargo was in the repository, but never thought to fix it. This adds the pepperoni pizza to the list of orderable pizzas.

Essentially a one-line change. I love you, pepperoni pizza.
