### PR TITLE
Integrated Circuitry Tweaks/Fixes

### DIFF
--- a/code/modules/integrated_electronics/passive/power.dm
+++ b/code/modules/integrated_electronics/passive/power.dm
@@ -48,7 +48,7 @@
 	name = "large tesla power relay"
 	desc = "A seemingly enigmatic device which connects to nearby APCs wirelessly and draws power from them, now in industiral size!"
 	w_class = WEIGHT_CLASS_BULKY
-	extended_desc = "The siphon generates 4 kW of energy, so long as an APC is in the same room, with a cell that has energy.  It will always drain \
+	extended_desc = "The siphon generates 4 kW of energy, so long as an APC is in the same room, with a cell that has energy. It will always drain \
 	from the 'equipment' power channel."
 	icon_state = "power_relay"
 	complexity = 15

--- a/code/modules/integrated_electronics/passive/power.dm
+++ b/code/modules/integrated_electronics/passive/power.dm
@@ -35,7 +35,7 @@
 	name = "tesla power relay"
 	desc = "A seemingly enigmatic device which connects to nearby APCs wirelessly and draws power from them."
 	w_class = WEIGHT_CLASS_NORMAL
-	extended_desc = "The siphon generates 1 kW of energy, so long as an APC is in the same room, with a cell that has energy.  It will always drain \
+	extended_desc = "The siphon generates 1 kW of energy, so long as an APC is in the same room, with a cell that has energy. It will always drain \
 	from the 'equipment' power channel."
 	icon_state = "power_relay"
 	complexity = 7

--- a/code/modules/integrated_electronics/passive/power.dm
+++ b/code/modules/integrated_electronics/passive/power.dm
@@ -13,19 +13,19 @@
 /obj/item/integrated_circuit/passive/power/solar_cell
 	name = "tiny photovoltaic cell"
 	desc = "It's a very tiny solar cell, generally used in calculators."
-	extended_desc = "The cell generates up to 200 W of energy in optimal lighting conditions. Less light will result in less power being generated."
+	extended_desc = "The cell generates up to 100 W of energy in optimal lighting conditions. Less light will result in less power being generated."
 	icon_state = "solar_cell"
 	complexity = 8
 	origin_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 3, TECH_DATA = 2)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
 	/// Multiplied by amount of lumens to get amount of power to generate.
-	var/power_factor = 25
+	var/power_factor = 15
 
 /obj/item/integrated_circuit/passive/power/solar_cell/make_energy()
 	var/turf/T = get_turf(src)
 	var/light_amount = T ? T.get_lumcount() : 0
-	var/adjusted_power = clamp(power_factor*light_amount, 0, 200)
+	var/adjusted_power = clamp(power_factor*light_amount, 0, 100)
 	adjusted_power = round(adjusted_power, 0.1)
 	if(adjusted_power && assembly)
 		assembly.give_power(adjusted_power)

--- a/code/modules/integrated_electronics/passive/power.dm
+++ b/code/modules/integrated_electronics/passive/power.dm
@@ -13,17 +13,19 @@
 /obj/item/integrated_circuit/passive/power/solar_cell
 	name = "tiny photovoltaic cell"
 	desc = "It's a very tiny solar cell, generally used in calculators."
-	extended_desc = "The cell generates 1W of energy per second in optimal lighting conditions.  Less light will result in less power being generated."
+	extended_desc = "The cell generates up to 200 W of energy in optimal lighting conditions. Less light will result in less power being generated."
 	icon_state = "solar_cell"
 	complexity = 8
 	origin_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 3, TECH_DATA = 2)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	var/max_power = 1
+
+	/// Multiplied by amount of lumens to get amount of power to generate.
+	var/power_factor = 25
 
 /obj/item/integrated_circuit/passive/power/solar_cell/make_energy()
 	var/turf/T = get_turf(src)
 	var/light_amount = T ? T.get_lumcount() : 0
-	var/adjusted_power = max(max_power * light_amount, 0)
+	var/adjusted_power = clamp(power_factor*light_amount, 0, 200)
 	adjusted_power = round(adjusted_power, 0.1)
 	if(adjusted_power && assembly)
 		assembly.give_power(adjusted_power)
@@ -33,26 +35,26 @@
 	name = "tesla power relay"
 	desc = "A seemingly enigmatic device which connects to nearby APCs wirelessly and draws power from them."
 	w_class = WEIGHT_CLASS_NORMAL
-	extended_desc = "The siphon generates 250W of energy, so long as an APC is in the same room, with a cell that has energy.  It will always drain \
+	extended_desc = "The siphon generates 1 kW of energy, so long as an APC is in the same room, with a cell that has energy.  It will always drain \
 	from the 'equipment' power channel."
 	icon_state = "power_relay"
 	complexity = 7
 	origin_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 3, TECH_DATA = 2)
 	spawn_flags = IC_SPAWN_RESEARCH
-	var/power_amount = 250
+	var/power_amount = 1000
 
 // For really fat machines.
 /obj/item/integrated_circuit/passive/power/relay/large
 	name = "large tesla power relay"
 	desc = "A seemingly enigmatic device which connects to nearby APCs wirelessly and draws power from them, now in industiral size!"
 	w_class = WEIGHT_CLASS_BULKY
