### PR TITLE
Fix GPS Test Fail

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -33,6 +33,8 @@
  * Engineering (Atmospherics) - Deck 1 - Combustion Turbine - Port Amidships, Aft
  */
 /proc/get_area_display_name(var/area/A, var/show_dept = TRUE, var/show_subdept = TRUE, var/show_deck = TRUE, var/show_location = TRUE, var/show_hidden_depts = FALSE)
+	if (!A) // Fallback case.
+		return "Unknown Area"
 	if(!is_station_area(A))
 		return A.name
 	var/horizon_deck = A.horizon_deck

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -248,7 +248,23 @@ GLOBAL_LIST_EMPTY(gps_list)
 		return
 	var/area/gpsarea = get_area(src)
 	var/gps_areaname = get_area_display_name(gpsarea, TRUE, FALSE, FALSE, TRUE)
-	GLOB.gps_list[gpstag] = list("tag" = gpstag, "pos_x" = T.x, "pos_y" = T.y, "pos_z" = T.z, "area" = "[gps_areaname]", "emped" = emped, "compass_color" = compass_color)
+
+	// Sanity checking with default locations in case something isn't right with locational data.
+	// The GPS will prefer the coordinate of its turf, but if the turf is null it will try the coordinate of whoever is holding it.
+	// And if both fail, it'll default to <0,0,0> so we don't crash.
+	var/x_coord = 0
+	var/y_coord = 0
+	var/z_coord = 0
+	if (T)
+		x_coord = T.x
+		y_coord = T.y
+		z_coord = T.z
+	else if (held_by)
+		x_coord = held_by.x
+		y_coord = held_by.y
+		z_coord = held_by.z
+
+	GLOB.gps_list[gpstag] = list("tag" = gpstag, "pos_x" = x_coord, "pos_y" = y_coord, "pos_z" = z_coord, "area" = "[gps_areaname]", "emped" = emped, "compass_color" = compass_color)
 	if(check_held_by && held_by && (held_by.get_active_hand() == src || held_by.get_inactive_hand() == src))
 		update_compass(TRUE)
 

--- a/html/changelogs/hellfirejag - GPS heisenbug.yml
+++ b/html/changelogs/hellfirejag - GPS heisenbug.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed a random test fail caused by GPS devices being spawned in a null location."


### PR DESCRIPTION
Fixes this test fail. One of our unit tests is randomly spawning a GPS in a null location, which causes a runtime error when the GPS attempts to print the coordinates of said null location. I've added sanity checking to prevent this obnoxious test fail.

<img width="1379" height="759" alt="image" src="https://github.com/user-attachments/assets/d5c15892-7272-4d24-886b-5c30432a35e5" />
