### PR TITLE
Some cargo tweaks and adjustments (Oct '25)

### DIFF
--- a/code/modules/cargo/items/cartridges.dm
+++ b/code/modules/cargo/items/cartridges.dm
@@ -45,7 +45,7 @@
 	name = "drink cartridge - champagne"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 55
+	price = 72
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/champagne
 	)
@@ -59,7 +59,7 @@
 	name = "drink cartridge - coffee"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 24
+	price = 20
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/coffee
 	)
@@ -73,7 +73,7 @@
 	name = "drink cartridge - cognac"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 55
+	price = 65
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/cognac
 	)
@@ -101,7 +101,7 @@
 	name = "drink cartridge - cream"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 18
+	price = 24
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/cream
 	)
@@ -129,7 +129,7 @@
 	name = "drink cartridge - gin"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 45
+	price = 55
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/gin
 	)
@@ -143,7 +143,7 @@
 	name = "drink cartridge - ice"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 18
+	price = 8
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/ice
 	)
@@ -227,7 +227,7 @@
 	name = "drink cartridge - orange juice"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 18
+	price = 22
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/orange
 	)
@@ -241,7 +241,7 @@
 	name = "drink cartridge - rum"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 45
+	price = 50
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/rum
 	)
@@ -269,7 +269,7 @@
 	name = "drink cartridge - soda water"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 18
+	price = 12
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/sodawater
 	)
@@ -283,7 +283,7 @@
 	name = "drink cartridge - Vacuum Fizz"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 18
+	price = 15
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/spaceup
 	)
@@ -311,7 +311,7 @@
 	name = "drink cartridge - tequila"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 45
+	price = 55
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/tequila
 	)
@@ -325,7 +325,7 @@
 	name = "drink cartridge - tonic"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 45
+	price = 18
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/tonic
 	)
@@ -339,7 +339,7 @@
 	name = "drink cartridge - vermouth"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 45
+	price = 28
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/vermouth
 	)
@@ -353,7 +353,7 @@
 	name = "drink cartridge - vodka"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 45
+	price = 50
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/vodka
 	)
@@ -367,7 +367,7 @@
 	name = "drink cartridge - watermelon"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 18
+	price = 20
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/watermelon
 	)
@@ -381,7 +381,7 @@
 	name = "drink cartridge - whiskey"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 45
+	price = 55
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/whiskey
 	)
@@ -395,7 +395,7 @@
 	name = "drink cartridge - wine"
 	supplier = "getmore"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 55
+	price = 42
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/wine
 	)
@@ -691,7 +691,7 @@
 	name = "chemical cartridge - water"
 	supplier = "zeng_hu"
 	description = "A metal canister containing 500 units of a substance. Mostly for use in liquid dispensers, though you can also pour it straight out of the can."
-	price = 1.50
+	price = 10
 	items = list(
 		/obj/item/reagent_containers/chem_disp_cartridge/water
 	)

--- a/code/modules/cargo/items/hydroponics.dm
+++ b/code/modules/cargo/items/hydroponics.dm
@@ -213,7 +213,7 @@
 	name = "hydroponics tray"
 	supplier = "nanotrasen"
 	description = "A safe space to raise your plants."
-	price = 50
+	price = 100
 	items = list(
 		/obj/machinery/portable_atmospherics/hydroponics
 	)

--- a/code/modules/cargo/items/hydroponics.dm
+++ b/code/modules/cargo/items/hydroponics.dm
@@ -73,7 +73,7 @@
 	name = "cat"
 	supplier = "molinaris"
 	description = "A domesticated, feline pet. Has a tendency to adopt crewmembers."
-	price = 150
+	price = 350
 	items = list(
 		/mob/living/simple_animal/cat
 	)
@@ -87,7 +87,7 @@
 	name = "chicken"
 	supplier = "molinaris"
 	description = "Adorable! They make such a racket though."
-	price = 30
+	price = 80
 	items = list(
 		/mob/living/simple_animal/chick
 	)
@@ -115,13 +115,69 @@
 	name = "cow"
 	supplier = "molinaris"
 	description = "Known for their milk, just don't tip them over."
