### PR TITLE
Fixes the stickynote pad in the horizon map file

### DIFF
--- a/html/changelogs/StickyMapFix.yml
+++ b/html/changelogs/StickyMapFix.yml
@@ -1,0 +1,5 @@
+author: TheGreyWolf
+delete-after: True
+
+changes:
+  - bugfix: "Fixed stickynote pad path in the map file."


### PR DESCRIPTION
And a hand labeler path.