-	extended_desc = "The siphon generates 2 kW of energy, so long as an APC is in the same room, with a cell that has energy.  It will always drain \
+	extended_desc = "The siphon generates 4 kW of energy, so long as an APC is in the same room, with a cell that has energy.  It will always drain \
 	from the 'equipment' power channel."
 	icon_state = "power_relay"
 	complexity = 15
 	origin_tech = list(TECH_POWER = 6, TECH_ENGINEERING = 5, TECH_DATA = 4)
 	spawn_flags = IC_SPAWN_RESEARCH
-	power_amount = 2000
+	power_amount = 4000
 
 /obj/item/integrated_circuit/passive/power/relay/make_energy()
 	if(!assembly)
@@ -92,10 +94,10 @@
 			host = implant_assembly.implant.imp_in
 			if(!get_pin_data(IC_INPUT, 1))
 				if(test_validity(host))
-					assembly.give_power(10)
+					assembly.give_power(100)
 					host.adjustNutritionLoss(HUNGER_FACTOR)
 			else
-				if(assembly.draw_power(10*inefficiency)) // slightly less efficient the other way around
+				if(assembly.draw_power(100*inefficiency)) // slightly less efficient the other way around
 					host.adjustNutritionLoss(-HUNGER_FACTOR)
 			set_pin_data(IC_OUTPUT, 1, host.nutrition)
 

--- a/code/modules/integrated_electronics/subtypes/arithmetic.dm
+++ b/code/modules/integrated_electronics/subtypes/arithmetic.dm
@@ -14,7 +14,7 @@
 	outputs = list("result" = IC_PINTYPE_NUMBER)
 	activators = list("compute" = IC_PINTYPE_PULSE_IN, "on computed" = IC_PINTYPE_PULSE_OUT)
 	category_text = "Arithmetic"
-	power_draw_per_use = 5 // Math is pretty cheap.
+	power_draw_per_use = 50 // Math is pretty cheap.
 
 // +Adding+ //
 

--- a/code/modules/integrated_electronics/subtypes/converters.dm
+++ b/code/modules/integrated_electronics/subtypes/converters.dm
@@ -5,7 +5,7 @@
 	outputs = list("output")
 	activators = list("convert" = IC_PINTYPE_PULSE_IN, "on convert" = IC_PINTYPE_PULSE_OUT)
 	category_text = "Converter"
-	power_draw_per_use = 10
+	power_draw_per_use = 100
 
 /obj/item/integrated_circuit/converter/num2text
 	name = "number to string"

--- a/code/modules/integrated_electronics/subtypes/data_transfer.dm
+++ b/code/modules/integrated_electronics/subtypes/data_transfer.dm
@@ -1,6 +1,6 @@
 /obj/item/integrated_circuit/transfer
 	category_text = "Data Transfer"
-	power_draw_per_use = 2
+	power_draw_per_use = 20
 
 /obj/item/integrated_circuit/transfer/multiplexer
 	name = "two multiplexer"
@@ -16,7 +16,7 @@
 		"on select" = IC_PINTYPE_PULSE_OUT
 	)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 4
+	power_draw_per_use = 40
 	var/number_of_inputs = 2
 
 /obj/item/integrated_circuit/transfer/multiplexer/Initialize()
@@ -73,7 +73,7 @@
 		"on select" = IC_PINTYPE_PULSE_OUT
 	)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 4
+	power_draw_per_use = 40
 	var/number_of_outputs = 2
 
 /obj/item/integrated_circuit/transfer/demultiplexer/Initialize()
@@ -119,7 +119,7 @@
 	complexity = 12
 	spawn_flags = IC_SPAWN_RESEARCH
 	icon_state = "bluespace"
