### PR TITLE
Reactor op alt title change

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -86,7 +86,7 @@
 	supervisors = "the chief engineer"
 	selection_color = "#c67519"
 	economic_modifier = 5
-	alt_titles = list("Reactor Technician", "Maintenance Technician", "Systems Engineer")
+	alt_titles = list("Reactor Operator", "Maintenance Technician", "Systems Engineer")
 
 	minimum_character_age = list(
 		SPECIES_HUMAN = 25,

--- a/html/changelogs/Bat-ReactorOp.yml
+++ b/html/changelogs/Bat-ReactorOp.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - rscadd: "Renames Engineer alt title 'Reactor Technician' to 'Reactor Operator'."


### PR DESCRIPTION
Renames the Engineering alt title 'Reactor Technician' to 'Reactor Operator' to better reflect in-game responsibilities with RL analogues.