### PR TITLE
Radiation refactor

### DIFF
--- a/code/__DEFINES/armor.dm
+++ b/code/__DEFINES/armor.dm
@@ -43,7 +43,7 @@
 #define  ARMOR_RAD_MINOR			10
 #define  ARMOR_RAD_SMALL			25
 #define  ARMOR_RAD_RESISTANT		40
-#define  ARMOR_RAD_STRONG			75
+#define  ARMOR_RAD_STRONG			80
 #define  ARMOR_RAD_SHIELDED			100
 
 #define  ARMOR_BOMB_MINOR			10

--- a/code/__DEFINES/armor.dm
+++ b/code/__DEFINES/armor.dm
@@ -43,7 +43,7 @@
 #define  ARMOR_RAD_MINOR			10
 #define  ARMOR_RAD_SMALL			25
 #define  ARMOR_RAD_RESISTANT		40
-#define  ARMOR_RAD_STRONG			80
+#define  ARMOR_RAD_STRONG			70
 #define  ARMOR_RAD_SHIELDED			100
 
 #define  ARMOR_BOMB_MINOR			10

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -459,11 +459,6 @@ example:
 
 #define LANDING_ZONE_RADIUS 15 // Used for autoplacing landmarks on exoplanets
 
-#define RAD_LEVEL_LOW 1 // Around the level at which radiation starts to become harmful
-#define RAD_LEVEL_MODERATE 25
-#define RAD_LEVEL_HIGH 40
-#define RAD_LEVEL_VERY_HIGH 100
-
 #define RADIATION_THRESHOLD_CUTOFF 0.1	// Radiation will not affect a tile when below this value.
 
 // Defines for formatting cooldown actions for the stat panel.

--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -6,4 +6,5 @@
 #define RAD_LEVEL_LOW 1 // Around the level at which radiation starts to become harmful
 #define RAD_LEVEL_MODERATE 25
 #define RAD_LEVEL_HIGH 40
-#define RAD_LEVEL_VERY_HIGH 100
+#define RAD_LEVEL_VERY_HIGH 80
+#define RAD_LEVEL_EXTREME 100

--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -3,7 +3,8 @@
 #define RADIATION_MATERIAL_RESISTANCE_DIVISOR 2
 #define RADIATION_RESISTANCE_MULTIPLIER 1.25
 
-#define RAD_LEVEL_LOW 1 // Around the level at which radiation starts to become harmful
+#define RAD_LEVEL_VERY_LOW 1 // Around the level at which radiation starts to become harmful
+#define RAD_LEVEL_LOW 10
 #define RAD_LEVEL_MODERATE 25
 #define RAD_LEVEL_HIGH 40
 #define RAD_LEVEL_VERY_HIGH 80

--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -8,6 +8,6 @@
 #define RAD_LEVEL_LOW 10
 #define RAD_LEVEL_MODERATE 25
 #define RAD_LEVEL_HIGH 40
-#define RAD_LEVEL_VERY_HIGH 80
+#define RAD_LEVEL_VERY_HIGH 70
 #define RAD_LEVEL_EXTREME 100
 #define RAD_LEVEL_CATASTROPHIC 120 // Higher then radsuits can absorb! Use with caution.

--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -2,3 +2,8 @@
 #define RADIATION_LOWER_LIMIT 0.15
 #define RADIATION_MATERIAL_RESISTANCE_DIVISOR 2
 #define RADIATION_RESISTANCE_MULTIPLIER 1.25
+
+#define RAD_LEVEL_LOW 1 // Around the level at which radiation starts to become harmful
+#define RAD_LEVEL_MODERATE 25
+#define RAD_LEVEL_HIGH 40
+#define RAD_LEVEL_VERY_HIGH 100

--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -3,6 +3,7 @@
 #define RADIATION_MATERIAL_RESISTANCE_DIVISOR 2
 #define RADIATION_RESISTANCE_MULTIPLIER 1.25
 
