### PR TITLE
Ensures hangar techs have 4 spots to spawn on, instead of 3

### DIFF
--- a/html/changelogs/SlotFix.yml
+++ b/html/changelogs/SlotFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "There are now four spawn spots for hangar techs, to fit the amount of slots they have."


### PR DESCRIPTION
As the description says, since there is now 4 slots.