### PR TITLE
Enforces that the tesla rig requires a military tesla spine to work

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -209,9 +209,17 @@
 	..()
 	if(wearer)
 		var/obj/item/organ/internal/augment/tesla/T = wearer.internal_organs_by_name[BP_AUG_TESLA]
-		if(T && !T.is_broken())
+		if(istype(T, /obj/item/organ/internal/augment/tesla/advanced) && !T.is_broken())
 			if(cell)
 				cell.give(T.max_charges)
+
+/obj/item/rig/tesla/toggle_seals(mob/initiator, instant)
+	var/obj/item/organ/internal/augment/tesla/T = wearer.internal_organs_by_name[BP_AUG_TESLA]
+	if(istype(T, /obj/item/organ/internal/augment/tesla/advanced) && !T.is_broken())
+		. = ..()
+	else
+		to_chat(initiator, SPAN_DANGER("Cannot toggle suit: A functional, military grade tesla spine is required to use the suit."))
+		return FALSE
 
 /obj/item/rig/tesla/ninja
 

--- a/html/changelogs/TeslaSpineRestrictions.yml
+++ b/html/changelogs/TeslaSpineRestrictions.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "The tesla hardsuit now requires an advanced military grade tesla spine to use."
+  - rscdel: "The tesla hardsuit has been removed from the golden deep submap and replaced with a hazard and AMI rig instead."

--- a/maps/away/ships/golden_deep/golden_deep_submaps.dmm
+++ b/maps/away/ships/golden_deep/golden_deep_submaps.dmm
@@ -808,8 +808,9 @@
 	name = "secure crate";
 	req_one_access = list(229, 217)
 	},
-/obj/item/rig/tesla,
 /obj/random/dirt_75,
+/obj/item/rig/hazard,
+/obj/item/rig/hazmat,
 /turf/template_noop,
 /area/template_noop)
 "ZZ" = (


### PR DESCRIPTION
Done after talks with Catsin/taj lore.

The tesla rig has been removed from the golden deep submap and replaced with more available rigs, and the rig now requires a military grade tesla spine to function.