### PR TITLE
Mech Examine Improvements

### DIFF
--- a/code/modules/heavy_vehicle/mecha.dm
+++ b/code/modules/heavy_vehicle/mecha.dm
@@ -156,7 +156,7 @@
 		. += SPAN_NOTICE("It has the following hardpoints:")
 		for(var/hardpoint in hardpoints)
 			var/obj/item/I = hardpoints[hardpoint]
-			. += "- <b>[hardpoint]</b>: [istype(I) ? SPAN_NOTICE("<i>[I]</i>") : "nothing"]."
+			. += "- <b>[hardpoint]</b>: [istype(I) ? "<a href='byond://?src=[REF(src)];examine=[REF(I)]'>[I.name]</a>" : "nothing"]."
 	else
 		. += "It has <b>no visible hardpoints</b>."
 
@@ -174,23 +174,6 @@
 			if(4)
 				damage_string = SPAN_DANGER("destroyed")
 		. += "Its <b>[thing.name]</b> [thing.gender == PLURAL ? "are" : "is"] [damage_string]."
-
-/mob/living/heavy_vehicle/mechanics_hints(mob/user, distance, is_adjacent)
-	. += ..()
-	var/list/hardpoint_hints = list()
-	for(var/hardpoint in hardpoints)
-		var/obj/item/mecha_equipment/I = hardpoints[hardpoint]
-		if(!istype(I) || !length(I.module_hints))
-			continue
-		hardpoint_hints += "- <b>[hardpoint]</b>: [SPAN_NOTICE("<i>[I]</i>")]"
-		hardpoint_hints += I.relayed_mechanics_hints(user, distance, is_adjacent)
-
-	if(length(hardpoint_hints))
-		. += "Its hardpoints have the following mechanics:"
-		. += hardpoint_hints
-		return
-	// Mech has no hardpoints, let's teach them how to fix that instead.
-	. += "modules can be attached to a mech by clicking on the mech with a module in hand."
 
 /mob/living/heavy_vehicle/Topic(href,href_list[])
 	if (href_list["examine"])

--- a/html/changelogs/hellfirejag-mech-examine-improvements.yml
+++ b/html/changelogs/hellfirejag-mech-examine-improvements.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "Examining a mech now provides clickable descriptions for its hardpoints, which can be further examined to view the mechanics hints of its mounted equipment."


### PR DESCRIPTION
This PR makes it so that examining a mech provides clickable descriptions for its hardpoints, which allows players to directly view the mechanics hints for specific pieces of equipment. I have actually tested this PR, and here's a screenshot showing it works.

<img width="1576" height="550" alt="image" src="https://github.com/user-attachments/assets/2e8a949d-952f-46ae-ad79-469ace45da64" />
