### PR TITLE
Ship Movement Guarding Fix

### DIFF
--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -188,49 +188,50 @@
 /obj/effect/overmap/visitable/ship/proc/get_brake_path()
 	if(!get_acceleration())
 		return INFINITY
-	if(is_still())
+
+	if(is_still() || !burn_delay || !get_speed())
 		return 0
-	if(!burn_delay)
-		return 0
-	if(!get_speed())
-		return 0
-	var/num_burns = get_speed()/get_acceleration() + 2 //some padding in case acceleration drops form fuel usage
-	var/burns_per_grid = 1/ (burn_delay * get_speed())
-	return round(num_burns/burns_per_grid)
+	var/num_burns = get_speed() / get_acceleration() + 2 // some padding in case acceleration drops form fuel usage
+	var/burns_per_grid = 1 / (burn_delay * get_speed())
+	return round(num_burns / burns_per_grid)
 
 /obj/effect/overmap/visitable/ship/proc/decelerate()
-	if(can_burn())
-		// Pythagorean theorem gives us the magnitude of the ship's velocity, which is always an absolute value.
-		// This is also the mathematical definition for Vector.size
-		var/magnitude_velocity = ((speed[1] ** 2) + (speed[2] **2)) ** (1/2)
+	if((!speed[1] && !speed[2]) || !can_burn())
+		return
 
-		// Get the magnitude of our desired change in velocity
-		var/alpha = min(get_burn_acceleration(), magnitude_velocity)
+	// Pythagorean theorem gives us the magnitude of the ship's velocity, which is always an absolute value.
+	// This is also the mathematical definition for Vector.size
+	var/magnitude_velocity = ((speed[1] ** 2) + (speed[2] **2)) ** (1/2)
 
-		// First we "Normalize" the current velocity to get the direction without a distance
-		// Then we take the exact negative of this direction to get its true opposite
-		// And finally multiply by the magnitude of our desired delta_v to get the true delta_v
-		var/delta_x = -(speed[1] / magnitude_velocity) * alpha
-		var/delta_y = -(speed[2] / magnitude_velocity) * alpha
+	// Get the magnitude of our desired change in velocity
+	var/alpha = min(get_burn_acceleration(), magnitude_velocity)
 
-		adjust_speed(delta_x, delta_y)
-		last_burn = world.time
+	// First we "Normalize" the current velocity to get the direction without a distance
+	// Then we take the exact negative of this direction to get its true opposite
+	// And finally multiply by the magnitude of our desired delta_v to get the true delta_v
+	var/delta_x = -(speed[1] / magnitude_velocity) * alpha
+	var/delta_y = -(speed[2] / magnitude_velocity) * alpha
+
+	adjust_speed(delta_x, delta_y)
+	last_burn = world.time
 
 /obj/effect/overmap/visitable/ship/proc/accelerate(direction, accel_limit)
-	if(can_burn())
-		last_burn = world.time
+	if(!can_burn())
+		return
 
-		// Get our "Alpha" value as the ship's desired acceleration (change in Velocity)
-		var/acceleration = min(get_burn_acceleration(), accel_limit)
+	last_burn = world.time
 
-		// Convert from cardinal directions to an angle (in degrees)
-		// !This is absolutely terrible and should at some point be swapped to Radians
-		// !But for now it's "Okay" until overmap ships are updated to work on time differentials properly.
-		var/theta = dir2degree(direction)
+	// Get our "Alpha" value as the ship's desired acceleration (change in Velocity)
+	var/acceleration = min(get_burn_acceleration(), accel_limit)
 
-		// This comes from the actual definition of a Vector2d, <Acos(theta), Asin(theta)>, where theta is an Angle, and A is a constant multiplier that traditionally represents distance.
-		// In this case A is our DeltaVelocity, or Acceleration.
-		adjust_speed(acceleration * cos(theta), acceleration * sin(theta))
+	// Convert from cardinal directions to an angle (in degrees)
+	// !This is absolutely terrible and should at some point be swapped to Radians
+	// !But for now it's "Okay" until overmap ships are updated to work on time differentials properly.
+	var/theta = dir2degree(direction)
+
+	// This comes from the actual definition of a Vector2d, <Acos(theta), Asin(theta)>, where theta is an Angle, and A is a constant multiplier that traditionally represents distance.
+	// In this case A is our DeltaVelocity, or Acceleration.
+	adjust_speed(acceleration * cos(theta), acceleration * sin(theta))
 
 /obj/effect/overmap/visitable/ship/process()
 	..()

--- a/html/changelogs/hellfirejag-ship-guard-clausing.yml
+++ b/html/changelogs/hellfirejag-ship-guard-clausing.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Added a check to prevent division by 0 in ship math."


### PR DESCRIPTION
It's not supposed to be possible to get into the decellerate() proc when your ship isn't moving, since the button to get there locks. Somehow this happens anyways, so here's a guard clause in case that softer check didn't work, in order to make a division by 0 not possible.