### PR TITLE
Fixes a Modulo Moment in lobby screens

### DIFF
--- a/code/modules/mob/abstract/new_player/menu.dm
+++ b/code/modules/mob/abstract/new_player/menu.dm
@@ -138,9 +138,11 @@ ABSTRACT_TYPE(/atom/movable/screen/new_player)
 			icon_state = pick(SSatlas.current_map.lobby_screens)
 		return
 
-	if(length(SSatlas.current_map.lobby_screens) >= 2)
+	var/num_lobby_screens = length(SSatlas.current_map.lobby_screens)
+
+	if(num_lobby_screens >= 2)
 		//Advance to the next icon
-		lobby_screen_index = max(++lobby_screen_index % length(SSatlas.current_map.lobby_screens), 1)
+		lobby_screen_index = (lobby_screen_index % num_lobby_screens) + 1
 
 		animate(src, alpha = 0, time = 1 SECOND)
 

--- a/html/changelogs/johnwildkins-fixlobby.yml
+++ b/html/changelogs/johnwildkins-fixlobby.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fix lobby screen system failing to switch to the last lobby screen in a set."


### PR DESCRIPTION
see title

(++index % num_lobby_screens) will only ever get you [0, num_lobby_screens), which is why it maxes with 1. but that still ignores the last screen. so instead we just do the smart thing which is to add +1 after.