### PR TITLE
IV Stand Click Fix

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -5,7 +5,7 @@
 	icon_state = "iv_stand"
 	anchored = 0
 	density = FALSE
-	pass_flags_self = PASSTABLE
+	pass_flags_self = PASSTABLE | LETPASSCLICKS
 	var/tipped = FALSE
 	var/last_full // Spam check
 	var/last_warning

--- a/html/changelogs/mneme - ivclickfix.yml
+++ b/html/changelogs/mneme - ivclickfix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Mneme
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed a bug blocking the ability to attach an IV to a patient in certain situations."


### PR DESCRIPTION
oh wow it's me Mneme. I don't know what changed but there's a new bug and or intended feature that's making it extremely hard to run the GTR/throwing off everyone's flow in high intensity situations because certain IV Stand clicks no longer register when there's a patient buckled between them. This makes it so that isn't an issue anymore. 

i.e. the IV in the solid red square would be inaccessible pre-this change, even though prior to a couple weeks ago it was accessible. Now, all IVs are accessible even if there's a patient buckled.
<img width="274" height="192" alt="image" src="https://github.com/user-attachments/assets/176c44f8-7c30-4646-8775-ef49da5b0f2d" />
