### PR TITLE
Applies needs_starlight to a few offships

### DIFF
--- a/html/changelogs/hazelmouse-starlightoffships.yml
+++ b/html/changelogs/hazelmouse-starlightoffships.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Several offships now render starlight more properly in their exterior areas."

--- a/maps/away/ships/coc/coc_scarab/coc_scarab.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab.dmm
@@ -6894,18 +6894,6 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/coc_scarab/starboardhallway)
-"Bj" = (
-/obj/machinery/power/solar{
-	id = "starboardsadarsolar";
-	name = "Starboard Solar Array"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/map_effect/perma_light/starlight/wide,
-/turf/simulated/floor/airless,
-/area/ship/coc_scarab/exterior)
 "Bk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -9493,18 +9481,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
-/area/ship/coc_scarab/exterior)
-"LH" = (
-/obj/machinery/power/solar{
-	id = "portsadarsolar";
-	name = "Port Solar Array"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/map_effect/perma_light/starlight/wide,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "LP" = (
@@ -104236,7 +104212,7 @@ qe
 rZ
 zo
 vx
-Bj
+qe
 zo
 am
 vx
@@ -104750,7 +104726,7 @@ qe
 rZ
 zo
 vx
-Bj
+qe
 zo
 am
 vx
@@ -105264,7 +105240,7 @@ qe
 rZ
 zo
 vx
-Bj
+qe
 zo
 am
 vx
@@ -105778,7 +105754,7 @@ qe
 rZ
 zo
 vx
-Bj
+qe
 zo
 am
 vx
@@ -106292,7 +106268,7 @@ tf
 rZ
 zo
 vx
-Bj
+qe
 zo
 am
 xY
@@ -116315,7 +116291,7 @@ GI
 DR
 KH
 Yv
-LH
+eQ
 KH
 cc
 Az
@@ -116829,7 +116805,7 @@ eQ
 DR
 KH
 Yv
-LH
+eQ
 KH
 cc
 Yv
@@ -117343,7 +117319,7 @@ eQ
 DR
 KH
 Yv
-LH
+eQ
 KH
 cc
 Yv
@@ -117857,7 +117833,7 @@ eQ
 DR
 KH
 Yv
-LH
+eQ
 KH
 cc
 Yv
@@ -118371,7 +118347,7 @@ eQ
 DR
 KH
 Yv
-LH
+eQ
 KH
 cc
 Yv

--- a/maps/away/ships/coc/coc_scarab/coc_scarab_areas.dm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab_areas.dm
@@ -127,6 +127,7 @@
 	name = "Scarab Salvage Vessel - Exterior"
 	requires_power = FALSE
 	icon_state = "exterior"
+	needs_starlight = TRUE
 
 // Shuttle
 /area/shuttle/coc_scarab

--- a/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dmm
+++ b/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dmm
@@ -617,7 +617,7 @@
 	dir = 4
 	},
 /obj/item/hullbeacon/red,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "cB" = (
 /obj/structure/lattice,
@@ -738,7 +738,7 @@
 	dir = 8
 	},
 /obj/effect/shuttle_landmark/freebooter_salvager/eva_aft_starboard,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "df" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
@@ -1048,7 +1048,7 @@
 "eI" = (
 /obj/structure/railing/mapped,
 /obj/structure/lattice/catwalk,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "eL" = (
 /obj/structure/inflatable/wall,
@@ -1249,7 +1249,7 @@
 /area/ship/freebooter_salvager/kitchen)
 "fM" = (
 /obj/structure/lattice/catwalk,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "fO" = (
 /obj/structure/table/reinforced/steel,
@@ -1949,7 +1949,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "js" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
@@ -3249,7 +3249,7 @@
 "pa" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "pb" = (
 /obj/structure/lattice/catwalk,
@@ -3257,7 +3257,7 @@
 	dir = 4
 	},
 /obj/structure/railing/mapped,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "pd" = (
 /obj/structure/sign/drop{
@@ -3280,7 +3280,7 @@
 /area/ship/freebooter_salvager/mining)
 "pk" = (
 /obj/structure/lattice,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "pm" = (
 /obj/effect/decal/cleanable/blood/oil,
@@ -3292,7 +3292,7 @@
 	dir = 8
 	},
 /obj/effect/shuttle_landmark/freebooter_salvager/eva_aft_port,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "po" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
@@ -3364,7 +3364,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "pA" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -4134,7 +4134,7 @@
 /turf/simulated/floor/airless,
 /area/ship/freebooter_salvager/crew_quarters)
 "sK" = (
-/turf/space,
+/turf/space/dynamic,
 /area/space)
 "sM" = (
 /obj/structure/table/rack,
@@ -4206,7 +4206,7 @@
 "sZ" = (
 /obj/structure/lattice/catwalk,
 /obj/item/hullbeacon/red,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "tc" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -4500,7 +4500,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "uw" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -4977,7 +4977,7 @@
 "wN" = (
 /obj/effect/step_trigger/teleporter,
 /obj/effect/step_trigger/teleporter,
-/turf/space,
+/turf/space/dynamic,
 /area/space)
 "wP" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
@@ -5851,7 +5851,7 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "Aw" = (
 /obj/effect/floor_decal/spline/plain/corner/yellow{
@@ -5969,7 +5969,7 @@
 	dir = 8
 	},
 /obj/structure/railing/mapped,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "Bg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6700,7 +6700,7 @@
 /obj/effect/shuttle_landmark/freebooter_salvager/eva_port{
 	dir = 8
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "Fs" = (
 /obj/effect/floor_decal/corner/dark_blue{
@@ -9380,7 +9380,7 @@
 /area/space)
 "Ra" = (
 /obj/effect/step_trigger/teleporter,
-/turf/space,
+/turf/space/dynamic,
 /area/space)
 "Re" = (
 /obj/structure/curtain/open/shower,
@@ -9841,7 +9841,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "Tm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9897,7 +9897,7 @@
 /obj/effect/shuttle_landmark/freebooter_salvager/eva_starboard{
 	dir = 4
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "TA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10567,7 +10567,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/freebooter_salvager/exterior)
 "WP" = (
 /obj/effect/decal/cleanable/dirt,

--- a/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager_areas.dm
+++ b/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager_areas.dm
@@ -46,6 +46,7 @@
 /area/ship/freebooter_salvager/exterior
 	name = "Freebooter Salvager Exterior"
 	icon_state = "exterior"
+	needs_starlight = TRUE
 
 /area/ship/freebooter_salvager/forehallway
 	name = "Freebooter Salvager Fore Hallway"

--- a/maps/away/ships/freebooter/freebooter_ship/freebooter_ship_areas.dm
+++ b/maps/away/ships/freebooter/freebooter_ship/freebooter_ship_areas.dm
@@ -77,6 +77,7 @@
 /area/ship/freebooter_ship/exterior
 	name = "Freebooter Ship Exterior"
 	requires_power = FALSE
+	needs_starlight = TRUE
 
 /area/shuttle/freebooter_shuttle
 	name = "Freebooter Shuttle"

--- a/maps/away/ships/sadar_scout/sadar_scout.dmm
+++ b/maps/away/ships/sadar_scout/sadar_scout.dmm
@@ -558,7 +558,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "du" = (
 /obj/effect/floor_decal/corner_wide/brown/diagonal,
@@ -593,7 +593,7 @@
 /area/ship/sadar_scout/cic)
 "dG" = (
 /obj/structure/grille,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "dI" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
@@ -1271,7 +1271,7 @@
 /obj/effect/shuttle_landmark/sadar_scout/dock/fore_starboard{
 	dir = 1
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "jm" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
@@ -1319,7 +1319,7 @@
 /obj/structure/bed/handrail{
 	dir = 8
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "jF" = (
 /obj/machinery/door/airlock/external{
@@ -1447,7 +1447,7 @@
 "kF" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "kO" = (
 /obj/structure/ship_weapon_dummy/barrel,
@@ -1878,7 +1878,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "ok" = (
 /obj/machinery/power/apc/west{
@@ -2173,7 +2173,7 @@
 	dir = 8
 	},
 /obj/structure/railing/mapped,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "qf" = (
 /obj/structure/mirror{
@@ -2391,7 +2391,7 @@
 /area/ship/sadar_scout/hydro)
 "ro" = (
 /obj/structure/lattice,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "rt" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -2628,7 +2628,7 @@
 /area/ship/sadar_scout/eva)
 "ts" = (
 /obj/structure/lattice/catwalk,
-/turf/space,
+/turf/space/dynamic,
 /area/space)
 "tt" = (
 /obj/structure/lattice/catwalk,
@@ -3389,7 +3389,7 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "yM" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -3879,7 +3879,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "Cu" = (
 /obj/structure/cable{
@@ -3920,7 +3920,7 @@
 	dir = 8
 	},
 /obj/effect/shuttle_landmark/sadar_scout/dock/aft_port,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "Cy" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -4103,12 +4103,12 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "DB" = (
 /obj/structure/bed/handrail,
 /obj/structure/lattice/catwalk,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "DK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -4188,7 +4188,7 @@
 	dir = 8
 	},
 /obj/effect/shuttle_landmark/sadar_scout/dock/aft_starboard,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "EW" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -4321,7 +4321,7 @@
 	dir = 4
 	},
 /obj/structure/lattice,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "Ga" = (
 /obj/structure/ship_weapon_dummy,
@@ -4634,7 +4634,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "Jn" = (
 /obj/machinery/door/blast/regular/open{
@@ -4814,7 +4814,7 @@
 	dir = 4
 	},
 /obj/structure/railing/mapped,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "Kl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -4922,7 +4922,7 @@
 /obj/structure/bed/handrail{
 	dir = 1
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "KP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -5130,7 +5130,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "Mi" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -5292,7 +5292,7 @@
 /obj/effect/shuttle_landmark/sadar_scout/dock/port{
 	dir = 8
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "NV" = (
 /obj/machinery/door/airlock/external{
@@ -5490,7 +5490,7 @@
 /obj/effect/shuttle_landmark/sadar_scout/dock/fore_port{
 	dir = 1
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "Ph" = (
 /obj/machinery/computer/ship/navigation/terminal{
@@ -5655,7 +5655,7 @@
 /obj/effect/shuttle_landmark/sadar_scout/dock/starboard{
 	dir = 4
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "Qi" = (
 /obj/structure/table/stone/marble,
@@ -5777,7 +5777,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "QU" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -5971,7 +5971,7 @@
 /obj/structure/bed/handrail{
 	dir = 4
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "Sm" = (
 /obj/structure/cable{
@@ -6385,7 +6385,7 @@
 /area/ship/sadar_scout/bridge)
 "Vj" = (
 /obj/structure/lattice/catwalk,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "Vx" = (
 /obj/structure/cable{
@@ -6514,7 +6514,7 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "Wo" = (
 /obj/machinery/computer/ship/navigation/terminal{
@@ -6736,7 +6736,7 @@
 "Xt" = (
 /obj/structure/lattice,
 /obj/structure/bed/handrail,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "Xw" = (
 /obj/machinery/alarm/north{
@@ -6824,14 +6824,14 @@
 	dir = 8
 	},
 /obj/structure/lattice,
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "Yc" = (
 /obj/structure/lattice,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/space,
+/turf/space/dynamic,
 /area/ship/sadar_scout/exterior)
 "Yd" = (
 /obj/structure/cable/yellow{

--- a/maps/away/ships/sadar_scout/sadar_scout_areas.dm
+++ b/maps/away/ships/sadar_scout/sadar_scout_areas.dm
@@ -10,6 +10,7 @@
 /area/ship/sadar_scout/exterior
 	name = "Ancient Expeditionary Vessel - Exterior"
 	requires_power = FALSE
+	needs_starlight = TRUE
 
 /area/ship/sadar_scout/thrusters
 	name = "Ancient Expeditionary Vessel - Propulsion"

--- a/maps/away/ships/scc/scc_scout_ship.dmm
+++ b/maps/away/ships/scc/scc_scout_ship.dmm
@@ -72,7 +72,7 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, thruster"
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/scc_scout_ship/exterior)
 "aC" = (
 /obj/machinery/computer/ship/engines/terminal{
@@ -216,7 +216,7 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, flak battery"
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/scc_scout_ship/exterior)
 "bi" = (
 /obj/structure/closet/cabinet,
@@ -330,7 +330,7 @@
 "bB" = (
 /obj/structure/lattice,
 /obj/structure/ship_weapon_dummy,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/scc_scout_ship/exterior)
 "bC" = (
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
@@ -943,7 +943,6 @@
 	},
 /obj/item/clothing/head/beret/corporate/zavod,
 /obj/item/clothing/head/softcap/zavod/alt,
-/obj/item/clothing/suit/storage/toggle/labcoat/alt,
 /obj/item/clothing/under/rank/engineer/zavod,
 /obj/item/clothing/under/rank/medical/surgeon/zavod,
 /obj/random/gloves,
@@ -1321,7 +1320,7 @@
 "gM" = (
 /obj/structure/lattice,
 /obj/structure/ship_weapon_dummy,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/scc_scout_ship/maint_atmos)
 "gN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2954,7 +2953,7 @@
 /area/shuttle/scc_scout_ship_shuttle/cargo)
 "qC" = (
 /obj/structure/lattice,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/scc_scout_ship/exterior)
 "qH" = (
 /obj/machinery/light/small{
@@ -3429,7 +3428,7 @@
 	pixel_y = -192;
 	weapon_id = "SCC Scout Ship Flak Cannon"
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/scc_scout_ship/maint_atmos)
 "tM" = (
 /obj/effect/map_effect/marker/airlock{
@@ -3585,7 +3584,7 @@
 "uw" = (
 /obj/structure/lattice,
 /obj/structure/ship_weapon_dummy/barrel,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/scc_scout_ship/exterior)
 "uz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -4078,7 +4077,7 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, flak battery"
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/scc_scout_ship/exterior)
 "xQ" = (
 /obj/structure/table/stone/marble,
@@ -4932,7 +4931,7 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, starboard airlock"
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/scc_scout_ship/exterior)
 "Eh" = (
 /obj/random/dirt_75,
@@ -5877,7 +5876,7 @@
 /obj/effect/landmark/entry_point/port{
 	name = "port, hydroponics"
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/scc_scout_ship/exterior)
 "KD" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
@@ -6309,7 +6308,7 @@
 /area/ship/scc_scout_ship/maint_propulsion_port)
 "NZ" = (
 /obj/structure/ship_weapon_dummy,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/scc_scout_ship/exterior)
 "Oc" = (
 /obj/effect/shuttle_landmark/scc_scout_ship/shuttle_hangar{
@@ -6515,7 +6514,7 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, cockpit"
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/scc_scout_ship/exterior)
 "Pj" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -6873,7 +6872,7 @@
 "Sl" = (
 /obj/structure/grille,
 /obj/structure/lattice,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/scc_scout_ship/exterior)
 "Sq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7186,7 +7185,7 @@
 /obj/effect/landmark/entry_point/aft{
 	name = "aft, center"
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/scc_scout_ship/exterior)
 "Uo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7907,7 +7906,7 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, crew quarters"
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/scc_scout_ship/exterior)
 "XA" = (
 /obj/item/ship_ammunition/grauwolf_bundle,
@@ -8264,7 +8263,7 @@
 /obj/effect/map_effect/map_helper/ruler_tiles_3{
 	dir = 4
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/scc_scout_ship/exterior)
 "ZP" = (
 /obj/structure/bed/stool/chair/shuttle{

--- a/maps/away/ships/scc/scc_scout_ship_areas.dm
+++ b/maps/away/ships/scc/scc_scout_ship_areas.dm
@@ -52,6 +52,7 @@
 /area/ship/scc_scout_ship/exterior
 	name = "Exterior Catwalks/Lattices"
 	icon_state = "exterior"
+	needs_starlight = TRUE
 
 // ---------------------- shuttle
 


### PR DESCRIPTION
Adds the new needs_starlight var to the exterior areas of a few offships, and replaces non-dynamic space/manually placed light markers where necessary. This should remove all weird dark spots or otherwise unusual lighting on the lattices of these offships - stuff like how the catwalks on the SCC Scout Ship are pitch dark.

<img width="846" height="940" alt="image" src="https://github.com/user-attachments/assets/caed7fb6-3f98-422d-9fb4-5c5c80a84224" />
