### PR TITLE
Adds the organ cooler to the list of orderable items from operations

### DIFF
--- a/code/modules/cargo/items/medical.dm
+++ b/code/modules/cargo/items/medical.dm
@@ -717,3 +717,17 @@
 	container_type = "crate"
 	groupable = TRUE
 	spawn_amount = 1
+
+/singleton/cargo_item/organcooler
+	category = "medical"
+	name = "organ cooler"
+	supplier = "zeng_hu"
+	description = "A sealed, cooled container to keep organs from decaying."
+	price = 300
+	items = list(
+		/obj/item/storage/box/freezer/organcooler
+	)
+	access = ACCESS_MEDICAL
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1

--- a/html/changelogs/cargoorgancooler.yml
+++ b/html/changelogs/cargoorgancooler.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Added the option to order an organ cooler through the cargo program."


### PR DESCRIPTION
Usually medical hand over their organ cooler to operations when there is an organ bounty. The price might need some adjustment, but for now it was mainly just set to be lower than the bounty, crate and handling fee aside.
