### PR TITLE
Fixes id cards being stuck in RFID removed from modular computers

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/hardware.dm
+++ b/code/modules/modular_computers/computers/modular_computer/hardware.dm
@@ -112,6 +112,7 @@
 		nano_printer = null
 		found = TRUE
 	else if(card_slot == H)
+		astype(H, /obj/item/computer_hardware/card_slot)?.eject_id()
 		card_slot = null
 		found = TRUE
 	else if(battery_module == H)

--- a/html/changelogs/PDAFix.yml
+++ b/html/changelogs/PDAFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "made the RFID card slot eject ID cards when removed from a pda, such as when a pda explodes."

--- a/html/changelogs/PDAFix.yml
+++ b/html/changelogs/PDAFix.yml
@@ -3,4 +3,4 @@ author: TheGreyWolf
 delete-after: True
 
 changes:
-  - rscadd: "made the RFID card slot eject ID cards when removed from a pda, such as when a pda explodes."
+  - bugfix: "Made the RFID card slot eject ID cards when removed from a pda, such as when a pda explodes."


### PR DESCRIPTION
When the RFID slot is removed from a modular computer, it now ejects the id card in it. This occurs for example when it is destroyed by various means.