### PR TITLE
Adds representative clip ons, fixes journalists.

### DIFF
--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -342,7 +342,7 @@
 	bowman = /obj/item/device/radio/headset/representative/alt
 	double_headset = /obj/item/device/radio/headset/alt/double/command/representative
 	wrist_radio = /obj/item/device/radio/headset/wrist/command/representative
-	clipon_radio = /obj/item/device/radio/headset/wrist/command/representative
+	clipon_radio = /obj/item/device/radio/headset/wrist/clip/command/representative
 
 /datum/job/diplomatic_aide/after_spawn(mob/living/carbon/human/H)
 	LAZYDISTINCTADD(blacklisted_citizenship, H.citizenship)
@@ -389,7 +389,7 @@
 	bowman = /obj/item/device/radio/headset/representative/alt
 	double_headset = /obj/item/device/radio/headset/alt/double/command/representative
 	wrist_radio = /obj/item/device/radio/headset/wrist/command/representative
-	clipon_radio = /obj/item/device/radio/headset/wrist/command/representative
+	clipon_radio = /obj/item/device/radio/headset/wrist/clip/command/representative
 
 /datum/job/diplomatic_bodyguard/after_spawn(mob/living/carbon/human/H)
 	LAZYDISTINCTADD(blacklisted_citizenship, H.citizenship)
@@ -433,4 +433,4 @@
 	bowman = /obj/item/device/radio/headset/representative/alt
 	double_headset = /obj/item/device/radio/headset/alt/double/command/representative
 	wrist_radio = /obj/item/device/radio/headset/wrist/command/representative
-	clipon_radio = /obj/item/device/encryptionkey/wrist/clip/command/representative
+	clipon_radio = /obj/item/device/radio/headset/wrist/clip/command/representative

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -389,7 +389,7 @@
 	bowman = /obj/item/device/radio/headset/representative/alt
 	double_headset = /obj/item/device/radio/headset/alt/double/command/representative
 	wrist_radio = /obj/item/device/radio/headset/wrist/command/representative
-	clipon_radio = /obj/item/device/radio/headset/wrist//command/representative
+	clipon_radio = /obj/item/device/radio/headset/wrist/command/representative
 
 /datum/job/diplomatic_bodyguard/after_spawn(mob/living/carbon/human/H)
 	LAZYDISTINCTADD(blacklisted_citizenship, H.citizenship)

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -42,6 +42,7 @@
 	bowman = /obj/item/device/radio/headset/headset_service/alt
 	double_headset = /obj/item/device/radio/headset/alt/double/service
 	wrist_radio = /obj/item/device/radio/headset/wrist/service
+	clipon_radio = /obj/item/device/radio/headset/wrist/clip/service
 
 	backpack_faction = /obj/item/storage/backpack/nt
 	satchel_faction = /obj/item/storage/backpack/satchel/nt
@@ -146,6 +147,7 @@
 	bowman = /obj/item/device/radio/headset/representative/alt
 	double_headset = /obj/item/device/radio/headset/alt/double/command/representative
 	wrist_radio = /obj/item/device/radio/headset/wrist/command/representative
+	clipon_radio = /obj/item/device/radio/headset/wrist/clip/command
 	accessory = /obj/item/clothing/accessory/tie/corporate
 	suit_accessory = /obj/item/clothing/accessory/pin/corporate
 
@@ -340,6 +342,7 @@
 	bowman = /obj/item/device/radio/headset/representative/alt
 	double_headset = /obj/item/device/radio/headset/alt/double/command/representative
 	wrist_radio = /obj/item/device/radio/headset/wrist/command/representative
+	clipon_radio = /obj/item/device/radio/headset/wrist/clip/command
 
 /datum/job/diplomatic_aide/after_spawn(mob/living/carbon/human/H)
 	LAZYDISTINCTADD(blacklisted_citizenship, H.citizenship)
@@ -386,6 +389,7 @@
 	bowman = /obj/item/device/radio/headset/representative/alt
 	double_headset = /obj/item/device/radio/headset/alt/double/command/representative
 	wrist_radio = /obj/item/device/radio/headset/wrist/command/representative
+	clipon_radio = /obj/item/device/radio/headset/wrist/clip/command
 
 /datum/job/diplomatic_bodyguard/after_spawn(mob/living/carbon/human/H)
 	LAZYDISTINCTADD(blacklisted_citizenship, H.citizenship)
@@ -429,3 +433,4 @@
 	bowman = /obj/item/device/radio/headset/representative/alt
 	double_headset = /obj/item/device/radio/headset/alt/double/command/representative
 	wrist_radio = /obj/item/device/radio/headset/wrist/command/representative
