### PR TITLE
Replace inventory procs with tgstation's system

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object/signals_object.dm
@@ -13,6 +13,16 @@
 	#define COMPONENT_EQUIPPED_FAILED (1<<0)
 /// A mob has just equipped an item. Called on [/mob] from base of [/obj/item/equipped()]: (/obj/item/equipped_item, slot)
 #define COMSIG_MOB_EQUIPPED_ITEM "mob_equipped_item"
+#define COMSIG_MOB_UNEQUIPPED_ITEM "mob_unequipped_item"
+/// from mob/proc/dropItemToGround()
+#define COMSIG_MOB_DROPPING_ITEM "mob_dropping_item"
+#define COMSIG_MOB_DROPPED_ITEM "mob_dropped_item"
+///called on [/obj/item] before unequip from base of [mob/proc/doUnEquip]: (force, atom/newloc, no_move, invdrop, silent)
+#define COMSIG_ITEM_PRE_UNEQUIP "item_pre_unequip"
+	///only the pre unequip can be cancelled
+	#define COMPONENT_ITEM_BLOCK_UNEQUIP (1<<0)
+///called on [/obj/item] AFTER unequip from base of [mob/proc/doUnEquip]: (force, atom/newloc, no_move, invdrop, silent)
+#define COMSIG_ITEM_POST_UNEQUIP "item_post_unequip"
 ///from base of obj/item/dropped(): (mob/user)
 #define COMSIG_ITEM_DROPPED "item_drop"
 ///from base of obj/item/pickup(): (mob/user)

--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -36,7 +36,9 @@
 #define EQUIP_SOUND_VOLUME 30
 #define PICKUP_SOUND_VOLUME 15
 #define DROP_SOUND_VOLUME 20
+#define HALFWAY_SOUND_VOLUME 50
 #define BLOCK_SOUND_VOLUME 70
+#define THROW_SOUND_VOLUME 90
 
 //default byond sound environments
 #define SOUND_ENVIRONMENT_OFF -2

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -322,7 +322,7 @@ GLOBAL_LIST_INIT(wire_name_directory, list())
 				if(!istype(I))
 					to_chat(usr, SPAN_WARNING("You do not have a signaler to attach!"))
 					return
-				usr.drop_from_inventory(I)
+				usr.temporarilyRemoveItemFromInventory(I)
 				if(!attach_assembly(target_wire, I))
 					I.forceMove(get_turf(L))
 				. = TRUE

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -237,7 +237,7 @@
 		user.visible_message(SPAN_WARNING("[user] has unsheathed \a [concealed_blade] from [user.get_pronoun("his")] [src]!"), "You unsheathe \the [concealed_blade] from \the [src].")
 		// Calling drop/put in hands to properly call item drop/pickup procs
 		playsound(user.loc, 'sound/weapons/holster/sheathout.ogg', 50, 1)
-		user.drop_from_inventory(src)
+		user.temporarilyRemoveItemFromInventory(src)
 		user.put_in_hands(concealed_blade)
 		user.put_in_hands(src)
 		user.update_inv_l_hand(0)
@@ -252,7 +252,7 @@
 	if(!src.concealed_blade && istype(attacking_canesword))
 		user.visible_message(SPAN_WARNING("[user] has sheathed \a [attacking_canesword] into [user.get_pronoun("his")] [src]!"), "You sheathe \the [attacking_canesword] into \the [src].")
 		playsound(user.loc, 'sound/weapons/holster/sheathin.ogg', 50, 1)
-		user.drop_from_inventory(attacking_canesword)
+		user.temporarilyRemoveItemFromInventory(attacking_canesword)
 		attacking_canesword.forceMove(src)
 		src.concealed_blade = attacking_canesword
 		update_icon()

--- a/code/game/antagonist/antagonist_equip.dm
+++ b/code/game/antagonist/antagonist_equip.dm
@@ -7,7 +7,7 @@
 	// This could use work.
 	if(flags & ANTAG_CLEAR_EQUIPMENT)
 		for(var/obj/item/thing in player.contents)
-			player.drop_from_inventory(thing)
+			player.temporarilyRemoveItemFromInventory(thing)
 			if(thing.loc != player)
 				qdel(thing)
 

--- a/code/game/antagonist/outsider/actor.dm
+++ b/code/game/antagonist/outsider/actor.dm
@@ -31,7 +31,7 @@ GLOBAL_DATUM(actors, /datum/antagonist/actor)
 	for (var/obj/item/I in player)
 		if (istype(I, /obj/item/implant))
 			continue
