### PR TITLE
fix observer hard del

### DIFF
--- a/code/modules/mob/abstract/ghost/observer/observer.dm
+++ b/code/modules/mob/abstract/ghost/observer/observer.dm
@@ -84,6 +84,10 @@
 		name = capitalize(pick(GLOB.first_names_male)) + " " + capitalize(pick(GLOB.last_names))
 	real_name = name
 
+/mob/abstract/ghost/observer/Destroy()
+	QDEL_NULL(hud)
+	return ..()
+
 /mob/abstract/ghost/observer/proc/initialise_postkey(set_timers = TRUE)
 	//This function should be run after a ghost has been created and had a ckey assigned
 	if (!set_timers)

--- a/html/changelogs/hellfirejag-observer-hard-del.yml
+++ b/html/changelogs/hellfirejag-observer-hard-del.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed a hard deleted related to ghost observers."


### PR DESCRIPTION
The Planemasters Update gave observers a hud reference to store, but no Destroy() method was added for them to clear this reference when despawning, which caused a hard del. Pretty simple fix.