### PR TITLE
Fix - Issue & PR triage action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,8 +2,8 @@ name: "Stale bot - Issue and PR triage"
 
 on:
   schedule:
-    # Run every monday and friday at 06:00 UTC, giving an update for the new week and the weekend
-    - cron: "0 6 * * 1,5"
+    # Run every day at 6 AM UTC - Daily run to utilize all operations-per-run without getting rate limited
+    - cron: "0 6 * * *"
   workflow_dispatch: # Allow manual trigger
 
 permissions:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,7 +27,7 @@ jobs:
           close-issue-message: >
             This issue has been closed automatically after 90 days of inactivity.
             If you think this issue is still relevant, please reopen it or create a new issue.
-          exempt-issue-labels-regex: "(?i).*replicable.*" # Problems that are waiting for resolution shouldn't be closed
+          exempt-issue-labels: "Bot Ignore,⛔ Lore Discussion,⛔ Maintainer Discussion,✔️ Issue Replicable"
 
           # --- PR settings ---
           days-before-pr-stale: 60
@@ -37,5 +37,5 @@ jobs:
             This pull request has been marked as stale due to the lack of activity within the last 60 days.
             If you are still working on this, please push your work or leave a comment.
             Pull requests marked as stale won't be auto-closed but are at the discretion of staff to be closed at any point without further notice.
-          exempt-pr-labels-regex: "(?i).*discussion.*" # Match any label containing "discussion"
+          exempt-pr-labels: "Bot Ignore,⛔ Lore Discussion,⛔ Maintainer Discussion,✔️ Issue Replicable"
           # Draft PRs are not exempted from getting marked as stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,9 +17,8 @@ jobs:
       - uses: actions/stale@v9
         with:
           # --- Issue settings ---
-          days-before-stale: 60
-          days-before-close: 30
-          stale-issue-label: "Stale"
+          days-before-issue-stale: 60
+          days-before-issue-close: 30
           stale-issue-message: >
             This issue has been marked as stale due to the lack of activity within the last 60 days.
             If you think the issue is still relevant, leave a comment or let the issue get labeled as replicable by staff.
@@ -32,10 +31,8 @@ jobs:
           # --- PR settings ---
           days-before-pr-stale: 60
           days-before-pr-close: -1 # Never auto-close PRs
-          stale-pr-label: "Stale"
           stale-pr-message: >
             This pull request has been marked as stale due to the lack of activity within the last 60 days.
             If you are still working on this, please push your work or leave a comment.
             Pull requests marked as stale won't be auto-closed but are at the discretion of staff to be closed at any point without further notice.
           exempt-pr-labels: "Bot Ignore,⛔ Lore Discussion,⛔ Maintainer Discussion,✔️ Issue Replicable"
-          # Draft PRs are not exempted from getting marked as stale

--- a/html/changelogs/fabiank3-bug-stale-action-label-setting.yml
+++ b/html/changelogs/fabiank3-bug-stale-action-label-setting.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed exempt labels getting ignore in the CI/CD stale triage action in the repository."


### PR DESCRIPTION
# Summary

This PR fixes the to-be exempt labels on issues and PRs that the stale action should ignore when trying to mark them as stale.

# Details

The label exempt regex syntax isn't supported [anymore?], this resulted in the setting being ignored.  
This PR also contains light cleaning, removal of defaults, update of cron to daily to utilize the rate limit per run without getting rate limited.

# On merge

Please trigger the action manually on merge so the output is immediately available to verify the fix.  
The documentation provides no info on the formatting of the labels within their comma brackets, it might be possible they have another format in code (e.g. `"Bot Ignore"` -> `"bot-ignore"`?).  
Not a real breaking behavior if wrong but possibly annoying and open to fix afterwards.