### PR TITLE
Access controller UI cleanup

### DIFF
--- a/code/game/machinery/embedded_controller/airlock_controllers.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers.dm
@@ -134,8 +134,11 @@
 /obj/machinery/embedded_controller/radio/airlock/access_controller/ui_data(mob/user)
 	var/list/data = list()
 
-	data["exterior_status"] = round(program.memory["exterior_status"])
-	data["interior_status"] = round(program.memory["interior_status"])
+	var/ext_door_status = (program.memory["exterior_status"]["state"] == "closed" && program.memory["exterior_status"]["lock"] == "locked")
+	var/int_door_status = (program.memory["interior_status"]["state"] == "closed" && program.memory["interior_status"]["lock"] == "locked")
+
+	data["exterior_secured"] = ext_door_status
+	data["interior_secured"] = int_door_status
 	data["processing"] = program.memory["processing"]
 
 	return data

--- a/html/changelogs/Bat-AccessController.yml
+++ b/html/changelogs/Bat-AccessController.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - bugfix: "Cleans up Access Controller TGUI to restore functionality of manually securing interior/exterior doors, general cleanup and jank reduction."

--- a/tgui/packages/tgui/interfaces/AirlockConsoleAccess.tsx
+++ b/tgui/packages/tgui/interfaces/AirlockConsoleAccess.tsx
@@ -1,15 +1,11 @@
 import { useBackend } from '../backend';
 import { Box, Button, LabeledList, Section } from '../components';
 import { Window } from '../layouts';
-
-export type StatusData = {
-  state: string;
-  lock: string;
-};
+import { BooleanLike } from '../../common/react';
 
 export type AccessAirlockConsoleData = {
-  exterior_status: StatusData;
-  interior_status: StatusData;
+  exterior_secured: BooleanLike;
+  interior_secured: BooleanLike;
   processing: boolean;
 };
 
@@ -22,18 +18,24 @@ export const AirlockConsoleAccess = (props, context) => {
         <Section title="Status">
           <Box>
             <LabeledList>
-              <LabeledList.Item label="Exterior Door Status">
-                {data.exterior_status.state === 'open' ? (
-                  <Box>Open</Box>
+              <LabeledList.Item
+                label="Exterior Door Status"
+                color={data.exterior_secured ? 'green' : 'red'}
+              >
+                {data.exterior_secured ? (
+                  <Box>Secured</Box>
                 ) : (
-                  <Box>Locked</Box>
+                  <Box>Unsecured</Box>
                 )}
               </LabeledList.Item>
-              <LabeledList.Item label="Interior Door Status">
-                {data.interior_status.state === 'open' ? (
-                  <Box>Open</Box>
+              <LabeledList.Item
+                label="Interior Door Status"
+                color={data.interior_secured ? 'green' : 'red'}
+              >
+                {data.interior_secured ? (
+                  <Box>Secured</Box>
                 ) : (
-                  <Box>Locked</Box>
+                  <Box>Unsecured</Box>
                 )}
               </LabeledList.Item>
             </LabeledList>
@@ -44,12 +46,26 @@ export const AirlockConsoleAccess = (props, context) => {
             <Button
               content="Cycle to Exterior"
               icon="arrow-right-from-bracket"
-              onClick={() => act('command', { command: 'cycle_ext' })}
+              onClick={() => act('command', { command: 'cycle_ext_door' })}
             />
             <Button
               content="Cycle to Interior"
               icon="arrow-right-to-bracket"
-              onClick={() => act('command', { command: 'cycle_int' })}
+              onClick={() => act('command', { command: 'cycle_int_door' })}
+            />
+          </Box>
+          <Box>
+            <Button
+              content="Lock Exterior Door"
+              disabled={data.exterior_secured}
+              icon="lock"
+              onClick={() => act('command', { command: 'force_ext' })}
+            />
+            <Button
+              content="Lock Interior Door"
+              disabled={data.interior_secured}
+              icon="lock"
+              onClick={() => act('command', { command: 'force_int' })}
             />
           </Box>
         </Section>


### PR DESCRIPTION
Fixes https://github.com/Aurorastation/Aurora.3/issues/21773

Restores missing functionality after [TGUI port of access controllers](https://github.com/Aurorastation/Aurora.3/pull/21732). Access Controller panels now allow users to manually open or close either door, work faster, and more reliably display door statuses. My original implementation was a little shaky, but now it feels much much nicer and smoother to interact with.

<img width="861" height="432" alt="image" src="https://github.com/user-attachments/assets/9b53b137-225c-4e59-9d05-16f1baa7d8fa" />