+#define RAD_LEVEL_NONE 0
 #define RAD_LEVEL_VERY_LOW 1 // Around the level at which radiation starts to become harmful
 #define RAD_LEVEL_LOW 10
 #define RAD_LEVEL_MODERATE 25

--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -9,3 +9,4 @@
 #define RAD_LEVEL_HIGH 40
 #define RAD_LEVEL_VERY_HIGH 80
 #define RAD_LEVEL_EXTREME 100
+#define RAD_LEVEL_CATASTROPHIC 120 // Higher then radsuits can absorb! Use with caution.

--- a/code/game/machinery/sm_growthtray.dm
+++ b/code/game/machinery/sm_growthtray.dm
@@ -4,7 +4,7 @@
 	icon_state = "smtray"
 	anchored = FALSE
 	density = TRUE
-	var/radioactivity = 25
+	var/radioactivity = RAD_LEVEL_MODERATE
 
 /obj/machinery/supermatter_growth_tray/Initialize()
 	. = ..()

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -96,7 +96,15 @@ ABSTRACT_TYPE(/obj/effect/decal/cleanable/greenglow/radioactive)
 
 /obj/effect/decal/cleanable/greenglow/radioactive/high/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
-	. += "Geiger counters will start clicking at ~9 tiles away from this object."
+	. += "Geiger counters will start clicking at ~7 tiles away from this object."
+	. += "A radsuit is necessary to move safely adjacent to it."
+
+/obj/effect/decal/cleanable/greenglow/radioactive/very_high
+	radioactivity = RAD_LEVEL_VERY_HIGH
+
+/obj/effect/decal/cleanable/greenglow/radioactive/very_high/antagonist_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "Geiger counters will start clicking at ~11 tiles away from this object."
 	. += "A radsuit is necessary to move safely adjacent to it."
 
 /obj/effect/decal/cleanable/greenglow/radioactive/extreme

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -96,7 +96,7 @@ ABSTRACT_TYPE(/obj/effect/decal/cleanable/greenglow/radioactive)
 
 /obj/effect/decal/cleanable/greenglow/radioactive/high/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
-	. += "Geiger counters will start clicking at ~8 tiles away from this object."
+	. += "Geiger counters will start clicking at ~9 tiles away from this object."
 	. += "A radsuit is necessary to move safely adjacent to it."
 
 /obj/effect/decal/cleanable/greenglow/radioactive/extreme
@@ -105,7 +105,7 @@ ABSTRACT_TYPE(/obj/effect/decal/cleanable/greenglow/radioactive)
 
 /obj/effect/decal/cleanable/greenglow/radioactive/extreme/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
-	. += "Geiger counters will start clicking at ~12 tiles away from this object."
+	. += "Geiger counters will start clicking at ~11 tiles away from this object."
 	. += "No living thing can safely stand next to this object! Borgs or IPCs only!"
 
 /obj/effect/decal/cleanable/greenglow/radioactive/Initialize()

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -76,32 +76,32 @@ ABSTRACT_TYPE(/obj/effect/decal/cleanable/greenglow/radioactive)
 	. += "Characters directly adjacent to or on top of this object will be exposed to <b>[radioactivity] IU/s</b> of radiation. Radiation falls off (approximately) by 75% for every tile away you move."
 
 /obj/effect/decal/cleanable/greenglow/radioactive/low
-	radioactivity = 20
+	radioactivity = RAD_LEVEL_LOW
 
 /obj/effect/decal/cleanable/greenglow/radioactive/low/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
-	. += "Geiger counters will start clicking at ~5 tiles away from this object."
+	. += "Geiger counters will start clicking at ~3 tiles away from this object."
 	. += "Almost all voidsuits, including softsuits, provide sufficient protection to move safely adjacent to it."
 
 /obj/effect/decal/cleanable/greenglow/radioactive/medium
-	radioactivity = 40
+	radioactivity = RAD_LEVEL_MODERATE
 
 /obj/effect/decal/cleanable/greenglow/radioactive/medium/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
