### PR TITLE
IPC HRA hotfix

### DIFF
--- a/code/game/jobs/faction/admin.dm
+++ b/code/game/jobs/faction/admin.dm
@@ -10,7 +10,8 @@
 
 	allowed_species_types = list(
 		/datum/species/human,
-		/datum/species/skrell
+		/datum/species/skrell,
+		/datum/species/machine
 	)
 
 /datum/faction/admin/is_visible(var/mob/user)

--- a/html/changelogs/fyni-ipc-hras-2.yml
+++ b/html/changelogs/fyni-ipc-hras-2.yml
@@ -1,0 +1,4 @@
+author: fyni
+delete-after: True
+changes:
+  - bugfix: "Allows all types of IPCs to select the admin faction, so they can be HRAs. Whoops!"


### PR DESCRIPTION
IPCs can now be HRAs, yay! Sadly, someone forgot to allow IPCs to select the admin faction to even get the HRA job appearing in the first place. Whoops!

This fixes that.