### PR TITLE
Clean variant: Removes helm console restrictions on silicons.

### DIFF
--- a/code/modules/overmap/ship_weaponry/_targeting_console.dm
+++ b/code/modules/overmap/ship_weaponry/_targeting_console.dm
@@ -119,9 +119,13 @@
 				if(SHIP_GUN_ERROR_NO_AMMO)
 					to_chat(usr, SPAN_WARNING("The console shows an error screen: the weapon isn't loaded!"))
 				if(SHIP_GUN_FIRING_SUCCESSFUL)
-					to_chat(usr, SPAN_WARNING("The console shows a positive message: firing sequence successful!"))
 					log_and_message_admins("[usr] has fired [cannon] with target [linked.targeting] and entry point [LM]!", location = get_turf(usr))
 					. = TRUE
+					if(issilicon(usr))
+						to_chat(usr,SPAN_WARNING("The targetting systems register, showing a sucessful firing sequence."))
+						visible_message(SPAN_WARNING("The console shows a neutral message: firing sequence successful, Silicon unit registered firing: [usr]"))
+					else
+						visible_message(SPAN_WARNING("The console shows a positive message: firing sequence successful!"))
 
 		if("viewing")
 			if(usr)

--- a/code/modules/overmap/ship_weaponry/_targeting_console.dm
+++ b/code/modules/overmap/ship_weaponry/_targeting_console.dm
@@ -122,7 +122,7 @@
 					log_and_message_admins("[usr] has fired [cannon] with target [linked.targeting] and entry point [LM]!", location = get_turf(usr))
 					. = TRUE
 					if(issilicon(usr))
-						to_chat(usr,SPAN_WARNING("The targetting systems register, showing a sucessful firing sequence."))
+						to_chat(usr,SPAN_WARNING("The targeting systems register, showing a successful firing sequence."))
 						visible_message(SPAN_WARNING("The console shows a neutral message: firing sequence successful, Silicon unit registered firing: [usr]"))
 					else
 						visible_message(SPAN_WARNING("The console shows a positive message: firing sequence successful!"))

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -259,7 +259,17 @@
 				to_chat(H, SPAN_WARNING("Automated piloting safeties prevent you from going into deep space."))
 				return
 			if(do_after(H, 1 SECOND) && connected.can_combat_roll())
-				visible_message(SPAN_DANGER("[H] tilts the yoke all the way to the [ndir == WEST ? "left" : "right"]!"))
+				visible_message(SPAN_DANGER("[H] tilts the yoke systematically all the way to the [ndir == WEST ? "left" : "right"]!"))
+				connected.combat_roll(ndir)
+		if(!issilicon(usr))
+			var/mob/living/silicon/ai/H = usr
+			var/dir_to_move = turn(connected.dir, ndir == WEST ? 90 : -90)
+			var/turf/new_turf = get_step(connected, dir_to_move)
+			if(new_turf.x > SSatlas.current_map.overmap_size || new_turf.y > SSatlas.current_map.overmap_size)
+				to_chat(H, SPAN_WARNING("Your integrated safeguards prevent you from going into deep space."))
+				return
+			if(do_after(H, 1 SECOND) && connected.can_combat_roll())
+				visible_message(SPAN_DANGER("[H] remotely tilts the yoke all the way to the [ndir == WEST ? "left" : "right"]!"))
 				connected.combat_roll(ndir)
 
 	if (action == "manual")
@@ -275,7 +285,7 @@
 		if(newlimit)
 			accellimit = max(newlimit/1000, 0)
 
-	if(!issilicon(usr)) // AI and robots aren't allowed to pilot
+	// AI and robots are allowed to pilot now!
 		if (action == "move")
 			if(prob(usr.confused * 5))
 				params["turn"] = pick("45", "-45")
@@ -296,6 +306,11 @@
 				if(do_after(H, 1 SECOND) && connected.can_combat_turn())
 					visible_message(SPAN_DANGER("[H] twists the yoke all the way to the [ndir == WEST ? "left" : "right"]!"))
 					connected.combat_turn(ndir)
+			if(!issilicon(usr))
+			var/mob/living/silicon/ai/H = usr
+				if(do_after(H, 1 SECOND) && connected.can_combat_turn())
+					visible_message(SPAN_DANGER("[H] remotely twists the yoke systematically all the way to the [ndir == WEST ? "left" : "right"]!"))
+					connected.combat_turn(ndir)
 
 		if (action == "brake")
 			connected.decelerate()
@@ -305,7 +320,6 @@
 			autopilot = !autopilot
 			check_processing()
 	else
-		to_chat(usr, SPAN_WARNING("Your software does not allow you to interact with the piloting controls."))
 		return TRUE
 
 	add_fingerprint(usr)

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -259,7 +259,7 @@
 				to_chat(H, SPAN_WARNING("Automated piloting safeties prevent you from going into deep space."))
 				return
 			if(do_after(H, 1 SECOND) && connected.can_combat_roll())
-				visible_message(SPAN_DANGER("[H] tilts the yoke systematically all the way to the [ndir == WEST ? "left" : "right"]!"))
+				visible_message(SPAN_DANGER("[H] tilts the yoke all the way to the [ndir == WEST ? "left" : "right"]!"))
 				connected.combat_roll(ndir)
 		if(!issilicon(usr))
 			var/mob/living/silicon/ai/H = usr
