### PR TITLE
6.8mm and PRA rifle rebalance

### DIFF
--- a/code/modules/cargo/items/weaponry.dm
+++ b/code/modules/cargo/items/weaponry.dm
@@ -213,7 +213,7 @@
 	name = "Tsarrayut'yan automatic rifle"
 	supplier = "zharkov"
 	description = "An Adhomian assault rifle from the People's Republic of Adhomai."
-	price = 1450
+	price = 1650
 	items = list(
 		/obj/item/gun/projectile/automatic/rifle/adhomian
 	)

--- a/code/modules/cargo/items/weaponry.dm
+++ b/code/modules/cargo/items/weaponry.dm
@@ -450,6 +450,20 @@
 
 /singleton/cargo_item/magazine_68ap
 	category = "weaponry"
+	name = "rifle magazine (6.8mm AP)"
+	supplier = "zharkov"
+	description = "An AP 6.8mm rifle magazine."
+	price = 80
+	items = list(
+		/obj/item/ammo_magazine/a68/ap
+	)
+	access = ACCESS_SECURITY
+	container_type = "crate"
+	groupable = TRUE
+	spawn_amount = 1
+
+/singleton/cargo_item/magazine_68sniper
+	category = "weaponry"
 	name = "sniper rifle magazine (6.8mm AP)"
 	supplier = "zharkov"
 	description = "An AP 6.8mm rifle magazine."

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -581,6 +581,10 @@ If nothing is chosen, reload sounds revert to the default, which is metal_slide_
 /obj/item/ammo_magazine/a68/empty
 	initial_ammo = 0
 
+/obj/item/ammo_magazine/a68/ap
+	name = "magazine (6.8mm AP)"
+	ammo_type = /obj/item/ammo_casing/a68/ap
+
 /obj/item/ammo_magazine/a68/hotaki
 	icon_state = "SVD"
 	ammo_type = /obj/item/ammo_casing/a68/ap

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -541,7 +541,7 @@
 	icon_state = "rifle-casing"
 	spent_icon = "rifle-casing-spent"
 	caliber = ".599 Kumar Super"
-	projectile_type = /obj/projectile/bullet
+	projectile_type = /obj/projectile/bullet/rifle/kumar_super
 	max_stack = 5
 
 /obj/item/ammo_casing/c6mm

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -310,8 +310,8 @@
 
 /obj/projectile/bullet/rifle/a68/ap
 	name = "Z33s Tamparii bullet"
-	damage = 40
-	armor_penetration = 16
+	damage = 30
+	armor_penetration = 30
 	penetrating = TRUE
 
 /obj/projectile/bullet/rifle/a145

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -303,15 +303,15 @@
 	penetrating = FALSE
 
 /obj/projectile/bullet/rifle/a68
-	name = "R33 Tamparii bullet"
+	name = "Z33 Tamparii bullet"
 	damage = 40
-	armor_penetration = 17
+	armor_penetration = 12
 	penetrating = FALSE
 
 /obj/projectile/bullet/rifle/a68/ap
-	name = "R33s Tamparii bullet"
-	damage = 30
-	armor_penetration = 30
+	name = "Z33s Tamparii bullet"
+	damage = 40
+	armor_penetration = 16
 	penetrating = TRUE
 
 /obj/projectile/bullet/rifle/a145
@@ -324,7 +324,7 @@
 	maim_rate = 3
 	anti_materiel_potential = 2
 
-/obj/projectile/rifle/kumar_super
+/obj/projectile/bullet/rifle/kumar_super
 	damage = 40
 	armor_penetration = 30
 	penetrating = TRUE

--- a/html/changelogs/CatsinHD - Tajgun-rebalance.yml
+++ b/html/changelogs/CatsinHD - Tajgun-rebalance.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: CatsinHD
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds an AP option for 6.8mm to the cargo order list."
+  - bugfix: "Rebalances 6.8mm and 6.8mm AP."
+  - bugfix: "Rebalances costs of 6.8mm and the Tsarratyun in the cargo order list."


### PR DESCRIPTION
Rebalances the 6.8mm bullet and it's AP variant to not be antag shredder 9000. Additionally, alters pricing in the cargo order list and adds an AP variant of the 6.8mm to the cargo order list. The values for the rounds are below.

6.8mm: 40 dam | 12 AP
6.8mm AP: 30 dam | 30 AP

Against 55 armor (major ballistics armor):
6.8mm: 13 damage
6.8mm AP: 18 damage
5.56: 16.67 Damage
5.56 AP: 25 Damage
7.62: 18.56 Damage

The thought process behind these values:
<details><summary></summary>
<p>
Adhomai does not make wide use of personal body armor. As a result, ammunition does not prioritize defeating body armor. Therefore, it is more effective the less armor one has, leading to a high damage value but low AP values. As they are rifle power cartridges, there is still some AP. The specific 6.8mm AP cartridge was created for defeating the armor of the S'rand'marr coalition, thus why it is comparable to 7.62
</p>
</details> 

These values can be tweaked as needed to make the rifle and ammo reasonable.
This PR DOES NOT modify the rifle itself, and therefore should not conflict with #22088 