+	clipon_radio = /obj/item/device/radio/headset/wrist/clip/command

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -147,7 +147,7 @@
 	bowman = /obj/item/device/radio/headset/representative/alt
 	double_headset = /obj/item/device/radio/headset/alt/double/command/representative
 	wrist_radio = /obj/item/device/radio/headset/wrist/command/representative
-	clipon_radio = /obj/item/device/radio/headset/wrist/clip/command
+	clipon_radio = /obj/item/device/radio/headset/wrist/clip/command/representative
 	accessory = /obj/item/clothing/accessory/tie/corporate
 	suit_accessory = /obj/item/clothing/accessory/pin/corporate
 
@@ -342,7 +342,7 @@
 	bowman = /obj/item/device/radio/headset/representative/alt
 	double_headset = /obj/item/device/radio/headset/alt/double/command/representative
 	wrist_radio = /obj/item/device/radio/headset/wrist/command/representative
-	clipon_radio = /obj/item/device/radio/headset/wrist/clip/command
+	clipon_radio = /obj/item/device/radio/headset/wrist/command/representative
 
 /datum/job/diplomatic_aide/after_spawn(mob/living/carbon/human/H)
 	LAZYDISTINCTADD(blacklisted_citizenship, H.citizenship)
@@ -389,7 +389,7 @@
 	bowman = /obj/item/device/radio/headset/representative/alt
 	double_headset = /obj/item/device/radio/headset/alt/double/command/representative
 	wrist_radio = /obj/item/device/radio/headset/wrist/command/representative
-	clipon_radio = /obj/item/device/radio/headset/wrist/clip/command
+	clipon_radio = /obj/item/device/radio/headset/wrist//command/representative
 
 /datum/job/diplomatic_bodyguard/after_spawn(mob/living/carbon/human/H)
 	LAZYDISTINCTADD(blacklisted_citizenship, H.citizenship)
@@ -433,4 +433,4 @@
 	bowman = /obj/item/device/radio/headset/representative/alt
 	double_headset = /obj/item/device/radio/headset/alt/double/command/representative
 	wrist_radio = /obj/item/device/radio/headset/wrist/command/representative
-	clipon_radio = /obj/item/device/radio/headset/wrist/clip/command
+	clipon_radio = /obj/item/device/encryptionkey/wrist/clip/command/representative

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -1024,6 +1024,12 @@
 /obj/item/device/radio/headset/wrist/command/representative
 	name = "wristbound representative radio"
 
+/obj/item/device/radio/headset/wrist/clip/command/representative
+	name = "clip-on representative radio"
+	icon_state = "clip_com"
+	item_state = "clip_com"
+	ks2type = /obj/item/device/encryptionkey/headset_com
+
 /obj/item/device/radio/headset/heads/ai_integrated //No need to care about icons, it should be hidden inside the AI anyway.
 	name = "\improper AI subspace transceiver"
 	desc = "Integrated AI radio transceiver."

--- a/html/changelogs/Fyni-OutsiderClipOns.yml
+++ b/html/changelogs/Fyni-OutsiderClipOns.yml
@@ -55,5 +55,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Adds the representative clip on radio for consulars, liasons, their aides and bodyguards
+  - rscadd: "Adds the representative clip on radio for consulars, liasons, their aides and bodyguards"
   - bugfix: "Makes sure the journalist gets the correct clip on radio"

--- a/html/changelogs/Fyni-OutsiderClipOns.yml
+++ b/html/changelogs/Fyni-OutsiderClipOns.yml
@@ -55,4 +55,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "Fixes the clip on radio for jobs under the "outsider" category (journalist, consulars, liasons, their aides and bodyguards)
+  - rscadd: "Adds the representative clip on radio for consulars, liasons, their aides and bodyguards
+  - bugfix: "Makes sure the journalist gets the correct clip on radio"

--- a/html/changelogs/Fyni-OutsiderClipOns.yml
+++ b/html/changelogs/Fyni-OutsiderClipOns.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Fyni
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes the clip on radio for jobs under the "outsider" category (journalist, consulars, liasons, their aides and bodyguards)


### PR DESCRIPTION
Currently, all "outsider" jobs (that is, journalist, consular, liason, aides and bodyguards) if set to a clip on radio would spawn with the default one (no command access, or no service in the case of the journalist)

This adds a clip on for the consular, liason, aides and bodyguards and makes sure the journalist gets their service clip on.
