### PR TITLE
Fix - Missing actions permission in triage bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch: # Allow manual trigger
 
 permissions:
+  actions: write
   issues: write
   pull-requests: write
 

--- a/html/changelogs/fabiank3-bug-stale-action-label-setting copy.yml
+++ b/html/changelogs/fabiank3-bug-stale-action-label-setting copy.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed missing permission for cache access in the issue triage workflow in the repository."


### PR DESCRIPTION
# Summary

This PR adds the missing actions write permission to the triage bot.

# Details

The actions write permission is required to access the actions cache that is needed for operations-per-run continuity. This one was simply missing.