-		player.drop_from_inventory(I)
+		player.dropItemToGround(I)
 		if(I.loc != player)
 			qdel(I)
 

--- a/code/game/antagonist/outsider/burglar.dm
+++ b/code/game/antagonist/outsider/burglar.dm
@@ -42,7 +42,7 @@ GLOBAL_DATUM(burglars, /datum/antagonist/burglar)
 	for(var/obj/item/I in player)
 		if(istype(I, /obj/item/implant))
 			continue
-		player.drop_from_inventory(I)
+		player.dropItemToGround(I)
 		if(I.loc != player)
 			qdel(I)
 

--- a/code/game/antagonist/outsider/jockey.dm
+++ b/code/game/antagonist/outsider/jockey.dm
@@ -41,7 +41,7 @@ GLOBAL_DATUM(jockeys, /datum/antagonist/jockey)
 	for(var/obj/item/I in player)
 		if(istype(I, /obj/item/implant))
 			continue
-		player.drop_from_inventory(I)
+		player.dropItemToGround(I)
 		if(I.loc != player)
 			qdel(I)
 

--- a/code/game/antagonist/outsider/loner.dm
+++ b/code/game/antagonist/outsider/loner.dm
@@ -33,7 +33,7 @@ GLOBAL_DATUM(loners, /datum/antagonist/loner)
 	for(var/obj/item/I in player)
 		if(istype(I, /obj/item/implant))
 			continue
-		player.drop_from_inventory(I)
+		player.dropItemToGround(I)
 		if(I.loc != player)
 			qdel(I)
 

--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -42,7 +42,7 @@ GLOBAL_DATUM(mercs, /datum/antagonist/mercenary)
 	for (var/obj/item/I in player)
 		if (istype(I, /obj/item/implant))
 			continue
-		player.drop_from_inventory(I)
+		player.dropItemToGround(I)
 		if(I.loc != player)
 			qdel(I)
 

--- a/code/game/antagonist/outsider/ninja.dm
+++ b/code/game/antagonist/outsider/ninja.dm
@@ -108,7 +108,7 @@ GLOBAL_DATUM(ninjas, /datum/antagonist/ninja)
 	for (var/obj/item/I in player)
 		if (istype(I, /obj/item/implant))
 			continue
-		player.drop_from_inventory(I)
+		player.dropItemToGround(I)
 		if(I.loc != player)
 			qdel(I)
 	player.preEquipOutfit(/obj/outfit/admin/syndicate/ninja, FALSE)

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -126,7 +126,7 @@ GLOBAL_DATUM(raiders, /datum/antagonist/raider)
 	for (var/obj/item/I in player)
 		if (istype(I, /obj/item/implant))
 			continue
-		player.drop_from_inventory(I)
+		player.dropItemToGround(I)
 		if(I.loc != player)
 			qdel(I)
 

--- a/code/game/antagonist/outsider/raider_techno.dm
+++ b/code/game/antagonist/outsider/raider_techno.dm
@@ -50,7 +50,7 @@ GLOBAL_DATUM(raider_techno, /datum/antagonist/raider_techno)
 	for(var/obj/item/I in player)
 		if(istype(I, /obj/item/implant))
 			continue
-		player.drop_from_inventory(I)
+		player.dropItemToGround(I)
 		if(I.loc != player)
 			qdel(I)
 

--- a/code/game/antagonist/station/highlander.dm
+++ b/code/game/antagonist/station/highlander.dm
@@ -37,7 +37,7 @@ GLOBAL_DATUM(highlanders, /datum/antagonist/highlander)
 	for (var/obj/item/I in player)
 		if (istype(I, /obj/item/implant))
 			continue
