### PR TITLE
Issue and pull request stale triage workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,12 +21,12 @@ jobs:
           days-before-close: 30
           stale-issue-label: "Stale"
           stale-issue-message: >
-            This issue has been marked as stale due to 60 days of inactivity.
-            If you think the issue is still relevant, add a comment or if it's a bug, let it get marked as replicable by staff.
-            Otherwise the issue will be automatically closed after 30 more days of inactivity. 
+            This issue has been marked as stale due to the lack of activity within the last 60 days.
+            If you think the issue still is relevant, leave a comment or let the issue get labeled as replicable by staff.
+            If there is no further activity in the next 30 days, this issue will be closed automatically.
           close-issue-message: >
             This issue has been closed automatically after 90 days of inactivity.
-            If you still think this issue is still relevant, please reopen or create a new issue.
+            If you think this issue is still relevant, please reopen it or create a new issue.
           exempt-issue-labels-regex: "(?i).*replicable.*" # Problems that are waiting for resolution shouldn't be closed
 
           # --- PR settings ---
@@ -34,8 +34,8 @@ jobs:
           days-before-pr-close: -1 # Never auto-close PRs
           stale-pr-label: "Stale"
           stale-pr-message: >
-            This issue has been marked as stale due to 60 days of inactivity.
+            This pull request has been marked as stale due to the lack of activity within the last 60 days.
             If you are still working on this, please push your work or leave a comment.
-            PRs marked as stale won't be auto-closed but are at the discretion of staff to be closed at any point.
+            Pull requests marked as stale won't be auto-closed but are at the discretion of staff to be closed at any point without further notice.
           exempt-pr-labels-regex: "(?i).*discussion.*" # Match any label containing "discussion"
           # Draft PRs are not exempted from getting marked as stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,7 +27,7 @@ jobs:
           close-issue-message: >
             This issue has been closed automatically after 90 days of inactivity.
             If you still think this issue is still relevant, please reopen or create a new issue.
-          exempt-issue-labels: "✔️ Issue Replicable" # Problems that are waiting for resolution shouldn't be closed
+          exempt-issue-labels-regex: "(?i).*replicable.*" # Problems that are waiting for resolution shouldn't be closed
 
           # --- PR settings ---
           days-before-pr-stale: 60

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,41 @@
+name: "Stale bot - Issue and PR triage"
+
+on:
+  schedule:
+    # Run every thursday (00:00 UTC), giving the weekend the first to react
+    - cron: "0 0 * * 4"
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # --- Issue settings ---
+          days-before-stale: 60
+          days-before-close: 30
+          stale-issue-label: "Stale"
+          stale-issue-message: >
+            This issue has been marked as stale due to 60 days of inactivity.
+            If you think the issue is still relevant, add a comment or if it's a bug, let it get marked as replicable by staff.
+            Otherwise the issue will be automatically closed after 30 more days of inactivity. 
+          close-issue-message: >
+            This issue has been closed automatically after 90 days of inactivity.
+            If you still think this issue is still relevant, please reopen or create a new issue.
+          exempt-issue-labels: "✔️ Issue Replicable" # Problems that are waiting for resolution shouldn't be closed
+
+          # --- PR settings ---
+          days-before-pr-stale: 60
+          days-before-pr-close: -1 # Never auto-close PRs
+          stale-pr-label: "Stale"
+          stale-pr-message: >
+            This issue has been marked as stale due to 60 days of inactivity.
+            If you are still working on this, please push your work or leave a comment.
+            PRs marked as stale won't be auto-closed but are at the discretion of staff to be closed at any point.
+          exempt-pr-labels-regex: "(?i).*discussion.*" # Match any label containing "discussion"
+          # Draft PRs are not exempted from getting marked as stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,7 +22,7 @@ jobs:
           stale-issue-label: "Stale"
           stale-issue-message: >
             This issue has been marked as stale due to the lack of activity within the last 60 days.
-            If you think the issue still is relevant, leave a comment or let the issue get labeled as replicable by staff.
+            If you think the issue is still relevant, leave a comment or let the issue get labeled as replicable by staff.
             If there is no further activity in the next 30 days, this issue will be closed automatically.
           close-issue-message: >
             This issue has been closed automatically after 90 days of inactivity.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,8 +2,8 @@ name: "Stale bot - Issue and PR triage"
 
 on:
   schedule:
-    # Run every thursday (00:00 UTC), giving the weekend the first to react
-    - cron: "0 0 * * 4"
+    # Run every monday and friday at 06:00 UTC, giving an update for the new week and the weekend
+    - cron: "0 6 * * 1,5"
   workflow_dispatch: # Allow manual trigger
 
 permissions:

--- a/html/changelogs/fabiank3-stale-repo-triage.yml
+++ b/html/changelogs/fabiank3-stale-repo-triage.yml
@@ -3,4 +3,4 @@ author: FabianK3
 delete-after: True
 
 changes:
-  - code_imp: "Added a stale bot to the GitHub repository to handle inactive issues and pull requests."
+  - code_imp: "Added a new Github action workflow to the repository to handle stale issues and pull requests."

--- a/html/changelogs/fabiank3-stale-repo-triage.yml
+++ b/html/changelogs/fabiank3-stale-repo-triage.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - code_imp: "Added a stale bot to the GitHub repository to handle inactive issues and pull requests."


### PR DESCRIPTION
# Summary

This PR adds a GitHub action workflow to automatically triage issues and pull requests regarding their activity.

## Intent

The repository features a lot of really old and no longer relevant issues. Those issues are commonly not maintained by their authors and processing them manually is not feasible.  
By adding this workflow we got a very transparent and user friendly way to keep the issues clear and meaningful: Issues that will be opened get more attention and don't drown in the sea of stale issue. Issues marked as replicable are easier to spot for anyone (developers *and* any other contributor), making them easier to get picked.

Similar for PRs: I have seen multiple manual clean ups of dead pull requests. This can be automated as well. For the start, I have opted out of auto closing PRs, but this can be easily added afterwards if it gains interest.

Generally, this keeps the repository cleaner, making it easier to interact with issues posted. This helps anyone looking for an issue to fix, which is, by my own experience, an easy for new contributors to start.

## Settings

### Issues

Issues will be marked as stale after 60 days of no activity. If the issue has been labeled replicable,  it won't get marked as stale. Any activity will remove the stale label again.

After additional 30 days the issue will be closed if its still marked as stale.

### Pull requests

Pull requests will be marked as stale after 60 days of no activity. If the pull requests has been labeled by any discussion label, it won't get marked as stale. Any activity will remove the stale label again.

Pull request will never be auto-closed, unlike issues.