### PR TITLE
Dionae Geras Speedbuff

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
@@ -35,7 +35,7 @@ They are very slow, reasonably strong, and quite durable. They also require ligh
 		/mob/living/carbon/proc/sample,
 	)
 	//primitive_form = "Nymph"
-	slowdown = 4
+	slowdown = 1.6
 	rarity_value = 4
 	hud_type = /datum/hud_data/diona
 	siemens_coefficient = 0.3

--- a/html/changelogs/dionae_speed.yml
+++ b/html/changelogs/dionae_speed.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Yonnimer
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Gives Geras Dionae a general speed buff, taking them from 2.2x slower than humans to about 1.5, or a little faster than G2S."

--- a/maps/away/ships/voidtamer/trader/voidtamer_trader.dmm
+++ b/maps/away/ships/voidtamer/trader/voidtamer_trader.dmm
@@ -471,7 +471,7 @@
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
 	name = "Airlock";
-	req_access = list(201)
+	req_access = list(256)
 	},
 /obj/machinery/door/firedoor/noid{
 	dir = 4
@@ -869,6 +869,10 @@
 "gG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 1
+	},
 /turf/simulated/floor/diona,
 /area/voidtamer/trader/temple)
 "gH" = (
@@ -1132,6 +1136,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/bed/stool/chair/office/hover/command{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2";
 	dir = 1
 	},
 /turf/simulated/floor/diona,
@@ -1704,6 +1712,10 @@
 /obj/structure/table/diona,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/gunmetal,
 /area/voidtamer/trader/temple)
 "oj" = (
@@ -3013,7 +3025,9 @@
 /obj/machinery/light/voidtamer{
 	dir = 8
 	},
-/obj/machinery/vending/engivend,
+/obj/machinery/vending/engivend{
+	req_access = null
+	},
 /turf/simulated/floor/tiled/dark,
 /area/voidtamer/trader/mining_blaster)
 "zn" = (
@@ -3100,6 +3114,10 @@
 /obj/structure/flora/tree/crystal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 1
+	},
 /turf/simulated/floor/grass/no_edge,
 /area/voidtamer/trader/temple)
 "Ab" = (
@@ -3262,6 +3280,10 @@
 /obj/machinery/door/airlock/diona{
 	req_access = list(256)
 	},
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 1
+	},
 /turf/simulated/floor/diona,
 /area/voidtamer/trader/temple)
 "Bv" = (
@@ -3299,6 +3321,12 @@
 /obj/item/reagent_containers/blood/AMinus,
 /obj/item/reagent_containers/blood/AMinus,
 /obj/item/reagent_containers/blood/OPlus,
+/obj/structure/mirror{
+	pixel_y = 35
+	},
+/obj/structure/sink{
+	pixel_y = 20
+	},
 /turf/simulated/floor/diona,
 /area/voidtamer/trader/crew)
 "BT" = (
@@ -3391,6 +3419,7 @@
 /area/voidtamer/trader/mining_blaster)
 "CY" = (
 /obj/structure/bed/roller/hover,
+/obj/item/geiger,
 /turf/simulated/floor/tiled/dark,
 /area/voidtamer/trader/supermatter)
 "Da" = (
@@ -3661,7 +3690,7 @@
 /area/voidtamer/trader/mining)
 "ES" = (
 /obj/structure/flora/pottedplant/crystal,
-/turf/simulated/floor/diona,
+/turf/simulated/floor/tiled/dark,
 /area/voidtamer/trader/supermatter)
 "EZ" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
