### PR TITLE
Minor tweaks to Freebooter ship cost

### DIFF
--- a/html/changelogs/kano-dot-freebooter-cost-tweak.yml
+++ b/html/changelogs/kano-dot-freebooter-cost-tweak.yml
@@ -1,0 +1,7 @@
+
+author: Kano
+
+delete-after: True
+
+changes:
+  - balance: "Tweaked freebooter ships' cost from 0.5 to 1."

--- a/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
+++ b/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
@@ -11,8 +11,8 @@
 		list(ZTRAIT_AWAY = TRUE, ZTRAIT_UP = FALSE, ZTRAIT_DOWN = TRUE),
 	)
 
-	ship_cost = 0.5 // halved from 1 as this is a variation
-	spawn_weight = 0.5
+	ship_cost = 1
+	spawn_weight = 0.5 // halved from 1 as this is a variation
 
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/freebooter_salvager, /datum/shuttle/autodock/multi/lift/freebooter_salvager)
 	sectors = list(ALL_POSSIBLE_SECTORS)

--- a/maps/away/ships/freebooter/freebooter_ship/freebooter_ship_.dm
+++ b/maps/away/ships/freebooter/freebooter_ship/freebooter_ship_.dm
@@ -10,7 +10,7 @@
 
 	sectors = list(ALL_POSSIBLE_SECTORS)
 	spawn_weight = 0.5 // halved from 1 as this is a variation
-	ship_cost = 0.5
+	ship_cost = 1
 	id = "freebooter_ship"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/freebooter_shuttle)
 	ban_ruins = list(/datum/map_template/ruin/away_site/freebooter_salvager)


### PR DESCRIPTION
```dm
while ((points > 0 || shippoints > 0) && length(available))
		var/datum/map_template/ruin/away_site/site = pickweight(available)
		if ((site.spawn_cost && site.spawn_cost > points) || (site.player_cost && site.player_cost > players) || (site.ship_cost && site.ship_cost > shippoints))
			unavailable += site
			available -= site
			continue
		var/list/costs = resolve_site_selection(site, selected, available, unavailable, by_type)
		points -= costs[1]
		players -= costs[2]
		shippoints -= costs[3]
``` 

This is the code is in `mapsystem/map.dm`, line 309.  Ship cost doesn't play a role here when a map is picked among the candidates pool. There is no reason to not treat a variation ship as a full ship after it's chosen. This was leaving budget points as a decimal number, preventing the loop from ending early before eliminating each candidates. 

This doesn't change the outcome but makes it more in line with the intended standard. I had no idea about this at the time when I made freebooter variation (oops)