### PR TITLE
Disables events with no players... finally

### DIFF
--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -60,7 +60,7 @@
 		return 0
 
 	var/n = 0
-	for (var/mob/living in GLOB.player_list)
+	for(var/mob/living/living in GLOB.player_list)
 		n++
 	if(n <= pop_requirement)
 		return 0

--- a/html/changelogs/Bat-NoPlayersNoEvents.yml
+++ b/html/changelogs/Bat-NoPlayersNoEvents.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Batrachophrenoboocosmomachia
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes variable typing oversight that caused events to fire in the absence of any players."


### PR DESCRIPTION
Finally tracked down the bug causing events to fire while no players were in-game; a check in GetWeight() was running a for loop for 'var/mob/living,' not 'var/mob/living/living' as it ought to have been, causing it to detect players observing and at the main menu as active participants.