### PR TITLE
Small reduction to the damage and armor penetration of Husked Creatures

### DIFF
--- a/html/changelogs/ASmallCuteCat-Husked Creature Balance.yml
+++ b/html/changelogs/ASmallCuteCat-Husked Creature Balance.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ASmallCuteCat
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Slightly reduced the damage and armor penetration of the Husked Creatures found at the Quarantined Outpost away site."
+

--- a/maps/away/away_site/quarantined_outpost/quarantined_outpost_objects.dm
+++ b/maps/away/away_site/quarantined_outpost/quarantined_outpost_objects.dm
@@ -52,9 +52,9 @@ GLOBAL_LIST_EMPTY(trackables_pool)
 	health = 300
 	speed = 6
 
-	melee_damage_lower = 30
-	melee_damage_upper = 30
-	armor_penetration = 15
+	melee_damage_lower = 15
+	melee_damage_upper = 25
+	armor_penetration = 10
 
 	/// Used on deleting revive timer if the mob is burning while being dead.
 	var/revive_timer


### PR DESCRIPTION
The Husked Creatures in the Quarantined Outpost away site dealt 30 damage per hit, with an armor penetration rating of 15. For comparison, the Plains Tyrant does 40 damage per hit and has 20 armor penetration.

This PR changes Husked Creatures to deal 15-25 damage, with an armor penetration rating of 10. Still dangerous, still frightening, but not nearly as likely to give you an arterial every time it hits you.

(i dont know what the numbers mean, let me know if they need tweaked again)