-	. += "Geiger counters will start clicking at ~8 tiles away from this object."
+	. += "Geiger counters will start clicking at ~5 tiles away from this object."
 	. += "An engineering or atmos voidsuit is necessary to move safely adjacent to it."
 
 /obj/effect/decal/cleanable/greenglow/radioactive/high
-	radioactivity = 80
+	radioactivity = RAD_LEVEL_HIGH
 
 /obj/effect/decal/cleanable/greenglow/radioactive/high/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
-	. += "Geiger counters will start clicking at ~10 tiles away from this object."
+	. += "Geiger counters will start clicking at ~8 tiles away from this object."
 	. += "A radsuit is necessary to move safely adjacent to it."
 
 /obj/effect/decal/cleanable/greenglow/radioactive/extreme
 	/// This is higher than radsuits can absorb! Use with caution.
-	radioactivity = 120
+	radioactivity = RAD_LEVEL_CATASTROPHIC
 
 /obj/effect/decal/cleanable/greenglow/radioactive/extreme/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -18,7 +18,7 @@
 /obj/item/geiger/feedback_hints(mob/user, distance, is_adjacent)
 	. += ..()
 	var/msg = "[scanning ? "ambient" : "stored"] Radiation level: <b>[radiation_count ? radiation_count : "0"] IU/s</b>."
-	if(radiation_count > RAD_LEVEL_LOW)
+	if(radiation_count > RAD_LEVEL_VERY_LOW)
 		. += SPAN_WARNING("[msg]")
 	else
 		. += SPAN_NOTICE("[msg]")
@@ -64,11 +64,11 @@
 
 	switch(radiation_count)
 		if(null) icon_state = "geiger_on_1"
-		if(-INFINITY to RAD_LEVEL_LOW)
+		if(-INFINITY to RAD_LEVEL_VERY_LOW)
 			icon_state = "geiger_on_1"
 			geiger_volume = 0
 			sound_token.SetVolume(geiger_volume)
-		if(RAD_LEVEL_LOW + 0.01 to RAD_LEVEL_MODERATE)
+		if(RAD_LEVEL_VERY_LOW + 0.01 to RAD_LEVEL_MODERATE)
 			icon_state = "geiger_on_2"
 			geiger_volume = 10
 			sound_token.SetVolume(geiger_volume)

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -76,11 +76,11 @@
 			icon_state = "geiger_on_3"
 			geiger_volume = 25
 			sound_token.SetVolume(geiger_volume)
-		if(RAD_LEVEL_HIGH + 1 to RAD_LEVEL_VERY_HIGH)
+		if(RAD_LEVEL_HIGH + 1 to RAD_LEVEL_EXTREME)
 			icon_state = "geiger_on_4"
 			geiger_volume = 40
 			sound_token.SetVolume(geiger_volume)
-		if(RAD_LEVEL_VERY_HIGH + 1 to INFINITY)
+		if(RAD_LEVEL_EXTREME + 1 to INFINITY)
 			icon_state = "geiger_on_5"
 			geiger_volume = 60
 			sound_token.SetVolume(geiger_volume)

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -281,7 +281,7 @@
 /material/uranium
 	name = MATERIAL_URANIUM
 	stack_type = /obj/item/stack/material/uranium
-	radioactivity = 12
+	radioactivity = RAD_LEVEL_LOW
 	icon_base = "stone"
 	reinf_icon = "reinf_stone"
 	icon_colour = "#007A00"
@@ -378,7 +378,7 @@
 /material/phoron/supermatter
 	name = MATERIAL_SUPERMATTER
 	icon_colour = "#ffff00"
-	radioactivity = 20
+	radioactivity = RAD_LEVEL_MODERATE
 	conductivity = 100
 	integrity = 10
 	luminescence = 3

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -235,12 +235,6 @@
 					Weaken(3)
 					if(!lying)
 						emote("collapse")
-				if(prob(5) && prob(100 * RADIATION_SPEED_COEFFICIENT) && species.name == SPECIES_HUMAN) //apes go bald
-					if((h_style != "Bald" || f_style != "Shaved" ))
-						to_chat(src, SPAN_WARNING("Your hair falls out."))
-						h_style = "Bald"
-						f_style = "Shaved"
-						update_hair()
 
 			if (total_radiation > 75)
 				src.apply_radiation(-1 * RADIATION_SPEED_COEFFICIENT)

