### PR TITLE
Fixed balloon alert blending

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -161,12 +161,12 @@
 
 #define GHOST_PLANE 80
 
+//-------------------- Lighting ---------------------
+
 #define LIGHTING_PLANE 100
 	#define LIGHTING_LAYER 1
 #define EXTERIOR_LIGHTING_PLANE 101
 #define NVG_PLANE 110
-
-#define BALLOON_CHAT_PLANE 110
 
 #define O_LIGHTING_VISUAL_PLANE 120
 #define O_LIGHTING_VISUAL_LAYER 16
@@ -184,7 +184,12 @@
 	#define SUPERMATTER_WALL_LAYER 3
 	#define LIGHTNING_LAYER 4
 
+//--------------- FULLSCREEN RUNECHAT BUBBLES ------------
+
+///Popup Chat Messages
 #define RUNECHAT_PLANE 501
+/// Plane for balloon text (text that fades up)
+#define BALLOON_CHAT_PLANE 502
 
 #define FULLSCREEN_PLANE 900
 	#define FULLSCREEN_LAYER 1

--- a/code/modules/rendering/plane_master.dm
+++ b/code/modules/rendering/plane_master.dm
@@ -135,13 +135,19 @@
 	name = "runechat plane master"
 	plane = RUNECHAT_PLANE
 	appearance_flags = PLANE_MASTER
-	blend_mode = BLEND_OVERLAY
 	render_relay_plane = RENDER_PLANE_NON_GAME
 
 /atom/movable/screen/plane_master/runechat/backdrop(mob/mymob)
 	. = ..()
 	remove_filter("AO")
 	add_filter("AO", 1, drop_shadow_filter(x = 0, y = -2, size = 4, color = "#04080FAA"))
+
+//Holds balloon chat images, those little text bars that pop up for a second when you do some things. NOT runechat.
+/atom/movable/screen/plane_master/balloon_chat
+	name = "balloon chat plane master"
+	plane = BALLOON_CHAT_PLANE
+	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
+	render_relay_plane = RENDER_PLANE_NON_GAME
 
 /atom/movable/screen/plane_master/o_light_visual
 	name = "overlight light visual plane master"

--- a/html/changelogs/GeneralCamo - Balloon Alert Fix.yml
+++ b/html/changelogs/GeneralCamo - Balloon Alert Fix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Balloon Alerts no longer blend improperly, giving them weird transparency."


### PR DESCRIPTION
Balloon Alerts were sharing planes with NVG effects, causing them to blend improperly. I re-added their proper plane, and ensured they work again.