### PR TITLE
Fixes plants dying in soil and open hydroponics trays

### DIFF
--- a/code/modules/hydroponics/trays/tray_process.dm
+++ b/code/modules/hydroponics/trays/tray_process.dm
@@ -104,7 +104,7 @@
 	// Handle light requirements for upcoming logic.
 	var/light_supplied
 	if(!closed_system)
-		light_supplied = T.get_lumcount(0, 3) * 10
+		light_supplied = T.get_lumcount(0, 3) * 5
 	else
 		light_supplied = tray_light
 

--- a/html/changelogs/ReopenTheGarden.yml
+++ b/html/changelogs/ReopenTheGarden.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes the gardening plots and open hydroponics trays being unable to grow plants."


### PR DESCRIPTION
The light for the plants was being counted as double their value, meaning a light level of 4 would be considered light level 8 by the plant, thus being vastly outside its preferred range