### PR TITLE
Fixes asteroid exoplanet turf lighting

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -763,8 +763,9 @@ GLOBAL_LIST_INIT(asteroid_floor_smooth, list(
 
 	if(smoothing_flags)
 		canSmoothWith = GLOB.asteroid_floor_smooth
-		pixel_x = -4
-		pixel_y = -4
+		var/matrix/M = new
+		M.Translate(-4, -4)
+		transform = M
 
 	if(light_range && light_power)
 		update_light()

--- a/code/modules/overmap/exoplanets/decor/turfs/snow.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/snow.dm
@@ -16,8 +16,9 @@
 
 /turf/simulated/floor/exoplanet/snow/Initialize()
 	. = ..()
-	pixel_x = -4
-	pixel_y = -4
+	var/matrix/M = new
+	M.Translate(-4, -4)
+	transform = M
 	icon_state = pick("snow[rand(1,2)]","snow0","snow0")
 	QUEUE_SMOOTH_NEIGHBORS(src)
 	QUEUE_SMOOTH(src)

--- a/html/changelogs/kano-dot-exoplanet-turf-turfing.yml
+++ b/html/changelogs/kano-dot-exoplanet-turf-turfing.yml
@@ -1,0 +1,7 @@
+
+author: Kano
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed asteroid expolanet turfs pixel-shifting its own lighting along with itself."


### PR DESCRIPTION
Replaces pixel_x/pixel_y adjustment for asteroid turfs with transform method. This is the same method /tg/ uses for their turfs equalivent to our asteroid turfs

Fixes #21587

## Images

<details><summary>Before:</summary>
<p>

<img width="997" height="981" alt="Screenshot_2" src="https://github.com/user-attachments/assets/60e8c95e-574c-4aca-b7b6-cc2e94812823" />

</p>
</details> 

<details><summary>After:</summary>
<p>

<img width="998" height="984" alt="Screenshot_1" src="https://github.com/user-attachments/assets/e49aa7d4-27e0-4c56-84d9-6002a768f621" />

</p>
</details> 
