### PR TITLE
Adds the poppet to the uplink

### DIFF
--- a/code/datums/uplink/stealthy and inconspicuous weapons.dm
+++ b/code/datums/uplink/stealthy and inconspicuous weapons.dm
@@ -86,3 +86,11 @@
 	desc = "A box for a sidearm double barrel shotgun, containing a sawn-off double barrel shotgun, a holster and some ammo."
 	telecrystal_cost = 4
 	path = /obj/item/storage/box/sawn_doublebarrel_shotgun
+
+/datum/uplink_item/item/stealthy_weapons/poppet
+	name = "Poppet"
+	desc = "With a drop of blood, this strange effigy can be used to torment someone."
+	telecrystal_cost = 3
+	bluecrystal_cost = 3
+	path = /obj/item/poppet
+

--- a/html/changelogs/fyni-poppet.yml
+++ b/html/changelogs/fyni-poppet.yml
@@ -1,0 +1,4 @@
+author: fyni
+delete-after: True
+changes:
+  - rscadd: "Adds the poppet to the uplink"


### PR DESCRIPTION
Add the poppet item, already in code, to the uplink.

By getting a drop of blood on the doll, you can stab and burn it to apply a similiar effect to the victim who's blood you stole.

This item is obviously paranormal in nature so it may warrant a discussion. However I believe the clearly none canon nature of antags, and how some of them are fully paranormal / magic (such as cult) shows people are fine with a little spookiness in their game from antags.