### PR TITLE
Fixes AI eye being unable to traverse Z-levels

### DIFF
--- a/code/modules/mob/abstract/freelook/eye.dm
+++ b/code/modules/mob/abstract/freelook/eye.dm
@@ -150,7 +150,7 @@
 		sprint = initial
 	return 1
 
-// If the eye movement needs to be restricted by any means, override this
+/// If the eye movement needs to be restricted by any additional means, override this.
 /mob/abstract/eye/proc/check_allowed_movement(turf/step)
 	return TRUE
 

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -31,6 +31,11 @@
  *			FALSE otherwise.
  */
 /mob/proc/zMove(direction)
+	// If the calling mob has an active eyeobj reference, we move it instead.
+	// This is important because zMove is called from the actual mob and not the eyeobj they're controlling.
+	if(eyeobj)
+		return eyeobj.zMove(direction)
+
 	// Check if we can actually travel a Z-level.
 	if (!can_ztravel(direction))
 		to_chat(src, SPAN_WARNING("You lack means of travel in that direction."))

--- a/html/changelogs/kano-dot-look-me-in-the-eye.yml
+++ b/html/changelogs/kano-dot-look-me-in-the-eye.yml
@@ -1,0 +1,6 @@
+author: Kano
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed an issue preventing the AI eye from traversing Z-levels."


### PR DESCRIPTION
## About PR

Fixes a bug introduced in #21626. I misunderstood the purpose of a check which was allowing eyeobjects to Z-travel, my bad!

- Fixes #21695