### PR TITLE
freelook hard del

### DIFF
--- a/code/modules/mob/abstract/freelook/ai/cameranet.dm
+++ b/code/modules/mob/abstract/freelook/ai/cameranet.dm
@@ -14,7 +14,7 @@
 
 /datum/visualnet/camera/Destroy()
 	cameras.Cut()
-	. = ..()
+	return ..()
 
 /datum/visualnet/camera/add_source(obj/machinery/camera/c)
 	if(istype(c))

--- a/code/modules/mob/abstract/freelook/ai/eye.dm
+++ b/code/modules/mob/abstract/freelook/ai/eye.dm
@@ -10,9 +10,6 @@
 	. = ..()
 	visualnet = GLOB.cameranet
 
-/mob/abstract/eye/freelook/Destroy()
-	visualnet = null
-	. = ..()
 
 /datum/click_handler/eye/freelook/OnDblClick(atom/A, params)
 	var/mob/abstract/eye = user.eyeobj

--- a/code/modules/mob/abstract/freelook/blueprints/blueprints.dm
+++ b/code/modules/mob/abstract/freelook/blueprints/blueprints.dm
@@ -46,7 +46,7 @@
 	selected_turfs = null
 	valid_z_levels = null
 	last_selected_turf = null
-	. = ..()
+	return ..()
 
 /mob/abstract/eye/blueprints/release(var/mob/user)
 	if(owner && owner.client && user == owner)

--- a/code/modules/mob/abstract/freelook/chunk.dm
+++ b/code/modules/mob/abstract/freelook/chunk.dm
@@ -19,7 +19,7 @@
 
 /datum/obfuscation/Destroy()
 	obfuscation_images.Cut()
-	. = ..()
+	return ..()
 
 /datum/obfuscation/proc/has_obfuscation(var/turf/T)
 	return !isnull(obfuscation_images[T])
@@ -88,7 +88,7 @@
 
 /datum/chunk/Destroy()
 	visualnet = null
-	. = ..()
+	return ..()
 
 /datum/chunk/proc/add_sources(var/list/sources)
 	var/turf/center = locate(x + 8, y + 8, z)

--- a/html/changelogs/hellfirejag-freelook-hard-del.yml
+++ b/html/changelogs/hellfirejag-freelook-hard-del.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed a hard del related to freelook cameras."


### PR DESCRIPTION
This fixes a hard del on freelook eyes, which are used by some antag items and building blueprints.

<img width="377" height="152" alt="image" src="https://github.com/user-attachments/assets/5b1f9b00-88ba-44e1-9888-abf37e59195d" />

The hard del was caused by eye/freelook/Destroy() deleting a **holder** for references before its parent eye/Destroy() could use that holder to correctly clear its references. 

eye/Destroy() calls release(owner)

<img width="189" height="90" alt="image" src="https://github.com/user-attachments/assets/2864debe-15aa-4974-84b1-bc308a886e8f" />

which can only correctly release a reference in the visualnet var if it wasn't already null. But the freelook was nulling it before it could be correctly deconstructed.

<img width="364" height="257" alt="image" src="https://github.com/user-attachments/assets/cc5c3010-42e7-4620-924e-564116e7b590" />
