### PR TITLE
Static Light Hard Del Fix

### DIFF
--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -149,6 +149,9 @@
 	if(length(overlays))
 		overlays.Cut()
 
+	if(static_light)
+		QDEL_NULL(static_light)
+
 	if(light)
 		QDEL_NULL(light)
 

--- a/html/changelogs/hellfirejag-static-light-hard-del.yml
+++ b/html/changelogs/hellfirejag-static-light-hard-del.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Removed a hard delete related to static light sources."


### PR DESCRIPTION
This fixes our current worst hard delete. I actually made this PR using part of my weekly allotment of "Expensive" AI tokens for Antigravity-Gemini3Pro, as an experiment to see if I could have it do the tedious "gruntwork" of searching the entire repo for hard dels like this.

<img width="397" height="178" alt="image" src="https://github.com/user-attachments/assets/7cf9d97e-3466-4199-a1b6-f8ba0f6136c7" />
