### PR TITLE
Remove Ives

### DIFF
--- a/html/changelogs/DeadIves.yml
+++ b/html/changelogs/DeadIves.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscdel: "Ives is removed."


### PR DESCRIPTION
Apparently Ives was shot by Purpose in the recent event. Maintainers can decide if that is kept canon or not I suppose, but here is the removal if it is wanted to keep it canon.
