### PR TITLE
Fix Credit Symbol On Paper

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -671,7 +671,7 @@
 	t = replacetext(t, "\[date\]", "[worlddate2text()]")
 	t = replacetext(t, "\[tajtime\]", "[tajaran_time()]")
 	t = replacetext(t, "\[tajdate\]", "[tajaran_full_date()]")
-	t = replacetext(t, "\[cr\]", "电")
+	t = replacetext(t, "\[cr\]", "\u7535")
 	t = replacetext(t, "\[editorbr\]", "<BR>")
 	t = replacetext(t, @"[image id=([\w]*?\.[\w]*?)]", "<img style=\"display:block;width:90%;\" src = [GLOB.config.docs_image_host]$1></img>")
 	return t

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -107,7 +107,7 @@
 <html>
 	<head>
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
-		<meta http-equiv="Content-Type" content="text/html; utf-8">
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 		[head_content]
 	</head>
 	<body scroll=auto>

--- a/html/changelogs/hellfirejag-fix-credit-symbol.yml
+++ b/html/changelogs/hellfirejag-fix-credit-symbol.yml
@@ -1,0 +1,4 @@
+author: Helfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed the credit symbol not being correctly applied when using [cr] on a paper."


### PR DESCRIPTION
I have a massive migraine right now so I threw this problem at Antigravity-Gemini3Flash. I have tested that the credit symbol works correctly though, and have looked at several papers to make sure their formatting wasn't messed up.

Tested: 

<img width="106" height="103" alt="image" src="https://github.com/user-attachments/assets/56672122-5404-4d98-bb4f-65a254ca3d2a" />