@@ -269,7 +269,7 @@
 				to_chat(H, SPAN_WARNING("Your integrated safeguards prevent you from going into deep space."))
 				return
 			if(do_after(H, 1 SECOND) && connected.can_combat_roll())
-				visible_message(SPAN_DANGER("[H] remotely tilts the yoke all the way to the [ndir == WEST ? "left" : "right"]!"))
+				visible_message(SPAN_DANGER("[H] remotely tilts the yoke systematically all the way to the [ndir == WEST ? "left" : "right"]!"))
 				connected.combat_roll(ndir)
 
 	if (action == "manual")

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -262,7 +262,7 @@
 				visible_message(SPAN_DANGER("[H] tilts the yoke all the way to the [ndir == WEST ? "left" : "right"]!"))
 				connected.combat_roll(ndir)
 		if(issilicon(usr))
-			var/mob/living/silicon = usr
+			var/mob/living/silicon/H = usr
 			var/dir_to_move = turn(connected.dir, ndir == WEST ? 90 : -90)
 			var/turf/new_turf = get_step(connected, dir_to_move)
 			if(new_turf.x > SSatlas.current_map.overmap_size || new_turf.y > SSatlas.current_map.overmap_size)
@@ -285,7 +285,7 @@
 		if(newlimit)
 			accellimit = max(newlimit/1000, 0)
 
-	// AI and robots are allowed to pilot now!
+	if(isliving(usr))// AI and robots are allowed to pilot now!
 		if (action == "move")
 			if(prob(usr.confused * 5))
 				params["turn"] = pick("45", "-45")
@@ -307,7 +307,7 @@
 					visible_message(SPAN_DANGER("[H] twists the yoke all the way to the [ndir == WEST ? "left" : "right"]!"))
 					connected.combat_turn(ndir)
 			if(issilicon(usr))
-				var/mob/living/silicon = usr
+				var/mob/living/silicon/H = usr
 				if(do_after(H, 1 SECOND) && connected.can_combat_turn())
 					visible_message(SPAN_DANGER("[H] remotely twists the yoke systematically all the way to the [ndir == WEST ? "left" : "right"]!"))
 					connected.combat_turn(ndir)

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -261,8 +261,8 @@
 			if(do_after(H, 1 SECOND) && connected.can_combat_roll())
 				visible_message(SPAN_DANGER("[H] tilts the yoke all the way to the [ndir == WEST ? "left" : "right"]!"))
 				connected.combat_roll(ndir)
-		if(!issilicon(usr))
-			var/mob/living/silicon/ai/H = usr
+		if(issilicon(usr))
+			var/mob/living/silicon = usr
 			var/dir_to_move = turn(connected.dir, ndir == WEST ? 90 : -90)
 			var/turf/new_turf = get_step(connected, dir_to_move)
 			if(new_turf.x > SSatlas.current_map.overmap_size || new_turf.y > SSatlas.current_map.overmap_size)
@@ -306,8 +306,8 @@
 				if(do_after(H, 1 SECOND) && connected.can_combat_turn())
 					visible_message(SPAN_DANGER("[H] twists the yoke all the way to the [ndir == WEST ? "left" : "right"]!"))
 					connected.combat_turn(ndir)
-			if(!issilicon(usr))
-				var/mob/living/silicon/ai/H = usr
+			if(issilicon(usr))
+				var/mob/living/silicon = usr
 				if(do_after(H, 1 SECOND) && connected.can_combat_turn())
 					visible_message(SPAN_DANGER("[H] remotely twists the yoke systematically all the way to the [ndir == WEST ? "left" : "right"]!"))
 					connected.combat_turn(ndir)

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -307,7 +307,7 @@
 					visible_message(SPAN_DANGER("[H] twists the yoke all the way to the [ndir == WEST ? "left" : "right"]!"))
 					connected.combat_turn(ndir)
 			if(!issilicon(usr))
-			var/mob/living/silicon/ai/H = usr
+				var/mob/living/silicon/ai/H = usr
 				if(do_after(H, 1 SECOND) && connected.can_combat_turn())
 					visible_message(SPAN_DANGER("[H] remotely twists the yoke systematically all the way to the [ndir == WEST ? "left" : "right"]!"))
 					connected.combat_turn(ndir)

--- a/html/changelogs/ArbiterAmbrose.yml
+++ b/html/changelogs/ArbiterAmbrose.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds new and exciting silicon descriptions for the helm console aswell as targetting console."
+  - rscdel: "Removes restrictions on the helm console."

--- a/html/changelogs/ArbiterAmbrose.yml
+++ b/html/changelogs/ArbiterAmbrose.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: ArbiterAmbrose
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True


### PR DESCRIPTION
No longer does the SCC see fit that their AI must be restricted by silly 'safety' regulations, this PR does away with restrictions around robots piloting the helm console allowing them to drive ships where they need to go in emergencies or low pop situations.

Clean variant from https://github.com/Aurorastation/Aurora.3/pull/22142
