### PR TITLE
Adds hydroponics trays to the public garden + hydro rebalance

### DIFF
--- a/code/__DEFINES/hydroponics.dm
+++ b/code/__DEFINES/hydroponics.dm
@@ -15,11 +15,11 @@
 #define GROWTH_MOLD				  "mold"
 
 // The various standardised ideal heat values.
-#define IDEAL_HEAT_MOGHES 333
+#define IDEAL_HEAT_MOGHES 313
 #define IDEAL_HEAT_TROPICAL 303
 #define IDEAL_HEAT_TEMPERATE 293
 #define IDEAL_HEAT_COLD 283
-#define IDEAL_HEAT_ADHOMAI 257
+#define IDEAL_HEAT_ADHOMAI 273
 
 // The various standardised ideal light values. They vary by incrmeents of 2.
 #define IDEAL_LIGHT_HIGH 7

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -87,12 +87,12 @@
 	set_trait(TRAIT_REQUIRES_NUTRIENTS,   1)
 	set_trait(TRAIT_REQUIRES_WATER,       1)
 	set_trait(TRAIT_WATER_CONSUMPTION,    3)
-	set_trait(TRAIT_LIGHT_TOLERANCE,      2.5) // Plants will begin to die if the light levels are 2.5 or more lumens from their ideal.
+	set_trait(TRAIT_LIGHT_TOLERANCE,      3.5) // Plants will begin to die if the light levels are 2.5 or more lumens from their ideal.
 	set_trait(TRAIT_TOXINS_TOLERANCE,     5)
 	set_trait(TRAIT_PEST_TOLERANCE,       5)
 	set_trait(TRAIT_WEED_TOLERANCE,       5)
 	set_trait(TRAIT_IDEAL_LIGHT,          IDEAL_LIGHT_TEMPERATE)
-	set_trait(TRAIT_HEAT_TOLERANCE,       12) // Plants will begin to die if they're twelve or more degrees from their ideal temperature.
+	set_trait(TRAIT_HEAT_TOLERANCE,       14) // Plants will begin to die if they're fourteen or more degrees from their ideal temperature.
 	set_trait(TRAIT_LOWKPA_TOLERANCE,     25) // Plants survive all the way down to a quarter of an atmosphere!
 	set_trait(TRAIT_ENDURANCE,            100)
 	set_trait(TRAIT_HIGHKPA_TOLERANCE,    200)
@@ -101,7 +101,7 @@
 	set_trait(TRAIT_PLANT_COLOUR,         "#46B543")
 	set_trait(TRAIT_LARGE,                0)
 	set_trait(TRAIT_HEAT_PREFERENCE,      5) // By default, plants grow faster in a temperature within five degrees of their ideal.
-	set_trait(TRAIT_LIGHT_PREFERENCE,     1.5) // Similarly, they grow faster under lumens within 1.5 of their ideal.
+	set_trait(TRAIT_LIGHT_PREFERENCE,     2.5) // Similarly, they grow faster under lumens within 1.5 of their ideal.
 
 	setup_traits()
 

--- a/html/changelogs/hazelmouse-thepain.yml
+++ b/html/changelogs/hazelmouse-thepain.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Light and heat requirements for all plants generally have been made more forgiving. Adhomian and Moghresian plants will now grow at less extreme temperatures."
+  - rscadd: "The public garden is now populated with hydroponics trays, rather than with soil plots, in the interest of making it more convenient to use."


### PR DESCRIPTION
Tweaks a few hydroponics values to make light and heat tolerances more forgiving, and adjusts the ideal heat levels of Adhomian and Moghresian crops to be more reasonable to reach. This means both are within tolerances at the cold and tropical temperature levels respectively, and it also means you can get within Adhomian preferences without going below freezing. Both Adhomian and Moghresian crops still can't be grown at room temperature.

Additionally, this replaces the soil plots in the public garden with actual hydroponics trays. After a good few months to observe how the garden has been used, the light levels in the garden are so inconsistent as to be very inconvenient to work with when your plants are growing in a soil plot with no lid. Soil plots also provide fairly scarce information about their crops by design, which has led to abundant confusion from players who tend to be unsure if light or heat is the problem, and they outright cannot be used to grown Adhomian or Moghresian crops short of heating or cooling the room directly.

The trays are connected to the wider system of hydroponics trays, so you could request a hydroponicist to heat up or cool down the air running into the garden specifically.

The light changes will mean that you fairly rarely need to actually modify tray light values.

<img width="384" height="256" alt="image" src="https://github.com/user-attachments/assets/2d0e9cda-0b1b-4321-853f-d75608368c79" />