-	power_draw_per_use = 100	// fancy subspace comms aren't cheap power-wise
+	power_draw_per_use = 1000	// fancy subspace comms aren't cheap power-wise
 	w_class = WEIGHT_CLASS_SMALL
 	inputs = list(
 		"data" = IC_PINTYPE_ANY,

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -1,7 +1,7 @@
 /obj/item/integrated_circuit/input
 	var/can_be_asked_input = 0
 	category_text = "Input"
-	power_draw_per_use = 5
+	power_draw_per_use = 50
 
 /obj/item/integrated_circuit/input/proc/ask_for_input(mob/user)
 	return
@@ -48,7 +48,7 @@
 	outputs = list("number entered" = IC_PINTYPE_NUMBER)
 	activators = list("on entered" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 4
+	power_draw_per_use = 40
 
 /obj/item/integrated_circuit/input/numberpad/ask_for_input(mob/user)
 	var/new_input = input(user, "Enter a number, please.","Number pad") as null|num
@@ -67,7 +67,7 @@
 	outputs = list("string entered" = IC_PINTYPE_STRING)
 	activators = list("on entered" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 4
+	power_draw_per_use = 40
 
 /obj/item/integrated_circuit/input/textpad/ask_for_input(mob/user)
 	var/new_input = sanitize(input(user, "Enter some words, please.","Number pad") as null|text, MAX_MESSAGE_LEN, 1, 0, 1)
@@ -86,7 +86,7 @@
 	outputs = list("color entered" = IC_PINTYPE_COLOR)
 	activators = list("on entered" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 4
+	power_draw_per_use = 40
 
 /obj/item/integrated_circuit/input/colorpad/ask_for_input(mob/user)
 	var/new_color = input(user, "Enter a color, please.", "Color pad", get_pin_data(IC_OUTPUT, 1)) as color|null
@@ -113,7 +113,7 @@
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2, TECH_BIO = 2)
-	power_draw_per_use = 40
+	power_draw_per_use = 400
 
 /obj/item/integrated_circuit/input/med_scanner/do_work()
 	var/mob/living/carbon/human/H = get_pin_data_as_type(IC_INPUT, 1, /mob/living/carbon/human)
@@ -160,7 +160,7 @@
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3, TECH_BIO = 4)
-	power_draw_per_use = 80
+	power_draw_per_use = 800
 
 /obj/item/integrated_circuit/input/adv_med_scanner/do_work()
 	var/mob/living/carbon/human/H = get_pin_data_as_type(IC_INPUT, 1, /mob/living/carbon/human)
@@ -210,7 +210,7 @@
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT, "not scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3, TECH_BIO = 4)
-	power_draw_per_use = 80
+	power_draw_per_use = 800
 
 /obj/item/integrated_circuit/input/examiner/do_work()
 	var/atom/H = get_pin_data_as_type(IC_INPUT, 1, /atom)
@@ -254,7 +254,7 @@
 		"on locate" = IC_PINTYPE_PULSE_OUT
 	)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 20
+	power_draw_per_use = 200
 
 /obj/item/integrated_circuit/input/local_locator/do_work()
 	if(assembly && istype(assembly.loc, /mob/living))
@@ -276,7 +276,7 @@
 	outputs = list("located ref" = IC_PINTYPE_REF)
 	activators = list("locate" = IC_PINTYPE_PULSE_IN)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 30
+	power_draw_per_use = 300
 
 /obj/item/integrated_circuit/input/adjacent_locator/do_work()
 	var/atom/A = get_pin_data_as_type(IC_INPUT, 1, /atom)
@@ -306,7 +306,7 @@
 	outputs = list("located ref" = IC_PINTYPE_REF )
 	activators = list("locate" = IC_PINTYPE_PULSE_IN,"found" = IC_PINTYPE_PULSE_OUT,"not found" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 30
+	power_draw_per_use = 300
 	var/radius = 1
 
 /obj/item/integrated_circuit/input/advanced_locator/on_data_written()
@@ -361,8 +361,8 @@
 	)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2, TECH_MAGNET = 2)
-	power_draw_idle = 5
-	power_draw_per_use = 40
+	power_draw_idle = 50
+	power_draw_per_use = 400
 
 	var/frequency = 1457
 	var/code = 30
@@ -446,7 +446,7 @@
 		"on get coordinates" = IC_PINTYPE_PULSE_OUT
 	)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 30
+	power_draw_per_use = 300
 
 /obj/item/integrated_circuit/input/gps/do_work()
 	var/turf/T = get_turf(src)
@@ -482,7 +482,7 @@
 		"on translation" = IC_PINTYPE_PULSE_OUT
 	)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 15
+	power_draw_per_use = 150
 
 /obj/item/integrated_circuit/input/microphone/Initialize()
 	. = ..()
