### PR TITLE
Stop Blank Records From Showing In Manifest

### DIFF
--- a/code/controllers/subsystems/records.dm
+++ b/code/controllers/subsystems/records.dm
@@ -279,6 +279,9 @@ SUBSYSTEM_DEF(records)
 	/* ----- START OF CASE FOR CREW ----- */
 	// Start with the "Crew", which are all of the IC manifest members.
 	for(var/datum/record/general/general_record in records)
+		if (!general_record.name || !general_record.rank)
+			continue
+
 		var/datum/job/job = SSjobs.GetJob(make_list_rank(general_record.real_rank))
 		var/list/departments = /* Jobs can be in more than one department. So we fact check that the departments are real. */\
 			(istype(job) && job.departments.len > 0 && all_in_list(job.departments, manifest))\

--- a/html/changelogs/hellfirejag-blank-records-fix.yml
+++ b/html/changelogs/hellfirejag-blank-records-fix.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
+  - rscdel: "Killed innocent kittens."


### PR DESCRIPTION
During last nights event, a few storyteller spawned mobs got snuck into the manifest with blank jobs. This PR prevents said blank records from showing up in the manifest. I'm genuinely not sure how they got there in the first place, but oh well.