### PR TITLE
Fix Mech Sleepers

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -64,7 +64,7 @@
 	parts_power_usage = active_power_usage
 
 /obj/machinery/sleeper/process(seconds_per_tick)
-	if(stat & (NOPOWER|BROKEN))
+	if((stat & (NOPOWER|BROKEN)) && !interact_offline)
 		return
 
 	if(filtering)
@@ -135,7 +135,7 @@
 
 /obj/machinery/sleeper/ui_data(mob/user)
 	var/list/data = list()
-	data["power"] = stat & (NOPOWER|BROKEN) ? FALSE : TRUE
+	data["power"] = (stat & (NOPOWER|BROKEN)) && !interact_offline ? FALSE : TRUE
 
 	if(occupant)
 		data["occupant"] = TRUE
@@ -322,7 +322,7 @@
 	if(filtering)
 		toggle_filter()
 
-	if(stat & (BROKEN|NOPOWER))
+	if((stat & (BROKEN|NOPOWER)) && !interact_offline)
 		return
 
 	if(occupant)
@@ -348,7 +348,7 @@
 /obj/machinery/sleeper/proc/go_in(var/mob/M, var/mob/user)
 	if(!M)
 		return
-	if(stat & (BROKEN|NOPOWER))
+	if((stat & (BROKEN|NOPOWER)) && !interact_offline)
 		return
 	if(occupant)
 		to_chat(user, SPAN_WARNING("\The [src] is already occupied."))
@@ -402,7 +402,7 @@
 		toggle_pump()
 
 /obj/machinery/sleeper/proc/inject_chemical(var/mob/living/user, var/chemical, var/add_amount)
-	if(stat & (BROKEN|NOPOWER))
+	if((stat & (BROKEN|NOPOWER)) && !interact_offline)
 		return
 
 	if(occupant?.reagents)

--- a/html/changelogs/hellfirejag-fix-mech-sleepers.yml
+++ b/html/changelogs/hellfirejag-fix-mech-sleepers.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed Mech Sleepers & Passenger Compartments not working at all."


### PR DESCRIPTION
It turns out that Sleepers weren't accounting for the variable used by Mech sleepers to indicate that they should work without a power network, and it was impossible for the Mech sleepers to ever be "powered" in this context. This meant that any attempt to use the Mech Mounted Sleeper or Mounted Passenger Compartment would always fail. 

This PR makes it so that if the sleeper has interact_offline set to TRUE (as is the case with the mech sleepers, but not with the regular machine), it will bypass its standard power requirements. Allowing mech sleepers to actually work correctly.