### PR TITLE
Adds the autopsy scanner to the protolathe

### DIFF
--- a/code/modules/research/designs/protolathe/medical_designs.dm
+++ b/code/modules/research/designs/protolathe/medical_designs.dm
@@ -110,3 +110,9 @@
 	req_tech = list(TECH_BLUESPACE = 2, TECH_MATERIAL = 6)
 	materials = list(DEFAULT_WALL_MATERIAL = 3000, MATERIAL_PHORON = 3000, MATERIAL_DIAMOND = 500)
 	build_path = /obj/item/reagent_containers/glass/beaker/bluespace
+
+/datum/design/item/medical/autopsy_scanner
+	name = "Autopsy Scanner"
+	req_tech = list(TECH_BIO = 3)
+	materials = list(DEFAULT_WALL_MATERIAL = 30, MATERIAL_GLASS = 20)
+	build_path = /obj/item/autopsy_scanner

--- a/html/changelogs/Fyni-AutopsyScanner.yml
+++ b/html/changelogs/Fyni-AutopsyScanner.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Fyni
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds the autopsy scanner to the protolathe, available at round start under biotech"


### PR DESCRIPTION
Adds the autopsy scanner to the protolathe. Available at bio tech level 3, which is where we currently start the round, and found udner the biotech category. The material is matching with other similiar devices.