### PR TITLE
Make Radios appear on character sprites again

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/item/radio/headset.dmi'
 	icon_state = "headset"
 	item_state = "headset"
+	contained_sprite = TRUE
 	matter = list(MATERIAL_ALUMINIUM = 75)
 	subspace_transmission = TRUE
 	canhear_range = 0 // can't hear headsets from very far away

--- a/html/changelogs/Bat-radio-sprites.yml
+++ b/html/changelogs/Bat-radio-sprites.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Batrachophrenoboocosmomachia
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Restores inhand sprites for all radio variants."


### PR DESCRIPTION
Back-end change caused radios to vanish due to not having explicit contained_sprite setting.

You can see clip-on radios, headsets, etc. on your characters again.