@@ -4517,11 +4546,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 1
+	},
 /turf/simulated/floor/diona,
 /area/voidtamer/trader/temple)
 "LI" = (
 /obj/structure/diona/bulb,
-/obj/structure/flora/pottedplant/crystal,
+/obj/machinery/supermatter_growth_tray,
 /turf/simulated/floor/diona,
 /area/voidtamer/trader/supermatter)
 "LJ" = (
@@ -5252,6 +5285,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing/mapped,
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 1
+	},
 /turf/simulated/floor/grass/no_edge,
 /area/voidtamer/trader/temple)
 "Sg" = (
@@ -5907,6 +5944,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2";
+	dir = 1
+	},
 /turf/simulated/floor/grass/no_edge,
 /area/voidtamer/trader/temple)
 "Yc" = (
@@ -30947,7 +30988,7 @@ CK
 sD
 Uh
 re
-ES
+bs
 ZY
 kn
 RM
@@ -31463,7 +31504,7 @@ Yr
 Zt
 bs
 eJ
-dn
+ES
 DJ
 RJ
 Gm
@@ -31720,7 +31761,7 @@ xq
 Zt
 dn
 dn
-dn
+ES
 DJ
 Oh
 Gm

--- a/maps/away/ships/voidtamer/trader/voidtamer_trader.dmm
+++ b/maps/away/ships/voidtamer/trader/voidtamer_trader.dmm
@@ -471,7 +471,7 @@
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
 	name = "Airlock";
-	req_access = list(256)
+	req_access = list(201)
 	},
 /obj/machinery/door/firedoor/noid{
 	dir = 4
@@ -869,10 +869,6 @@
 "gG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 1
-	},
 /turf/simulated/floor/diona,
 /area/voidtamer/trader/temple)
 "gH" = (
@@ -1136,10 +1132,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/bed/stool/chair/office/hover/command{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2";
 	dir = 1
 	},
 /turf/simulated/floor/diona,
@@ -1712,10 +1704,6 @@
 /obj/structure/table/diona,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/gunmetal,
 /area/voidtamer/trader/temple)
 "oj" = (
@@ -3025,9 +3013,7 @@
 /obj/machinery/light/voidtamer{
 	dir = 8
 	},
-/obj/machinery/vending/engivend{
-	req_access = null
-	},
+/obj/machinery/vending/engivend,
 /turf/simulated/floor/tiled/dark,
 /area/voidtamer/trader/mining_blaster)
 "zn" = (
@@ -3114,10 +3100,6 @@
 /obj/structure/flora/tree/crystal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 1
-	},
 /turf/simulated/floor/grass/no_edge,
 /area/voidtamer/trader/temple)
 "Ab" = (
@@ -3280,10 +3262,6 @@
 /obj/machinery/door/airlock/diona{
 	req_access = list(256)
 	},
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 1
-	},
 /turf/simulated/floor/diona,
 /area/voidtamer/trader/temple)
 "Bv" = (
@@ -3321,12 +3299,6 @@
 /obj/item/reagent_containers/blood/AMinus,
 /obj/item/reagent_containers/blood/AMinus,
 /obj/item/reagent_containers/blood/OPlus,
-/obj/structure/mirror{
-	pixel_y = 35
-	},
-/obj/structure/sink{
-	pixel_y = 20
-	},
 /turf/simulated/floor/diona,
 /area/voidtamer/trader/crew)
 "BT" = (
@@ -3419,7 +3391,6 @@
 /area/voidtamer/trader/mining_blaster)
 "CY" = (
 /obj/structure/bed/roller/hover,
-/obj/item/geiger,
 /turf/simulated/floor/tiled/dark,
 /area/voidtamer/trader/supermatter)
 "Da" = (
@@ -3690,7 +3661,7 @@
 /area/voidtamer/trader/mining)
 "ES" = (
 /obj/structure/flora/pottedplant/crystal,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/diona,
 /area/voidtamer/trader/supermatter)
 "EZ" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
@@ -4546,15 +4517,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 1
-	},
 /turf/simulated/floor/diona,
 /area/voidtamer/trader/temple)
 "LI" = (
 /obj/structure/diona/bulb,
-/obj/machinery/supermatter_growth_tray,
+/obj/structure/flora/pottedplant/crystal,
 /turf/simulated/floor/diona,
 /area/voidtamer/trader/supermatter)
 "LJ" = (
@@ -5285,10 +5252,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing/mapped,
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 1
-	},
 /turf/simulated/floor/grass/no_edge,
 /area/voidtamer/trader/temple)
 "Sg" = (
@@ -5944,10 +5907,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 1
-	},
 /turf/simulated/floor/grass/no_edge,
 /area/voidtamer/trader/temple)
 "Yc" = (
@@ -30988,7 +30947,7 @@ CK
 sD
 Uh
 re
-bs
+ES
 ZY
 kn
 RM
@@ -31504,7 +31463,7 @@ Yr
 Zt
 bs
 eJ
-ES
+dn
 DJ
 RJ
 Gm
@@ -31761,7 +31720,7 @@ xq
 Zt
 dn
 dn
-ES
+dn
 DJ
 Oh
 Gm


### PR DESCRIPTION
From testing roughly the same distance, this is how long it took each species to make it

Geras - 8.49
Coeus - 4.1s
G2 - 6.31
Human - 3.97
Unathi - 4.67

Geras Dionae, while slower than Coeus and humans, should not be this slow, almost 2.2x slower than a human is by default, which is near-unplayable, especially given the current balance of Dionae as being pretty weak. This PR changes it so, from the same distance, Dionae are roughly 1.5 slower than humans, taking 5.76s. This can be looked at again in the future when Dionae are in a better place balance wise, but a weak species with a near-unplayable speed aint a good combo. 
(the rotate room thing was from me fugging up and doing something to the wrong branch)