### PR TITLE
Reverts Overmap Hazard Movement for Dust Clouds, Asteroid Fields, and Ion Clouds

### DIFF
--- a/code/modules/overmap/events/event.dm
+++ b/code/modules/overmap/events/event.dm
@@ -266,10 +266,6 @@
 	opacity = 1
 	event_icon_states = list("meteor1", "meteor2", "meteor3", "meteor4")
 	difficulty = EVENT_LEVEL_MAJOR
-	// Faster than carp, but only ever move in a single direction.
-	movable_event_chance = 20
-	movable_speed = 50
-	dir_change_chance = 0
 
 /obj/effect/overmap/event/electric
 	name = "electrical storm"
@@ -284,10 +280,6 @@
 	opacity = 1
 	event_icon_states = list("dust1", "dust2", "dust3", "dust4")
 	can_be_destroyed = FALSE
-	// Faster than carp, but only ever move in a single direction.
-	movable_event_chance = 20
-	movable_speed = 40
-	dir_change_chance = 0
 
 /obj/effect/overmap/event/ion
 	name = "ion cloud"
@@ -295,10 +287,6 @@
 	event_icon_states = list("ion1", "ion2", "ion3", "ion4")
 	difficulty = EVENT_LEVEL_MAJOR
 	can_be_destroyed = FALSE
-	// Very rare to move, very slow to move when it does, but hilarious.
-	movable_event_chance = 5
-	movable_speed = 240
-	dir_change_chance = 0
 
 /obj/effect/overmap/event/carp
 	name = "carp shoal"

--- a/html/changelogs/Bat-OvermapHazards.yml
+++ b/html/changelogs/Bat-OvermapHazards.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Batrachophrenoboocosmomachia
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Reverts overmap hazard movement chance for Dust Clouds, Asteroid Fields, and Ion Clouds, pending improvement to balance mechanics for these."


### PR DESCRIPTION
As title. Those movables proved not to be super fun in-round largely due to lack of balancing mechanics and counterplay from players. Reverting for now! Original reduction in hazard density from https://github.com/Aurorastation/Aurora.3/pull/21571 unchanged.