### PR TITLE
Fixes Odyssey maps spawning outside of its gamemode

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -451,7 +451,8 @@ example:
 #define TEMPLATE_FLAG_PORT_SPAWN       BITFLAG(5)
 
 //Ruin map template flags
-/// Ruin is not available during spawning unless another ruin permits it, or whitelisted by the exoplanet
+/// Ruin is not available during spawning unless another ruin permits it, whitelisted by the exoplanet or tied to an external subsystem like Odyssey gamemode.
+/// This should also be added to Odssey maps.
 #define TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED BITFLAG(6)
 
 #define LANDING_ZONE_RADIUS 15 // Used for autoplacing landmarks on exoplanets

--- a/maps/away/scenarios/cryo_outpost/cryo_outpost_.dm
+++ b/maps/away/scenarios/cryo_outpost/cryo_outpost_.dm
@@ -22,6 +22,7 @@
 	spawn_weight = 0 // so it does not spawn as ordinary away site
 	spawn_cost = 1
 	sectors = list(ALL_POSSIBLE_SECTORS)
+	template_flags = TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED
 
 	unit_test_groups = list(3)
 

--- a/maps/away/scenarios/enviro_testing_facility/enviro_testing_facility.dm
+++ b/maps/away/scenarios/enviro_testing_facility/enviro_testing_facility.dm
@@ -21,6 +21,7 @@
 	spawn_cost = 1
 	spawn_weight = 0 // so it does not spawn as ordinary away site
 	sectors = list(ALL_POSSIBLE_SECTORS)
+	template_flags = TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED
 	unit_test_groups = list(1)
 
 /singleton/submap_archetype/enviro_testing_facility

--- a/maps/away/scenarios/nuclear_silo/nuclear_silo_.dm
+++ b/maps/away/scenarios/nuclear_silo/nuclear_silo_.dm
@@ -14,6 +14,7 @@
 	)
 
 	sectors = list(ALL_POSSIBLE_SECTORS)
+	template_flags = TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED
 	spawn_weight = 0
 	spawn_cost = 1
 	id = "nuclear_silo"

--- a/maps/away/scenarios/ruined_propellant_depot/ruined_propellant_depot_.dm
+++ b/maps/away/scenarios/ruined_propellant_depot/ruined_propellant_depot_.dm
@@ -9,6 +9,7 @@
 	spawn_cost = 1
 	spawn_weight = 0 // so it does not spawn as ordinary away site
 	sectors = list(ALL_POSSIBLE_SECTORS)
+	template_flags = TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED
 	unit_test_groups = list(1)
 
 /singleton/submap_archetype/ruined_propellant_depot


### PR DESCRIPTION
To break down the way we handle map spawning logic:

- in `mapsystem/map.dm`, `build_away_sites()` evaluates every map_template and organizes suitable candidates considering: flags they bear, if the current sector allows this away site to spawn, etc...

- It randomly picks among available maps via `pickweight()`, decreasing relevant cost from the total budget

So far why this never caused any problems is, `pickweight()` will never pick a key with 0 value _unless_ every key passed to this function has 0 value. What was happening here is system runs out of other candidates before exhausting its budget, leaving only odyssey maps with 0 weight in the list.

This fix should only affect natural map spawning process, since Odyssey has its own method on choosing candidates. Fixes #21276