### PR TITLE
Fix Set Odyssey

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1399,11 +1399,14 @@ var/global/enabled_spooking = 0
 /datum/admins/proc/set_odyssey()
 	set name = "Set Odyssey Type"
 	set category = "Special Verbs"
+	if (!SSodyssey.initialized)
+		to_chat(usr, SPAN_WARNING("You must wait for the server to finish initializing."))
+		return
 
 	if(!check_rights(R_ADMIN))
 		return
 
-	if(SSticker.current_state != GAME_STATE_SETTING_UP)
+	if(SSticker.current_state > GAME_STATE_SETTING_UP)
 		to_chat(usr, SPAN_WARNING("You need to use this verb while the game is still setting up!"))
 		return
 

--- a/html/changelogs/hellfirejag fix-set-ody.yml
+++ b/html/changelogs/hellfirejag fix-set-ody.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed the Set Odyssey verb not working. It can now be used anytime after initialization, but before the round actually starts."


### PR DESCRIPTION
This PR fixes the Set Odyssey verb to work after server initialization, but before the round has actually started. It can actually be run even before the round type has been voted for.

 I have actually tested this PR and verified that it works.