### PR TITLE
Update Light's Edge to be included among Coalition sectors

### DIFF
--- a/code/__DEFINES/space_sectors.dm
+++ b/code/__DEFINES/space_sectors.dm
@@ -27,10 +27,10 @@
 #define SECTOR_XANU					"Xanu"				// Xanu Prime is here
 #define SECTOR_BURZSIA				"Burzsia" 			//Burzsia I and II are here
 #define SECTOR_HANEUNIM				"Haneunim"			//Haneunim and its gravity well, Konyang is found here
-#define ALL_COALITION_SECTORS	list(SECTOR_COALITION, SECTOR_XANU, SECTOR_WEEPING_STARS, SECTOR_ARUSHA, SECTOR_LIBERTYS_CRADLE, SECTOR_BURZSIA, SECTOR_HANEUNIM)
+#define ALL_COALITION_SECTORS	list(SECTOR_COALITION, SECTOR_XANU, SECTOR_WEEPING_STARS, SECTOR_ARUSHA, SECTOR_LIBERTYS_CRADLE, SECTOR_BURZSIA, SECTOR_HANEUNIM, SECTOR_LIGHTS_EDGE)
 
 //Light's edge, which should have unique properties all around
-#define SECTOR_LIGHTS_EDGE			"Light's Edge"	//For the area of Light's Edge that is somewhat inhabited
+#define SECTOR_LIGHTS_EDGE			"Light's Edge"	//For the area of Light's Edge that is somewhat inhabited. NOTE- this also lives in ALL_COALITION_SECTORS, per lore.
 #define SECTOR_LEMURIAN_SEA			"Lemurian Sea"	//For the actual black void area
 #define SECTOR_LEMURIAN_SEA_FAR		"Lemurian Sea (Uncharted)"	//For the actual black void area
 #define ALL_VOID_SECTORS		list(SECTOR_LIGHTS_EDGE, SECTOR_LEMURIAN_SEA, SECTOR_LEMURIAN_SEA_FAR)

--- a/html/changelogs/Bat-LightsEdgeCoalition.yml
+++ b/html/changelogs/Bat-LightsEdgeCoalition.yml
@@ -1,0 +1,5 @@
+author: Batrachophrenooboocosmomaachia
+delete-after: True
+changes:
+  - rscadd: "Adds Light's Edge sector to the ALL_COALITION_SECTORS define."
+


### PR DESCRIPTION
Add's the Light's Edge sector to the ALL_COALITION_SECTORS define, per Schwann.