### PR TITLE
Fix installing atmos pipes

### DIFF
--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -37,10 +37,12 @@
 /obj/machinery/atmospherics/pipe/drain_power()
 	return -1
 
-/obj/machinery/atmospherics/pipe/Initialize()
+/obj/machinery/atmospherics/pipe/Initialize(mapload)
 	if(istype(get_turf(src), /turf/simulated/wall) || istype(get_turf(src), /turf/unsimulated/wall))
 		level = 1
 	. = ..()
+	if(!mapload)
+		return INITIALIZE_HINT_NORMAL
 
 /obj/machinery/atmospherics/pipe/hides_under_flooring()
 	return level != 2

--- a/html/changelogs/johnwildkins-atmosfix.yml
+++ b/html/changelogs/johnwildkins-atmosfix.yml
@@ -1,0 +1,12 @@
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fix atmospheric pipes becoming invisible or failing to be wrenched down."


### PR DESCRIPTION
See title

obj/machinery/atmospherics/pipe and co. were expecting to only LateInitialize during mapload, but the recent power signals change caused them to always fire LateInitialize, which because of pipe shitcode resulted in a ton of errors