### PR TITLE
Tajaran Diplomatic Bodyguard uniform replacements

### DIFF
--- a/code/modules/background/citizenship/tajara.dm
+++ b/code/modules/background/citizenship/tajara.dm
@@ -117,11 +117,13 @@
 
 /obj/outfit/job/diplomatic_bodyguard/pra
 	name = "PRA Diplomatic Bodyguard"
-	uniform = /obj/item/clothing/under/tajaran/fancy/alt2
+	uniform = /obj/item/clothing/under/tajaran/pra_cop
+	suit = /obj/item/clothing/suit/storage/tajaran/pra_cop
+	head = /obj/item/clothing/head/tajaran/pra_cop
+	shoes = /obj/item/clothing/shoes/jackboots/tajara
 	backpack_contents = list(
 		/obj/item/gun/projectile/pistol/adhomai = 1
 	)
-	accessory = /obj/item/clothing/accessory/hadii_pin
 
 /datum/citizenship/dpra
 	name = CITIZENSHIP_DPRA
@@ -240,7 +242,9 @@
 
 /obj/outfit/job/diplomatic_bodyguard/dpra
 	name = "DPRA Diplomatic Bodyguard"
-	uniform = /obj/item/clothing/under/tajaran/fancy/alt2
+	uniform = /obj/item/clothing/under/tajaran/ala/black/dress/ajic
+	shoes = /obj/item/clothing/shoes/jackboots/tajara
+	head = /obj/item/clothing/head/beret/tajaran/dpra/ajic
 	backpack_contents = list(
 		/obj/item/gun/projectile/silenced = 1,
 	)
@@ -361,7 +365,6 @@
 		/obj/item/storage/box/nka_manifesto = 1,
 		/obj/item/storage/field_ration/nka = 1
 	)
-	accessory = /obj/item/clothing/accessory/nka_pin
 
 /obj/outfit/job/diplomatic_bodyguard/nka
 	name = "NKA Diplomatic Bodyguard"

--- a/code/modules/clothing/head/xenos/tajara.dm
+++ b/code/modules/clothing/head/xenos/tajara.dm
@@ -78,6 +78,10 @@
 	icon_state = "alaberet"
 	item_state = "alaberet"
 
+/obj/item/clothing/head/beret/tajaran/dpra/ajic
+	name = "protective services group of the adhomai joint intelligence committee beret."
+	desc = "A surplus Adhomai Liberation Army beret. The ALA symbol has been replaced with the symbol of the Adhomai Joint Intelligence Committee."
+
 /obj/item/clothing/head/beret/tajaran/dpra/alt
 	icon_state = "alaberetalt"
 	item_state = "alaberetalt"

--- a/code/modules/clothing/under/xenos/tajara.dm
+++ b/code/modules/clothing/under/xenos/tajara.dm
@@ -378,6 +378,11 @@
 	icon_state = "ala-soldatdress"
 	item_state = "ala-soldatdress"
 
+/obj/item/clothing/under/tajaran/ala/black/dress/ajic
+	name = "protective services group of the adhomai joint intelligence committee uniform"
+	desc = "A surplus Adhomai Liberation Army dress uniform. The ALA symbols have been replaced with the symbol of the Adhomai Joint Intelligence Committee."
+	starting_accessories = null
+
 /obj/item/clothing/under/tajaran/ala/black/officer
 	name = "adhomai liberation army officer uniform"
 	desc = "A military uniform issued to officers of the adhomai liberation army."

--- a/html/changelogs/Greenjoe - tajguard.yml
+++ b/html/changelogs/Greenjoe - tajguard.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Greenjoe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Changes the uniforms of the Tajaran diplomatic bodyguards."


### PR DESCRIPTION
The Tajaran diplomatic bodyguards now have uniforms to better fit with their lore.
<img width="131" height="125" alt="image" src="https://github.com/user-attachments/assets/aaaaf03a-d61a-406a-8f3a-0e84b40595f7" />
The PRA consular now gets a National Police Department officer as their guard.

<img width="133" height="141" alt="image" src="https://github.com/user-attachments/assets/46eb859a-6d94-44b9-98d3-833297a612ca" />

The DPRA consular now gets a Adhomai Joint Intelligence Committee agent
as their guard, who uses a surplus ALA dress uniform and beret.

<img width="133" height="136" alt="image" src="https://github.com/user-attachments/assets/ff73dada-d7bb-4d38-814d-73191f53557a" />

The NKA Consular now gets a member of the Imperial Adhomai Army as their guard.