-		player.drop_from_inventory(I)
+		player.dropItemToGround(I)
 		if(I.loc != player)
 			qdel(I)
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -187,6 +187,18 @@ GLOBAL_LIST_INIT(area_blurb_stated_to, list())
 	return area_flags & AREA_FLAG_NO_CREW_EXPECTED
 
 /**
+ * Causes a runtime error
+ */
+/area/AllowDrop()
+	CRASH("Bad op: area/AllowDrop() called")
+
+/**
+ * Causes a runtime error
+ */
+/area/drop_location()
+	CRASH("Bad op: area/drop_location() called")
+
+/**
  * Set lights in area.
  *
  * * state - TRUE for on, FALSE for off, NULL for initial state

--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -222,6 +222,17 @@
 		return
 	return
 
+///Where atoms should drop if taken from this atom
+/atom/proc/drop_location()
+	var/atom/location = loc
+	if(!location)
+		return null
+	return location.AllowDrop() ? location : location.drop_location()
+
+/// Are you allowed to drop stuff inside this atom
+/atom/proc/AllowDrop()
+	return FALSE
+
 
 /**
  * An atom has entered this atom's contents

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -753,6 +753,7 @@
 			return
 		source = loc
 	var/image/pickup_animation = image(icon = src)
+	pickup_animation.plane = GAME_PLANE
 	pickup_animation.transform.Scale(0.75)
 	pickup_animation.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 
@@ -783,6 +784,9 @@
 /atom/movable/proc/do_drop_animation(atom/moving_from)
 	if(!isturf(loc))
 		return
+	if(!istype(moving_from))
+		return
+
 	var/turf/current_turf = get_turf(src)
 	var/direction = get_dir(moving_from, current_turf)
 	var/from_x = 0

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -115,7 +115,7 @@
 			to_chat(user, SPAN_WARNING("A beaker is already loaded into the machine."))
 			return TRUE
 		beaker = attacking_item
-		user.drop_from_inventory(attacking_item,src)
+		user.transferItemToLoc(attacking_item, src)
 		user.visible_message("\The [user] adds \a [attacking_item] to \the [src]!", "You add \a [attacking_item] to \the [src]!")
 		return TRUE
 
@@ -284,7 +284,7 @@
 /obj/machinery/computer/scan_consolenew/attackby(obj/item/attacking_item, mob/user)
 	if (istype(attacking_item, /obj/item/disk/data)) //INSERT SOME diskS
 		if (!src.disk)
-			user.drop_from_inventory(attacking_item, src)
+			user.transferItemToLoc(attacking_item, src)
 			src.disk = attacking_item
 			to_chat(user, "You insert [attacking_item].")
 			SSnanoui.update_uis(src) // update all UIs attached to src

--- a/code/game/gamemodes/changeling/implements/items.dm
+++ b/code/game/gamemodes/changeling/implements/items.dm
@@ -47,7 +47,7 @@
 							organ.implants -= src
 			host.pinned -= src
 			host.embedded -= src
-			host.drop_from_inventory(src)
+			host.temporarilyRemoveItemFromInventory(src)
 		QDEL_IN(src, 1)
 
 /obj/item/melee/arm_blade/iscrowbar()

--- a/code/game/gamemodes/cult/items/sword.dm
+++ b/code/game/gamemodes/cult/items/sword.dm
@@ -36,18 +36,13 @@
 		return ..()
 
 	var/zone = (user.hand ? BP_L_ARM:BP_R_ARM)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/external/affecting = H.get_organ(zone)
-		to_chat(user, SPAN_CULT("An inexplicable force rips through your [affecting.name], tearing the sword from your grasp!"))
-	else
-		to_chat(user, SPAN_CULT("An inexplicable force rips through you, tearing the sword from your grasp!"))
+	user.visible_message(SPAN_WARNING("A powerful force shoves [user] away from \the [target_mob]!"), FONT_LARGE(SPAN_CULT("\"You shouldn't play with sharp things. You'll poke someone's eye out.\"")))
 
 	//random amount of damage between half of the blade's force and the full force of the blade.
 	user.apply_damage(rand(force/2, force), DAMAGE_BRUTE, zone, 0, damage_flags = DAMAGE_FLAG_SHARP|DAMAGE_FLAG_EDGE)
 	user.Weaken(5)
 
-	user.drop_from_inventory(src)
+	user.dropItemToGround(src, TRUE)
 	throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), throw_speed)
 
 	var/spooky = pick('sound/hallucinations/growl1.ogg', 'sound/hallucinations/growl2.ogg', 'sound/hallucinations/growl3.ogg', 'sound/hallucinations/wail.ogg')

--- a/code/game/gamemodes/cult/runes/free_cultist.dm
+++ b/code/game/gamemodes/cult/runes/free_cultist.dm
@@ -29,16 +29,16 @@
 			cultist.buckled_to = null
 		if(cultist.handcuffed)
 			cultist_free = FALSE
-			cultist.drop_from_inventory(cultist.handcuffed)
+			cultist.dropItemToGround(cultist.handcuffed)
 		if(cultist.legcuffed)
 			cultist_free = FALSE
-			cultist.drop_from_inventory(cultist.legcuffed)
+			cultist.dropItemToGround(cultist.legcuffed)
 		if(istype(cultist.wear_mask, /obj/item/clothing/mask/muzzle))
 			cultist_free = FALSE
-			cultist.drop_from_inventory(cultist.wear_mask)
+			cultist.dropItemToGround(cultist.wear_mask)
 		if(istype(cultist.wear_suit, /obj/item/clothing/suit/straight_jacket))
 			cultist_free = FALSE
-			cultist.drop_from_inventory(cultist.wear_suit)
+			cultist.dropItemToGround(cultist.wear_suit)
 		if(istype(cultist.loc, /obj/structure/closet))
 			var/obj/structure/closet/C = cultist.loc
 			if(C.welded)

--- a/code/game/gamemodes/endgame/bluespace_jump/bluespace_jump.dm
+++ b/code/game/gamemodes/endgame/bluespace_jump/bluespace_jump.dm
@@ -116,7 +116,7 @@
 		H.sync_organ_dna()
 		H.UpdateAppearance()
 		for(var/obj/item/entry in daddy.get_equipped_items(INCLUDE_POCKETS|INCLUDE_HELD))
-			daddy.remove_from_mob(entry) //steals instead of copies so we don't end up with duplicates
+			daddy.temporarilyRemoveItemFromInventory(entry) //steals instead of copies so we don't end up with duplicates
 			H.equip_to_appropriate_slot(entry)
 	else
 		H = new daddy.type(get_turf(src))

--- a/code/game/gamemodes/endgame/supermatter_cascade/blob.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/blob.dm
@@ -94,7 +94,7 @@
 
 	playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
 
-	user.drop_from_inventory(attacking_item,src)
+	user.transferItemToLoc(attacking_item,src)
 	Consume(attacking_item)
 	return TRUE
 

--- a/code/game/gamemodes/technomancer/assistance/assistance.dm
+++ b/code/game/gamemodes/technomancer/assistance/assistance.dm
@@ -51,7 +51,7 @@
 		to_chat(user, SPAN_WARNING("You're already in the fold, you can't use this!"))
 		return
 	var/turf/user_turf = get_turf(user)
-	user.drop_from_inventory(src, user_turf)
+	user.transferItemToTurf(src, user_turf)
 	user.visible_message(SPAN_DANGER("<b>[user]</b> crushes \the [src] in their hand with a shower of sparks! A small bracelet appears on their wrist, and a catalog flies into their hand."), SPAN_DANGER("You crush \the [src] in your hand with a shower of sparks! A small bracelet appears on your wrist, and a catalog flies into your hand."))
 	spark(user_turf, 4, GLOB.alldirs)
 	var/initiate_welcome_text = "You will need to purchase <b>functions</b> and perhaps some <b>equipment</b> from your initiate's catalogue. \
@@ -59,7 +59,7 @@
 	powerless, and therefore you will be as well."
 	GLOB.technomancers.add_antagonist_mind(user.mind, 1, "Technomancer Initiate", initiate_welcome_text)
 	if(user.wrists)
-		user.drop_from_inventory(user.wrists, get_turf(user_turf))
+		user.transferItemToTurf(user.wrists, get_turf(user_turf))
 	var/obj/item/technomancer_core/bracelet/bracelet = new(user_turf)
 	user.equip_to_slot_if_possible(bracelet, slot_wrists, assisted_equip = TRUE)
 	var/obj/item/technomancer_catalog/initiate/catalog = new(user_turf)

--- a/code/game/machinery/autolathe/autolathe.dm
+++ b/code/game/machinery/autolathe/autolathe.dm
@@ -414,7 +414,7 @@
 			amount_needed = total_used / mass_per_sheet
 		stack.use(min(stack.get_amount(), (round(amount_needed) == amount_needed)? amount_needed : round(amount_needed) + 1)) // Prevent maths imprecision from leading to infinite resources
 	else
-		user.remove_from_mob(O)
+		user.temporarilyRemoveItemFromInventory(O)
 		qdel(O)
 
 /obj/machinery/autolathe/mounted

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -620,8 +620,8 @@ EMAG/ILLEGAL
 		if(beaker)
 			to_chat(user, SPAN_NOTICE("\The [src] is already loaded."))
 		else
-			user.remove_from_mob(attacking_item)
-			attacking_item.forceMove(src)
+			if (!user.transferItemToLoc(attacking_item, src))
+				return FALSE
 			beaker = attacking_item
 			updateUsrDialog()
 		. = TRUE
@@ -658,8 +658,8 @@ EMAG/ILLEGAL
 		if(i >= capacity)
 			to_chat(user, SPAN_NOTICE("\The [src] is full! Activate it."))
 		else
-			user.remove_from_mob(attacking_item)
-			attacking_item.forceMove(src)
+			if (!user.transferItemToLoc(attacking_item, src))
+				return FALSE
 			to_chat(user, SPAN_NOTICE("You put \the [attacking_item] in \the [src]"))
 			. = TRUE
 	update_icon()

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -135,8 +135,7 @@
 				return
 		to_chat(user, "You attach \the [attacking_item] into the assembly inner circuits.")
 		upgrades += attacking_item
-		user.remove_from_mob(attacking_item)
-		attacking_item.forceMove(src)
+		user.transferItemToLoc(attacking_item, src)
 		return
 
 	// Taking out upgrades

--- a/code/game/machinery/floor_frames.dm
+++ b/code/game/machinery/floor_frames.dm
@@ -50,7 +50,7 @@
 	M.fingerprints = src.fingerprints
 	M.fingerprintshidden = src.fingerprintshidden
 	M.fingerprintslast = src.fingerprintslast
-	user.remove_from_mob(src) //Prevents gripper duplication
+	user.temporarilyRemoveItemFromInventory(src) //Prevents gripper duplication
 	qdel(src)
 
 /obj/item/floor_frame/light

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -606,17 +606,17 @@
 		var/loc_check = breath_mask.loc
 		if(ismob(loc_check))
 			var/mob/living/carbon/human/holder = loc_check
-			holder.remove_from_mob(breath_mask)
+			holder.transferItemToLoc(breath_mask, src, force = TRUE)
 			holder.update_inv_wear_mask()
 			holder.update_inv_l_hand()
 			holder.update_inv_r_hand()
-		breath_mask.forceMove(src)
+		else
+			breath_mask.forceMove(src)
 		breather = null
 		update_icon()
 		return
-	breather.remove_from_mob(breath_mask)
+	breather.transferItemToLoc(breath_mask, src, force = TRUE)
 	breather.update_inv_wear_mask()
-	breath_mask.forceMove(src)
 	breather = null
 	update_icon()
 

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -124,7 +124,7 @@
 		add_fingerprint(user)
 	if(istype(attacking_item, /obj/item/pipe) || istype(attacking_item, /obj/item/pipe_meter))
 		to_chat(usr, SPAN_NOTICE("You put \the [attacking_item] back into \the [src]."))
-		user.remove_from_mob(attacking_item) //Catches robot gripper duplication
+		user.transferItemToLoc(attacking_item, src) //Catches robot gripper duplication
 		qdel(attacking_item)
 		return TRUE
 	else if(attacking_item.iswrench())

--- a/code/game/machinery/seed_extractor.dm
+++ b/code/game/machinery/seed_extractor.dm
@@ -11,7 +11,7 @@
 	// Fruits and vegetables.
 	if(istype(attacking_item, /obj/item/reagent_containers/food/snacks/grown) || istype(attacking_item, /obj/item/grown))
 
-		user.remove_from_mob(attacking_item)
+		user.transferItemToLoc(attacking_item, src)
 
 		var/datum/seed/new_seed_type
 		if(istype(attacking_item, /obj/item/grown))

--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -481,7 +481,7 @@
 		for(var/datum/data/vending_product/R in product_records)
 			if(attacking_item.type == R.product_path)
 				stock(R, user)
-				user.remove_from_mob(attacking_item) //Catches gripper duplication
+				user.transferItemToLoc(attacking_item, src) //Catches gripper duplication
 				qdel(attacking_item)
 				return TRUE
 	return ..()

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -49,7 +49,7 @@
 	M.fingerprints = src.fingerprints
 	M.fingerprintshidden = src.fingerprintshidden
 	M.fingerprintslast = src.fingerprintslast
-	user.remove_from_mob(src) //Prevents gripper duplication
+	user.temporarilyRemoveItemFromInventory(src) //Prevents gripper duplication
 	qdel(src)
 
 /obj/item/frame/fire_alarm

--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -449,17 +449,17 @@
 		var/loc_check = breath_mask.loc
 		if(ismob(loc_check))
 			var/mob/living/carbon/human/holder = loc_check
-			holder.remove_from_mob(breath_mask)
+			holder.transferItemToLoc(breath_mask, src)
 			holder.update_inv_wear_mask()
 			holder.update_inv_l_hand()
 			holder.update_inv_r_hand()
-		breath_mask.forceMove(src)
+		else
+			breath_mask.forceMove(src)
 		breather = null
 		mask_on = FALSE
 		return
-	breather.remove_from_mob(breath_mask)
+	breather.transferItemToLoc(breath_mask, src)
 	breather.update_inv_wear_mask()
-	breath_mask.forceMove(src)
 	breather = null
 	mask_on = FALSE
 

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -43,9 +43,9 @@
 		if(attached_device)
 			to_chat(user, SPAN_WARNING("There is already an device attached to the valve, remove it first."))
 			return
-		user.remove_from_mob(attacking_item)
+		if(!user.transferItemToLoc(attacking_item, src))
+			return
 		attached_device = A
-		A.forceMove(src)
 		to_chat(user, SPAN_NOTICE("You attach the [attacking_item] to the valve controls and secure it."))
 		A.holder = src
 		A.toggle_secure()	//this calls update_icon(), which calls update_icon() on the holder (i.e. the bomb).

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -210,7 +210,7 @@
 		amount -= used
 		if (amount <= 0)
 			if(usr)
-				usr.remove_from_mob(src)
+				usr.temporarilyRemoveItemFromInventory(src)
 			qdel(src) //should be safe to qdel immediately since if someone is still using this stack it will persist for a little while longer
 		update_icon()
 		return 1

--- a/code/game/objects/items/weapons/chewables.dm
+++ b/code/game/objects/items/weapons/chewables.dm
@@ -114,11 +114,8 @@
 			if(!no_message)
 				to_chat(M, SPAN_NOTICE("The [name] runs out of flavor."))
 			if(M.wear_mask)
-				M.remove_from_mob(src) //un-equip it so the overlays can update
-				M.update_inv_wear_mask(0)
+				M.temporarilyRemoveItemFromInventory(src) //un-equip it so the overlays can update
 				if(!M.equip_to_slot_if_possible(butt, slot_wear_mask))
-					M.update_inv_l_hand(0)
-					M.update_inv_r_hand(1)
 					M.put_in_hands(butt)
 	STOP_PROCESSING(SSprocessing, src)
 	qdel(src)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -129,13 +129,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			if(!nomessage)
 				to_chat(M, span("notice", "Your [name] goes out."))
 			if(M.wear_mask)
-				M.remove_from_mob(src) //un-equip it so the overlays can update
-				M.update_inv_wear_mask(0)
+				M.temporarilyRemoveItemFromInventory(src) //un-equip it so the overlays can update
 				M.equip_to_slot_if_possible(burnt, slot_wear_mask)
 			else
-				M.remove_from_mob(src) // if it dies in your hand.
-				M.update_inv_l_hand(0)
-				M.update_inv_r_hand(1)
+				M.temporarilyRemoveItemFromInventory(src) // if it dies in your hand.
 				M.put_in_hands(burnt)
 		set_light_on(FALSE)
 		STOP_PROCESSING(SSprocessing, src)
@@ -247,14 +244,11 @@ ABSTRACT_TYPE(/obj/item/clothing/mask/smokable)
 			if(intentionally)
 				butt.loc = T
 			else if(M.wear_mask == src)
-				M.remove_from_mob(src) //un-equip it so the overlays can update
-				M.update_inv_wear_mask(0)
+				M.temporarilyRemoveItemFromInventory(src) //un-equip it so the overlays can update
 				if(!(M.equip_to_slot_if_possible(butt, slot_wear_mask, bypass_blocked_check = TRUE)))
 					M.put_in_hands(butt) // In case the above somehow fails, ensure it is placed somewhere
 			else
-				M.remove_from_mob(src) // if it dies in your hand.
-				M.update_inv_l_hand(0)
-				M.update_inv_r_hand(1)
+				M.temporarilyRemoveItemFromInventory(src) // if it dies in your hand.
 				M.put_in_hands(butt)
 
 		STOP_PROCESSING(SSprocessing, src)

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -72,7 +72,7 @@
 		path = 1
 		to_chat(user, SPAN_NOTICE("You add [attacking_item] to the metal casing."))
 		playsound(src.loc, attacking_item.usesound, 25, -3)
-		user.remove_from_mob(det)
+		user.temporarilyRemoveItemFromInventory(det, newloc = src)
 		det.forceMove(src)
 		detonator = det
 		if(istimer(detonator.a_left))

--- a/code/game/objects/items/weapons/vaurca_items.dm
+++ b/code/game/objects/items/weapons/vaurca_items.dm
@@ -166,7 +166,7 @@
 	if(isvaurca(user))
 		to_chat(user, SPAN_NOTICE("You are familiar with the box's solution, and open it to reveal an ancient thing. How tedious."))
 		var/obj/item/archaeological_find/X = new /obj/item/archaeological_find
-		user.remove_from_mob(src)
+		user.temporarilyRemoveItemFromInventory(src)
 		user.put_in_hands(X)
 		qdel(src)
 
@@ -177,7 +177,7 @@
 			if(do_after(user, 600))
 				to_chat(user, SPAN_NOTICE("After a minute of brute-force puzzle solving, the box finally opens to reveal an ancient thing."))
 				var/obj/item/archaeological_find/X = new /obj/item/archaeological_find
-				user.remove_from_mob(src)
+				user.temporarilyRemoveItemFromInventory(src)
 				user.put_in_hands(X)
 				qdel(src)
 
@@ -502,7 +502,7 @@
 	if(belt.len >= belt_size)
 		to_chat(user, SPAN_WARNING("[src] is full."))
 		return
-	user.remove_from_mob(W)
+	user.temporarilyRemoveItemFromInventory(W)
 	W.forceMove(src)
 	belt.Insert(1, W) //add to the head of the list, so that it is loaded on the next pump
 	user.visible_message("[user] inserts \a [W] into [src].", SPAN_NOTICE("You insert \a [W] into [src]."))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -488,6 +488,9 @@
 				I.contaminate()
 				break
 
+/turf/AllowDrop()
+	return TRUE
+
 /turf/hitby(atom/movable/hitting_atom, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 	. = ..()
 	if(src.density)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -126,8 +126,8 @@
 
 /client/verb/drop_item()
 	set hidden = 1
-	if(!isrobot(mob) && mob.stat == CONSCIOUS && isturf(mob.loc))
-		return mob.drop_item()
+	if(!isrobot(mob) && mob.stat == CONSCIOUS)
+		return mob.dropItemToGround(mob.get_active_hand())
 	return
 
 

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -342,7 +342,7 @@
 
 	// Placing stuff on tables
 	if(user.unEquip(attacking_item, 0, loc)) //Loc is intentional here so we don't forceMove() items into oblivion
-		user.make_item_drop_sound(attacking_item)
+		attacking_item.play_drop_sound()
 		auto_align(attacking_item, params)
 		return
 

--- a/html/changelogs/GeneralCamo - Item Refactor.yml
+++ b/html/changelogs/GeneralCamo - Item Refactor.yml
@@ -1,0 +1,61 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - refactor: "Replaced inventory management procs with /tg/'s system."
+  - refactor: "Item sounds are now handled at the item-level, rather than the mob-level."
+  - bugfix: "Throwing an item no longer passes the volume into the vary boolean."
+  - bugfix: "Cult swords are now forcibly removed from your inventory when used."

--- a/maps/away/away_site/romanovich/grand_romanovich.dm
+++ b/maps/away/away_site/romanovich/grand_romanovich.dm
@@ -85,7 +85,7 @@
 	if (!attacking_item) return
 
 	if(user.unEquip(attacking_item, 0, src.loc))
-		user.make_item_drop_sound(attacking_item)
+		attacking_item.play_drop_sound()
 		return 1
 
 /obj/item/coin/casino


### PR DESCRIPTION
Our current procs are old, -very- old. This started as I needed a signal for when an item is dropped, and discovered it didn't exist. This is the end-result of my attempt to add it, when I decided against trying to untangle the mess and just ripped it all out in favor of /tg/'s system.

I didn't stop there however, as there are a few other tweaks included. This PR should add the following:
- Signals now exist for various stages of mob dropping items and items being dropped.
- All item sounds are handled in the item itself. Mobs no longer handle item sounds directly.
- Item dropping can now be made silent.
- Item move/drop animations can be suspended on a per-case basis.

PR is unfinished as I need to manually process each usecase of the old procs. The old procs still live for me to test any potential regressions (so far, none).
