### PR TITLE
Commune can now be used on adjacent objects to store & later send a mental image of their icon and examine

### DIFF
--- a/code/modules/psionics/abilities/commune.dm
+++ b/code/modules/psionics/abilities/commune.dm
@@ -21,6 +21,10 @@
 	var/image //chat icon
 	var/warpdesc //Custom text added right after normal note desc
 
+/obj/item/spell/commune/Destroy()
+	object = null
+	return ..()
+
 /obj/item/spell/commune/on_use_cast(mob/user)
 	. = ..()
 	if(warpdesc)

--- a/code/modules/psionics/abilities/commune.dm
+++ b/code/modules/psionics/abilities/commune.dm
@@ -85,7 +85,7 @@
 
 		log_say("[key_name(user)] communed to [key_name(target)]: [image] [object]\n[note]" + " [warpdesc]")
 
-		for(var/mob/M in GLOB.player_list)
+		for(var/mob/M as anything in GLOB.player_list)
 			if(istype(M, /mob/abstract/new_player))
 				continue
 			else if(M.stat == DEAD && M.client.prefs.toggles & CHAT_GHOSTEARS)

--- a/code/modules/psionics/abilities/commune.dm
+++ b/code/modules/psionics/abilities/commune.dm
@@ -86,9 +86,7 @@
 		log_say("[key_name(user)] communed to [key_name(target)]: [image] [object]\n[note]" + " [warpdesc]")
 
 		for(var/mob/M as anything in GLOB.player_list)
-			if(istype(M, /mob/abstract/new_player))
-				continue
-			else if(M.stat == DEAD && M.client.prefs.toggles & CHAT_GHOSTEARS)
+			if(M.stat == DEAD && M.client.prefs.toggles & CHAT_GHOSTEARS)
 				to_chat(M, "<span class='notice'>[user] psionically says to [target]:</span> [image] [object]\n[note]" + " [warpdesc]")
 		return
 	var/text = tgui_input_text(user, "What would you like to say?", "Commune", "", MAX_MESSAGE_LEN, TRUE)

--- a/code/modules/psionics/abilities/commune.dm
+++ b/code/modules/psionics/abilities/commune.dm
@@ -25,13 +25,13 @@
 	. = ..()
 	if(warpdesc)
 		warpdesc = null
-		to_chat(user, SPAN_NOTICE("You rein back to your initial mental image of [object], clearing the warped additions."))
+		to_chat(user, SPAN_NOTICE("You rein back to your initial mental image of \the [object], clearing the warped additions."))
 	else if(warpdesc == null && (object))
-		warpdesc = tgui_input_text(user, "How would you warp the mental image of [object]? This will only add to its existing description, never override or delete.", "Warp Mental Image", "", MAX_MESSAGE_LEN, TRUE)
+		warpdesc = tgui_input_text(user, "How would you warp the mental image of \the [object]? This will only add to its existing description, never override or delete.", "Warp Mental Image", "", MAX_MESSAGE_LEN, TRUE)
 		if(!warpdesc)
 			warpdesc = null
 			return
-		to_chat(user, SPAN_NOTICE("You rethink your mental image of [object], warping in additions to its details."))
+		to_chat(user, SPAN_NOTICE("You rethink your mental image of \the [object], warping in additions to its details."))
 	else return
 
 /obj/item/spell/commune/on_melee_cast(atom/hit_atom, mob/living/user, def_zone)
@@ -39,13 +39,13 @@
 	if(!.)
 		return
 	if(object)
-		to_chat(user, SPAN_NOTICE("You already have a mental image in mind of [object]."))
+		to_chat(user, SPAN_NOTICE("You already have a mental image in mind of \the [object]."))
 		return
 	else if(isobj(hit_atom) && !object)
-		object = "[hit_atom]" //Save a snapshot of its info so they don't auto-update.
+		object = "[hit_atom.name]" //Save a snapshot of its info so they don't auto-update.
 		note = ("[hit_atom.desc]" + " [hit_atom.desc_feedback]")
 		image = icon2html(hit_atom, user)
-		to_chat(user, SPAN_NOTICE("You note and refine a mental image of [object] for sending."))
+		to_chat(user, SPAN_NOTICE("You note and refine a mental image of \the [object] for sending."))
 
 /obj/item/spell/commune/on_ranged_cast(atom/hit_atom, mob/user)
 	. = ..()
@@ -74,14 +74,14 @@
 		var/target_sensitivity = T.check_psi_sensitivity()
 		if(target_sensitivity >= 1) //Small detail, psions can subtly tell apart warped descriptions easier with the new line.
 			to_chat(T, SPAN_NOTICE("<i>[user] blinks, their eyes briefly developing an unnatural shine.</i>"))
