### PR TITLE
Add species insulated gloves to the syndicate toolbox

### DIFF
--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -113,6 +113,8 @@
 	force = 16
 	starts_with = list(\
 		/obj/item/clothing/gloves/yellow = 1,\
+		/obj/item/clothing/gloves/yellow/specialt = 1,\
+		/obj/item/clothing/gloves/yellow/specialu = 1,\
 		/obj/item/screwdriver = 1,\
 		/obj/item/wrench = 1,\
 		/obj/item/weldingtool = 1,

--- a/html/changelogs/SpeciesInsulatedGloves.yml
+++ b/html/changelogs/SpeciesInsulatedGloves.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "The antag toolbox now also have insulated gloves fitting taj and unathi."


### PR DESCRIPTION
You're an antag, you spawn a toolbox expecting to have all the tools. Nope. No gloves for you because you're a taj or unathi.

This is just the quick fix solution to this since they got separate insulated gloves.