### PR TITLE
Prevent update tgs dmapi workflow from running on forks

### DIFF
--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   update-dmapi:
     runs-on: ubuntu-24.04
+    if: github.repository == 'Aurorastation/Aurora.3' # to prevent this running on forks
     name: Update the TGS DMAPI
     steps:
     - name: Clone


### PR DESCRIPTION
NUFC

Discovered this being an issue when I checked our pulse, and noticed this running on _every single fork._