-	price = 1200
+	price = 800
 	items = list(
 		/mob/living/simple_animal/cow
 	)
 	access = 0
 	container_type = "box"
 	groupable = FALSE
+	spawn_amount = 1
+
+/singleton/cargo_item/icetunneler
+	category = "hydroponics"
+	name = "ice tunneler"
+	supplier = "zharkov"
+	description = "A crate containing a ice tunneler."
+	price = 700
+	items = list(
+		/obj/structure/largecrate/animal/adhomai
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
+/singleton/cargo_item/goat
+	category = "hydroponics"
+	name = "goat"
+	supplier = "molinaris"
+	description = "Not known for their pleasant disposition."
+	price = 400
+	items = list(
+		/mob/living/simple_animal/hostile/retaliate/goat
+	)
+	access = 0
+	container_type = "box"
+	groupable = FALSE
+	spawn_amount = 1
+
+/singleton/cargo_item/pig
+	category = "hydroponics"
+	name = "pig"
+	supplier = "molinaris"
+	description = "Used in the past simply as meat farms, modern people recognize the affectionate side of these bacon factories."
+	price = 300
+	items = list(
+		/mob/living/simple_animal/pig
+	)
+	access = 0
+	container_type = "box"
+	groupable = FALSE
+	spawn_amount = 1
+
+/singleton/cargo_item/hakhma
+	category = "hydroponics"
+	name = "hakhma"
+	supplier = "molinaris"
+	description = "An oversized insect breed by Scarab colony ships, known for their milk."
+	price = 800
+	items = list(
+		/mob/living/simple_animal/hakhma
+	)
+	access = 0
+	container_type = "box"
+	groupable = TRUE
 	spawn_amount = 1
 
 /singleton/cargo_item/schlorrgoegg
@@ -166,34 +222,6 @@
 	groupable = TRUE
 	spawn_amount = 1
 
-/singleton/cargo_item/goat
-	category = "hydroponics"
-	name = "goat"
-	supplier = "molinaris"
-	description = "Not known for their pleasant disposition."
-	price = 250
-	items = list(
-		/mob/living/simple_animal/hostile/retaliate/goat
-	)
-	access = 0
-	container_type = "box"
-	groupable = FALSE
-	spawn_amount = 1
-
-/singleton/cargo_item/hakhma
-	category = "hydroponics"
-	name = "hakhma"
-	supplier = "molinaris"
-	description = "An oversized insect breed by Scarab colony ships, known for their milk."
-	price = 300
-	items = list(
-		/mob/living/simple_animal/hakhma
-	)
-	access = 0
-	container_type = "box"
-	groupable = TRUE
-	spawn_amount = 1
-
 /singleton/cargo_item/honeyextractor
 	category = "hydroponics"
 	name = "honey extractor"
@@ -216,20 +244,6 @@
 	price = 100
 	items = list(
 		/obj/machinery/portable_atmospherics/hydroponics
-	)
-	access = 0
-	container_type = "crate"
-	groupable = TRUE
-	spawn_amount = 1
-
-/singleton/cargo_item/icetunneler
-	category = "hydroponics"
-	name = "ice tunneler"
-	supplier = "zharkov"
-	description = "A crate containing a ice tunneler."
-	price = 300
-	items = list(
-		/obj/structure/largecrate/animal/adhomai
 	)
 	access = 0
 	container_type = "crate"

--- a/code/modules/cargo/items/medical.dm
+++ b/code/modules/cargo/items/medical.dm
@@ -74,7 +74,7 @@
 
 /singleton/cargo_item/oxygendeprivationfirstaid
 	category = "medical"
-	name = "oxygen deprivation first aid"
+	name = "oxygen deprivation first aid kit"
 	supplier = "nanotrasen"
 	description = "An emergency medical kit for oxygen deprivation, including cardiac arrest."
 	price = 150
@@ -88,7 +88,7 @@
 
 /singleton/cargo_item/toxinfirstaid
 	category = "medical"
-	name = "toxin first aid"
+	name = "toxin first aid kit"
 	supplier = "nanotrasen"
 	description = "An emergency medical kit for toxin exposure."
 	price = 150
@@ -102,7 +102,7 @@
 
 /singleton/cargo_item/radfirstaid
 	category = "medical"
-	name = "radiation first aid"
+	name = "radiation first aid kit"
 	supplier = "nanotrasen"
 	description = "An emergency medical kit for severe radiation exposure."
 	price = 150
@@ -119,7 +119,7 @@
 	name = "O- blood pack (x2)"
 	supplier = "zeng_hu"
 	description = "A blood pack filled with universally-compatible O- Blood."
-	price = 800
+	price = 600
 	items = list(
 		/obj/item/reagent_containers/blood/OMinus
 	)
@@ -130,17 +130,17 @@
 
 /singleton/cargo_item/bloodpack_sbs
 	category = "medical"
-	name = "SBS blood pack (x1)"
+	name = "SBS blood pack (x2)"
 	supplier = "zeng_hu"
 	description = "A blood pack filled with Synthetic Blood Substitute. WARNING: Not compatible with organic blood!"
-	price = 675
+	price = 475
 	items = list(
 		/obj/item/reagent_containers/blood/sbs
 	)
 	access = ACCESS_MEDICAL
 	container_type = "freezer"
 	groupable = TRUE
-	spawn_amount = 1
+	spawn_amount = 2
 
 /singleton/cargo_item/bloodpacksbags
 	category = "medical"
@@ -154,35 +154,7 @@
 	access = ACCESS_MEDICAL
 	container_type = "crate"
 	groupable = TRUE
-	spawn_amount = 1
-
-/singleton/cargo_item/dexplus_vial
-	category = "medical"
-	name = "dexalin plus vial"
-	supplier = "nanotrasen"
-	description = "A vial that comes with 15 units of Dexalin Plus, an advanced chemical used to rapidly oxygenate blood cells."
-	price = 900
-	items = list(
-		/obj/item/reagent_containers/glass/beaker/vial/dexalin_plus
-	)
-	access = 0
-	container_type = "crate"
-	groupable = TRUE
-	spawn_amount = 1
-
-/singleton/cargo_item/peridaxon_vial
-	category = "medical"
-	name = "peridaxon vial"
-	supplier = "nanotrasen"
-	description = "A vial that comes with 15 units of Peridaxon, an advanced organ regenerative compound."
-	price = 1300
-	items = list(
-		/obj/item/reagent_containers/glass/beaker/vial/peridaxon
-	)
-	access = ACCESS_MEDICAL
-	container_type = "crate"
-	groupable = TRUE
-	spawn_amount = 1
+	spawn_amount = 3
 
 /singleton/cargo_item/pneumalin_inhalers
 	category = "medical"
@@ -324,20 +296,6 @@
 	groupable = TRUE
 	spawn_amount = 1
 
-/singleton/cargo_item/arithrazine_vial
-	category = "medical"
-	name = "arithrazine vial"
-	supplier = "nanotrasen"
-	description = "A bottle containing Arithrazine, a potent anti-radiation medication."
-	price = 750
-	items = list(
-		/obj/item/reagent_containers/glass/beaker/vial/arithrazine
-	)
-	access = 0
-	container_type = "crate"
-	groupable = TRUE
-	spawn_amount = 1
-
 /singleton/cargo_item/inaprovaline_bottle
 	category = "medical"
 	name = "inaprovaline bottle"
@@ -388,6 +346,48 @@
 	price = 350
 	items = list(
 		/obj/item/reagent_containers/glass/bottle/thetamycin
+	)
+	access = ACCESS_MEDICAL
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
+/singleton/cargo_item/arithrazine_vial
+	category = "medical"
+	name = "arithrazine vial"
+	supplier = "nanotrasen"
+	description = "A bottle containing Arithrazine, a potent anti-radiation medication."
+	price = 750
+	items = list(
+		/obj/item/reagent_containers/glass/beaker/vial/arithrazine
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
+/singleton/cargo_item/dexplus_vial
+	category = "medical"
+	name = "dexalin plus vial"
+	supplier = "nanotrasen"
+	description = "A vial that comes with 15 units of Dexalin Plus, an advanced chemical used to rapidly oxygenate blood cells."
+	price = 900
+	items = list(
+		/obj/item/reagent_containers/glass/beaker/vial/dexalin_plus
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
+/singleton/cargo_item/peridaxon_vial
+	category = "medical"
+	name = "peridaxon vial"
+	supplier = "nanotrasen"
+	description = "A vial that comes with 15 units of Peridaxon, an advanced organ regenerative compound."
+	price = 1300
+	items = list(
+		/obj/item/reagent_containers/glass/beaker/vial/peridaxon
 	)
 	access = ACCESS_MEDICAL
 	container_type = "crate"
@@ -751,7 +751,7 @@
 	name = "organ cooler"
 	supplier = "zeng_hu"
 	description = "A sealed, cooled container to keep organs from decaying."
-	price = 300
+	price = 80
 	items = list(
 		/obj/item/storage/box/freezer/organcooler
 	)

--- a/code/modules/cargo/items/operations.dm
+++ b/code/modules/cargo/items/operations.dm
@@ -14,20 +14,6 @@
 	groupable = TRUE
 	spawn_amount = 2
 
-/singleton/cargo_item/camera
-	category = "operations"
-	name = "camera"
-	supplier = "nanotrasen"
-	description = "A polaroid camera. 10 photos left."
-	price = 45
-	items = list(
-		/obj/item/device/camera
-	)
-	access = 0
-	container_type = "crate"
-	groupable = TRUE
-	spawn_amount = 1
-
 /singleton/cargo_item/cargotraintrolley
 	category = "operations"
 	name = "cargo train trolley"
@@ -110,20 +96,6 @@
 	access = 0
 	container_type = "box"
 	groupable = FALSE
-	spawn_amount = 1
-
-/singleton/cargo_item/filmcartridge
-	category = "operations"
-	name = "film cartridge"
-	supplier = "nanotrasen"
-	description = "A camera film cartridge. Insert it into a camera to reload it."
-	price = 8
-	items = list(
-		/obj/item/device/camera_film
-	)
-	access = 0
-	container_type = "crate"
-	groupable = TRUE
 	spawn_amount = 1
 
 /singleton/cargo_item/flare

--- a/code/modules/cargo/items/robotics.dm
+++ b/code/modules/cargo/items/robotics.dm
@@ -1,3 +1,45 @@
+/singleton/cargo_item/cleanbot
+	category = "robotics"
+	name = "Cleanbot"
+	supplier = "hephaestus"
+	description = "A little cleaning robot, consisting of a bucket, a proximity sensor, and a prosthetic arm. It looks excited to clean!"
+	price = 175
+	items = list(
+		/mob/living/bot/cleanbot
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
+/singleton/cargo_item/farmbot
+	category = "robotics"
+	name = "Cleanbot"
+	supplier = "hephaestus"
+	description = "The botanist's best friend. Various farming equipment seems haphazardly attached to it."
+	price = 220
+	items = list(
+		/mob/living/bot/farmbot
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
+/singleton/cargo_item/medibot
+	category = "robotics"
+	name = "Medibot"
+	supplier = "nanotrasen"
+	description = "A little medical robot. He looks somewhat underwhelmed."
+	price = 400
+	items = list(
+		/mob/living/bot/medbot
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
 /singleton/cargo_item/positronicbrain
 	category = "robotics"
 	name = "positronic brain"

--- a/code/modules/cargo/items/security.dm
+++ b/code/modules/cargo/items/security.dm
@@ -562,3 +562,17 @@
 	container_type = "crate"
 	groupable = TRUE
 	spawn_amount = 1
+
+/singleton/cargo_item/autopsy_scanner
+	category = "security"
+	name = "autopsy scanner"
+	supplier = "nanotrasen"
+	description = "A handheld autopsy scanner that extracts information on wounds."
+	price = 250
+	items = list(
+		/obj/item/autopsy_scanner
+	)
+	access = ACCESS_FORENSICS_LOCKERS
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1

--- a/code/modules/cargo/items/supply.dm
+++ b/code/modules/cargo/items/supply.dm
@@ -12,6 +12,34 @@
 	groupable = TRUE
 	spawn_amount = 5
 
+/singleton/cargo_item/package_wrapper
+	category = "supply"
+	name = "package wrapping paper (x2)"
+	supplier = "orion"
+	description = "Package wrapping paper, for deliveries."
+	price = 10
+	items = list(
+		/obj/item/stack/packageWrap
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 2
+
+/singleton/cargo_item/gift_wrapper
+	category = "supply"
+	name = "gift wrapping paper (x2)"
+	supplier = "orion"
+	description = "Gift wrapping paper, for festive activities."
+	price = 10
+	items = list(
+		/obj/item/stack/wrapping_paper
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 2
+
 /singleton/cargo_item/bucket
 	category = "supply"
 	name = "bucket"
@@ -44,7 +72,7 @@
 	category = "supply"
 	name = "clipboard"
 	supplier = "orion"
-	description = "The timeless prop for looking like your working."
+	description = "The timeless prop for looking like you're working."
 	price = 12
 	items = list(
 		/obj/item/clipboard
@@ -56,9 +84,9 @@
 
 /singleton/cargo_item/folderblue
 	category = "supply"
-	name = "blue folder"
+	name = "blue folders (x5)"
 	supplier = "orion"
-	description = "A blue folder."
+	description = "Five blue folders."
 	price = 4.50
 	items = list(
 		/obj/item/folder/blue
@@ -66,13 +94,13 @@
 	access = 0
 	container_type = "crate"
 	groupable = TRUE
-	spawn_amount = 1
+	spawn_amount = 5
 
 /singleton/cargo_item/folderyellow
 	category = "supply"
-	name = "yellow folder"
+	name = "yellow folders (x5)"
 	supplier = "orion"
-	description = "A yellow folder."
+	description = "Five yellow folders."
 	price = 4.50
 	items = list(
 		/obj/item/folder/yellow
@@ -80,13 +108,13 @@
 	access = 0
 	container_type = "crate"
 	groupable = TRUE
-	spawn_amount = 1
+	spawn_amount = 5
 
 /singleton/cargo_item/folderred
 	category = "supply"
-	name = "red folder"
+	name = "red folders (x5)"
 	supplier = "orion"
-	description = "A red folder."
+	description = "Five red folders."
 	price = 4.50
 	items = list(
 		/obj/item/folder/red
@@ -94,13 +122,13 @@
 	access = 0
 	container_type = "crate"
 	groupable = TRUE
-	spawn_amount = 1
+	spawn_amount = 5
 
 /singleton/cargo_item/folderwhite
 	category = "supply"
-	name = "white folder"
+	name = "white folders (x5)"
 	supplier = "orion"
-	description = "A white folder."
+	description = "Five white folders."
 	price = 4.50
 	items = list(
 		/obj/item/folder/white
@@ -108,7 +136,7 @@
 	access = 0
 	container_type = "crate"
 	groupable = TRUE
-	spawn_amount = 1
+	spawn_amount = 5
 
 /singleton/cargo_item/handlabeler
 	category = "supply"
@@ -126,7 +154,7 @@
 
 /singleton/cargo_item/inflatableduck
 	category = "supply"
-	name = "inflatable duck"
+	name = "rubber duck"
 	supplier = "nanotrasen"
 	description = "No bother to sink or swim when you can just float!"
 	price = 4.50
@@ -249,6 +277,104 @@
 	container_type = "crate"
 	groupable = TRUE
 	spawn_amount = 2
+
+/singleton/cargo_item/camera
+	category = "supply"
+	name = "camera"
+	supplier = "nanotrasen"
+	description = "A polaroid camera. 10 photos left."
+	price = 45
+	items = list(
+		/obj/item/device/camera
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
+/singleton/cargo_item/filmcartridge
+	category = "supply"
+	name = "film cartridge"
+	supplier = "nanotrasen"
+	description = "A camera film cartridge. Insert it into a camera to reload it."
+	price = 8
+	items = list(
+		/obj/item/device/camera_film
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
+/singleton/cargo_item/pda
+	category = "supply"
+	name = "PDA"
+	supplier = "nanotrasen"
+	description = "A personal data assistant. Useful for replacing lost ones, or ordering for new crew."
+	price = 200
+	items = list(
+		/obj/item/modular_computer/handheld/pda
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
+/singleton/cargo_item/taperecorder
+	category = "supply"
+	name = "universal recorder"
+	supplier = "nanotrasen"
+	description = "A device that can record up to an hour of dialogue and play it back. It automatically translates the content in playback."
+	price = 20
+	items = list(
+		/obj/item/device/taperecorder
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
+/singleton/cargo_item/paperscanner
+	category = "supply"
+	name = "paper scanner"
+	supplier = "nanotrasen"
+	description = "A simple device that can be used to scan paper or paper bundles in order to digitize them."
+	price = 15
+	items = list(
+		/obj/item/paper_scanner
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
+/singleton/cargo_item/datadisk
+	category = "supply"
+	name = "basic data disk"
+	supplier = "nanotrasen"
+	description = "Small diskette with imprinted photonic circuits that can be used to store data. Its capacity is 16 GQ."
+	price = 8.50
+	items = list(
+		/obj/item/computer_hardware/hard_drive/portable
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
+/singleton/cargo_item/datadisk_adv
+	category = "supply"
+	name = "advanced data disk"
+	supplier = "nanotrasen"
+	description = "Small diskette with imprinted high-density photonic circuits that can be used to store data. Its capacity is 64 GQ."
+	price = 20
+	items = list(
+		/obj/item/computer_hardware/hard_drive/portable/advanced
+	)
+	access = 0
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
 
 /singleton/cargo_item/potted_plant_small
 	category = "supply"

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -17,7 +17,6 @@ GLOBAL_LIST_INIT(minevendor_list, list(
 	new /datum/data/mining_equipment(/obj/item/stack/flag/yellow,								10,					50),
 	new /datum/data/mining_equipment(/obj/item/stack/flag/purple,								10,					50),
 	new /datum/data/mining_equipment(/obj/item/storage/bag/ore,									25,					50),
-	new /datum/data/mining_equipment(pick(subtypesof(/obj/item/pizzabox)), 									25,					50),
 	new /datum/data/mining_equipment(/obj/item/device/flashlight/lantern,						10,					75),
 	new /datum/data/mining_equipment(/obj/item/shovel,											15,					100),
 	new /datum/data/mining_equipment(/obj/item/pickaxe,											10,					100),

--- a/html/changelogs/nauticall-cargochanges.yml
+++ b/html/changelogs/nauticall-cargochanges.yml
@@ -1,0 +1,62 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: nauticall
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added the following items to cargo: pig, Cleanbot, Farmbot, Medibot, autopsy scanner, package/gift wrapping paper, PDA, universal (tape) recorder, paper scanner, data drives."
+  - qol: "Moved certain cargo items to other categories."
+  - qol: "Modified the pricing of blood, hydroponics trays, certain drink canisters, and organ coolers. Made folders and SBS blood come in multiple per order."
+  - spellcheck: "Miscellaneous spellchecks and grammar fixes in cargo."
+  - rscdel: "Removed the ability to vend pizza from the mining vendor."


### PR DESCRIPTION
- Added the following items to cargo: pig, Cleanbot, Farmbot, Medibot, autopsy scanner, package/gift wrapping paper, PDA, universal (tape) recorder, paper scanner, data drives.
- Moved certain cargo items to other categories.
- Modified the pricing of blood, hydroponics trays, certain drink canisters, and organ coolers. Made folders and SBS blood come in multiple per order.
- Miscellaneous spellchecks and grammar fixes in cargo.
- Removed the ability to vend pizza from the mining vendor.

Certain tweaks, adjustments and additions for QOL and ordering the unfindable for people (i.e. autopsy scanner).

Pizza vending thing was changed so that miners can no longer skirt supply shortages by simply unloading 500 pizzas into everyone's lap. Sorry.