### PR TITLE
Mech Riot SMG Burstfire Fix

### DIFF
--- a/code/modules/heavy_vehicle/equipment/combat.dm
+++ b/code/modules/heavy_vehicle/equipment/combat.dm
@@ -45,7 +45,7 @@
 	icon_state = "mecha_ballistic"
 	holding_type = /obj/item/gun/energy/mountedsmg/mech
 
-/obj/item/mecha_equipment/mounted_system/combat/smg_ltl
+/obj/item/mecha_equipment/mounted_system/combat/smg/ltl
 	name = "mounted riot submachinegun"
 	desc = "An exosuit-mounted automatic weapon that has been modified to fire rubber ammunition for riot control. Handle with care."
 	icon_state = "mecha_ballistic_ltl"

--- a/code/modules/research/designs/mechfab/mechs/designs_exosuit_equipment.dm
+++ b/code/modules/research/designs/mechfab/mechs/designs_exosuit_equipment.dm
@@ -28,7 +28,7 @@
 /datum/design/item/mechfab/exosuit_equipment/uac_ltl
 	name = "Mounted Riot Submachine Gun"
 	req_tech = list(TECH_COMBAT = 2)
-	build_path = /obj/item/mecha_equipment/mounted_system/combat/smg_ltl
+	build_path = /obj/item/mecha_equipment/mounted_system/combat/smg/ltl
 
 /datum/design/item/mechfab/exosuit_equipment/plasma
 	name = "Mounted Plasma Cutter"

--- a/html/changelogs/hellfirejag-riotmech-burst-fix.yml
+++ b/html/changelogs/hellfirejag-riotmech-burst-fix.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed the mech-mounted riot smg not being able to change into burst fire."


### PR DESCRIPTION

<img width="504" height="112" alt="image" src="https://github.com/user-attachments/assets/e95708f0-958c-4dfa-b131-b64db1b559a5" />

This PR fixes an issue where the mech "Riot SMG" could not be toggled into burst fire mode. 