@@ -521,7 +521,7 @@
 	outputs = list("scanned" = IC_PINTYPE_REF)
 	activators = list("on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 120
+	power_draw_per_use = 1200
 
 /obj/item/integrated_circuit/input/sensor/proc/sense(var/atom/A, mob/user)
 	if(!user.Adjacent(A))
@@ -566,7 +566,7 @@
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
-	power_draw_per_use = 60
+	power_draw_per_use = 600
 
 /obj/item/integrated_circuit/input/internalbm
 	name = "internal battery monitor"
@@ -585,7 +585,7 @@
 	activators = list("read" = IC_PINTYPE_PULSE_IN, "on read" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_DATA = 4, TECH_POWER = 4, TECH_MAGNET = 3)
-	power_draw_per_use = 1
+	power_draw_per_use = 10
 
 /obj/item/integrated_circuit/input/internalbm/do_work()
 	set_pin_data(IC_OUTPUT, 1, null)
@@ -617,7 +617,7 @@
 	activators = list("read" = IC_PINTYPE_PULSE_IN, "on read" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_DATA = 4, TECH_POWER = 4, TECH_MAGNET = 3)
-	power_draw_per_use = 1
+	power_draw_per_use = 10
 
 /obj/item/integrated_circuit/input/externalbm/do_work()
 
@@ -723,7 +723,7 @@
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
-	power_draw_per_use = 20
+	power_draw_per_use = 200
 
 /obj/item/integrated_circuit/input/pressure_sensor/do_work()
 	var/turf/T = get_turf(src)
@@ -753,7 +753,7 @@
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
-	power_draw_per_use = 20
+	power_draw_per_use = 200
 
 /obj/item/integrated_circuit/input/temperature_sensor/do_work()
 	var/turf/T = get_turf(src)
@@ -778,7 +778,7 @@
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
-	power_draw_per_use = 20
+	power_draw_per_use = 200
 
 	var/gas_name = GAS_OXYGEN
 	var/gas_display_name = GAS_OXYGEN
@@ -900,7 +900,7 @@
 	outputs = list("tile" = IC_PINTYPE_REF)
 	activators = list("calculate dir" = IC_PINTYPE_PULSE_IN, "on calculated" = IC_PINTYPE_PULSE_OUT,"not calculated" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
-	power_draw_per_use = 40
+	power_draw_per_use = 400
 
 /obj/item/integrated_circuit/input/turfpoint/do_work()
 	if(!assembly)
@@ -938,7 +938,7 @@
 		"not scanned" = IC_PINTYPE_PULSE_OUT
 		)
 	spawn_flags = IC_SPAWN_RESEARCH
-	power_draw_per_use = 40
+	power_draw_per_use = 400
 	cooldown_per_use = 10
 
 /obj/item/integrated_circuit/input/turfscan/do_work()
@@ -979,7 +979,7 @@
 	outputs = list("located ref" = IC_PINTYPE_LIST)
 	activators = list("locate" = IC_PINTYPE_PULSE_IN,"found" = IC_PINTYPE_PULSE_OUT,"not found" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 30
+	power_draw_per_use = 300
 	var/radius = 1
 	cooldown_per_use = 10
 
@@ -1036,7 +1036,7 @@
 	outputs = list("scanned" = IC_PINTYPE_REF)
 	activators = list("on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 120
+	power_draw_per_use = 1200
 
 /obj/item/integrated_circuit/input/sensor/ranged/sense(atom/A, mob/user)
 	if(!user || (!istype(A)  && !isliving(A)))
@@ -1070,7 +1070,7 @@
 	outputs = list("scanned" = IC_PINTYPE_REF)
 	activators = list("on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 20
+	power_draw_per_use = 200
 
 /obj/item/integrated_circuit/input/obj_scanner/attackby_react(var/atom/A,var/mob/user,intent)
 	if(intent!=I_HELP)
@@ -1143,7 +1143,7 @@
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
-	power_draw_per_use = 20
+	power_draw_per_use = 200
 
 /obj/item/integrated_circuit/input/radiation_sensor/do_work()
 	var/turf/T = get_turf(src)
@@ -1170,7 +1170,7 @@
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
-	power_draw_per_use = 20
+	power_draw_per_use = 200
 
 /obj/item/integrated_circuit/input/light_sensor/do_work()
 	var/turf/T = get_turf(src)
@@ -1204,7 +1204,7 @@
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "on scanned" = IC_PINTYPE_PULSE_OUT, "not scanned" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3, TECH_BIO = 5)
-	power_draw_per_use = 100
+	power_draw_per_use = 1000
 
 /obj/item/integrated_circuit/input/face_scanner/do_work()
 	var/mob/living/carbon/human/H = get_pin_data_as_type(IC_INPUT, 1, /mob/living/carbon/human)
@@ -1237,7 +1237,7 @@
 	activators = list("scan" = IC_PINTYPE_PULSE_IN, "anomaly found" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_DATA = 4, TECH_MAGNET = 6, TECH_BLUESPACE = 4)
-	power_draw_per_use = 200
+	power_draw_per_use = 2000
 	cooldown_per_use = 15 SECONDS // sizeable cooldown to prevent view spam
 
 /obj/item/integrated_circuit/input/anomaly_scanner/do_work()

--- a/code/modules/integrated_electronics/subtypes/insert_slot.dm
+++ b/code/modules/integrated_electronics/subtypes/insert_slot.dm
@@ -7,7 +7,7 @@
 	var/list/items_contained = list()
 	activators = list("eject contents" = IC_PINTYPE_PULSE_IN)
 	outputs = list("has item" = IC_PINTYPE_BOOLEAN)
-	power_draw_per_use = 1
+	power_draw_per_use = 10
 	w_class = WEIGHT_CLASS_NORMAL
 	size = 5
 	complexity = 1
@@ -53,7 +53,7 @@
 	Paper can be inserted through a slot in the casing. Holds 10 sheets"
 	capacity = 10
 	size = 8
-	power_draw_per_use = 3
+	power_draw_per_use = 30
 	allowed_types = list(/obj/item/paper)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_MATERIAL = 2)

--- a/code/modules/integrated_electronics/subtypes/lists.dm
+++ b/code/modules/integrated_electronics/subtypes/lists.dm
@@ -7,7 +7,7 @@
 	outputs = list("result" = IC_PINTYPE_STRING)
 	activators = list("compute" = IC_PINTYPE_PULSE_IN, "on computed" = IC_PINTYPE_PULSE_OUT)
 	category_text = "Lists"
-	power_draw_per_use = 20
+	power_draw_per_use = 200
 
 /obj/item/integrated_circuit/list/pick
 	name = "pick circuit"

--- a/code/modules/integrated_electronics/subtypes/logic.dm
+++ b/code/modules/integrated_electronics/subtypes/logic.dm
@@ -6,7 +6,7 @@
 	outputs = list("result" = IC_PINTYPE_BOOLEAN)
 	activators = list("compare" = IC_PINTYPE_PULSE_IN)
 	category_text = "Logic"
-	power_draw_per_use = 1
+	power_draw_per_use = 10
 
 /obj/item/integrated_circuit/logic/binary
 	inputs = list(

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -22,7 +22,7 @@
 	var/obj/item/gun/installed_gun
 	spawn_flags = IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3, TECH_COMBAT = 4)
-	power_draw_per_use = 50 // The targeting mechanism uses this.  The actual gun uses its own cell for firing if it's an energy weapon.
+	power_draw_per_use = 500 // The targeting mechanism uses this.  The actual gun uses its own cell for firing if it's an energy weapon.
 
 /obj/item/integrated_circuit/manipulation/weapon_firing/Destroy()
 	QDEL_NULL(installed_gun)
@@ -95,7 +95,7 @@
 	outputs = list()
 	activators = list("step towards dir" = IC_PINTYPE_PULSE_IN)
 	spawn_flags = IC_SPAWN_RESEARCH
-	power_draw_per_use = 100
+	power_draw_per_use = 1000
 
 /obj/item/integrated_circuit/manipulation/locomotion/do_work()
 	..()
@@ -200,7 +200,7 @@
 	outputs = list("first" = IC_PINTYPE_REF, "last" = IC_PINTYPE_REF, "amount" = IC_PINTYPE_NUMBER)
 	activators = list("pulse in" = IC_PINTYPE_PULSE_IN,"pulse out" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
-	power_draw_per_use = 50
+	power_draw_per_use = 500
 
 /obj/item/integrated_circuit/manipulation/grabber/do_work()
 	var/turf/T = get_turf(src)
@@ -250,7 +250,7 @@
 	)
 	spawn_flags = IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3, TECH_COMBAT = 4)
-	power_draw_per_use = 50
+	power_draw_per_use = 500
 
 /obj/item/integrated_circuit/manipulation/thrower/do_work()
 
@@ -325,7 +325,7 @@
 
 /obj/item/integrated_circuit/manipulation/shocker/on_data_written()
 	var/s = get_pin_data(IC_INPUT, 2)
-	power_draw_per_use = clamp(s,0,20)*20 // big power draw to shock large creatures
+	power_draw_per_use = clamp(s,0,20)*200 // big power draw to shock large creatures
 
 /obj/item/integrated_circuit/manipulation/shocker/do_work()
 	..()
@@ -363,7 +363,7 @@
 
 /obj/item/integrated_circuit/manipulation/flasher/on_data_written()
 	var/s = get_pin_data(IC_INPUT, 2)
-	power_draw_per_use = clamp(s,1,4)*200 // big power draw to achieve a blinding flash
+	power_draw_per_use = clamp(s,1,4)*2000 // big power draw to achieve a blinding flash
 
 /obj/item/integrated_circuit/manipulation/flasher/do_work()
 	..()
@@ -397,7 +397,7 @@
 	outputs = list("bluespace crystals stored" = IC_PINTYPE_NUMBER)
 	activators = list("open portal" = IC_PINTYPE_PULSE_IN, "portal opened" = IC_PINTYPE_PULSE_OUT, "cannot open portal" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
-	power_draw_per_use = 100 // multiplied by up to 50 during on_data_written(). should slurp up power in smaller assemblies or those without power generation
+	power_draw_per_use = 1000 // multiplied by up to 50 during on_data_written(). should slurp up power in smaller assemblies or those without power generation
 	cooldown_per_use = 30 SECONDS // big cooldown
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 5)
 
@@ -485,7 +485,8 @@
 	outputs = list("shields projected" = IC_PINTYPE_NUMBER)
 	activators = list("create shield" = IC_PINTYPE_PULSE_IN, "shield created" = IC_PINTYPE_PULSE_OUT, "shield capacity reached" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
-	power_draw_per_use = 100
+	power_draw_per_use = 1000
+	power_draw_idle = 0 // Adjusted by amount of active shields.
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_MAGNET = 5)
 
 	/// A list of shields deployed by this circuit for amount checks/shield deletions.
@@ -538,9 +539,9 @@
 
 	// power stuff
 	if(deployed_shields)
-		power_draw_per_use = initial(power_draw_per_use)*(strength/10)*LAZYLEN(deployed_shields)
+		power_draw_idle = power_draw_per_use*(strength/10)*LAZYLEN(deployed_shields)
 	else
-		power_draw_per_use = initial(power_draw_per_use)
+		power_draw_idle = 0
 
 	..()
 

--- a/code/modules/integrated_electronics/subtypes/memory.dm
+++ b/code/modules/integrated_electronics/subtypes/memory.dm
@@ -1,7 +1,7 @@
 /obj/item/integrated_circuit/memory
 	complexity = 1
 	category_text = "Memory"
-	power_draw_per_use = 1
+	power_draw_per_use = 10
 
 /obj/item/integrated_circuit/memory/storage
 	name = "memory chip"
@@ -48,7 +48,7 @@
 	name = "memory circuit"
 	desc = "This circuit can store four pieces of data."
 	icon_state = "memory4"
-	power_draw_per_use = 2
+	power_draw_per_use = 20
 	number_of_pins = 4
 
 /obj/item/integrated_circuit/memory/storage/large
@@ -56,7 +56,7 @@
 	desc = "This big circuit can hold eight pieces of data."
 	icon_state = "memory8"
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
-	power_draw_per_use = 4
+	power_draw_per_use = 40
 	number_of_pins = 8
 
 /obj/item/integrated_circuit/memory/storage/huge
@@ -66,7 +66,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	spawn_flags = IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_DATA = 4)
-	power_draw_per_use = 8
+	power_draw_per_use = 80
 	number_of_pins = 16
 
 /obj/item/integrated_circuit/memory/constant

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -9,7 +9,7 @@
 	outputs = list()
 	activators = list("load data" = IC_PINTYPE_PULSE_IN)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 10
