### PR TITLE
Fertilizer yield_mod reapplication fix

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -800,22 +800,28 @@
 			return
 
 		var/total_yield = 0
+		var/extra_yield = 0
 		if(!isnull(force_amount))
 			total_yield = force_amount
 		else
 			if(GET_SEED_TRAIT(src, TRAIT_YIELD) > -1)
 				if(isnull(yield_mod) || yield_mod < 1)
 					yield_mod = 0
-					total_yield = GET_SEED_TRAIT(src, TRAIT_YIELD)
 				else
-					total_yield = GET_SEED_TRAIT(src, TRAIT_YIELD) + rand(yield_mod)
-				total_yield = max(1,total_yield)
+					extra_yield = rand(0, yield_mod)
+				total_yield = max(1,GET_SEED_TRAIT(src, TRAIT_YIELD))
 
 		// If the plant is stunted, you get half the yield.
 		if(stunted_status)
 			total_yield *= 0.5
+			extra_yield *= 0.5
 
-		for(var/i = 0;i<total_yield;i++)
+		// Apply extra_yield only once.
+		if(extra_yield)
+			for(var/x = 1 to extra_yield)
+				spawn_seed(get_turf(user))
+
+		for(var/y = 1 to total_yield)
 			spawn_seed(get_turf(user))
 
 /datum/seed/proc/spawn_seed(var/turf/spawning_loc)

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -85,11 +85,16 @@
 	/// Currently displayed growth stage, set in update_icon.
 	var/displayed_stage
 
-
-	/**
+	/*
 	Reagent information for process(), consider moving this to a controller along
 	with cycle information under 'mechanical concerns' at some point.
 	*/
+
+	/**
+	 * Toxin levels beyond the plant's tolerance cause damage, but
+	 * toxins are sucked up each tick and slowly reduce over time.
+	 * The current water in the tray will dilute toxins.
+	 */
 	var/global/list/toxic_reagents = list(
 		/singleton/reagent/dylovene =			 -2,
 		/singleton/reagent/toxin =				  2,
@@ -103,6 +108,10 @@
 		/singleton/reagent/radium =				  2,
 		/singleton/reagent/drugs/raskara_dust =		2.5
 		)
+	/**
+	 * Nutrients increase the plant's nutrilevel by the given amount
+	 * multiplied by the number of units added. Includes fertilizers.
+	 */
 	var/global/list/nutrient_reagents = list(
 		/singleton/reagent/drink/milk =				 0.1,
 		/singleton/reagent/alcohol/beer =			0.25,
@@ -119,6 +128,10 @@
 		/singleton/reagent/toxin/fertilizer/left4zed =				1,
 		/singleton/reagent/toxin/fertilizer/monoammoniumphosphate =	1
 		)
+	/**
+	 * Weedkillers decrease the plant's weedlevel by the given amount
+	 * multiplied by the number of units added.
+	 */
 	var/global/list/weedkiller_reagents = list(
 		/singleton/reagent/hydrazine =			-4,
 		/singleton/reagent/phosphorus =			-2,
@@ -129,11 +142,19 @@
 		/singleton/reagent/toxin/plantbgone =	-8,
 		/singleton/reagent/adminordrazine =		-5
 		)
+	/**
+	 * Pestkillers decrease the plant's pestlevel by the given amount
+	 * multiplied by the number of units added.
+	 */
 	var/global/list/pestkiller_reagents = list(
 		/singleton/reagent/sugar =           2,
 		/singleton/reagent/diethylamine =   -2,
 		/singleton/reagent/adminordrazine = -5
 		)
+	/**
+	 * 'Water reagents' will affect the plant's waterlevel by the given amount
+	 * multiplied by the number of units added.
+	 */
 	var/global/list/water_reagents = list(
 		/singleton/reagent/water =					  1,
 		/singleton/reagent/adminordrazine =			  1,
@@ -144,8 +165,10 @@
 		/singleton/reagent/water =					  1,
 		/singleton/reagent/drink/sodawater =		  1
 		)
-
-	/// Beneficial reagents also have values for modifying yield_mod and mut_mod (in that order).
+	/**
+	 * Beneficial reagents also have values for modifying health, yield_mod and
+	 * mut_mod (in that order).
+	 */
 	var/global/list/beneficial_reagents = list(
 		/singleton/reagent/alcohol/beer=list( -0.05, 0,   0  ),
 		/singleton/reagent/hydrazine =			list( -2,    0,   0  ),
@@ -165,10 +188,9 @@
 		/singleton/reagent/toxin/fertilizer/robustharvest =	list(  0,	0.2, 0  ),
 		/singleton/reagent/toxin/fertilizer/left4zed =		list(  0,	0,   0.2)
 		)
-
 	/**
-	Mutagen list specifies minimum value for the mutation to take place, rather
-	than a bound as the lists above specify.
+	* Mutagen list specifies minimum value for the mutation to take place, rather
+	* than a bound as the lists above specify.
 	*/
 	var/global/list/mutagenic_reagents = list(
 		/singleton/reagent/radium =   8,

--- a/html/changelogs/Bat-ExtraYieldFix.yml
+++ b/html/changelogs/Bat-ExtraYieldFix.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Batrachophrenoboocosmomachia
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed hydroponics yield modifiers reapplying itself to plants that natively yield multiple products."


### PR DESCRIPTION
In Hydroponics code, fertilizing reagents affecting yield_mod were massively overproducing product for all plants which already natively yielded multiple fruits, because the yield_mod was being reapplied individually to each fruit.

This PR makes it so that a plant with a positive yield_mod will return the correct number of additional (fertilizer-derived) fruits, plus the original number it was going to drop in the first place, making fertilizer equally effective for all plants independent of their intrinsic yield#.