### PR TITLE
Generic IPC Creation

### DIFF
--- a/code/modules/mob/living/silicon/robot/items/robot_parts.dm
+++ b/code/modules/mob/living/silicon/robot/items/robot_parts.dm
@@ -8,7 +8,7 @@
 	var/list/part = null // Order of args is important for installing robolimbs.
 	var/sabotaged = 0 //Emagging limbs can have repercussions when installed as prosthetics.
 	var/model_info
-	var/linked_frame = SPECIES_IPC_UNBRANDED
+	var/linked_frame = SPECIES_IPC
 	dir = SOUTH
 
 /obj/item/robot_parts/set_dir()

--- a/html/changelogs/hellfirejag.yml
+++ b/html/changelogs/hellfirejag.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "Creating a new IPC will now default to a baseline frame instead of the deprecated 'unbranded' frame."


### PR DESCRIPTION
Since the unbranded IPC frame is not canonical and isn't intended to exist anywhere, this PR makes it so that when you create a new IPC as a machinist, the IPC will default to a Baseline frame rather than an Unbranded frame. 