### PR TITLE
Fix cultures not firing on_remove if they're replaced by the same culture

### DIFF
--- a/code/modules/background/origins/_origins.dm
+++ b/code/modules/background/origins/_origins.dm
@@ -30,7 +30,7 @@
 	if(!istype(OI))
 		crash_with("Invalid culture supplied: [OI]!")
 	culture = OI
-	if(old_culture && culture != old_culture)
+	if(old_culture)
 		old_culture.on_remove(src)
 	OI.on_apply(src)
 
@@ -39,7 +39,7 @@
 	if(!istype(OI))
 		crash_with("Invalid origin supplied: [OI]!")
 	origin = OI
-	if(old_origin && origin != old_origin)
+	if(old_origin)
 		old_origin.on_remove(src)
 	OI.on_apply(src)
 

--- a/html/changelogs/JohnWildkins-aug.yml
+++ b/html/changelogs/JohnWildkins-aug.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Augments given by culture (i.e. Vaurca language processors) no longer get applied twice when spawning in."


### PR DESCRIPTION
see title

the better option would be for set_culture to only fire once when spawning in, but i am not refactoring that mess