--- a/code/modules/mob/living/carbon/human/species/station/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/station/golem.dm
@@ -762,9 +762,7 @@ GLOBAL_LIST_INIT(golem_types, list(
 	..()
 
 /datum/species/golem/uranium/handle_environment_special(var/mob/living/carbon/human/H)
-	if(prob(25))
-		for(var/mob/living/L in view(7, H))
-			L.apply_damage(20, DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED)
+	SSradiation.radiate(src, RAD_LEVEL_LOW)
 
 /datum/species/golem/homunculus
 	name = SPECIES_GOLEM_MEAT

--- a/code/modules/power/fusion/fuel_assembly/fuel_assembly.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_assembly.dm
@@ -8,7 +8,7 @@
 	var/list/rod_quantities = list()
 	var/fuel_type
 	var/fuel_colour
-	var/radioactivity = 0
+	var/radioactivity = RAD_LEVEL_NONE
 	var/initial_amount
 
 /obj/item/fuel_assembly/New(newloc, _material, _colour)

--- a/code/modules/radiation/radiation.dm
+++ b/code/modules/radiation/radiation.dm
@@ -86,12 +86,12 @@
 /**
  * Called when radiation affects a /mob/living.
  *
- * * severity - The amount of radiation being applied. Anything over RAD_LEVEL_LOW will deal [severity] dispersed damage and run rad_act to everything in it.
+ * * severity - The amount of radiation being applied. Anything over RAD_LEVEL_VERY_LOW will deal [severity] dispersed damage and run rad_act to everything in it.
  *
  * Returns boolean
  */
 /mob/living/rad_act(severity)
-	if(severity > RAD_LEVEL_LOW)
+	if(severity > RAD_LEVEL_VERY_LOW)
 		apply_damage(severity, DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED)
 		for(var/atom/I in src)
 			I.rad_act(severity)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -519,7 +519,15 @@ ABSTRACT_TYPE(/obj/structure/reagent_dispensers/radioactive_waste/hazardous)
 	radioactivity = RAD_LEVEL_HIGH
 
 /obj/structure/reagent_dispensers/radioactive_waste/hazardous/high/antagonist_hints(mob/user, distance, is_adjacent)
-	. += "Geiger counters will start clicking at ~9 tiles away from this object."
+	. += "Geiger counters will start clicking at ~7 tiles away from this object."
+	. += "A radsuit is necessary to move safely adjacent to it."
+
+/obj/structure/reagent_dispensers/radioactive_waste/hazardous/very_high
+	/// This is as high as radsuits can absorb! Use with caution.
+	radioactivity = RAD_LEVEL_VERY_HIGH
+
+/obj/structure/reagent_dispensers/radioactive_waste/hazardous/very_high/antagonist_hints(mob/user, distance, is_adjacent)
+	. += "Geiger counters will start clicking at ~11 tiles away from this object."
 	. += "A radsuit is necessary to move safely adjacent to it."
 
 /obj/structure/reagent_dispensers/radioactive_waste/hazardous/extreme

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -500,34 +500,34 @@ ABSTRACT_TYPE(/obj/structure/reagent_dispensers/radioactive_waste/hazardous)
 	. += "Characters directly adjacent to this object will be exposed to <b>[radioactivity] IU/s</b> of radiation. Radiation falls off (approximately) by 75% for every tile away you move."
 
 /obj/structure/reagent_dispensers/radioactive_waste/hazardous/low
-	radioactivity = 25
+	radioactivity = RAD_LEVEL_LOW
 
 /obj/structure/reagent_dispensers/radioactive_waste/hazardous/low/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
-	. += "Geiger counters will start clicking at ~7 tiles away from this object."
+	. += "Geiger counters will start clicking at ~3 tiles away from this object."
 	. += "Almost all voidsuits, including softsuits, provide sufficient protection to move safely adjacent to it."
 
 /obj/structure/reagent_dispensers/radioactive_waste/hazardous/medium
-	radioactivity = 50
+	radioactivity = RAD_LEVEL_MODERATE
 
 /obj/structure/reagent_dispensers/radioactive_waste/hazardous/medium/antagonist_hints(mob/user, distance, is_adjacent)
-	. += "Geiger counters will start clicking at ~9 tiles away from this object."
+	. += "Geiger counters will start clicking at ~5 tiles away from this object."
 	. += "An engineering voidsuit is necessary to move safely adjacent to it."
 
 /obj/structure/reagent_dispensers/radioactive_waste/hazardous/high
 	/// This is as high as radsuits can absorb! Use with caution.
-	radioactivity = 100
+	radioactivity = RAD_LEVEL_HIGH
 
 /obj/structure/reagent_dispensers/radioactive_waste/hazardous/high/antagonist_hints(mob/user, distance, is_adjacent)
-	. += "Geiger counters will start clicking at ~11 tiles away from this object."
+	. += "Geiger counters will start clicking at ~9 tiles away from this object."
 	. += "A radsuit is necessary to move safely adjacent to it."
 
 /obj/structure/reagent_dispensers/radioactive_waste/hazardous/extreme
 	/// This is higher than radsuits can absorb! Use with caution.
-	radioactivity = 150
+	radioactivity = RAD_LEVEL_CATASTROPHIC
 
 /obj/structure/reagent_dispensers/radioactive_waste/hazardous/extreme/antagonist_hints(mob/user, distance, is_adjacent)
-	. += "Geiger counters will start clicking at ~13 tiles away from this object."
+	. += "Geiger counters will start clicking at ~11 tiles away from this object."
 	. += "No living thing can safely stand next to this object! Borgs or IPCs only!"
 
 /obj/structure/reagent_dispensers/radioactive_waste/hazardous/Initialize()

--- a/html/changelogs/fabiank3-radiation-refactor.yml
+++ b/html/changelogs/fabiank3-radiation-refactor.yml
@@ -1,0 +1,9 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed uranium golems not emitting detectable radiation by geiger counters."
+  - balance: "Replaced arbitrarily radioacitivty values in a lot of things with new more inline radiation level defines. These balances are minor and don't effect item, object or material behavior."
+  - rscadd: "Added a new version for radioactive green glow and waste barrels, radiation level very high."
+  - rscdel: "Removed the LRP hairloss on radiation exposure."

--- a/html/changelogs/fabiank3-radiation-refactor.yml
+++ b/html/changelogs/fabiank3-radiation-refactor.yml
@@ -4,6 +4,6 @@ delete-after: True
 
 changes:
   - bugfix: "Fixed uranium golems not emitting detectable radiation by geiger counters."
-  - balance: "Replaced arbitrarily radioacitivty values in a lot of things with new more inline radiation level defines. These balances are minor and don't effect item, object or material behavior."
+  - balance: "Replaced arbitrary radioactivity values in a lot of things with new more inline radiation level defines. These balances are minor and don't effect item, object or material behavior."
   - rscadd: "Added a new version for radioactive green glow and waste barrels, radiation level very high."
   - rscdel: "Removed the LRP hairloss on radiation exposure."


### PR DESCRIPTION
# Summary

This PR refactors radiation values and cleans up custom radiation values without a definition.  
This also fixes #22155.

## Changes

- Update ARMOR_RAD_STRONG 75 -> 70, now fits RAD_LEVEL_VERY_HIGH.
- Update radiation level defines:
  - NONE         = 0
  - VERY_LOW     = 1 (old LOW)
  - LOW          = 10
  - MODERATE     = 25
  - HIGH         = 40
  - VERY_HIGH    = 70 (old value was 100)
  - EXTREME      = 100
  - CATASTROPHIC = 120
- Update a couple of rad values to their respective define name (with minor implicit balancing).
- Remove the super awkward/LRP hairloss with high radiation exposure.