### PR TITLE
Add workflow to enforce merge blockers on PRs

### DIFF
--- a/.github/workflows/enforce_merge_blockers.yaml
+++ b/.github/workflows/enforce_merge_blockers.yaml
@@ -26,3 +26,9 @@ jobs:
         run: |
           echo "Pull request is labelled Do Not Merge and cannot be merged in this state. Refer to the developer who set this label for information."
           exit 1
+
+      - name: Enforce Changes Required Label
+        if: contains(github.event.pull_request.labels.*.name, 'Changes Required')
+        run: |
+          echo "Pull request is labelled Changes Required and cannot be merged in this state. Refer to the developer who set this label for information."
+          exit 1


### PR DESCRIPTION
No User Facing changes.

Avoids accidental merges when the Do Not Merge, Maintainer Discussion, or Lore Discussion labels are set on a PR.

[Credit to Baystation for the inspiration.](https://github.com/Baystation12/Baystation12/pull/35046)