+	power_draw_per_use = 100
 	var/stuff_to_display = null
 
 /obj/item/integrated_circuit/output/screen/disconnect_all()
@@ -36,7 +36,7 @@
 	name = "screen"
 	desc = "This screen allows for people holding the device to see a piece of data."
 	icon_state = "screen_medium"
-	power_draw_per_use = 20
+	power_draw_per_use = 200
 
 /obj/item/integrated_circuit/output/screen/medium/do_work()
 	..()
@@ -49,7 +49,7 @@
 	name = "large screen"
 	desc = "This screen allows for people able to see the device to see a piece of data."
 	icon_state = "screen_large"
-	power_draw_per_use = 40
+	power_draw_per_use = 400
 
 /obj/item/integrated_circuit/output/screen/large/do_work()
 	..()
@@ -139,7 +139,7 @@
 	)
 	outputs = list()
 	activators = list("play sound" = IC_PINTYPE_PULSE_IN)
-	power_draw_per_use = 20
+	power_draw_per_use = 200
 	var/list/sounds = list()
 
 /obj/item/integrated_circuit/output/text_to_speech
@@ -153,7 +153,7 @@
 	outputs = list()
 	activators = list("to speech" = IC_PINTYPE_PULSE_IN)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 60
+	power_draw_per_use = 600
 
 /obj/item/integrated_circuit/output/text_to_speech/do_work()
 	text = get_pin_data(IC_INPUT, 1)
