### PR TITLE
Fixes lattice duplicate check

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -59,7 +59,7 @@
 
 /obj/structure/lattice/proc/check_for_duplicates()
 	for(var/obj/structure/lattice/found_lattice in get_turf(src))
-		if(found_lattice == src || istype(found_lattice, /obj/structure/lattice/ceiling))
+		if(found_lattice == src || found_lattice.type != src.type) // if the instance we're comparing is us or a different type, then it's not a duplicate
 			continue
 		return TRUE
 	return FALSE
@@ -98,13 +98,6 @@
 /obj/structure/lattice/ceiling/Initialize()
 	. = ..()
 	AddComponent(/datum/component/large_transparency, 0, 0, 0, 0)
-
-/obj/structure/lattice/ceiling/check_for_duplicates()
-	for(var/obj/structure/lattice/ceiling/found_lattice in get_turf(src))
-		if(found_lattice == src)
-			continue
-		return TRUE
-	return FALSE
 
 /obj/structure/lattice/catwalk
 	name = "catwalk"

--- a/html/changelogs/kano-dot-schrodingers-lattice.yml
+++ b/html/changelogs/kano-dot-schrodingers-lattice.yml
@@ -1,0 +1,6 @@
+author: Kano
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed an issue pertinent to lattice duplicate check, which was causing issues in away_site_testing checks."


### PR DESCRIPTION
## About PR

Attempts to fix an issue introduced in #21500, which was failing away_site_testing checks randomly.

Randomized destruction objects were occassionally calling `ex_act(2)` (which has a chance to replace the turf with lattice, and damage the grate) on plating turfs with grates (which is also a lattice), triggering the duplicate check. This PR changes it so, only the same type of lattices are considered duplicate