### PR TITLE
Fix psi commune sanitization

### DIFF
--- a/code/modules/psionics/abilities/commune.dm
+++ b/code/modules/psionics/abilities/commune.dm
@@ -43,7 +43,6 @@
 
 	user.visible_message(SPAN_NOTICE("<i>[user] blinks, their eyes briefly developing an unnatural shine.</i>"))
 	var/text = tgui_input_text(user, "What would you like to say?", "Commune", "", MAX_MESSAGE_LEN, TRUE)
-	text = sanitize(text)
 	if(!text)
 		return
 	text = formalize_text(text)

--- a/html/changelogs/johnwildkins-nlom.yml
+++ b/html/changelogs/johnwildkins-nlom.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fix psi commune messages being double-encoded, causing apostrophes and other characters to show up incorrectly."


### PR DESCRIPTION
see title

tgui_input_text already html_encodes the result by default, so we were double-encoding our text and causing it to look garbage