### PR TITLE
Removes some rogue objects from Horizon

### DIFF
--- a/html/changelogs/kano-dot-horizon-map-fixes.yml
+++ b/html/changelogs/kano-dot-horizon-map-fixes.yml
@@ -1,0 +1,7 @@
+
+author: Kano
+
+delete-after: True
+
+changes:
+  - bugfix: "Removed some rogue objects in the Horizon."


### PR DESCRIPTION
Removes some objects in:

- Deck 3 port docks space, random lattices
- Deck 2 telescience, rogue platforms under the windows
- Deck 1 turbine room, duplicate pipe under combustion chamber blast door

Replaces floor in:

- Bridge, one tile in front of conference room
- Intrepid, one tile under the grate

Additional changes:

- Moves cargo conveyor switch from under the railings to somewhere visible
- Adjusts Intrepid pumps in starboard nacelle to make "Fuel to Thrusters" pump stand atop for better visibility
- Puts a light fixture in front of commissary