@@ -252,7 +252,7 @@
 	outputs = list()
 	activators = list()
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_idle = 5 // Raises to 80 when on.
+	power_draw_idle = 5 // Raises to 200 when on.
 	var/obj/machinery/camera/network/research/camera
 
 /obj/item/integrated_circuit/output/video_camera/Initialize()
@@ -267,7 +267,7 @@
 /obj/item/integrated_circuit/output/video_camera/proc/set_camera_status(var/status)
 	if(camera)
 		camera.set_status(status)
-		power_draw_idle = camera.status ? 80 : 5
+		power_draw_idle = camera.status ? 200 : 5
 		if(camera.status) // Ensure that there's actually power.
 			if(!draw_idle_power())
 				power_fail()
@@ -302,13 +302,13 @@
 	inputs = list("lit" = IC_PINTYPE_BOOLEAN)
 	outputs = list()
 	activators = list()
-	power_draw_idle = 0 // Raises to 1 when lit.
+	power_draw_idle = 0 // Raises to 10 when lit.
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	var/led_color
 	var/color_name
 
 /obj/item/integrated_circuit/output/led/on_data_written()
-	power_draw_idle = get_pin_data(IC_INPUT, 1) ? 1 : 0
+	power_draw_idle = get_pin_data(IC_INPUT, 1) ? 10 : 0
 
 /obj/item/integrated_circuit/output/led/power_fail()
 	set_pin_data(IC_INPUT, 1, FALSE)
@@ -381,7 +381,7 @@
 	outputs = list()
 	activators = list("print page" = IC_PINTYPE_PULSE_IN)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 20
+	power_draw_per_use = 200
 	w_class = WEIGHT_CLASS_NORMAL
 	size = 5
 	var/stuff_to_print = null

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -164,7 +164,7 @@
 /obj/item/integrated_circuit/reagent/pump/do_work()
 	var/atom/movable/source = get_pin_data_as_type(IC_INPUT, 1, /atom/movable)
 	var/atom/movable/target = get_pin_data_as_type(IC_INPUT, 2, /atom/movable)
-	if(!source)
+	if(!source || !assembly)
 		return
 
 	var/obj/item/integrated_circuit/insert_slot/beaker_holder/beaker_slot = source
@@ -172,7 +172,11 @@
 		source = beaker_slot.get_item(FALSE)
 	if(!istype(source) || (!istype(target))) //Invalid input
 		return
-	if((src.Adjacent(source)  || istype(beaker_slot)) && src.Adjacent(target))
+
+	var/turf/our_turf = get_turf(assembly) // there is probably a more elegant way to do this, but it covers all the bases (including assembly being held [or source/target being in a being held assembly], which prev implementation didn't)
+	var/turf/source_turf = get_turf(source)
+	var/turf/target_turf = get_turf(target)
+	if((source_turf.Adjacent(our_turf)  || istype(beaker_slot)) && target_turf.Adjacent(our_turf))
 		if(!source.reagents || !target.reagents)
 			return
 		if(ismob(source) || ismob(target))

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -23,7 +23,7 @@
 	activators = list("inject" = IC_PINTYPE_PULSE_IN, "on injected" = IC_PINTYPE_PULSE_OUT, "on fail" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	volume = 30
-	power_draw_per_use = 15
+	power_draw_per_use = 150
 	var/direc = 1
 	var/transfer_amount = 10
 
@@ -148,7 +148,7 @@
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2, TECH_BIO = 2)
 	var/transfer_amount = 10
 	var/direc = 1
