### PR TITLE
Destroy several sources of lag

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -13,6 +13,7 @@
 	var/build_eff = 1
 	var/eat_eff = 1
 	var/capacity = 100
+	var/ref_for_ui
 
 	component_types = list(
 		/obj/item/circuitboard/biogenerator,
@@ -536,6 +537,7 @@ EMAG/ILLEGAL
 	R.my_atom = src
 	beaker = new /obj/item/reagent_containers/glass/bottle(src)
 	update_icon()
+	ref_for_ui = "[REF(src)]"
 
 /obj/machinery/biogenerator/on_reagent_change()			//When the reagents change, change the icon as well.
 	update_icon()
@@ -618,8 +620,8 @@ EMAG/ILLEGAL
 			if("menu")
 				if (beaker)
 					dat += "<table style='width:100%'><tr><td colspan='6'><H2>Commands</H2></td></tr>"
-					dat += "<tr><td colspan='2'><A href='byond://?src=[REF(src)];action=activate'>Activate Biogenerator</A></td></tr>"
-					dat += "<tr><td colspan='2'><A href='byond://?src=[REF(src)];action=detach'>Detach Container</A><BR></td></tr>"
+					dat += "<tr><td colspan='2'><A href='byond://?src=[ref_for_ui];action=activate'>Activate Biogenerator</A></td></tr>"
+					dat += "<tr><td colspan='2'><A href='byond://?src=[ref_for_ui];action=detach'>Detach Container</A><BR></td></tr>"
 					dat += "<tr><td colspan='2'>Name</td><td colspan='2'>Cost</td><td colspan='4'>Production Amount</td></tr>"
 					var/lastclass = "Commands"
 
@@ -639,7 +641,7 @@ EMAG/ILLEGAL
 								if(num*round(current_recipe.cost/build_eff) > points)
 									dat += "<div class='no-build inline'>([fakenum][num])</div>"
 								else
-									dat += "<A href='byond://?src=[REF(src)];action=create;itemtype=[current_recipe.type];count=[num]'>([fakenum][num])</A>"
+									dat += "<A href='byond://?src=[ref_for_ui];action=create;itemtype=[current_recipe.type];count=[num]'>([fakenum][num])</A>"
 							dat += "</td>"
 							dat += "</tr>"
 
@@ -649,13 +651,13 @@ EMAG/ILLEGAL
 					dat += "<BR><FONT COLOR=red>No beaker inside. Please insert a beaker.</FONT><BR>"
 			if("nopoints")
 				dat += "You do not have biomass to create products.<BR>Please put growns into the reactor and activate it.<BR>"
-				dat += "<A href='byond://?src=[REF(src)];action=menu'>Return to menu</A>"
+				dat += "<A href='byond://?src=[ref_for_ui];action=menu'>Return to menu</A>"
 			if("complete")
 				dat += "Operation complete.<BR>"
-				dat += "<A href='byond://?src=[REF(src)];action=menu'>Return to menu</A>"
+				dat += "<A href='byond://?src=[ref_for_ui];action=menu'>Return to menu</A>"
 			if("void")
 				dat += "<FONT COLOR=red>Error: No growns inside.</FONT><BR>Please put growns into the reactor.<BR>"
-				dat += "<A href='byond://?src=[REF(src)];action=menu'>Return to menu</A>"
+				dat += "<A href='byond://?src=[ref_for_ui];action=menu'>Return to menu</A>"
 	dat += "</body></html>"
 
 	var/datum/browser/biogen_win = new(user, "biogenerator", "Biogenerator", 450, 500)

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -7,6 +7,7 @@
 	var/id = null
 	var/active = 0
 	var/operating = 0
+	var/active_time = 1 SECOND
 	anchored = 1.0
 	idle_power_usage = 2
 	active_power_usage = 4
@@ -38,19 +39,22 @@
 	activate(user)
 	intent_message(BUTTON_FLICK, 5)
 
+/obj/machinery/button/proc/deactivate(mob/living/user)
+	active = FALSE
+	update_icon()
+	operating = FALSE
+
 /obj/machinery/button/proc/activate(mob/living/user)
 	if(operating || !istype(wifi_sender))
-		return
+		return FALSE
 
-	operating = 1
-	active = 1
+	operating = TRUE
+	active = TRUE
 	use_power_oneoff(5)
 	update_icon()
 	wifi_sender.activate(user)
-	sleep(10)
-	active = 0
-	update_icon()
-	operating = 0
+	addtimer(CALLBACK(src, PROC_REF(deactivate)), active_time, TIMER_DELETE_ME)
+	return TRUE
 
 /obj/machinery/button/update_icon()
 	if(active)

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -66,18 +66,28 @@
 	name = "holosign switch"
 	desc = "A remote control switch for a holosign."
 	icon_state = "light0"
+	var/list/datum/weakref/linked_signs
+
+/obj/machinery/button/switch/holosign/Initialize()
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/button/switch/holosign/LateInitialize()
+	. = ..()
+	for(var/obj/machinery/holosign/H in SSmachinery.machinery)
+		if(H.id == id)
+			LAZYADD(linked_signs, WEAKREF(H))
 
 /obj/machinery/button/switch/holosign/attack_hand(mob/user as mob)
 	if(..())
 		return
 	add_fingerprint(user)
 
-	use_power_oneoff(5)
-
 	active = !active
 	update_icon()
-	for(var/obj/machinery/holosign/M in SSmachinery.machinery)
-		if (M.id == src.id)
-			INVOKE_ASYNC(M, TYPE_PROC_REF(/obj/machinery/holosign, toggle))
+	for(var/datum/weakref/W in linked_signs)
+		var/obj/machinery/holosign/H = W.resolve()
+		if(!isnull(H))
+			INVOKE_ASYNC(H, TYPE_PROC_REF(/obj/machinery/holosign, toggle))
 
 	return

--- a/code/game/machinery/telecomms/telecommunications.dm
+++ b/code/game/machinery/telecomms/telecommunications.dm
@@ -151,8 +151,9 @@
 		AddOverlays("[icon_state]_panel")
 
 /obj/machinery/telecomms/process()
-	update_icon()
-	if(!use_power) return PROCESS_KILL
+	if(!use_power)
+		update_icon()
+		return PROCESS_KILL
 	if(!operable(EMPED))
 		toggle_power(additional_flags = EMPED)
 		return PROCESS_KILL

--- a/code/modules/mob/living/carbon/slime/powers.dm
+++ b/code/modules/mob/living/carbon/slime/powers.dm
@@ -167,7 +167,7 @@
 				M.mutation_chance = clamp(mutation_chance + rand(-3, 3), 0, 100)
 				babies += M
 				M.set_content(TRUE)
-				addtimer(CALLBACK(M, TYPE_PROC_REF(/mob/living/carbon/slime, set_content), FALSE), 1200) // You get two minutes of safety
+				addtimer(CALLBACK(M, TYPE_PROC_REF(/mob/living/carbon/slime, set_content), FALSE), 1200, TIMER_DELETE_ME) // You get two minutes of safety
 				feedback_add_details("slime_babies_born", "slimebirth_[replacetext(M.colour," ","_")]")
 
 			var/mob/living/carbon/slime/new_slime = pick(babies)

--- a/code/modules/research/designs/circuit/hardsuit_circuits.dm
+++ b/code/modules/research/designs/circuit/hardsuit_circuits.dm
@@ -10,12 +10,12 @@
 	build_path = /obj/item/circuitboard/rig_assembly/civilian/industrial
 
 /datum/design/circuit/hardsuit/eva
-	name = "EVA suit central circuit Board"
+	name = "EVA Suit Central Circuit Board"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/circuitboard/rig_assembly/civilian/eva
 
 /datum/design/circuit/hardsuit/eva/pilot
-	name = "pilot suit central circuit Board"
+	name = "Pilot Suit Central Circuit Board"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/circuitboard/rig_assembly/civilian/eva/pilot
 

--- a/code/modules/research/designs/circuit/machine_circuits.dm
+++ b/code/modules/research/designs/circuit/machine_circuits.dm
@@ -147,22 +147,22 @@
 	build_path = /obj/item/circuitboard/candymachine
 
 /datum/design/circuit/machine/portgen
-	name = "portable generator"
+	name = "Portable Generator"
 	req_tech = list(TECH_DATA = 3, TECH_PHORON = 3, TECH_POWER = 3, TECH_ENGINEERING = 3)
 	build_path = /obj/item/circuitboard/portgen
 
 /datum/design/circuit/machine/advancedportgen
-	name = "advanced portable generator"
+	name = "Advanced Portable Generator"
 	req_tech = list(TECH_DATA = 3, TECH_POWER = 4, TECH_ENGINEERING = 4)
 	build_path = /obj/item/circuitboard/portgen/advanced
 
 /datum/design/circuit/machine/superportgen
-	name = "super portable generator"
+	name = "Super Portable Generator"
 	req_tech = list(TECH_DATA = 3, TECH_POWER = 5, TECH_ENGINEERING = 5)
 	build_path = /obj/item/circuitboard/portgen/super
 
 /datum/design/circuit/machine/fusionportgen
-	name = "miniature fusion reactor"
+	name = "Miniature Fusion Reactor"
 	req_tech = list(TECH_DATA = 3, TECH_POWER = 6, TECH_ENGINEERING = 6)
 	build_path = /obj/item/circuitboard/portgen/fusion
 
@@ -238,12 +238,12 @@
 	build_path = /obj/item/circuitboard/slime_extractor
 
 /datum/design/circuit/machine/iv_drip
-	name = "IV drip"
+	name = "IV Drip"
 	req_tech = list(TECH_DATA = 1, TECH_BIO = 2)
 	build_path = /obj/item/circuitboard/iv_drip
 
 /datum/design/circuit/oxyregenerator
-	name = "oxygen regenerator"
+	name = "Oxygen Regenerator"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/circuitboard/oxyregenerator
 

--- a/code/modules/research/designs/mechfab/hardsuit/rigs.dm
+++ b/code/modules/research/designs/mechfab/hardsuit/rigs.dm
@@ -27,7 +27,7 @@
 	materials = list(MATERIAL_ALUMINIUM = 12500, MATERIAL_GLASS = 12500, DEFAULT_WALL_MATERIAL = 7000, MATERIAL_LEAD = 5500)
 
 /datum/design/rig/eva/pilot
-	name = "pilot Suit Control Module Assembly"
+	name = "Pilot Suit Control Module Assembly"
 	desc = "An assembly for a light hardsuit that is designed for pilots. It features a plasteel lining that offers excellent protection from shrapnel."
 	build_path = /obj/item/rig_assembly/eva/pilot
 	materials = list(DEFAULT_WALL_MATERIAL = 25000, MATERIAL_GLASS = 12500, MATERIAL_PLASTEEL = 5500)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -55,6 +55,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	var/protolathe_category = "All"
 	var/imprinter_category = "All"
 
+	var/ref_for_ui
+
 	req_access = list(ACCESS_TOX)	//Data and setting manipulation requires scientist access.
 
 /obj/machinery/computer/rdconsole/proc/CallMaterialName(var/ID)
@@ -134,6 +136,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			S.setup()
 			break
 	SyncRDevices()
+	ref_for_ui = "[REF(src)]"
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/computer/rdconsole/LateInitialize()
@@ -504,7 +507,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 		if(0.2)
 			dat += "SYSTEM LOCKED<BR><BR>"
-			dat += "<A href='byond://?src=[REF(src)];lock=1.6'>Unlock</A>"
+			dat += "<A href='byond://?src=[ref_for_ui];lock=1.6'>Unlock</A>"
 
 		if(0.3)
 			dat += "Constructing Prototype. Please Wait..."
@@ -520,70 +523,70 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "Loaded disk: "
 			dat += (t_disk || d_disk) ? (t_disk ? "technology storage disk" : "design storage disk") : "None"
 			dat += "<HR><UL>"
-			dat += "<LI><A href='byond://?src=[REF(src)];menu=1.1'>Current Research Levels</A>"
-			dat += "<LI><A href='byond://?src=[REF(src)];menu=5.0'>View Researched Technologies</A>"
+			dat += "<LI><A href='byond://?src=[ref_for_ui];menu=1.1'>Current Research Levels</A>"
+			dat += "<LI><A href='byond://?src=[ref_for_ui];menu=5.0'>View Researched Technologies</A>"
 			if(t_disk)
-				dat += "<LI><A href='byond://?src=[REF(src)];menu=1.2'>Disk Operations</A>"
+				dat += "<LI><A href='byond://?src=[ref_for_ui];menu=1.2'>Disk Operations</A>"
 			else if(d_disk)
-				dat += "<LI><A href='byond://?src=[REF(src)];menu=1.4'>Disk Operations</A>"
+				dat += "<LI><A href='byond://?src=[ref_for_ui];menu=1.4'>Disk Operations</A>"
 			else
 				dat += "<LI><div class='no-build'>Disk Operations</div>"
 			if(linked_destroy)
-				dat += "<LI><A href='byond://?src=[REF(src)];menu=2.2'>Destructive Analyzer Menu</A>"
+				dat += "<LI><A href='byond://?src=[ref_for_ui];menu=2.2'>Destructive Analyzer Menu</A>"
 			if(linked_lathe)
-				dat += "<LI><A href='byond://?src=[REF(src)];menu=3.1'>Protolathe Construction Menu</A>"
+				dat += "<LI><A href='byond://?src=[ref_for_ui];menu=3.1'>Protolathe Construction Menu</A>"
 			if(linked_imprinter)
-				dat += "<LI><A href='byond://?src=[REF(src)];menu=4.1'>Circuit Construction Menu</A>"
-			dat += "<LI><A href='byond://?src=[REF(src)];menu=1.6'>Settings</A>"
+				dat += "<LI><A href='byond://?src=[ref_for_ui];menu=4.1'>Circuit Construction Menu</A>"
+			dat += "<LI><A href='byond://?src=[ref_for_ui];menu=1.6'>Settings</A>"
 			dat += "</UL>"
 			dat += "</div>"
 
 		if(1.1) //Research viewer
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A> || "
-			dat += "<A href='byond://?src=[REF(src)];print=1'>Print This Page</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];print=1'>Print This Page</A><HR>"
 			dat += "<b><u>Current Research Levels:</u></b><HR>"
 			dat += GetResearchLevelsInfo()
 			dat += "</UL>"
 
 		if(1.2) //Technology Disk Menu
 
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A><HR>"
 			dat += "Disk Contents: (Technology Data Disk)<BR><BR>"
 			dat += "<div class='menu'>"
 			if(t_disk.stored == null)
 				dat += "The disk has no data stored on it.<HR>"
 				dat += "Operations: "
-				dat += "<A href='byond://?src=[REF(src)];menu=1.3'>Load Tech to Disk</A> || "
+				dat += "<A href='byond://?src=[ref_for_ui];menu=1.3'>Load Tech to Disk</A> || "
 			else
 				dat += "Name: [t_disk.stored.name]<BR>"
 				dat += "Level: [t_disk.stored.level]<BR>"
 				dat += "Description: [t_disk.stored.desc]<HR>"
 				dat += "Operations: "
-				dat += "<A href='byond://?src=[REF(src)];updt_tech=1'>Upload to Database</A> || "
-				dat += "<A href='byond://?src=[REF(src)];clear_tech=1'>Clear Disk</A> || "
-			dat += "<A href='byond://?src=[REF(src)];eject_tech=1'>Eject Disk</A>"
+				dat += "<A href='byond://?src=[ref_for_ui];updt_tech=1'>Upload to Database</A> || "
+				dat += "<A href='byond://?src=[ref_for_ui];clear_tech=1'>Clear Disk</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];eject_tech=1'>Eject Disk</A>"
 			dat += "</div>"
 
 		if(1.3) //Technology Disk submenu
-			dat += "<BR><A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A> || "
-			dat += "<A href='byond://?src=[REF(src)];menu=1.2'>Return to Disk Operations</A><HR>"
+			dat += "<BR><A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.2'>Return to Disk Operations</A><HR>"
 			dat += "<div class='menu'>"
 			dat += "Load Technology to Disk:<BR><BR>"
 			dat += "<UL>"
 			for(var/tech_id in files.known_tech)
 				var/datum/tech/T = files.known_tech[tech_id]
 				dat += "<LI>[T.name] "
-				dat += "\[<A href='byond://?src=[REF(src)];copy_tech=1;copy_tech_sent=[T.id]'>copy to disk</A>\]"
+				dat += "\[<A href='byond://?src=[ref_for_ui];copy_tech=1;copy_tech_sent=[T.id]'>copy to disk</A>\]"
 			dat += "</UL>"
 			dat += "</div>"
 
 		if(1.4) //Design Disk menu.
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A><HR>"
 			dat += "<div class='menu'>"
 			if(d_disk.blueprint == null)
 				dat += "The disk has no data stored on it.<HR>"
 				dat += "Operations: "
-				dat += "<A href='byond://?src=[REF(src)];menu=1.5'>Load Design to Disk</A> || "
+				dat += "<A href='byond://?src=[ref_for_ui];menu=1.5'>Load Design to Disk</A> || "
 			else
 				dat += "Name: [d_disk.blueprint.name]<BR>"
 				switch(d_disk.blueprint.build_type)
@@ -594,14 +597,14 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					if(copytext(M, 1, 2) == "$") dat += "* [copytext(M, 2)] x [d_disk.blueprint.materials[M]]<BR>"
 					else dat += "* [M] x [d_disk.blueprint.materials[M]]<BR>"
 				dat += "<HR>Operations: "
-				dat += "<A href='byond://?src=[REF(src)];updt_design=1'>Upload to Database</A> || "
-				dat += "<A href='byond://?src=[REF(src)];clear_design=1'>Clear Disk</A> || "
-			dat += "<A href='byond://?src=[REF(src)];eject_design=1'>Eject Disk</A>"
+				dat += "<A href='byond://?src=[ref_for_ui];updt_design=1'>Upload to Database</A> || "
+				dat += "<A href='byond://?src=[ref_for_ui];clear_design=1'>Clear Disk</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];eject_design=1'>Eject Disk</A>"
 			dat += "</div>"
 
 		if(1.5) //Technology disk submenu
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A> || "
-			dat += "<A href='byond://?src=[REF(src)];menu=1.4'>Return to Disk Operations</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.4'>Return to Disk Operations</A><HR>"
 			dat += "<div class='menu'>"
 			dat += "Load Design to Disk:<BR><BR>"
 			dat += "<UL>"
@@ -609,50 +612,50 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				var/datum/design/D = files.known_designs[path]
 				if(D.build_path)
 					dat += "<LI>[D.name] "
-					dat += "<A href='byond://?src=[REF(src)];copy_design=1;copy_design_sent=[D.type]'>\[copy to disk\]</A>"
+					dat += "<A href='byond://?src=[ref_for_ui];copy_design=1;copy_design_sent=[D.type]'>\[copy to disk\]</A>"
 			dat += "</UL>"
 			dat += "</div>"
 
 		if(1.6) //R&D console settings
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A><HR>"
 			dat += "<b><u>R&D Console Setting:</u></b><HR>"
 			dat += "<div class='menu'>"
 			dat += "<UL>"
 			if(sync)
-				dat += "<LI><A href='byond://?src=[REF(src)];sync=1'>Sync Database with Network</A><BR>"
-				dat += "<LI><A href='byond://?src=[REF(src)];togglesync=1'>Disconnect from Research Network</A><BR>"
+				dat += "<LI><A href='byond://?src=[ref_for_ui];sync=1'>Sync Database with Network</A><BR>"
+				dat += "<LI><A href='byond://?src=[ref_for_ui];togglesync=1'>Disconnect from Research Network</A><BR>"
 			else
-				dat += "<LI><A href='byond://?src=[REF(src)];togglesync=1'>Connect to Research Network</A><BR>"
-			dat += "<LI><A href='byond://?src=[REF(src)];menu=1.7'>Device Linkage Menu</A><BR>"
-			dat += "<LI><A href='byond://?src=[REF(src)];lock=0.2'>Lock Console</A><BR>"
-			dat += "<LI><A href='byond://?src=[REF(src)];reset=1'>Reset R&D Database</A><BR>"
+				dat += "<LI><A href='byond://?src=[ref_for_ui];togglesync=1'>Connect to Research Network</A><BR>"
+			dat += "<LI><A href='byond://?src=[ref_for_ui];menu=1.7'>Device Linkage Menu</A><BR>"
+			dat += "<LI><A href='byond://?src=[ref_for_ui];lock=0.2'>Lock Console</A><BR>"
+			dat += "<LI><A href='byond://?src=[ref_for_ui];reset=1'>Reset R&D Database</A><BR>"
 			dat += "<UL>"
 			dat += "</div>"
 
 		if(1.7) //R&D device linkage
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A> || "
-			dat += "<A href='byond://?src=[REF(src)];menu=1.6'>Settings Menu</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.6'>Settings Menu</A><HR>"
 			dat += "<b><u>R&D Console Device Linkage Menu:</u></b><HR>"
 			dat += "<div class='menu'>"
-			dat += "<A href='byond://?src=[REF(src)];find_device=1'>Re-sync with Nearby Devices</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];find_device=1'>Re-sync with Nearby Devices</A><HR>"
 			dat += "Linked Devices:"
 			dat += "<UL>"
 
 			if(allow_analyzer)
 				if(linked_destroy)
-					dat += "<LI>Destructive Analyzer <A href='byond://?src=[REF(src)];disconnect=destroy'>Disconnect</A>"
+					dat += "<LI>Destructive Analyzer <A href='byond://?src=[ref_for_ui];disconnect=destroy'>Disconnect</A>"
 				else
 					dat += "<LI>(No Destructive Analyzer Linked)"
 
 			if(allow_lathe)
 				if(linked_lathe)
-					dat += "<LI>Protolathe <A href='byond://?src=[REF(src)];disconnect=lathe'>Disconnect</A>"
+					dat += "<LI>Protolathe <A href='byond://?src=[ref_for_ui];disconnect=lathe'>Disconnect</A>"
 				else
 					dat += "<LI>(No Protolathe Linked)"
 
 			if(allow_imprinter)
 				if(linked_imprinter)
-					dat += "<LI>Circuit Imprinter <A href='byond://?src=[REF(src)];disconnect=imprinter'>Disconnect</A>"
+					dat += "<LI>Circuit Imprinter <A href='byond://?src=[ref_for_ui];disconnect=imprinter'>Disconnect</A>"
 				else
 					dat += "<LI>(No Circuit Imprinter Linked)"
 				dat += "</UL>"
@@ -660,44 +663,44 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 		////////////////////DESTRUCTIVE ANALYZER SCREENS////////////////////////////
 		if(2.0)
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A><HR>"
 			dat += "NO DESTRUCTIVE ANALYZER LINKED TO CONSOLE<BR><BR>"
 
 		if(2.1)
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A><HR>"
 			dat += "No Item Loaded. Standing-by...<BR><HR>"
 
 		if(2.2)
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A><HR>"
 			dat += "<b><u>Deconstruction Menu</u></b><HR>"
 			dat += "Name: [linked_destroy.loaded_item.name]<BR>"
 			dat += "Origin Tech:"
 			dat += "<UL>"
 			for(var/tech_id in linked_destroy.loaded_item.origin_tech)
 				var/datum/tech/T = files.known_tech[tech_id]
-				dat += "<LI>[capitalize_first_letters(T.name)]: \[Level: [linked_destroy.loaded_item.origin_tech[tech_id]] || Progress Contribution: [files.get_level_value(linked_destroy.loaded_item.origin_tech[tech_id])]\]"
+				dat += "<LI>[T.name]: \[Level: [linked_destroy.loaded_item.origin_tech[tech_id]] || Progress Contribution: [files.get_level_value(linked_destroy.loaded_item.origin_tech[tech_id])]\]"
 				dat += " (Current Level: [T.level] || Current Progress: [T.next_level_progress]/[T.next_level_threshold])"
 			dat += "</UL>"
 			if(!istype(linked_destroy.loaded_item, /obj/item/stack))
-				dat += "<HR><A href='byond://?src=[REF(src)];deconstruct=1'>Deconstruct Item</A> || "
+				dat += "<HR><A href='byond://?src=[ref_for_ui];deconstruct=1'>Deconstruct Item</A> || "
 			else
-				dat += "<HR><A href='byond://?src=[REF(src)];deconstruct=1'>Deconstruct One In Stack</A> || "
-			dat += "<A href='byond://?src=[REF(src)];eject_item=1'>Eject Item</A>"
+				dat += "<HR><A href='byond://?src=[ref_for_ui];deconstruct=1'>Deconstruct One In Stack</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];eject_item=1'>Eject Item</A>"
 
 		/////////////////////PROTOLATHE SCREENS/////////////////////////
 		if(3.0)
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A><HR>"
 			dat += "NO PROTOLATHE LINKED TO CONSOLE<BR><BR>"
 
 		if(3.1)
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A> || "
-			dat += "<A href='byond://?src=[REF(src)];menu=3.4'>View Queue</A> || "
-			dat += "<A href='byond://?src=[REF(src)];menu=3.2'>Material Storage</A> || "
-			dat += "<A href='byond://?src=[REF(src)];menu=3.3'>Chemical Storage</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];menu=3.4'>View Queue</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];menu=3.2'>Material Storage</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];menu=3.3'>Chemical Storage</A><HR>"
 			dat += "<b><u>Protolathe Menu:</u></b><HR>"
 			dat += "<B>Material Amount:</B> [linked_lathe.TotalMaterials()] cm<sup>3</sup> (MAX: [linked_lathe.max_material_storage])<BR>"
 			dat += "<B>Chemical Volume:</B> [linked_lathe.reagents.total_volume] (MAX: [linked_lathe.reagents.maximum_volume])<HR>"
-			dat += "<font size='3'; color='#5c87a8'><b>Category:</b></font> <a href='byond://?src=[REF(src)];protolathe_category=1'>[protolathe_category]</a><hr>"
+			dat += "<font size='3'; color='#5c87a8'><b>Category:</b></font> <a href='byond://?src=[ref_for_ui];protolathe_category=1'>[protolathe_category]</a><hr>"
 			dat += "<div class='rdconsole-build'>"
 			dat += "<ul>"
 			var/last_category = ""
@@ -718,16 +721,16 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				if(temp_dat)
 					temp_dat = " \[[copytext(temp_dat, 3)]\]"
 				if(linked_lathe.canBuild(D))
-					dat += "<li class='highlight'><b><a href='byond://?src=[REF(src)];build=[D.type]'>[capitalize_first_letters(D.name)]</a></b>"
+					dat += "<li class='highlight'><b><a href='byond://?src=[ref_for_ui];build=[D.type]'>[D.name]</a></b>"
 				else
-					dat += "<li class='highlight'><b><div class='no-build'>[capitalize_first_letters(D.name)]</div></b>"
+					dat += "<li class='highlight'><b><div class='no-build'>[D.name]</div></b>"
 				dat += "[temp_dat]<br><i>[D.desc]</i>"
 			dat += "</ul>"
 			dat += "</div>"
 
 		if(3.2) //Protolathe Material Storage Sub-menu
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A> || "
-			dat += "<A href='byond://?src=[REF(src)];menu=3.1'>Protolathe Menu</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];menu=3.1'>Protolathe Menu</A><HR>"
 			dat += "<b><u>Material Storage</u></b><BR><HR>"
 			dat += "<UL>"
 			for(var/M in linked_lathe.materials)
@@ -738,25 +741,25 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					for (var/C in list(1, 3, 5, 10, 15, 20, 25, 30, 40))
 						if(amount < C * SHEET_MATERIAL_AMOUNT)
 							break
-						dat += "[C > 1 ? ", " : ""]<A href='byond://?src=[REF(src)];lathe_ejectsheet=[M];amount=[C]'>[C]</A> "
+						dat += "[C > 1 ? ", " : ""]<A href='byond://?src=[ref_for_ui];lathe_ejectsheet=[M];amount=[C]'>[C]</A> "
 
-					dat += " or <A href='byond://?src=[REF(src)];lathe_ejectsheet=[M];amount=50'>max</A> sheets"
+					dat += " or <A href='byond://?src=[ref_for_ui];lathe_ejectsheet=[M];amount=50'>max</A> sheets"
 				dat += ""
 			dat += "</UL>"
 
 		if(3.3) //Protolathe Chemical Storage Submenu
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A> || "
-			dat += "<A href='byond://?src=[REF(src)];menu=3.1'>Protolathe Menu</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];menu=3.1'>Protolathe Menu</A><HR>"
 			dat += "<b><u>Chemical Storage</u></b><BR><HR>"
 			for(var/_R in linked_lathe.reagents.reagent_volumes)
 				var/singleton/reagent/R = GET_SINGLETON(_R)
 				dat += "Name: [R.name] | Units: [linked_lathe.reagents.reagent_volumes[_R]] "
-				dat += "<A href='byond://?src=[REF(src)];disposeP=[_R]'>(Purge)</A><BR>"
-				dat += "<A href='byond://?src=[REF(src)];disposeallP=1'><U>Disposal All Chemicals in Storage</U></A><BR>"
+				dat += "<A href='byond://?src=[ref_for_ui];disposeP=[_R]'>(Purge)</A><BR>"
+				dat += "<A href='byond://?src=[ref_for_ui];disposeallP=1'><U>Disposal All Chemicals in Storage</U></A><BR>"
 
 		if(3.4) // Protolathe queue
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A> || "
-			dat += "<A href='byond://?src=[REF(src)];menu=3.1'>Protolathe Menu</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];menu=3.1'>Protolathe Menu</A><HR>"
 			dat += "<b><u>Queue</u></b><BR><HR>"
 			if(!linked_lathe.queue.len)
 				dat += "Empty"
@@ -767,25 +770,25 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 						if(linked_lathe.busy)
 							dat += "<B>1: [D.name]</B><BR>"
 						else
-							dat += "<B>1: [D.name]</B> (Awaiting materials) <A href='byond://?src=[REF(src)];removeP=[tmp]'>Remove</A><BR>"
+							dat += "<B>1: [D.name]</B> (Awaiting materials) <A href='byond://?src=[ref_for_ui];removeP=[tmp]'>Remove</A><BR>"
 					else
-						dat += "[tmp]: [D.name] <A href='byond://?src=[REF(src)];removeP=[tmp]'>Remove</A><BR>"
+						dat += "[tmp]: [D.name] <A href='byond://?src=[ref_for_ui];removeP=[tmp]'>Remove</A><BR>"
 					++tmp
 
 		///////////////////CIRCUIT IMPRINTER SCREENS////////////////////
 		if(4.0)
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A><HR>"
 			dat += "NO CIRCUIT IMPRINTER LINKED TO CONSOLE<BR><BR>"
 
 		if(4.1)
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A> || "
-			dat += "<A href='byond://?src=[REF(src)];menu=4.4'>View Queue</A> || "
-			dat += "<A href='byond://?src=[REF(src)];menu=4.3'>Material Storage</A> || "
-			dat += "<A href='byond://?src=[REF(src)];menu=4.2'>Chemical Storage</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];menu=4.4'>View Queue</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];menu=4.3'>Material Storage</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];menu=4.2'>Chemical Storage</A><HR>"
 			dat += "<b><u>Circuit Imprinter Menu:</u></b><BR><HR>"
 			dat += "Material Amount: [linked_imprinter.TotalMaterials()] cm<sup>3</sup><BR>"
 			dat += "Chemical Volume: [linked_imprinter.reagents.total_volume]<HR>"
-			dat += "<font size='3'; color='#5c87a8'><b>Category:</b></font> <a href='byond://?src=[REF(src)];imprinter_category=1'>[imprinter_category]</a><hr>"
+			dat += "<font size='3'; color='#5c87a8'><b>Category:</b></font> <a href='byond://?src=[ref_for_ui];imprinter_category=1'>[imprinter_category]</a><hr>"
 			dat += "<div class='rdconsole-build'>"
 			dat += "<ul>"
 			var/last_category = ""
@@ -806,7 +809,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				if(temp_dat)
 					temp_dat = " \[[copytext(temp_dat,3)]\]"
 				if(linked_imprinter.canBuild(D))
-					dat += "<li class='highlight'><b><a href='byond://?src=[REF(src)];imprint=[D.type]'>[D.name]</a></b>"
+					dat += "<li class='highlight'><b><a href='byond://?src=[ref_for_ui];imprint=[D.type]'>[D.name]</a></b>"
 				else
 					dat += "<li class='highlight'><b><div class='no-build'>[D.name]</div></b>"
 				dat += "[temp_dat]<br><i>[D.desc]</i>"
@@ -814,18 +817,18 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "</div>"
 
 		if(4.2)
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A> || "
-			dat += "<A href='byond://?src=[REF(src)];menu=4.1'>Imprinter Menu</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];menu=4.1'>Imprinter Menu</A><HR>"
 			dat += "<b><u>Chemical Storage</u></b><BR><HR>"
 			for(var/_R in linked_imprinter.reagents.reagent_volumes)
 				var/singleton/reagent/R = GET_SINGLETON(_R)
 				dat += "Name: [R.name] | Units: [linked_imprinter.reagents.reagent_volumes[_R]] "
-				dat += "<A href='byond://?src=[REF(src)];disposeI=[_R]'>(Purge)</A><BR>"
-				dat += "<A href='byond://?src=[REF(src)];disposeallI=1'><U>Disposal All Chemicals in Storage</U></A><BR>"
+				dat += "<A href='byond://?src=[ref_for_ui];disposeI=[_R]'>(Purge)</A><BR>"
+				dat += "<A href='byond://?src=[ref_for_ui];disposeallI=1'><U>Disposal All Chemicals in Storage</U></A><BR>"
 
 		if(4.3)
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A> || "
-			dat += "<A href='byond://?src=[REF(src)];menu=4.1'>Circuit Imprinter Menu</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];menu=4.1'>Circuit Imprinter Menu</A><HR>"
 			dat += "<b><u>Material Storage</u></b><BR><HR>"
 			dat += "<UL>"
 			for(var/M in linked_imprinter.materials)
@@ -836,15 +839,15 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					for (var/C in list(1, 3, 5, 10, 15, 20, 25, 30, 40))
 						if(amount < C * SHEET_MATERIAL_AMOUNT)
 							break
-						dat += "[C > 1 ? ", " : ""]<A href='byond://?src=[REF(src)];imprinter_ejectsheet=[M];amount=[C]'>[C]</A> "
+						dat += "[C > 1 ? ", " : ""]<A href='byond://?src=[ref_for_ui];imprinter_ejectsheet=[M];amount=[C]'>[C]</A> "
 
-					dat += " or <A href='byond://?src=[REF(src)];imprinter_ejectsheet=[M];amount=50'>max</A> sheets"
+					dat += " or <A href='byond://?src=[ref_for_ui];imprinter_ejectsheet=[M];amount=50'>max</A> sheets"
 				dat += ""
 			dat += "</UL>"
 
 		if(4.4)
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A> || "
-			dat += "<A href='byond://?src=[REF(src)];menu=4.1'>Circuit Imprinter Menu</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];menu=4.1'>Circuit Imprinter Menu</A><HR>"
 			dat += "<b><u>Queue</u></b><BR><HR>"
 			if(linked_imprinter.queue.len == 0)
 				dat += "Empty"
@@ -854,13 +857,13 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					if(tmp == 1)
 						dat += "<B>1: [D.name]</B><BR>"
 					else
-						dat += "[tmp]: [D.name] <A href='byond://?src=[REF(src)];removeI=[tmp]'>Remove</A><BR>"
+						dat += "[tmp]: [D.name] <A href='byond://?src=[ref_for_ui];removeI=[tmp]'>Remove</A><BR>"
 					++tmp
 
 		///////////////////Research Information Browser////////////////////
 		if(5.0)
-			dat += "<A href='byond://?src=[REF(src)];menu=1.0'>Main Menu</A> || "
-			dat += "<A href='byond://?src=[REF(src)];print=2'>Print This Page</A><HR>"
+			dat += "<A href='byond://?src=[ref_for_ui];menu=1.0'>Main Menu</A> || "
+			dat += "<A href='byond://?src=[ref_for_ui];print=2'>Print This Page</A><HR>"
 			dat += "<b><u>List of Researched Technologies and Designs:</u></b><HR>"
 			dat += GetResearchListInfo()
 

--- a/html/changelogs/johnwildkins-lagdeath.yml
+++ b/html/changelogs/johnwildkins-lagdeath.yml
@@ -1,0 +1,16 @@
+# Your name.
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - refactor: "Refactored several machines backend code to reduce server load."
+  - refactor: "Fixed an issue where slimes would hard-delete, causing server lag."
+  - refactor: "Optimized igniter and holosign buttons to reduce server load when used."
+  - refactor: "Optimized atmos meters to only update their icon state when necessary."


### PR DESCRIPTION
Destroys a ton of sources of lag:

- /obj/machinery/biogenerator/interact and /obj/machinery/computer/rdconsole/attack_hand

Both of these call REF(src) constantly on their UI update, which also happens constantly. Death by a thousand cuts

- /obj/machinery/button/ignition/attack_hand and /obj/machinery/button/switch/holosign/attack_hand

Sleeps rather than timers, iterating the entire machinery list rather than just storing the IDs we need at roundstart

- /obj/machinery/telecomms/update_icon and /obj/machinery/meter/process

Calling overlay updates WAY TOO MUCH. UpdateOverlays is a significant overhead for the server at this point and the two of these combined are responsible for a little over 20% of updates. They now should only update overlays when necessary rather than every tick.

- /mob/living/carbon/slime

Hard-del'd if grinded into slime extract less than two minutes after being "born". Fixed by adding TIMER_DELETE_ME flag. 