### PR TITLE
Fixes non-human mobs not displaying their name in chat

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -15,7 +15,7 @@
 	//make sure the air can transmit speech - hearer's side
 	var/turf/T = get_turf(src)
 	var/vacuum_proof = ((language && (language.flags & PRESSUREPROOF)) || isghost(src))
-	var/speaker_name
+	var/speaker_name = speaker.name
 
 	if(ishuman(speaker))
 		var/mob/living/carbon/human/H = speaker

--- a/html/changelogs/kano-dot-name-named.yml
+++ b/html/changelogs/kano-dot-name-named.yml
@@ -1,0 +1,7 @@
+
+author: Kano
+
+delete-after: True
+
+changes:
+  - rscadd: "Fixed non-human types not displaying their name in chat."


### PR DESCRIPTION
Assigns speakers name to the speaker_name var, previously this was only assigned for human types

Fixes #21585
