### PR TITLE
More Stasis Stuff

### DIFF
--- a/code/game/machinery/stasis_bed.dm
+++ b/code/game/machinery/stasis_bed.dm
@@ -44,6 +44,7 @@
 /obj/machinery/stasis_bed/upgrade_hints(mob/user, distance, is_adjacent)
 	. += ..()
 	. += "Upgraded <b>scanning modules</b> increase the unit's stasis strength."
+	. += "Upgraded <b>capacitors</b> increase the unit's stasis strength."
 
 /obj/machinery/stasis_bed/Initialize(mapload, d, populate_components)
 	. = ..()
@@ -61,12 +62,15 @@
 /obj/machinery/stasis_bed/RefreshParts()
 	..()
 	var/scanner_rating = 0
+	var/capacitor_rating = 0
 
 	for(var/obj/item/stock_parts/P in component_parts)
 		if(isscanner(P))
 			scan_rating += P.rating
+		else if (iscapacitor(P))
+			capacitor_rating += P.rating
 
-	 stasis_power = initial(stasis_power) * scanner_rating / 2
+	 stasis_power = initial(stasis_power) * scanner_rating * capacitor_rating / 4
 
 /obj/machinery/stasis_bed/proc/play_power_sound()
 	var/_running = stasis_running()

--- a/code/game/machinery/stasis_bed.dm
+++ b/code/game/machinery/stasis_bed.dm
@@ -18,6 +18,15 @@
 	var/last_stasis_sound = FALSE
 	var/stasis_can_toggle = 0
 
+	/// The amount of Stasis Value that this machine provides to an occupant.
+	var/stasis_power = 10
+
+	/**
+	 * The type of stasis this machine provides to an occupant.
+	 * Two identical stasis source names do not stack.
+	 */
+	var/stasis_source_name = "Stasis Bed"
+
 	component_types = list(
 		/obj/item/circuitboard/stasis_bed,
 		/obj/item/stock_parts/micro_laser = 1,
@@ -29,6 +38,12 @@
 /obj/machinery/stasis_bed/mechanics_hints(mob/user, distance, is_adjacent)
 	. += ..()
 	. += "You can alt-click this to toggle it on or off."
+	. += "Applies a [stasis_power]x stasis effect to any living creature buckled to an active stasis unit."
+	. += "This causes effects such as bleeding and brain damage to accumulate [stasis_power]x slower."
+
+/obj/machinery/stasis_bed/upgrade_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "Upgraded <b>scanning modules</b> increase the unit's stasis strength."
 
 /obj/machinery/stasis_bed/Initialize(mapload, d, populate_components)
 	. = ..()
@@ -42,6 +57,16 @@
 	else if(default_deconstruction_crowbar(user, attacking_item))
 		return TRUE
 	return ..()
+
+/obj/machinery/stasis_bed/RefreshParts()
+	..()
+	var/scanner_rating = 0
+
+	for(var/obj/item/stock_parts/P in component_parts)
+		if(isscanner(P))
+			scan_rating += P.rating
+
+	 stasis_power = initial(stasis_power) * scanner_rating / 2
 
 /obj/machinery/stasis_bed/proc/play_power_sound()
 	var/_running = stasis_running()
@@ -126,4 +151,4 @@
 	if(!chilled_occupant)
 		chill_occupant(occupant)
 
-	occupant.SetStasis(10)
+	occupant.SetStasis(stasis_power, stasis_source_name)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -170,6 +170,12 @@
 	var/stasis_power = 20
 	var/degradation_time = 60 // 2 minutes: 60 ticks * 2 seconds per tick
 
+/obj/structure/closet/body_bag/cryobag/mechanics_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "Applies a [stasis_power]x stasis effect to any living creature stored inside this bag."
+	. += "This causes effects such as bleeding and brain damage to accumulate 10x slower."
+	. += "stasis bags will only last for [degradation_time] seconds before becoming useless. The bag will turn from blue to grey when this happens."
+
 /obj/structure/closet/body_bag/cryobag/feedback_hints(mob/user, distance, is_adjacent)
 	. += ..()
 	. += "The stasis meter shows <b>'[stasis_power]x'</b>."

--- a/html/changelogs/hellfirejag_stasis-mechanics-hints.yml
+++ b/html/changelogs/hellfirejag_stasis-mechanics-hints.yml
@@ -1,0 +1,5 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "Stasis beds and stasis bags now have mechanics hints explaining what they do."
+  - rscadd: "Stasis beds can now be upgraded to provide more stasis."


### PR DESCRIPTION
This PR adds part upgrading for stasis beds, making it so that improving the parts will also improve the stasis value provided by the bed. 

I've also added new mechanics hints to both stasis beds and stasis bags to help explain to players why they should totally be shoving dying people into stasis.