### PR TITLE
Fixes the white label on several boxes

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -271,6 +271,7 @@
 	desc = "A box with several compact tungsten slugs, aimed for use in gauss carbines."
 	icon_state = "ammobox"
 	item_state = "ammobox"
+	label = null
 	illustration = null
 	drop_sound = 'sound/items/drop/ammobox.ogg'
 	pickup_sound = 'sound/items/pickup/ammobox.ogg'
@@ -582,6 +583,7 @@
 	name = "unique box"
 	desc = "A unique box. How is it unique? You have no idea."
 	color = COLOR_WHITE
+	label = null
 	illustration = null
 	chewable = FALSE
 

--- a/html/changelogs/BoxLabelFix.yml
+++ b/html/changelogs/BoxLabelFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes the white label on several types of boxes that shouldn't have them."


### PR DESCRIPTION
The white label was on most (not quite all) of the items in the screenshot below. This simply removes it as it should be.
<img width="405" height="261" alt="image" src="https://github.com/user-attachments/assets/a41b6f58-277a-4349-a23c-5e77e5467917" />
