### PR TITLE
Fix - Add missing D2 bridge/service stairwell APC

### DIFF
--- a/html/changelogs/fabiank3-bug-missing-apc-service-stairwell.yml
+++ b/html/changelogs/fabiank3-bug-missing-apc-service-stairwell.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Added missing APC to D2 service/bridge stairwell."


### PR DESCRIPTION
# Summary

This PR adds a missing APC to the D2 bridge/service stairwell.

# Preview

Before:
<img width="246" height="258" alt="image" src="https://github.com/user-attachments/assets/744d7ccb-3414-4c8e-872c-8918960207ff" />

After:
<img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/a1f4f340-3bed-4dd4-940a-8980ff898f19" />
