### PR TITLE
Fix - Missing APCs on D3 fore/starboard

### DIFF
--- a/html/changelogs/fabiank3-fix-missing-apcs.yml
+++ b/html/changelogs/fabiank3-fix-missing-apcs.yml
@@ -3,4 +3,4 @@ author: FabianK3
 delete-after: True
 
 changes:
-  - bugfix: "Fixed missing APCs in the D3 fore bridge airlock, D3 stairwell and D3 holodeck maint. Slight shuffeling of affected areas."
+  - bugfix: "Added missing APCs to the D3 fore bridge airlock, D3 stairwell and D3 holodeck maint."

--- a/html/changelogs/fabiank3-fix-missing-apcs.yml
+++ b/html/changelogs/fabiank3-fix-missing-apcs.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed missing APCs in the D3 fore bridge airlock, D3 stairwell and D3 holodeck maint. Slight shuffeling of affected areas."


### PR DESCRIPTION
# Summary

This PR adds APCs to D3 fore bridge airlock, D3 stairwell and D3 holodeck maint.

## Detailed changes

- Added APC to D3 fore bridge airlock
- Added APC to D3 stairwell
- Added APC to D3 holodeck maints
- Remove airlock splitting the holodeck maint into two, as dedicated shutters are the preferred option to segment larger areas
- Add hull deck beacons to D3 fore-starboard
- The usual slight movement of things to make things pretty and neat