### PR TITLE
The light replacer can load lights much faster from boxes

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -53,7 +53,7 @@
 	var/emagged = 0
 	var/failmsg = ""
 	var/charge = 0
-	var/load_interval = 60
+	var/load_interval = 20
 	var/store_broken = 0//If set, this lightreplacer will suck up and store broken bulbs
 	var/max_stored = 10
 

--- a/html/changelogs/FastLights.yml
+++ b/html/changelogs/FastLights.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "The light replacer is now much faster when loading from a box of lights."


### PR DESCRIPTION
The light replacer now takes double the time of the advanced light replacer to fill in from boxes, so it actually make sense to do that instead of just manually filling it.