### PR TITLE
Blobs can now spawn up to three cores per event

### DIFF
--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -16,22 +16,27 @@
 	var/health
 	var/regen_rate = 5
 
-	// damage gets divided by these modifiers, based on damage type
+	/// Damage gets divided by these modifiers, based on damage type
 	var/brute_resist = 4.3
 	var/fire_resist = 0.8
-	var/laser_resist = 2	// Special resist for laser based weapons - Emitters or handheld energy weaponry. Damage is divided by this and THEN by fire_resist.
+	/// Special resist for laser based weapons - Emitters or handheld energy weaponry. Damage is divided by this and THEN by fire_resist.
+	var/laser_resist = 2
 
 	var/expandType = /obj/effect/blob
-	var/secondary_core_growth_chance = 5 //% chance to grow a secondary blob core instead of whatever was supposed to grow. Secondary cores are considerably weaker, but still nasty.
+	/// % chance to grow a secondary blob core instead of whatever was supposed to grow. Secondary cores are considerably weaker, but still nasty.
+	var/secondary_core_growth_chance = 5
 	var/damage_min = 15
 	var/damage_max = 25
 	var/pruned = FALSE
 	var/product = /obj/item/blob_tendril
 	var/attack_time = 0
-	var/attack_cooldown = 60 // time in deciseconds before next attack will occur
+	/// Time in deciseconds before next attack will occur
+	var/attack_cooldown = 60
 
-	var/obj/effect/blob/parent_core // the core this blob piece belongs to
-	var/is_core = FALSE // determines how to pass core inheritance
+	/// The core this blob piece belongs to
+	var/obj/effect/blob/parent_core
+	/// Determines how to pass core inheritance
+	var/is_core = FALSE
 
 /obj/effect/blob/Initialize()
 	. = ..()

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -1,9 +1,6 @@
 /datum/event/blob
 	// Quite a short fuse due to the potential severity of this event.
 	announceWhen = 12
-
-	/// The number of blob cores active.
-	var/list/obj/effect/blob/core/cores = list()
 	ic_name = "a biohazard"
 
 /datum/event/blob/announce()
@@ -16,7 +13,7 @@
 	var/list/numberOfBlobs = list(1, 2, 2, 3)
 
 	// We pick randomly from the list to determine how many we spawn.
