### PR TITLE
Fixes rags being unable to clean bowls

### DIFF
--- a/code/modules/cooking/plates.dm
+++ b/code/modules/cooking/plates.dm
@@ -84,7 +84,7 @@ Plates that can hold your cooking stuff
 	return
 
 /obj/item/reagent_containers/bowl/on_rag_wipe(obj/item/reagent_containers/glass/rag/R)
-	. = ..()
+	clean_blood()
 	if(grease)
 		grease = FALSE
 		update_icon()

--- a/html/changelogs/RagFix.yml
+++ b/html/changelogs/RagFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Rags can now clean bowls properly."


### PR DESCRIPTION
Before, trying to clean a bowl with a rag would fill it with water, preventing it from being cleaned. This stops the water from being moved to the bowl.