### PR TITLE
Psi Awakener Tweaks

### DIFF
--- a/code/modules/psionics/equipment/cerebro_enhancers.dm
+++ b/code/modules/psionics/equipment/cerebro_enhancers.dm
@@ -180,5 +180,5 @@
 	desc = "Use this to jumpstart your psionic rank to Psionically Sensitive, enabling you to use the Psionic Point Shop and buy basic psionic abilities. \
 			This won't work on species with no Zona Bovinae, like synthetics, vaurcae or dionae! This item is definitely not canon."
 	psi_rank_to_set = PSI_RANK_SENSITIVE
-	psi_points_override = -1 // Uses the default 2 psi points allotted to psionic sensitive.
+	psi_points_override = 3
 	awakening_message = SPAN_NOTICE("You've awakened your psionic potential.")

--- a/html/changelogs/hellfirejag psi-awakener-tweaks.yml
+++ b/html/changelogs/hellfirejag psi-awakener-tweaks.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - balance: "Psionic Awakeners now provide 3 psi-shop points, so you can actually buy powers."


### PR DESCRIPTION
This makes the Psionic Awakener actually give the user points to spend in the psionic power shop. This item is strictly limited to the crew-psionics, so to make it a bit more interesting it gives 3 points instead of the standard 2. It did not previously give any points, essentially meaning the user only had telepathy and nothing interesting.