### PR TITLE
Fixes Kathira's custom item

### DIFF
--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -2124,13 +2124,13 @@ All custom items with worn sprites must follow the contained sprite system: http
 
 /obj/item/clothing/accessory/poncho/tajarancloak/fluff/kathira_cloak/update_icon(var/hooded = FALSE)
 	var/obj/item/clothing/accessory/poncho/tajarancloak/fluff/kathira_cloak/K = get_accessory(/obj/item/clothing/accessory/poncho/tajarancloak/fluff/kathira_cloak)
-	K.icon_state = "[K.changed ? K.style : initial(K.icon_state)]"
 	SEND_SIGNAL(K, COMSIG_ITEM_STATE_CHECK, args)
+	. = ..()
+	K.icon_state = "[K.changed ? K.style : initial(K.icon_state)]"
 	K.item_state = "[K.icon_state][hooded ? "_up" : ""]"
 	K.name = "[K.changed ? K.name2 : initial(K.name)]"
 	K.desc = "[K.changed ? K.desc2 : initial(K.desc)]"
 	K.accessory_mob_overlay = null
-	. = ..()
 	SEND_SIGNAL(K, COMSIG_ITEM_ICON_UPDATE)
 	if(usr)
 		usr.update_inv_w_uniform()

--- a/html/changelogs/CloakFix.yml
+++ b/html/changelogs/CloakFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes Kathira's custom item cloak."


### PR DESCRIPTION
I accidentally broke it when I implemented Tulkir's custom dagger, due to how the icon states are reset in accessories now. So now I just handle that part earlier instead so it works again.