### PR TITLE
Fix Melty IPC In Space Suits

### DIFF
--- a/code/modules/organs/internal/species/machine/cooling_unit.dm
+++ b/code/modules/organs/internal/species/machine/cooling_unit.dm
@@ -142,9 +142,7 @@
 	if(owner.wear_suit)
 		if(!spaceproof && istype(owner.wear_suit, /obj/item/clothing/suit/space))
 			//cooling is going to SUCK if you have heat-regulating clothes
-			if(owner.bodytemperature < species.heat_level_3)
-				owner.bodytemperature = min(owner.bodytemperature + 5, owner.species.heat_level_2)
-				temperature_change *= 0.5
+			temperature_change *= 0.5
 
 	// Check if there is somehow no air, or if we are in an ambient without enough air to properly cool us.
 	if((!ambient || (ambient && owner.calculate_affecting_pressure(ambient.return_pressure()) < owner.species.warning_low_pressure)))

--- a/html/changelogs/hellfirejag ipc-spacesuit-unmelty.yml
+++ b/html/changelogs/hellfirejag ipc-spacesuit-unmelty.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed IPCs instantly starting to die if they put on a space suit. It just makes cooling half as effective now."


### PR DESCRIPTION
This was extremely overtuned to an unreasonable degree. To a point it was physically impossible for an IPC who puts a hardsuit on to be able to turn their suit cooler on fast enough before they die. Directly setting their temperature to "Start dying" was also really bad for not accounting for space suits and hardsuits having the option of being equipped with cooling units for IPCs. You should still want to have a cooling unit in a suit, so they instead just cut your standard cooling rate in half.