-	power_draw_per_use = 10
+	power_draw_per_use = 100
 
 /obj/item/integrated_circuit/reagent/pump/on_data_written()
 	var/new_amount = get_pin_data(IC_INPUT, 3)
@@ -273,7 +273,7 @@
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2, TECH_BIO = 2)
 	var/transfer_amount = 10
 	var/direc = 1
-	power_draw_per_use = 10
+	power_draw_per_use = 100
 
 /obj/item/integrated_circuit/reagent/filter/on_data_written()
 	var/new_amount = get_pin_data(IC_INPUT, 3)

--- a/code/modules/integrated_electronics/subtypes/smart.dm
+++ b/code/modules/integrated_electronics/subtypes/smart.dm
@@ -12,7 +12,7 @@
 	outputs = list("dir" = IC_PINTYPE_DIR)
 	activators = list("calculate dir" = IC_PINTYPE_PULSE_IN, "on calculated" = IC_PINTYPE_PULSE_OUT,"not calculated" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
-	power_draw_per_use = 40
+	power_draw_per_use = 400
 
 /obj/item/integrated_circuit/smart/basic_pathfinder/do_work()
 	var/datum/integrated_io/I = inputs[1]
@@ -50,7 +50,7 @@
 	)
 	activators = list("calculate dir" = IC_PINTYPE_PULSE_IN, "on calculated" = IC_PINTYPE_PULSE_OUT,"not calculated" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_RESEARCH
-	power_draw_per_use = 40
+	power_draw_per_use = 400
 
 /obj/item/integrated_circuit/smart/coord_basic_pathfinder/do_work()
 	if(!assembly)

--- a/code/modules/integrated_electronics/subtypes/time.dm
+++ b/code/modules/integrated_electronics/subtypes/time.dm
@@ -105,7 +105,7 @@
 	desc = "This advanced circuit sends an automatic pulse every two seconds."
 	icon_state = "tick-f"
 	complexity = 12
-	seconds_to_pulse = 2 SECONDS
+	seconds_to_pulse = 2
 	spawn_flags = IC_SPAWN_RESEARCH
 	power_draw_per_use = 80
 
@@ -114,7 +114,7 @@
 	desc = "This simple circuit sends an automatic pulse every thirty seconds."
 	icon_state = "tick-s"
 	complexity = 4
-	seconds_to_pulse = 30 SECONDS
+	seconds_to_pulse = 30
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	power_draw_per_use = 20
 
@@ -123,7 +123,7 @@
 	desc = "This simple circuit sends an automatic pulse every five minutes (three hundred seconds)."
 	icon_state = "tick-s"
 	complexity = 4
-	seconds_to_pulse = 300 SECONDS
+	seconds_to_pulse = 300
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	power_draw_per_use = 20
 
@@ -132,13 +132,13 @@
 	desc = "This advanced circuit sends an automatic pulse with a configurable interval between 2 and 600 seconds. Default: 60 seconds."
 	icon_state = "tick-f"
 	complexity = 15
-	seconds_to_pulse = 60 SECONDS
+	seconds_to_pulse = 60
 	spawn_flags = IC_SPAWN_RESEARCH
 	power_draw_per_use = 80
 	inputs = list("enable ticking" = IC_PINTYPE_BOOLEAN, "ticker time" = IC_PINTYPE_NUMBER)
 
 /obj/item/integrated_circuit/time/ticker/custom/on_data_written()
-	seconds_to_pulse = between(2 SECONDS, get_pin_data(IC_INPUT, 2), 600 SECONDS)
+	seconds_to_pulse = between(2, get_pin_data(IC_INPUT, 2), 600)
 	..()
 
 /obj/item/integrated_circuit/time/clock

--- a/code/modules/integrated_electronics/subtypes/time.dm
+++ b/code/modules/integrated_electronics/subtypes/time.dm
@@ -14,7 +14,7 @@
 	var/delay = 2 SECONDS
 	activators = list("incoming"= IC_PINTYPE_PULSE_IN,"outgoing" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 2
+	power_draw_per_use = 20
 
 /obj/item/integrated_circuit/time/delay/do_work()
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/integrated_circuit, activate_pin), 2), delay)
@@ -74,7 +74,7 @@
 	inputs = list("enable ticking" = IC_PINTYPE_BOOLEAN)
 	activators = list("outgoing pulse" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 4
+	power_draw_per_use = 40
 
 /obj/item/integrated_circuit/time/ticker/Destroy()
 	STOP_PROCESSING(SSelectronics, src)
@@ -107,7 +107,7 @@
 	complexity = 12
 	seconds_to_pulse = 2 SECONDS
 	spawn_flags = IC_SPAWN_RESEARCH
-	power_draw_per_use = 8
+	power_draw_per_use = 80
 
 /obj/item/integrated_circuit/time/ticker/slow
 	name = "thirty second ticker"
@@ -116,7 +116,7 @@
 	complexity = 4
 	seconds_to_pulse = 30 SECONDS
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 2
+	power_draw_per_use = 20
 
 /obj/item/integrated_circuit/time/ticker/very_slow
 	name = "five minute ticker"
@@ -125,7 +125,7 @@
 	complexity = 4
 	seconds_to_pulse = 300 SECONDS
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 2
+	power_draw_per_use = 20
 
 /obj/item/integrated_circuit/time/ticker/custom
 	name = "custom ticker"
@@ -134,7 +134,7 @@
 	complexity = 15
 	seconds_to_pulse = 60 SECONDS
 	spawn_flags = IC_SPAWN_RESEARCH
-	power_draw_per_use = 8
+	power_draw_per_use = 80
 	inputs = list("enable ticking" = IC_PINTYPE_BOOLEAN, "ticker time" = IC_PINTYPE_NUMBER)
 
 /obj/item/integrated_circuit/time/ticker/custom/on_data_written()
@@ -154,7 +154,7 @@
 	)
 	activators = list("get time" = IC_PINTYPE_PULSE_IN, "on time got" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	power_draw_per_use = 4
+	power_draw_per_use = 40
 
 /obj/item/integrated_circuit/time/clock/do_work()
 	set_pin_data(IC_OUTPUT, 1, time2text(station_time_in_ticks, "hh:mm:ss") )

--- a/code/modules/integrated_electronics/subtypes/trig.dm
+++ b/code/modules/integrated_electronics/subtypes/trig.dm
@@ -18,7 +18,7 @@
 	)
 	category_text = "Trig"
 	extended_desc = "Input and output are in degrees."
