### PR TITLE
Fixes several earwear not being visible on tajara

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -424,10 +424,6 @@
 	throwforce = 2
 	slot_flags = SLOT_EARS
 
-	sprite_sheets = list(
-		BODYTYPE_TAJARA = 'icons/mob/species/tajaran/l_ear.dmi',
-		)
-
 /obj/item/clothing/ears/attack_hand(mob/user as mob)
 	if (!user) return
 

--- a/code/modules/clothing/ears/earrings.dm
+++ b/code/modules/clothing/ears/earrings.dm
@@ -6,6 +6,10 @@
 	item_state = "stud"
 	contained_sprite = TRUE
 
+	sprite_sheets = list(
+		BODYTYPE_TAJARA = 'icons/mob/species/tajaran/l_ear.dmi'
+		)
+
 /obj/item/clothing/ears/earring/dangle
 	name = "dangle earrings"
 	desc = "A pair of small dangle earrings."
@@ -18,14 +22,20 @@
 	icon_state = "bangle"
 	item_state = "bangle"
 
+	sprite_sheets = null
+
 /obj/item/clothing/ears/earring/crescent
 	name = "crescent earrings"
 	desc = "A pair of hefty crescent earrings."
 	icon_state = "crescent"
 	item_state = "crescent"
 
+	sprite_sheets = null
+
 /obj/item/clothing/ears/earring/heavy
 	name = "overweight earrings"
 	desc = "A pair of dazzling, painfully large earrings."
 	icon_state = "heavy"
 	item_state = "heavy"
+
+	sprite_sheets = null

--- a/html/changelogs/EarFix.yml
+++ b/html/changelogs/EarFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Several types of earwear, such as headphones, are no longer invisible on the taj mob sprite."


### PR DESCRIPTION
Perhaps not the most elegant solution, but it works better than having no onmob sprite at all.
