### PR TITLE
Adds stickynote pads in a bunch of places and to the loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/utility.dm
+++ b/code/modules/client/preference_setup/loadout/items/utility.dm
@@ -57,6 +57,7 @@
 
 /datum/gear/utility/stickynote
 	display_name = "Sticky note pad"
+	description = "A pad full of sticky notes, to stick notes to places with."
 	path = /obj/item/paper/stickynotes/pad
 	flags = GEAR_HAS_COLOR_SELECTION
 

--- a/code/modules/client/preference_setup/loadout/items/utility.dm
+++ b/code/modules/client/preference_setup/loadout/items/utility.dm
@@ -55,6 +55,11 @@
 	path = /obj/item/journal/notepad/filled
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
 
+/datum/gear/utility/stickynote
+	display_name = "Sticky note pad"
+	path = /obj/item/paper/stickynotes/pad
+	flags = GEAR_HAS_COLOR_SELECTION
+
 /datum/gear/utility/fountainpen
 	display_name = "fountain pen selection"
 	description = "A selection of fountain pens."

--- a/code/modules/client/preference_setup/loadout/items/utility.dm
+++ b/code/modules/client/preference_setup/loadout/items/utility.dm
@@ -56,7 +56,7 @@
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
 
 /datum/gear/utility/stickynote
-	display_name = "Sticky note pad"
+	display_name = "sticky note pad"
 	description = "A pad full of sticky notes, to stick notes to places with."
 	path = /obj/item/paper/stickynotes/pad
 	flags = GEAR_HAS_COLOR_SELECTION

--- a/html/changelogs/StickyNotesForEveryone.yml
+++ b/html/changelogs/StickyNotesForEveryone.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Added stickynote pads to the following locations: Command offices, bridge, rep and liasion offices, journalist office, eng, medical and operations lobby, invest office and lab, galley, vacant office on D3, all three custodial closets, security meeting room, HR meeting room, machinist workshop and tool storage."

--- a/html/changelogs/StickyNotesForEveryone.yml
+++ b/html/changelogs/StickyNotesForEveryone.yml
@@ -3,5 +3,5 @@ author: TheGreyWolf
 delete-after: True
 
 changes:
-  - rscadd: "Added stickynote pads to the following locations: Command offices, bridge, rep and liasion offices, journalist office, eng, medical and operations lobby, invest office and lab, galley, vacant office on D3, all three custodial closets, security meeting room, HR meeting room, machinist workshop and tool storage."
+  - rscadd: "Added stickynote pads to the following locations: Command offices, bridge, rep and liaison offices, journalist office, eng, medical and operations lobby, invest office and lab, galley, vacant office on D3, all three custodial closets, security meeting room, HR meeting room, machinist workshop, and tool storage."
   - rscadd: "Added stickynotes to the loadout."

--- a/html/changelogs/StickyNotesForEveryone.yml
+++ b/html/changelogs/StickyNotesForEveryone.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - rscadd: "Added stickynote pads to the following locations: Command offices, bridge, rep and liasion offices, journalist office, eng, medical and operations lobby, invest office and lab, galley, vacant office on D3, all three custodial closets, security meeting room, HR meeting room, machinist workshop and tool storage."
+  - rscadd: "Added stickynotes to the loadout."


### PR DESCRIPTION
"Added stickynote pads to the following locations: Command offices, bridge, rep and liasion offices, journalist office, eng, medical and operations lobby, invest office and lab, galley, vacant office on D3, all three custodial closets, security meeting room, HR meeting room, machinist workshop and tool storage."

yeah. Apparently they weren't added properly in the original PR to a lot of places. So I went wide with it.

This also adds them to the loadout.