### PR TITLE
Nerf incendiary projectiles

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_beacon_projectiles.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_beacon_projectiles.dm
@@ -19,7 +19,7 @@
 	damage_type = DAMAGE_BURN
 	damage = 20
 	armor_penetration = 15
-	incinerate = 5
+	incinerate = 2
 	muzzle_type = /obj/effect/projectile/muzzle/laser/blue
 	tracer_type = /obj/effect/projectile/tracer/laser/blue
 	impact_type = /obj/effect/projectile/impact/laser/blue

--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_harvester_projectiles.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_harvester_projectiles.dm
@@ -1,4 +1,4 @@
 /obj/projectile/beam/hivebot/incendiary/heavy
 	name = "archaic mining laser"
 	damage = 25
-	incinerate = 10
+	incinerate = 3

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -379,7 +379,7 @@
 	name = "thermal lance"
 	icon_state = "gauss"
 	damage = 10
-	incinerate = 5
+	incinerate = 2
 	armor_penetration = 10
 
 	muzzle_type = /obj/effect/projectile/muzzle/solar
@@ -397,9 +397,6 @@
 					M.emitter_blasts_taken += 1
 				else if(prob(33))
 					M.emitter_blasts_taken += 1
-	if(ismob(target))
-		var/mob/living/M = target
-		M.apply_effect(1, INCINERATE, 0)
 	explosion(target, -1, 0, 2)
 	. = ..()
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -235,7 +235,7 @@
 	agony = 0
 	embed = 0
 	sharp = 0
-	incinerate = 10
+	incinerate = 2
 
 /obj/projectile/bullet/tracking
 	name = "tracking shot"

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -216,7 +216,7 @@
 	icon_state = "laser"
 	damage = 35
 	armor_penetration = 60
-	incinerate = 15
+	incinerate = 2
 
 /obj/projectile/energy/disruptorstun/skrell // for nralakk fed consular pistol
 	agony = 45

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -283,7 +283,7 @@
 	damage_type = DAMAGE_BRUTE
 	damage_flags = DAMAGE_FLAG_LASER
 	check_armor = ENERGY
-	incinerate = 10
+	incinerate = 2
 	armor_penetration = 60
 	penetrating = 1
 
@@ -291,7 +291,7 @@
 	name = "plasma bolt"
 	damage = 15
 	armor_penetration = 60
-	incinerate = 8
+	incinerate = 1
 
 /obj/item/missile
 	icon = 'icons/obj/grenade.dmi'

--- a/html/changelogs/GeneralCamo - Incendiary Nerf.yml
+++ b/html/changelogs/GeneralCamo - Incendiary Nerf.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Drastically reduced the amount of fire stacks all incendiary projectiles gave."
+  - bugfix: "Thermal lances no longer call ignition effects twice."


### PR DESCRIPTION
Incendiary projectiles, from things like hivebots, plasma weapons, and incendiary shotguns, were too powerful. This nerfs them drastically.