### PR TITLE
IPC Limb Hard Del Fix

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -224,8 +224,6 @@
 
 /obj/item/organ/external/Destroy()
 
-	. = ..()
-
 	if(parent?.children)
 		parent.children -= src
 
@@ -262,7 +260,7 @@
 	QDEL_NULL(nymph)
 
 	QDEL_NULL(tendon)
-
+	return ..()
 
 /obj/item/organ/external/proc/invalidate_marking_cache()
 	cached_markings = null

--- a/html/changelogs/hellfirejag limb hard dels.yml
+++ b/html/changelogs/hellfirejag limb hard dels.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed a hard del related to limbs being deleted in the wrong order."


### PR DESCRIPTION
Another smallish hard del fix, this time for external organs. Turns out it really is pretty important that Destroy() procs need to close with return ..() instead of open with . = ..() 

I made this after watching an IPC ghostrole leave a round via cryo, and then triggered 3s worth of hard dels all at once. 

<img width="406" height="774" alt="image" src="https://github.com/user-attachments/assets/096c084e-6953-4eb5-a708-0fa7018890d6" />
