### PR TITLE
Fix Loadout Sound Spam

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -371,7 +371,7 @@ SUBSYSTEM_DEF(jobs)
 
 	//Gives glasses to the vision impaired
 	if(H.disabilities & NEARSIGHTED)
-		var/equipped = H.equip_to_slot_or_del(new /obj/item/clothing/glasses/regular(H), slot_glasses)
+		var/equipped = H.equip_to_slot_or_del(new /obj/item/clothing/glasses/regular(H), slot_glasses, TRUE)
 		if(equipped != 1)
 			var/obj/item/clothing/glasses/G = H.glasses
 			G.prescription = 7
@@ -691,7 +691,7 @@ SUBSYSTEM_DEF(jobs)
 				// This is a miserable way to fix the loadout overwrite bug, but the alternative requires
 				// adding an arg to a bunch of different procs. Will look into it after this merge. ~ Z
 				var/obj/item/CI = G.spawn_item(null,metadata, H)
-				if (H.equip_to_slot_or_del(CI, G.slot))
+				if (H.equip_to_slot_or_del(CI, G.slot, TRUE))
 					to_chat(H, SPAN_NOTICE("Equipping you with [thing]!"))
 					if(G.slot != slot_tie)
 						custom_equip_slots += G.slot
@@ -752,7 +752,7 @@ SUBSYSTEM_DEF(jobs)
 							equip_slot = slot_wear_suit
 
 			if(!handled_accessory)
-				if (H.equip_to_slot_or_del(CI, equip_slot))
+				if (H.equip_to_slot_or_del(CI, equip_slot, TRUE))
 					to_chat(H, SPAN_NOTICE("Equipping you with [thing]!"))
 					used_slots += equip_slot
 					log_loadout("ECD/([H]): Equipped [thing] successfully.")

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -72,10 +72,10 @@
  * * item_to_equip - An `/obj/item` to try to equip
  * * slot - The slot to equip it to, one of the `slot_*` defines in `code\__DEFINES\items_clothing.dm`
  */
-/mob/proc/equip_to_slot_or_del(obj/item/item_to_equip, slot)
+/mob/proc/equip_to_slot_or_del(obj/item/item_to_equip, slot, initial = TRUE)
 	SHOULD_NOT_SLEEP(TRUE)
 
-	. = equip_to_slot_if_possible(item_to_equip, slot, TRUE, TRUE, FALSE, TRUE)
+	. = equip_to_slot_if_possible(item_to_equip, slot, TRUE, TRUE, FALSE, TRUE, initial)
 
 // Convinience proc.  Collects crap that fails to equip either onto the mob's back, or drops it.
 // Used in job equipping so shit doesn't pile up at the start loc.

--- a/html/changelogs/hellfirejag-remove-loadout-sound-spam.yml
+++ b/html/changelogs/hellfirejag-remove-loadout-sound-spam.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed loadouts spamming on_equip sounds during roundstart."


### PR DESCRIPTION
This PR fixes a literally 12 year old bug, by making it so that roundstart loadout items no longer spam the world with their on_equip sounds. I have not however found the cause for the backpack sounds though. That one is significantly harder to locate.

https://github.com/user-attachments/assets/54fbeada-d685-4c15-8383-d197ecf26363

