### PR TITLE
Signals update to power_change()

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -18,6 +18,7 @@
 	var/seclevel
 	///looping sound datum for our fire alarm siren.
 	var/datum/looping_sound/firealarm/soundloop
+	always_area_sensitive = TRUE
 
 /obj/machinery/firealarm/Initialize(mapload, var/dir, var/building = 0)
 	. = ..(mapload)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -149,6 +149,10 @@ Class Procs:
 	 */
 	var/manufacturer = null
 
+	///Do we want to hook into on_enter_area and on_exit_area?
+	///Disables some optimizations
+	var/always_area_sensitive = FALSE
+
 /obj/machinery/feedback_hints(mob/user, distance, is_adjacent)
 	. = list()
 	if(signaler && is_adjacent)
@@ -189,6 +193,8 @@ Class Procs:
 
 		if(component_parts.len)
 			RefreshParts()
+
+	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/Destroy()
 	//Stupid macro used in power usage

--- a/code/modules/power/lights/fixtures.dm
+++ b/code/modules/power/lights/fixtures.dm
@@ -16,6 +16,7 @@
 	idle_power_usage = 2
 	active_power_usage = 20
 	power_channel = AREA_USAGE_LIGHT //Lights are calc'd via area so they dont need to be in the machine list
+	always_area_sensitive = TRUE
 	gfi_layer_rotation = GFI_ROTATION_DEFDIR
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 	var/brightness_range = 8	// luminosity when on, also used in power calculation

--- a/code/modules/power/power_usage.dm
+++ b/code/modules/power/power_usage.dm
@@ -78,7 +78,6 @@ This is /obj/machinery level code to properly manage power usage from the area.
 /obj/machinery/Initialize(mapload, d = 0, populate_components = TRUE, is_internal = FALSE)
 	internal = is_internal
 	REPORT_POWER_CONSUMPTION_CHANGE(0, get_power_usage())
-	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(update_power_on_move))
 	power_init_complete = TRUE
 	. = ..()
 
@@ -88,20 +87,25 @@ This is /obj/machinery level code to properly manage power usage from the area.
 	REPORT_POWER_CONSUMPTION_CHANGE(get_power_usage(), 0)
 	. = ..()
 
-/obj/machinery/proc/update_power_on_move(atom/movable/mover, atom/old_loc, dir, forced, list/old_locs)
-	area_changed(get_area(old_loc), get_area(src))
+/obj/machinery/LateInitialize()
+	SHOULD_NOT_OVERRIDE(TRUE)
+	post_machine_initialize()
 
-/obj/machinery/proc/area_changed(area/old_area, area/new_area)
-	if(old_area == new_area)
-		return
-	var/power = get_power_usage()
-	if(!power)
-		return // This is the most likely case anyway.
-	if(old_area)
-		old_area.power_use_change(power, 0, power_channel)
-	if(new_area)
-		new_area.power_use_change(0, power, power_channel)
+/**
+ * Called in LateInitialize meant to be the machine replacement to it
+ * This sets up power for the machine and requires parent be called,
+ * ensuring power works on all machines unless exempted with POWER_USE_OFF.
+ * This is the proc to override if you want to do anything in LateInitialize.
+ */
+/obj/machinery/proc/post_machine_initialize()
+	PROTECTED_PROC(TRUE)
+	SHOULD_CALL_PARENT(TRUE)
+
 	power_change()
+	if(use_power == POWER_USE_OFF)
+		return
+	update_current_power_usage()
+	setup_area_power_relationship()
 
 // The three procs below are the only allowed ways of modifying the corresponding variables.
 /// Use this to modify the use_power variable of machines, do not modify them directly!
@@ -115,6 +119,80 @@ This is /obj/machinery level code to properly manage power usage from the area.
 	use_power = new_use_power
 	var/new_power = get_power_usage()
 	REPORT_POWER_CONSUMPTION_CHANGE(old_power, new_power)
+
+/// Makes this machine draw power from its area according to which use_power mode it is set to.
+/obj/machinery/proc/update_current_power_usage()
+	var/area/our_area = get_area(src)
+	if(!our_area)
+		return FALSE
+
+	var/new_usage = 0
+	switch(use_power)
+		if(POWER_USE_IDLE)
+			new_usage = idle_power_usage
+		if(POWER_USE_ACTIVE)
+			new_usage = active_power_usage
+		if(POWER_USE_OFF)
+			return
+
+	if(new_usage)
+		update_use_power(new_usage)
+
+	return TRUE
+
+/**
+ * proc to call when the machine starts to require power after a duration of not requiring power
+ * sets up power related connections to its area if it exists and becomes area sensitive
+ * does not affect power usage itself
+ *
+ * Returns TRUE if it triggered a full registration, FALSE otherwise
+ * We do this so machinery that want to sidestep the area sensitiveity optimization can
+ */
+/obj/machinery/proc/setup_area_power_relationship()
+	var/area/our_area = get_area(src)
+	if(our_area)
+		RegisterSignal(our_area, COMSIG_AREA_POWER_CHANGE, PROC_REF(power_change))
+
+	if(HAS_TRAIT_FROM(src, TRAIT_AREA_SENSITIVE, INNATE_TRAIT)) // If we for some reason have not lost our area sensitivity, there's no reason to set it back up
+		return FALSE
+
+	become_area_sensitive(INNATE_TRAIT)
+	RegisterSignal(src, COMSIG_ENTER_AREA, PROC_REF(on_enter_area))
+	RegisterSignal(src, COMSIG_EXIT_AREA, PROC_REF(on_exit_area))
+	return TRUE
+
+/**
+ * proc to call when the machine stops requiring power after a duration of requiring power
+ * saves memory by removing the power relationship with its area if it exists and loses area sensitivity
+ * does not affect power usage itself
+ */
+/obj/machinery/proc/remove_area_power_relationship()
+	var/area/our_area = get_area(src)
+	if(our_area)
+		UnregisterSignal(our_area, COMSIG_AREA_POWER_CHANGE)
+
+	if(always_area_sensitive)
+		return
+
+	lose_area_sensitivity(INNATE_TRAIT)
+	UnregisterSignal(src, COMSIG_ENTER_AREA)
+	UnregisterSignal(src, COMSIG_EXIT_AREA)
+
+/obj/machinery/proc/on_enter_area(datum/source, area/area_to_register)
+	SIGNAL_HANDLER
+	// If we're always area sensitive, and this is called while we have no power usage, do nothing and return
+	if(always_area_sensitive && use_power == POWER_USE_OFF)
+		return
+	update_current_power_usage()
+	power_change()
+	RegisterSignal(area_to_register, COMSIG_AREA_POWER_CHANGE, PROC_REF(power_change))
+
+/obj/machinery/proc/on_exit_area(datum/source, area/area_to_unregister)
+	SIGNAL_HANDLER
+	// If we're always area sensitive, and this is called while we have no power usage, do nothing and return
+	if(always_area_sensitive && use_power == POWER_USE_OFF)
+		return
+	UnregisterSignal(area_to_unregister, COMSIG_AREA_POWER_CHANGE)
 
 /// Use this to modify the power channel variable of machines, do not modify them directly!
 /obj/machinery/proc/update_power_channel(new_channel)


### PR DESCRIPTION
As title. Makes area/power_change() and area on_enter/on_exit procs both rely on signals for machinery handling where they draw power from.