### PR TITLE
Power Cell Bounty Fix

### DIFF
--- a/code/modules/research/designs/protolathe/power_designs.dm
+++ b/code/modules/research/designs/protolathe/power_designs.dm
@@ -13,11 +13,19 @@
 	C.charge = 0 //shouldn't produce power out of thin air.
 	return C
 
+// This is actually a battery.
 /datum/design/item/powercell/basic
 	name = "Basic"
 	req_tech = list(TECH_POWER = 1)
 	materials = list(DEFAULT_WALL_MATERIAL = 700, MATERIAL_GLASS = 50)
 	build_path = /obj/item/cell
+
+// This is actually the standard power cell found in APCs. And is called for by logistics bounties.
+/datum/design/item/powercell/apc
+	name = "Heavy-Duty"
+	req_tech = list(TECH_POWER = 1)
+	materials = list(DEFAULT_WALL_MATERIAL = 700, MATERIAL_GLASS = 50)
+	build_path = /obj/item/cell/apc
 
 /datum/design/item/powercell/high
 	name = "High-Capacity"

--- a/html/changelogs/hellfirejag-heavy-duty-cell-bounty-fix.yml
+++ b/html/changelogs/hellfirejag-heavy-duty-cell-bounty-fix.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "Heavy-Duty power cells required for logistics bounties can now actually be made in protolathes without having to steal them from APCs."


### PR DESCRIPTION
Logistics bounties sometimes asked for a "Heavy Duty Power Cell" which was an item that was not actually manufacturable by the ship, and could only be obtained by stealing them from the APCs they spawned in. This PR adds the ability for protolathes to manufacture them directly, just like the other upgraded versions of APC power cells. 