-			to_chat(T, SPAN_CULT("What must be [user]'s mental image of [image] [object] appears in your mind.\n[note]\n[warpdesc]"))
+			to_chat(T, SPAN_CULT("What must be [user]'s mental image of \a [image] [object] appears in your mind.\n[note]\n[warpdesc]"))
 		else if(target_sensitivity >= 0) //Info span so it feels like an actual examine at a glance
-			to_chat(T, SPAN_INFO("<b>A mental image of [image] [object] suddenly builds in your mind.</b>\n[note]" + " [warpdesc]"))
+			to_chat(T, SPAN_INFO("<b>A mental image of \a [image] [object] suddenly builds in your mind.</b>\n[note]" + " [warpdesc]"))
 		else //60% chance low-targets don't even get the icon. 35% (per point) of the object's name is scrambled, but base desc can still clue the item
 			var/scrmbldobject = stars(object, (abs(target_sensitivity) * 35))
 			var/scrmbldnote = stars(note, (abs(target_sensitivity) * 25))
 			var/scrmbldwarp = stars(warpdesc, (abs(target_sensitivity) * 45)) //Warped descriptions are even more abnormal, so extra scrambled
-			to_chat(T, SPAN_ALIEN("<b>A mental image of [prob(40)?"[image] ":""][scrmbldobject] attempts to form in your mind.</b>\n[scrmbldnote]" + " [scrmbldwarp]"))
+			to_chat(T, SPAN_ALIEN("<b>A mental image of \a [prob(40)?"[image] ":""][scrmbldobject] attempts to form in your mind.</b>\n[scrmbldnote]" + " [scrmbldwarp]"))
 
 		log_say("[key_name(user)] communed to [key_name(target)]: [image] [object]\n[note]" + " [warpdesc]")
 

--- a/code/modules/psionics/abilities/commune.dm
+++ b/code/modules/psionics/abilities/commune.dm
@@ -15,7 +15,7 @@
 	aspect = ASPECT_PSIONIC
 	cooldown = 10
 	psi_cost = 15
- //For shared/remote-examine Communes, similar to Show-Held-Object
+//For shared/remote-examine Communes, similar to Show-Held-Object
 	var/object
 	var/note //desc
 	var/image //chat icon

--- a/code/modules/psionics/abilities/commune.dm
+++ b/code/modules/psionics/abilities/commune.dm
@@ -60,7 +60,6 @@
 /obj/item/spell/commune/proc/commune(atom/hit_atom, mob/user)
 	if(!isliving(hit_atom))
 		return
-
 	var/mob/living/target = hit_atom
 	if(target.stat == DEAD)
 		to_chat(user, SPAN_WARNING("Not even a psion of your level can speak to the dead."))

--- a/code/modules/psionics/abilities/commune.dm
+++ b/code/modules/psionics/abilities/commune.dm
@@ -1,6 +1,6 @@
 /singleton/psionic_power/commune
 	name = "Commune"
-	desc = "Psionically commune with the target."
+	desc = "Psionically commune with the target. Use on an adjacent object to store a mental image for sending. Use in hand with a mental image to warp and add to its description, or clear a warped one."
 	icon_state = "tech_audibledeception"
 	point_cost = 0
 	ability_flags = PSI_FLAG_FOUNDATIONAL
@@ -11,16 +11,41 @@
 	desc = "Déjà-vu."
 	icon_state = "overload"
 	item_icons = null
-	cast_methods = CAST_RANGED|CAST_MELEE
+	cast_methods = CAST_RANGED|CAST_MELEE|CAST_USE
 	aspect = ASPECT_PSIONIC
 	cooldown = 10
 	psi_cost = 15
+ //For shared/remote-examine Communes, similar to Show-Held-Object
+	var/object
+	var/note //desc
+	var/image //chat icon
+	var/warpdesc //Custom text added right after normal note desc
+
+/obj/item/spell/commune/on_use_cast(mob/user)
+	. = ..()
+	if(warpdesc)
+		warpdesc = null
+		to_chat(user, SPAN_NOTICE("You rein back to your initial mental image of [object], clearing the warped additions."))
+	else if(warpdesc == null && (object))
+		warpdesc = tgui_input_text(user, "How would you warp the mental image of [object]? This will only add to its existing description, never override or delete.", "Warp Mental Image", "", MAX_MESSAGE_LEN, TRUE)
+		if(!warpdesc)
+			warpdesc = null
+			return
+		to_chat(user, SPAN_NOTICE("You rethink your mental image of [object], warping in additions to its details."))
+	else return
 
 /obj/item/spell/commune/on_melee_cast(atom/hit_atom, mob/living/user, def_zone)
 	. = ..()
 	if(!.)
 		return
