### PR TITLE
Area sensitivity restoration - fixes ambience, ship hum, gravity, area blurbs, etc.

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -432,7 +432,7 @@ GLOBAL_LIST_INIT(area_blurb_stated_to, list())
  * * mob/living/L - Affected mob.
  */
 /area/proc/play_ambience(var/mob/living/L)
-	if((world.time >= L.client.ambience_last_played_time + 5 MINUTES) && prob(20))
+	if((world.time >= L.client.ambience_last_played_time + 3 MINUTES) && prob(30))
 		var/picked_ambience = pick(ambience)
 		L << sound(picked_ambience, volume = VOLUME_AMBIENCE, channel = CHANNEL_AMBIENCE)
 		L.client.ambience_last_played_time = world.time

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -215,21 +215,6 @@
 
 /mob/living/carbon/human/get_status_tab_items()
 	. = ..()
-
-	/// This needs to be updated to use signals.
-	var/holding_gps = FALSE
-	if(istype(src.get_active_hand(), /obj/item/gps) || istype(src.get_inactive_hand(), /obj/item/gps))
-		holding_gps = TRUE
-
-	var/area/A = get_area(src)
-	var/area_name
-	if(holding_gps)
-		area_name = get_area_display_name(A)
-		. += "[area_name]"
-		. += ""
-	if(A.area_blurb)
-		. += "[A.area_blurb]"
-		. += ""
 	. += "Intent: [a_intent]"
 	. += "Move Mode: [m_intent]"
 	if(is_diona() && DS)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -103,6 +103,10 @@
 
 	become_hearing_sensitive()
 
+	// This impacts area/entered(), gravity drifting, and probably plenty more. This will likely
+	// need to be removed/moved if and when any 'moodlet' system is implemented (ref. TG component).
+	become_area_sensitive(INNATE_TRAIT)
+
 /**
  * Generate the tag for this mob
  *

--- a/html/changelogs/Bat-AreaSensitivity.yml
+++ b/html/changelogs/Bat-AreaSensitivity.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Batrachophrenoboocosmomachia
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Restores area_sensitive trait for mobs, fixing zero-gravity drifting, ambience and ship hum, and area blurbs."
+  - rscdel: "Removes area blurb text from status window (band-aid fix prior to discovering root cause of them not appearing consistently)."


### PR DESCRIPTION
Finally tracked this rat bastard down; requisite trait assignment was removed from mobs at some point.

Drifting in zero-gravity works again (including throwing things to change speed and direction).
Area text blurbs work again (my band-aid fix adding them to status window has been removed).
Random ambience sounds now play again.
Ship hum works again while on the Horizon.
Probably fixes more stuff that its removal broke.