### PR TITLE
False Alarm Name Reference Fix

### DIFF
--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -274,7 +274,7 @@
 		return station_name()
 
 	var/obj/effect/overmap/O = GLOB.map_sectors["[pick(affecting_z)]"]
-	return O ? O.name : "Unknown Location"
+	return O ? O.name : station_name()
 
 /datum/event/proc/get_skybox_image()
 	return

--- a/html/changelogs/Bat-FalseAlarm.yml
+++ b/html/changelogs/Bat-FalseAlarm.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Batrachophrenoboocosmomachia
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Event False Alarms now give refer to proper ship name instead of 'Unknown Location.'"


### PR DESCRIPTION
Makes it so False Alarm events correctly refer to the SCCV Horizon instead of 'Unknown Location.' Not the most elegant fix but it works.