### PR TITLE
Phoron Scarcity Electronics

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/weapons/circuitboards/circuitboard.dm
@@ -28,6 +28,9 @@
 	var/list/req_components
 	var/contain_parts = 1
 
+	recyclable = TRUE
+	matter = list(MATERIAL_GLASS = 20, MATERIAL_PHORON = 10)
+
 /obj/item/circuitboard/feedback_hints(mob/user, distance, is_adjacent)
 	. += ..()
 	if(build_path)

--- a/code/modules/research/designs/circuit/circuits.dm
+++ b/code/modules/research/designs/circuit/circuits.dm
@@ -1,7 +1,7 @@
 /datum/design/circuit
 	build_type = IMPRINTER
 	req_tech = list(TECH_DATA = 2)
-	materials = list(MATERIAL_GLASS = 2000)
+	materials = list(MATERIAL_GLASS = 2000, MATERIAL_PHORON = 25)
 	chemicals = list(/singleton/reagent/acid = 20)
 
 /datum/design/circuit/AssembleDesignDesc()

--- a/html/changelogs/hellfirejag-phoron-scarcity-circuits.yml
+++ b/html/changelogs/hellfirejag-phoron-scarcity-circuits.yml
@@ -2,3 +2,4 @@ author: Hellfirejag
 delete-after: True
 changes:
   - rscadd: "Circuit Imprinters now require a tiny amount of phoron for lining the superconducting elements in the trace of all modern electronics."
+  - rscadd: "Circuitboards can now be recycled."

--- a/html/changelogs/hellfirejag-phoron-scarcity-circuits.yml
+++ b/html/changelogs/hellfirejag-phoron-scarcity-circuits.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "Circuit Imprinters now require a tiny amount of phoron for lining the superconducting elements in the trace of all modern electronics."


### PR DESCRIPTION
This PR was requested by the loremaster @Triogenics. According to the loremaster, all modern electronics in the setting should require a small amount of elemental phoron for its capacity as a room temperature superconductor. This is also needed to play into the "Phoron Scarcity" lore arc.

So this PR does exactly that, making all electronics cost a very small amount of Phoron to create. Existing machine shop and science stockpiles of phoron crystals are sufficient to manufacture these for the time being, though that may not be the case in the future. :)

To keep things logically consistent, I've also made it so that circuit boards both actually contain the matter used to print them, and can be recycled to at least partially recover that matter. Have fun breaking down thousands and thousands of old circuit boards to get a few flakes of phoron once things start getting bad.