### PR TITLE
Fixes shuttle shutter access requirement

### DIFF
--- a/html/changelogs/kano-dot-shuttle-shutter-access-fix.yml
+++ b/html/changelogs/kano-dot-shuttle-shutter-access-fix.yml
@@ -1,0 +1,6 @@
+author: Kano
+
+delete-after: True
+
+changes:
+  - bugfix: "Moved shuttle shutter access requirements from req_access to req_one_access."


### PR DESCRIPTION
## About PR
Moves shuttle shutter access requirements from `req_access` to `req_one_access.`

Fixes #21998