### PR TITLE
Make consoles print paper into the users hand

### DIFF
--- a/code/modules/modular_computers/hardware/nano_printer.dm
+++ b/code/modules/modular_computers/hardware/nano_printer.dm
@@ -29,6 +29,7 @@
 		P.color = paper_color
 
 	stored_paper--
+	usr.put_in_hands(P, TRUE)
 	return P
 
 /obj/item/computer_hardware/nano_printer/attackby(obj/item/attacking_item, mob/user)

--- a/html/changelogs/PaperGiving.yml
+++ b/html/changelogs/PaperGiving.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Papers printed from consoles now try to put it in the hand before putting it on the floor."


### PR DESCRIPTION
As per the title, printed papers from consoles are now put into the users hand instead of on the floor.