-	for(var/i = 0; i <= pick(numberOfBlobs); i++)
+	for(var/i = 1; i <= pick(numberOfBlobs); i++)
 		var/turf/T = pick_subarea_turf(/area/horizon/maintenance, list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
 		if(!T)
 			log_and_message_admins("Blob failed to find a viable turf.")
@@ -26,8 +23,6 @@
 		log_and_message_admins("Blob spawned at \the [get_area(T)]", location = T)
 		// Spawn the blob in.
 		var/obj/effect/blob/core/Blob = new /obj/effect/blob/core(T)
-		// Add this blob to the list of all currently extant blobs.
-		cores.Add(Blob)
 
 		// Blobs receive a burst of growth from the moment they spawn!
 		for(var/int = 1; int < rand(3, 4); int++)

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -9,7 +9,7 @@
 /datum/event/blob/start()
 	..()
 
-	// This stores the list of the possible number of blobs, weighted towards 2. Adjust if a different weighting is desired.
+	// This stores the list of the possible number of blobs, weighted towards 2. Adjust if a different weighting if desired.
 	var/list/numberOfBlobs = list(1, 2, 2, 3)
 
 	// We pick randomly from the list to determine how many we spawn.

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -32,19 +32,3 @@
 		// Blobs receive a burst of growth from the moment they spawn!
 		for(var/int = 1; int < rand(3, 4); int++)
 			Blob.process()
-
-/datum/event/blob/tick()
-	for(var/obj/effect/blob/core in cores)
-		// If a core is absent, remove it from the list.
-		if(!core || !core.loc)
-			cores.Remove(core)
-
-		// If the list is empty, kill the event - all blobs have been destroyed.
-		if(isemptylist(cores))
-			end()
-			kill()
-			return
-
-		// Otherwise, process for every third tick.
-		if(IsMultiple(activeFor, 3))
-			core.process()

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -34,14 +34,17 @@
 			Blob.process()
 
 /datum/event/blob/tick()
-	// If there's no cores, empty everything out.
-	if(isemptylist(cores))
-		cores = null
-		end()
-		kill()
-		return
-
 	for(var/obj/effect/blob/core in cores)
-		// Process for every third tick.
+		// If a core is absent, remove it from the list.
+		if(!core || !core.loc)
+			cores.Remove(core)
+
+		// If the list is empty, kill the event - all blobs have been destroyed.
+		if(isemptylist(cores))
+			end()
+			kill()
+			return
+
+		// Otherwise, process for every third tick.
 		if(IsMultiple(activeFor, 3))
 			core.process()

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -16,33 +16,32 @@
 	var/list/numberOfBlobs = list(1, 2, 2, 3)
 
 	// We pick randomly from the list to determine how many we spawn.
-	for(var/i = 1; i < pick(numberOfBlobs); i++)
+	for(var/i = 0; i <= pick(numberOfBlobs); i++)
 		var/turf/T = pick_subarea_turf(/area/horizon/maintenance, list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
 		if(!T)
 			log_and_message_admins("Blob failed to find a viable turf.")
 			kill(TRUE)
-			return
+			break
 
 		log_and_message_admins("Blob spawned at \the [get_area(T)]", location = T)
 		// Spawn the blob in.
-		var/Blob = new /obj/effect/blob/core(T)
+		var/obj/effect/blob/core/Blob = new /obj/effect/blob/core(T)
 		// Add this blob to the list of all currently extant blobs.
 		cores.Add(Blob)
 
 		// Blobs receive a burst of growth from the moment they spawn!
-		for(var/i = 1; i < rand(3, 4); i++)
+		for(var/int = 1; int < rand(3, 4); int++)
 			Blob.process()
 
 /datum/event/blob/tick()
 	// If there's no cores, empty everything out.
-	if(isempty(cores))
+	if(isemptylist(cores))
 		cores = null
 		end()
 		kill()
 		return
 
-	// Iterate through all the blobs so they can process.
-	for(obj/effect/blob/core in cores)
+	for(var/obj/effect/blob/core in cores)
 		// Process for every third tick.
 		if(IsMultiple(activeFor, 3))
 			core.process()

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -1,7 +1,9 @@
 /datum/event/blob
-	announceWhen	= 12
+	// We provide a fair amount of leeway prior to the announcement, so blobs aren't caught so early that they're trivial.
+	announceWhen = 30
 
-	var/obj/effect/blob/core/Blob
+	/// The number of blob cores active.
+	var/list/obj/effect/blob/core/cores = list()
 	ic_name = "a biohazard"
 
 /datum/event/blob/announce()
@@ -10,22 +12,37 @@
 /datum/event/blob/start()
 	..()
 
-	var/turf/T = pick_subarea_turf(/area/horizon/maintenance, list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
-	if(!T)
-		log_and_message_admins("Blob failed to find a viable turf.")
-		kill(TRUE)
-		return
+	// This stores the list of the possible number of blobs, weighted towards 2. Adjust if a different weighting is desired.
+	var/list/numberOfBlobs = list(1, 2, 2, 3)
 
-	log_and_message_admins("Blob spawned at \the [get_area(T)]", location = T)
-	Blob = new /obj/effect/blob/core(T)
-	for(var/i = 1; i < rand(3, 4); i++)
-		Blob.process()
+	// We pick randomly from the list to determine how many we spawn.
+	for(var/i = 1; i < pick(numberOfBlobs); i++)
+		var/turf/T = pick_subarea_turf(/area/horizon/maintenance, list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
+		if(!T)
+			log_and_message_admins("Blob failed to find a viable turf.")
+			kill(TRUE)
+			return
+
+		log_and_message_admins("Blob spawned at \the [get_area(T)]", location = T)
+		// Spawn the blob in.
+		var/Blob = new /obj/effect/blob/core(T)
+		// Add this blob to the list of all currently extant blobs.
+		cores.Add(Blob)
+
+		// Blobs receive a burst of growth from the moment they spawn!
+		for(var/i = 1; i < rand(3, 4); i++)
+			Blob.process()
 
 /datum/event/blob/tick()
-	if(!Blob || !Blob.loc)
-		Blob = null
+	// If there's no cores, empty everything out.
+	if(isempty(cores))
+		cores = null
 		end()
 		kill()
 		return
-	if(IsMultiple(activeFor, 3))
-		Blob.process()
+
+	// Iterate through all the blobs so they can process.
+	for(obj/effect/blob/core in cores)
+		// Process for every third tick.
+		if(IsMultiple(activeFor, 3))
+			core.process()

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -1,6 +1,6 @@
 /datum/event/blob
-	// We provide a fair amount of leeway prior to the announcement, so blobs aren't caught so early that they're trivial.
-	announceWhen = 30
+	// Quite a short fuse due to the potential severity of this event.
+	announceWhen = 12
 
 	/// The number of blob cores active.
 	var/list/obj/effect/blob/core/cores = list()

--- a/html/changelogs/hazelmouse-blobbuff.yml
+++ b/html/changelogs/hazelmouse-blobbuff.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Blob events now have the potential to spawn as many as three cores across the map."


### PR DESCRIPTION
Blobs are too trivial, this should make them exciting. 

Requirements for this event to proc are two engineers, so in the worst-case you still have two people with an emitter each who can each destroy one blob and circle to the third after.

Could use scrutiny from someone more familiar with event code than myself, I feel I've stepped on something here.