### PR TITLE
Magclaws

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -26,8 +26,8 @@ Contains helper procs for airflow, handled in /connection_group.
 	return
 
 /mob/living/carbon/human/airflow_stun()
-	if(shoes)
-		if(shoes.item_flags & ITEM_FLAG_NO_SLIP) return 0
+	if(Check_Shoegrip())
+		return FALSE
 	..()
 
 /atom/movable/proc/check_airflow_movable(n)
@@ -73,8 +73,7 @@ Contains helper procs for airflow, handled in /connection_group.
 		return 0
 	if(buckled_to)
 		return 0
-	var/obj/item/shoes = get_equipped_item(slot_shoes)
-	if(istype(shoes) && (shoes.item_flags & ITEM_FLAG_NO_SLIP))
+	if(Check_Shoegrip())
 		return 0
 	return 1
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -113,7 +113,7 @@
 	return prob_slip
 
 /mob/living/carbon/human/Check_Shoegrip(checkSpecies = TRUE)
-	 //magboots + dense_object = no floating. Doesn't work if lying. Grabbedby and buckled_to are for mob carrying, wheelchairs, roller beds, etc.
+	//magboots + dense_object = no floating. Doesn't work if lying. Grabbedby and buckled_to are for mob carrying, wheelchairs, roller beds, etc.
 	if(shoes && (shoes.item_flags & ITEM_FLAG_NO_SLIP) && istype(shoes, /obj/item/clothing/shoes/magboots) && !lying && !buckled_to && !length(grabbed_by))
 		return TRUE
 	if(HAS_TRAIT(src, TRAIT_SHOE_GRIP))

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -113,7 +113,8 @@
 	return prob_slip
 
 /mob/living/carbon/human/Check_Shoegrip(checkSpecies = TRUE)
-	if(shoes && (shoes.item_flags & ITEM_FLAG_NO_SLIP) && istype(shoes, /obj/item/clothing/shoes/magboots) && !lying && !buckled_to && !length(grabbed_by))  //magboots + dense_object = no floating. Doesn't work if lying. Grabbedby and buckled_to are for mob carrying, wheelchairs, roller beds, etc.
+	 //magboots + dense_object = no floating. Doesn't work if lying. Grabbedby and buckled_to are for mob carrying, wheelchairs, roller beds, etc.
+	if(shoes && (shoes.item_flags & ITEM_FLAG_NO_SLIP) && istype(shoes, /obj/item/clothing/shoes/magboots) && !lying && !buckled_to && !length(grabbed_by))
 		return TRUE
 	if(HAS_TRAIT(src, TRAIT_SHOE_GRIP))
 		return TRUE

--- a/html/changelogs/Bat-Magclaws.yml
+++ b/html/changelogs/Bat-Magclaws.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - bugfix: "Sudden strong airflow now checks for more than just shoes with NO_SLIP (like active magboots) when determining whether to knock people over."


### PR DESCRIPTION
Fixes https://github.com/Aurorastation/Aurora.3/issues/22096

changes:
  - bugfix: "Sudden strong airflow now checks for more than just shoes with NO_SLIP (like active magboots) when determining whether to knock people over."