### PR TITLE
Fixes loadout item description for Koko Cigarettes

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/drugs_meds.dm
+++ b/code/modules/client/preference_setup/loadout/items/drugs_meds.dm
@@ -61,7 +61,7 @@
 	cigarettes["Eriuyushi Sunset cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/federation
 	cigarettes["Xaqixal Dyn Fields cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/dyn
 	cigarettes["Natural Vysokan Soothsayer oracle cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/oracle
-	cigarettes["Koko-Reed cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/koko
+	cigarettes["Ha'zana Corsair Afterburners cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/koko
 	gear_tweaks += new /datum/gear_tweak/path(cigarettes)
 
 /datum/gear/drugs_meds/chew

--- a/html/changelogs/crozarius-kokofix.yml
+++ b/html/changelogs/crozarius-kokofix.yml
@@ -1,0 +1,6 @@
+author: Crozarius
+
+delete-after: True
+
+changes:
+  - qol: "Updates the loadout name of the new koko cigarettes."


### PR DESCRIPTION
My mistake; I forgot to change the loadout entry for these things away from the generic name that I used. Updates that from 'koko-reed cigarette packet' to 'Ha'zana Corsair Afterburners cigarette packet'