### PR TITLE
Implements a delay to loading the PEAC & adds assisted loading

### DIFF
--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -488,6 +488,29 @@
 	name = "anti-materiel FRAG cannon cartridge"
 	projectile_type = /obj/projectile/bullet/peac/shrapnel
 
+/obj/item/ammo_casing/peac/attack(mob/living/target_mob, mob/living/user, target_zone)
+	if(istype(target_mob, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = target_mob
+		if(user.Adjacent(H))
+			var/obj/item/gun/projectile/peac/G = null
+			var/obj/item/I = H.get_active_hand()
+			if(istype(I, /obj/item/gun/projectile/peac))
+				G = I
+			else
+				I = H.get_inactive_hand()
+				if(istype(I, /obj/item/gun/projectile/peac))
+					G = I
+			if(G && G.get_ammo() <= 0 && G.loaded.len < G.max_shells && G.caliber == caliber && src.loc == user)
+				user.remove_from_mob(src)
+				src.forceMove(G)
+				G.loaded.Insert(1, src)
+				user.visible_message("[user] loads [src] into [G] for [H].", SPAN_NOTICE("You load [src] into [G] for [H]."))
+				playsound(G.loc, src.reload_sound, 50, extrarange = SILENCED_SOUND_EXTRARANGE)
+				G.update_maptext()
+				G.update_icon()
+				return TRUE
+	return ..()
+
 /obj/item/ammo_casing/kumar_super
 	name =".599 kumar super casing"
 	icon_state = "rifle-casing"

--- a/code/modules/projectiles/guns/projectile/cannon.dm
+++ b/code/modules/projectiles/guns/projectile/cannon.dm
@@ -134,6 +134,10 @@
 
 	max_shells = 1
 
+/obj/item/gun/projectile/peac/mechanics_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "The PEAC can only be fired when wielded. Loading it is delayed by 5 seconds, which can be bypassed by having someone adjacent click on you with the ammo in their hand."
+
 /obj/item/gun/projectile/peac/update_icon()
 	..()
 	if(loaded.len)
@@ -151,3 +155,38 @@
 
 /obj/item/gun/projectile/peac/unloaded
 	ammo_type = null
+
+/obj/item/gun/projectile/peac/load_ammo(var/obj/item/A, mob/user)
+	if(!istype(A, /obj/item/ammo_casing))
+		return ..()
+	var/obj/item/ammo_casing/C = A
+	if(caliber != C.caliber)
+		to_chat(user,SPAN_WARNING("\The [C] does not fit."))
+		return
+	if(loaded.len >= max_shells)
+		to_chat(user,SPAN_WARNING("[src] is full."))
+		return
+
+	user.visible_message("[user] starts loading \a [C] into [src].", SPAN_NOTICE("You start loading \a [C] into [src]..."))
+	if(!do_after(user, 5 SECONDS, target = src))
+		to_chat(user, SPAN_WARNING("You stop loading \the [src]."))
+		return
+
+	if(loaded.len >= max_shells)
+		to_chat(user,SPAN_WARNING("[src] is full."))
+		return
+	if(!istype(C) || C.loc != user)
+		to_chat(user, SPAN_WARNING("You no longer have \a [C] to load."))
+		return
+	if(caliber != C.caliber)
+		to_chat(user,SPAN_WARNING("\The [C] does not fit."))
+		return
+
+	user.remove_from_mob(C)
+	C.forceMove(src)
+	loaded.Insert(1, C)
+	user.visible_message("[user] inserts \a [C] into [src].", SPAN_NOTICE("You insert \a [C] into [src]."))
+	playsound(src.loc, C.reload_sound, 50, extrarange = SILENCED_SOUND_EXTRARANGE)
+	update_maptext()
+	update_icon()
+	return

--- a/html/changelogs/4000daniel1-peac_cooldown.yml
+++ b/html/changelogs/4000daniel1-peac_cooldown.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: 4000daniel1
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Implemented a delay to loading the PEAC. This delay can be bypassed by having someone else click on you with the ammo in their hand, performing an 'assisted reload'."


### PR DESCRIPTION
Had to remake this PR since for some reason TGUI changes snuck in on some commit on the last one.

As requested the PEAC now has to instead go through a 5 second windup before being loaded. This also gave me the totally original, definitely not stolen from elsewhere idea to make it possible for someone else to load it instantaneously for you, making fast reloading and rapid fire still possible through the power of teamwork.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/d71dd82c-0f53-4923-a3d4-b9a3b5240b88" />

