### PR TITLE
Change's Mortaphenyl's Description in Cargo to Label it as a Weak Opioid

### DIFF
--- a/code/modules/cargo/items/medical.dm
+++ b/code/modules/cargo/items/medical.dm
@@ -328,7 +328,7 @@
 	category = "medical"
 	name = "mortaphenyl bottle"
 	supplier = "nanotrasen"
-	description = "A bottle of mortaphenyl, a strong non-opioid painkiller."
+	description = "A bottle of mortaphenyl, a weak, synthetic, opioid painkiller."
 	price = 455
 	items = list(
 		/obj/item/reagent_containers/glass/bottle/mortaphenyl

--- a/html/changelogs/Evandorf-Morta-Designation.yml
+++ b/html/changelogs/Evandorf-Morta-Designation.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Evandorf
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Changes the description in the cargo order menu to depict Mortaphenyl as a weak, synthetic, opioid."


### PR DESCRIPTION
This was created to help @Acetrea as they were having technical issues publishing a PR. I don't see any other clear distinction to it being an opioid or non-opioid in code or the wiki so I'll let them make the case for the designation change below.