### PR TITLE
Adds the price and crate scanner to the hangar tech lockers and toolbelt

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -121,7 +121,11 @@
 		/obj/item/device/geiger,
 		/obj/item/clothing/gloves/yellow,
 		/obj/item/clothing/gloves/yellow/specialu,
-		/obj/item/clothing/gloves/yellow/specialt
+		/obj/item/clothing/gloves/yellow/specialt,
+		/obj/item/export_scanner,
+		/obj/item/device/price_scanner,
+		/obj/item/device/cratescanner,
+		/obj/item/device/quikpay
 	)
 	content_overlays = TRUE
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/operations.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/operations.dm
@@ -41,15 +41,13 @@
 /obj/structure/closet/secure_closet/hangar_tech/fill()
 	..()
 	new /obj/item/clothing/under/rank/hangar_technician(src)
-	new /obj/item/clothing/shoes/sneakers/black(src)
 	new /obj/item/device/radio/headset/headset_cargo(src)
 	new /obj/item/device/radio/headset/headset_cargo/alt(src)
-	new /obj/item/clothing/gloves/black(src)
-	new /obj/item/clothing/head/softcap/cargo(src)
-	new /obj/item/clothing/head/bandana/cargo(src)
-	new /obj/item/clothing/head/beret/cargo(src)
 	new /obj/item/modular_computer/handheld/preset/supply/cargo_delivery(src)
 	new /obj/item/export_scanner(src)
+	new /obj/item/device/price_scanner(src)
+	new /obj/item/device/cratescanner(src)
+	new /obj/item/clipboard(src)
 	new /obj/item/device/flashlight/marshallingwand(src)
 
 // Machinist

--- a/html/changelogs/OperationsTools.yml
+++ b/html/changelogs/OperationsTools.yml
@@ -1,0 +1,8 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Added the price scanner and crate scanner to hangar tech lockers."
+  - rscdel: "Removed clothing items from hangar tech lockers that was in the drobe."
+  - rscadd: "Toolbelts can now hold the export scanner, price scanner, crate scanner and quikpay."


### PR DESCRIPTION
This adds the price scanner, crate scanner and a clipboard to the hangar technician lockers. 
It also add the various scanners alongside the quikpay to the toolbelt, as it could already have the EFTPOS scanner.
Lastly while doing this, I removed some of the department clothes from the lockers that were already in their drobe.