### PR TITLE
Fixes ID cards being left behind by the residential lifts

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -116,7 +116,7 @@
 		QDEL_LIST(hard_drive.stored_files)
 
 	for(var/obj/item/computer_hardware/CH in src.get_all_components())
-		uninstall_component(null, CH)
+		uninstall_component(null, CH, eject_id = FALSE)
 		qdel(CH)
 
 	registered_id = null

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -116,6 +116,7 @@
 		QDEL_LIST(hard_drive.stored_files)
 
 	for(var/obj/item/computer_hardware/CH in src.get_all_components())
+		// Eject_id is made false here as we want to delete the id too
 		uninstall_component(null, CH, eject_id = FALSE)
 		qdel(CH)
 

--- a/code/modules/modular_computers/computers/modular_computer/hardware.dm
+++ b/code/modules/modular_computers/computers/modular_computer/hardware.dm
@@ -97,7 +97,7 @@
 		update_icon()
 
 // Uninstalls component. Found and Critical vars may be passed by parent types, if they have additional hardware.
-/obj/item/modular_computer/proc/uninstall_component(var/mob/living/user, var/obj/item/computer_hardware/H, var/found = FALSE, var/critical = FALSE, var/put_in_hands = FALSE)
+/obj/item/modular_computer/proc/uninstall_component(mob/living/user, obj/item/computer_hardware/H, found = FALSE, critical = FALSE, put_in_hands = FALSE, eject_id = TRUE)
 	if(portable_drive == H)
 		portable_drive = null
 		found = TRUE
@@ -112,7 +112,8 @@
 		nano_printer = null
 		found = TRUE
 	else if(card_slot == H)
-		astype(H, /obj/item/computer_hardware/card_slot)?.eject_id()
+		if(eject_id)
+			astype(H, /obj/item/computer_hardware/card_slot)?.eject_id()
 		card_slot = null
 		found = TRUE
 	else if(battery_module == H)

--- a/code/modules/modular_computers/computers/modular_computer/hardware.dm
+++ b/code/modules/modular_computers/computers/modular_computer/hardware.dm
@@ -1,4 +1,4 @@
-// Attempts to install the hardware into appropriate slot.
+/// Attempts to install the hardware into appropriate slot.
 /obj/item/modular_computer/proc/try_install_component(var/mob/living/user, var/obj/item/computer_hardware/H, var/found = FALSE)
 	// "USB" flash drive.
 	if(istype(H, /obj/item/computer_hardware/hard_drive/portable))
@@ -96,7 +96,8 @@
 		user.drop_from_inventory(H, src)
 		update_icon()
 
-// Uninstalls component. Found and Critical vars may be passed by parent types, if they have additional hardware.
+/// Uninstalls component. Found and Critical vars may be passed by parent types, if they have additional hardware.
+/// Eject_id should only ever be made false if we're trying to delete the whole thing, such as when using cryo to leave the round.
 /obj/item/modular_computer/proc/uninstall_component(mob/living/user, obj/item/computer_hardware/H, found = FALSE, critical = FALSE, put_in_hands = FALSE, eject_id = TRUE)
 	if(portable_drive == H)
 		portable_drive = null
@@ -161,7 +162,7 @@
 			to_chat(user, SPAN_WARNING("\The [src]'s screen freezes for few seconds and then displays, \"HARDWARE ERROR: Critical component disconnected. Please verify component connection and reboot the device. If the problem persists contact technical support for assistance.\"."))
 			shutdown_computer()
 
-// Checks all hardware pieces to determine if name matches, if yes, returns the hardware piece, otherwise returns null
+/// Checks all hardware pieces to determine if name matches, if yes, returns the hardware piece, otherwise returns null
 /obj/item/modular_computer/proc/find_hardware_by_name(var/name)
 	if(portable_drive && (initial(portable_drive.name) == name))
 		return portable_drive
@@ -191,7 +192,7 @@
 		return access_cable_dongle
 	return null
 
-// Returns list of all components
+/// Returns list of all components
 /obj/item/modular_computer/proc/get_all_components()
 	var/list/all_components = list()
 	if(hard_drive)

--- a/html/changelogs/IDFixAgain.yml
+++ b/html/changelogs/IDFixAgain.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes ID being ejected on the floor when going to cryo/residential deck."


### PR DESCRIPTION
Adds a new var to the uninstall component that defaults to true. We only disable it if we're trying to delete the id card too, such as by the deleting the pda in the residential lift.