-	commune(hit_atom, user)
+	if(object)
+		to_chat(user, SPAN_NOTICE("You already have a mental image in mind of [object]."))
+		return
+	else if(isobj(hit_atom) && !object)
+		object = "[hit_atom]" //Save a snapshot of its info so they don't auto-update.
+		note = ("[hit_atom.desc]" + " [hit_atom.desc_feedback]")
+		image = icon2html(hit_atom, user)
+		to_chat(user, SPAN_NOTICE("You note and refine a mental image of [object] for sending."))
 
 /obj/item/spell/commune/on_ranged_cast(atom/hit_atom, mob/user)
 	. = ..()
@@ -42,6 +67,30 @@
 		to_chat(user, psi_blocked)
 		return
 
+//Checks psi-sensitivity for remote item examines, because normal Commune gets blocked
+	if(object)
+		to_chat(user, SPAN_CULT("You psionically project to [target]: [image] [object]\n[note]" + " [warpdesc]"))
+		var/mob/living/carbon/human/T = target
+		var/target_sensitivity = T.check_psi_sensitivity()
+		if(target_sensitivity >= 1) //Small detail, psions can subtly tell apart warped descriptions easier with the new line.
+			to_chat(T, SPAN_NOTICE("<i>[user] blinks, their eyes briefly developing an unnatural shine.</i>"))
+			to_chat(T, SPAN_CULT("What must be [user]'s mental image of [image] [object] appears in your mind.\n[note]\n[warpdesc]"))
+		else if(target_sensitivity >= 0) //Info span so it feels like an actual examine at a glance
+			to_chat(T, SPAN_INFO("<b>A mental image of [image] [object] suddenly builds in your mind.</b>\n[note]" + " [warpdesc]"))
+		else //60% chance low-targets don't even get the icon. 35% (per point) of the object's name is scrambled, but base desc can still clue the item
+			var/scrmbldobject = stars(object, (abs(target_sensitivity) * 35))
+			var/scrmbldnote = stars(note, (abs(target_sensitivity) * 25))
+			var/scrmbldwarp = stars(warpdesc, (abs(target_sensitivity) * 45)) //Warped descriptions are even more abnormal, so extra scrambled
+			to_chat(T, SPAN_ALIEN("<b>A mental image of [prob(40)?"[image] ":""][scrmbldobject] attempts to form in your mind.</b>\n[scrmbldnote]" + " [scrmbldwarp]"))
+
+		log_say("[key_name(user)] communed to [key_name(target)]: [image] [object]\n[note]" + " [warpdesc]")
+
+		for(var/mob/M in GLOB.player_list)
+			if(istype(M, /mob/abstract/new_player))
+				continue
+			else if(M.stat == DEAD && M.client.prefs.toggles & CHAT_GHOSTEARS)
+				to_chat(M, "<span class='notice'>[user] psionically says to [target]:</span> [image] [object]\n[note]" + " [warpdesc]")
+		return
 	var/text = tgui_input_text(user, "What would you like to say?", "Commune", "", MAX_MESSAGE_LEN, TRUE)
 	if(!text)
 		return

--- a/html/changelogs/diggiez - CommuneHeldItem.yml
+++ b/html/changelogs/diggiez - CommuneHeldItem.yml
@@ -1,0 +1,13 @@
+author: diggiez
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Commune can now be used on adjacent objects to later send a mental image of their icon and examine, like a psionic Show-Held-Item"
+  - rscadd: "With a mental image stored, Commune may be used in hand to warp and add custom text after its description."


### PR DESCRIPTION
Initially inspired by Show-Held-Object, hence the branch name, but this doesn't actually make a hyperlink for it.

With a mental image stored, Commune can also be activated to "warp" and (ONLY) add to the image's description or clear a previous warp. Everything here is already canon (encouraged, actually https://wiki.aurorastation.org/index.php/Skrell#Telepathy | "Telepathy is versatile, and you can convey IMAGES, sounds, emotions, and sensations along with regular speech.)" and technically mechanically possible, just done through "You see X" phrasing in normal Commune.

Slightly unique sensitivity checks for low targets having a 60% chance to not even get the icon and separate, varying amounts of scrambling for object name, note description, and warp description. Standard targets will get a blue message that can pass as an actual examine at a glance
Low-Sensitivity (and sender's message)
<img width="758" height="160" alt="image" src="https://github.com/user-attachments/assets/39235fc4-91dc-4d73-ba26-90f116068ea2" />
Standard
<img width="765" height="140" alt="image" src="https://github.com/user-attachments/assets/a1778983-1208-47bd-a4a7-0fac6e428cc4" />
High/Psion (and a warped description)
<img width="656" height="83" alt="image" src="https://github.com/user-attachments/assets/a6a2dcac-6db0-4627-8c53-c837241907ba" />