-	power_draw_per_use = 1 // Still cheap math.
+	power_draw_per_use = 10 // Still cheap math.
 
 // Sine //
 

--- a/html/changelogs/kermit-more-circuitry-tweaks.yml
+++ b/html/changelogs/kermit-more-circuitry-tweaks.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
+  - rscdel: "Killed innocent kittens."

--- a/html/changelogs/kermit-more-circuitry-tweaks.yml
+++ b/html/changelogs/kermit-more-circuitry-tweaks.yml
@@ -3,6 +3,6 @@ author: kermit
 delete-after: True
 
 changes:
-  - bugfix: "Integrated circuits actually draw significant amounts of power"
-  - bugfix: "Reagent pumps can pump while in a held assembly"
-  - bugfix: "Tickers work as advertised, take 2"
+  - bugfix: "Integrated circuits actually draw significant amounts of power."
+  - bugfix: "Reagent pumps can pump while in a held assembly."
+  - bugfix: "Tickers work as advertised, take 2."

--- a/html/changelogs/kermit-more-circuitry-tweaks.yml
+++ b/html/changelogs/kermit-more-circuitry-tweaks.yml
@@ -5,3 +5,4 @@ delete-after: True
 changes:
   - bugfix: "Integrated circuits actually draw significant amounts of power"
   - bugfix: "Reagent pumps can pump while in a held assembly"
+  - bugfix: "Tickers work as advertised, take 2"

--- a/html/changelogs/kermit-more-circuitry-tweaks.yml
+++ b/html/changelogs/kermit-more-circuitry-tweaks.yml
@@ -1,59 +1,7 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes:
-#   bugfix
-#     - (fixes bugs)
-#   wip
-#     - (work in progress)
-#   qol
-#     - (quality of life)
-#   soundadd
-#     - (adds a sound)
-#   sounddel
-#     - (removes a sound)
-#   rscadd
-#     - (adds a feature)
-#   rscdel
-#     - (removes a feature)
-#   imageadd
-#     - (adds an image or sprite)
-#   imagedel
-#     - (removes an image or sprite)
-#   spellcheck
-#     - (fixes spelling or grammar)
-#   experiment
-#     - (experimental change)
-#   balance
-#     - (balance changes)
-#   code_imp
-#     - (misc internal code change)
-#   refactor
-#     - (refactors code)
-#   config
-#     - (makes a change to the config files)
-#   admin
-#     - (makes changes to administrator tools)
-#   server
-#     - (miscellaneous changes to server)
-#################################
+author: kermit
 
-# Your name.
-author: ChangeMe
-
-# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
 
-# Any changes you've made.  See valid prefix list above.
-# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
-# SCREW THIS UP AND IT WON'T WORK.
-# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
-# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
-  - rscdel: "Killed innocent kittens."
+  - bugfix: "Integrated circuits actually draw significant amounts of power"
+  - bugfix: "Reagent pumps can pump while in a held assembly"


### PR DESCRIPTION
**power stuff**
- generally 10Xs all power draw stuff so they actually have a significant effect on assembly power cells. 
- buffs some of the lower-end power gen. circuits to go with, but the higher-end ones can already handle the new numbers

**reagent pump**
- changes adjacent check to use turfs to cover more bases (ie. assembly being held in-hand, or source/target being in an assembly thats held in-hand — these being 90% of reagent pump uses)

**tickers**
- shouldn't have appended `SECONDS` to them all. they work as advertised now (again)