### PR TITLE
Fix - Persistent stashed trash

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -519,6 +519,7 @@
 		if(A && !(A.area_flags & AREA_FLAG_PREVENT_PERSISTENT_TRASH))
 			persistance_expiration_time_days = 3 // Ensure expiration date is set to prevent long term trash
 			SSpersistence.register_track(src, usr == null ? null : ckey(usr.key))
+			return
 
 	SSpersistence.deregister_track(src)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -505,18 +505,22 @@
 /obj/item/proc/try_make_persistent_trash()
 	SHOULD_NOT_OVERRIDE(TRUE)
 	PROTECTED_PROC(TRUE)
-	if(persistency_considered_trash) // Persistent trash - Applicable if considered_persistent_trash is true
-		// Trash-like items should become only persistent when they are not dropped in a maint or disposals, otherwise they get deregistered
-		var/turf/T = get_turf(src)
-		if(T)
-			var/area/A = get_area(T)
-			if(A && !(A.area_flags & AREA_FLAG_PREVENT_PERSISTENT_TRASH))
-				persistance_expiration_time_days = 3 // Ensure expiration date is set to prevent long term trash
-				SSpersistence.register_track(src, usr == null ? null : ckey(usr.key))
-			else
-				SSpersistence.deregister_track(src)
-		else
-			SSpersistence.deregister_track(src)
+	if(!persistency_considered_trash)
+		return
+
+	if(in_storage) // Items getting moved into storages (lunchboxes, backpacks) triggers the dropped handler and requires no persistency as a result
+		SSpersistence.deregister_track(src)
+		return
+	
+	// Trash-like items should become only persistent when they are not dropped in an area flagged with AREA_FLAG_PREVENT_PERSISTENT_TRASH
+	var/turf/T = get_turf(src)
+	if(T)
+		var/area/A = get_area(T)
+		if(A && !(A.area_flags & AREA_FLAG_PREVENT_PERSISTENT_TRASH))
+			persistance_expiration_time_days = 3 // Ensure expiration date is set to prevent long term trash
+			SSpersistence.register_track(src, usr == null ? null : ckey(usr.key))
+
+	SSpersistence.deregister_track(src)
 
 /obj/item/proc/remove_item_verbs(mob/user)
 	if(ismech(user)) //very snowflake, but necessary due to how mechs work

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -521,6 +521,7 @@
 			SSpersistence.register_track(src, usr == null ? null : ckey(usr.key))
 			return
 
+	// Fallback - No persistency
 	SSpersistence.deregister_track(src)
 
 /obj/item/proc/remove_item_verbs(mob/user)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -511,7 +511,7 @@
 	if(in_storage) // Items getting moved into storages (lunchboxes, backpacks) triggers the dropped handler and requires no persistency as a result
 		SSpersistence.deregister_track(src)
 		return
-	
+
 	// Trash-like items should become only persistent when they are not dropped in an area flagged with AREA_FLAG_PREVENT_PERSISTENT_TRASH
 	var/turf/T = get_turf(src)
 	if(T)

--- a/html/changelogs/fabiank3-bug-persistent-stashed-trash.yml
+++ b/html/changelogs/fabiank3-bug-persistent-stashed-trash.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed trash items becoming persistent when put into storage containers (e.g. backpacks, lunchboxes)."


### PR DESCRIPTION
# Summary

This PR fixes trash items becoming persistent when they get stashed in storage containers (e.g. backpacks or lunchboxes).

## Details

When items get added to storage containers like backpacks, during the insertion `dropped` is called and makes the item persistent.

During feature dev this was an unknown edge case of `dropped`.