### PR TITLE
Improves plastic bags and make toptart boxes smaller

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -108,7 +108,7 @@
 	item_state = "plasticbag"
 	storage_slots = null
 	w_class = WEIGHT_CLASS_BULKY
-	max_w_class = WEIGHT_CLASS_SMALL
+	storage_slots = DEFAULT_LARGEBOX_STORAGE
 	can_hold = null // any
 	cant_hold = list(/obj/item/disk/nuclear)
 	drop_sound = 'sound/items/drop/wrapper.ogg'

--- a/code/modules/reagents/reagent_containers/food/snacks/processed.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/processed.dm
@@ -1039,6 +1039,7 @@
 	icon_state = "toptart_strawberry_box"
 	icon_type = "toptart"
 	storage_type = "box"
+	w_class = WEIGHT_CLASS_SMALL
 	starts_with = list(/obj/item/reagent_containers/food/snacks/toptart_strawberry_raw = 4)
 	can_hold = list(
 		/obj/item/reagent_containers/food/snacks/toptart_strawberry_raw,
@@ -1058,6 +1059,7 @@
 	icon_state = "toptart_chocolate_box"
 	icon_type = "toptart"
 	storage_type = "box"
+	w_class = WEIGHT_CLASS_SMALL
 	starts_with = list(/obj/item/reagent_containers/food/snacks/toptart_chocolate_peanutbutter_raw = 4)
 	can_hold = list(
 		/obj/item/reagent_containers/food/snacks/toptart_strawberry_raw,
@@ -1077,6 +1079,7 @@
 	icon_state = "toptart_blueberry_box"
 	icon_type = "toptart"
 	storage_type = "box"
+	w_class = WEIGHT_CLASS_SMALL
 	starts_with = list(/obj/item/reagent_containers/food/snacks/toptart_blueberry_raw = 4)
 	can_hold = list(
 		/obj/item/reagent_containers/food/snacks/toptart_strawberry_raw,

--- a/html/changelogs/PlasticBagImprovement.yml
+++ b/html/changelogs/PlasticBagImprovement.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - qol: "Plastic bags can now hold more items and slightly bigger ones."
+  - qol: "Made toptart packages smaller so they fit in plastic bags."


### PR DESCRIPTION
Plastic bags can hold more items and slightly bigger ones. They already can't fit into a backpack, so giving them the ability to actually carry something seemed fine.
Toptart boxes were also made a bit smaller, given how few items are in them and to make them fit better in plastic bags.