### PR TITLE
Allow M'sai tajara to be bridge crew.

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -170,7 +170,7 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 		ACCESS_TELEPORTER, ACCESS_EXTERNAL_AIRLOCKS
 	)
 
-	blacklisted_species = list(SPECIES_TAJARA_MSAI, SPECIES_TAJARA_ZHAN, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_ATTENDANT, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER)
+	blacklisted_species = list(SPECIES_TAJARA_ZHAN, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_ATTENDANT, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER)
 
 /obj/outfit/job/bridge_crew
 	name = "Bridge Crew"
@@ -191,3 +191,9 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 	tab_pda = /obj/item/modular_computer/handheld/pda/bridge
 	wristbound = /obj/item/modular_computer/handheld/wristbound/preset/pda/bridge
 	tablet = /obj/item/modular_computer/handheld/preset/bridge
+
+	species_shoes = list(
+		SPECIES_UNATHI = /obj/item/clothing/shoes/winter/toeless,
+		SPECIES_TAJARA = /obj/item/clothing/shoes/laceup/tajara,
+		SPECIES_TAJARA_MSAI = /obj/item/clothing/shoes/laceup/tajara
+	)

--- a/html/changelogs/GeneralCamo - M'sai Bridge Crew.yml
+++ b/html/changelogs/GeneralCamo - M'sai Bridge Crew.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "M'sai tajara can now spawn as bridge crew"
+  - bugfix: "Fixed unathi and tajara bridge crew receiving human lace-up shoes."


### PR DESCRIPTION
This restriction made sense when bridge crew were essentially command's assistants. However, their job has morphed into being dedicated pilots for odysseys, as well as expected to defend the bridge and/or shuttles. This restriction therefore no longer makes sense as M'sai were historically tasked as pilots, and are able to be part of security.

This also fixes a bug where unathi and tajara bridge crew spawn with human shoes.
