### PR TITLE
Hoverthrusters Require Uranium instead of Phoron

### DIFF
--- a/code/modules/research/designs/mechfab/mechs/designs_exosuits.dm
+++ b/code/modules/research/designs/mechfab/mechs/designs_exosuits.dm
@@ -187,7 +187,7 @@
 	name = "Heavy Hoverthrusters"
 	time = 105 SECONDS
 	// Significantly heavier armor than light hoverthrusters, gold, silver, and phoron are for the ion engines.
-	materials = list(DEFAULT_WALL_MATERIAL = 15000, MATERIAL_ALUMINIUM = 7500, MATERIAL_GOLD = 2500, MATERIAL_SILVER = 2500, MATERIAL_PHORON = 2500)
+	materials = list(DEFAULT_WALL_MATERIAL = 15000, MATERIAL_ALUMINIUM = 7500, MATERIAL_GOLD = 2500, MATERIAL_SILVER = 2500, MATERIAL_URANIUM = 2500)
 	build_path = /obj/item/mech_component/propulsion/hover
 
 /datum/design/item/mechfab/exosuit/hover_legs/light
@@ -195,7 +195,7 @@
 	time = 75 SECONDS
 	// Harder to obtain materials than other leg types, though not unobtainable by any means. You can get them roundstart by partnering up with engineering.
 	// The cost is kind of intentionally set to discourage "Light hoverthruster meta", there is otherwise no actual reason to ever make anything else.
-	materials = list(MATERIAL_ALUMINIUM = 15000, MATERIAL_GOLD = 4500, MATERIAL_SILVER = 4500, MATERIAL_PHORON = 4500)
+	materials = list(MATERIAL_ALUMINIUM = 15000, MATERIAL_GOLD = 4500, MATERIAL_SILVER = 4500, MATERIAL_URANIUM = 4500)
 	build_path = /obj/item/mech_component/propulsion/hover/light
 
 /datum/design/item/mechfab/exosuit/track

--- a/html/changelogs/Ben10083 - Hoverthruster Price.yml
+++ b/html/changelogs/Ben10083 - Hoverthruster Price.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Mech Hoverthrusters now require uranium instead of phoron."


### PR DESCRIPTION
Follow up from https://github.com/Aurorastation/Aurora.3/pull/21170

I totally agree with hover thrusters being the hardest to make bc of its inherent power, but requiring Phoron is too much. Instead Uranium is a better alternative.