### PR TITLE
Portal Hard Del Fix

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -61,7 +61,10 @@
 	if(istype(creator, /obj/item/hand_tele))
 		var/obj/item/hand_tele/HT = creator
 		HT.remove_portal(src)
-	. = ..()
+
+	target = null
+	creator = null
+	return ..()
 
 /obj/effect/portal/CollidedWith(atom/bumped_atom)
 	. = ..()

--- a/html/changelogs/hellfirejag portal hard del.yml
+++ b/html/changelogs/hellfirejag portal hard del.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed a hard delete related to telescience portals."


### PR DESCRIPTION
Another small fix, but for a hard del that was "Player on demand harddelete". Each and every single time Telescience activated their portal machine, a hard delete occurred. Which is pretty silly considering the average science player- if they use the machine, will press it like 50 times in a round, and I know this because they'll make 50 hard dels lol.

It was a pretty simple problem. Portals stored two references to the thing that made them, but weren't clearing them when destroyed.