### PR TITLE
Jarable Borer

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -26,6 +26,7 @@
 	holder_type = /obj/item/holder/borer
 	mob_size = 1
 	hunger_enabled = FALSE
+	mob_size = MOB_TINY
 
 	var/used_dominate
 	var/datum/progressbar/ability_bar

--- a/html/changelogs/hellfirejag-jarable_borer.yml
+++ b/html/changelogs/hellfirejag-jarable_borer.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "Cortical Borers can now be Jar'd"


### PR DESCRIPTION
This PR makes it so that Borers now correctly have the same size as a diona nymph and not a full grown human. Thus they can be scooped into glass jars. 