### PR TITLE
Fix Tajaran movespeed

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -44,8 +44,8 @@
 	if (!(species.flags & NO_COLD_SLOWDOWN))	// Bugs and machines don't move slower when cold.
 		if((mutations & FAT))
 			tally += 1.5
-		if (bodytemperature < 283.222)
-			tally += (283.222 - bodytemperature) / 10 * 1.75
+		if (bodytemperature < species.cold_discomfort_level)
+			tally += (species.cold_discomfort_level - bodytemperature) / 10 * 1.75
 
 	tally += max(2 * stance_damage, 0) //damaged/missing feet or legs is slow
 	if((mutations & mRun))

--- a/html/changelogs/johnwildkins-tajmove.yml
+++ b/html/changelogs/johnwildkins-tajmove.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: JohnWildkins
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fix issue whereby Tajara would lose movement speed due to lowering their body temperature."


### PR DESCRIPTION
Fixes #21974

Turns out we had ancient code that used a hardcoded bodytemp value to lower people's movespeed if they got too cold. Tajara naturally want a cooler body temp, and as a result they could end up movespeed nerfing themselves silently. Now the movespeed nerf is pegged to cold_discomfort_level, so your move speed will only be nerfed when you start getting warnings about feeling too cold.