### PR TITLE
Fixes light sensitivity origin traits behaviors not firing

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -94,7 +94,7 @@
 	if(O.visor && O.visor.active && O.visor.vision && O.visor.vision.glasses && (!O.helmet || (head && O.helmet == head)))
 		process_glasses(O.visor.vision.glasses)
 
-// Applies organ/markings prefs to this mob.
+/// Applies organ/markings prefs to this mob.
 /mob/living/carbon/human/proc/sync_organ_prefs_to_mob(datum/preferences/prefs, apply_prosthetics = TRUE, apply_markings = TRUE)
 	if (apply_prosthetics)
 		var/list/rlimb_data = prefs.rlimb_data
@@ -188,18 +188,20 @@
 		var/datum/character_disabilities/trait = GLOB.chargen_disabilities_list[M]
 		trait.apply_self(src)
 
-// Helper proc that grabs whatever organ this humantype uses to see.
-// Usually eyes, but can be something else.
-// If `no_synthetic` is TRUE, returns null for mobs that are mechanical, or for mechanical eyes.
+/**
+ * Helper proc that grabs whatever organ this humantype uses to see.
+ * Usually eyes, but can be something else.
+ * If `no_synthetic` is TRUE, returns null for mobs that are mechanical, or for mechanical eyes.
+ */
 /mob/living/carbon/human/proc/get_eyes(no_synthetic = FALSE)
 	if (!species.vision_organ || !species.has_organ[species.vision_organ] || (no_synthetic && (species.flags & IS_MECHANICAL)))
 		return null
 
-	var/obj/item/organ/O = internal_organs_by_name[species.vision_organ]
-	if (!istype(O, /obj/item/organ/internal/eyes) || (no_synthetic && (O.status & ORGAN_ROBOT)))
+	var/obj/item/organ/eyes = internal_organs_by_name[species.vision_organ]
+	if (!istype(eyes, /obj/item/organ/internal/eyes) || (no_synthetic && (eyes.status & ORGAN_ROBOT)))
 		return null
 
-	return O
+	return eyes
 
 /mob/living/carbon/human/proc/awaken_psi_basic(var/source)
 	var/static/list/psi_operancy_messages = list(
@@ -220,7 +222,7 @@
 /mob/living/carbon/human/get_resist_power()
 	return species.resist_mod
 
-// Handle cases where the mob's awareness may reside in another mob, but still cares about how its brain is doing
+/// Handle cases where the mob's awareness may reside in another mob, but still cares about how its brain is doing
 /mob/living/carbon/human/proc/find_mob_consciousness()
 	if(istype(bg) && bg.client)
 		return bg

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1206,31 +1206,44 @@
 			else if (prob(1))
 				vomit()
 
-	//0.1% chance of playing a scary sound to someone who's in complete darkness
-	if(isturf(loc) && rand(1,1000) == 1)
-		var/turf/T = loc
-		if (T.get_lumcount() < 0.01)	// give a little bit of tolerance for near-dark areas.
-			playsound(null, pick(GLOB.scarySounds), 50, TRUE)
+	// Handle turf brightness behavior:
+	if(isturf(loc))
+		var/turf/T
+		// 0.1% chance of playing a scary sound to someone who's in complete darkness
+		if(rand(1,1000) == 1)
+			T = loc
+			if(T.get_lumcount() < 0.05)	// give a little bit of tolerance for near-dark areas.
+				playsound(null, pick(GLOB.scarySounds), 50, TRUE)
 
+		// People who are afraid of the dark (Assunzionii) get anxious.
 		if(HAS_TRAIT(src, TRAIT_ORIGIN_DARK_AFRAID))
-			if(T.get_lumcount() < 0.1)
-				if(prob(2))
-					var/list/assunzione_messages = list(
-						"You feel a bit afraid...",
-						"You feel somewhat nervous...",
-						"You could use a little light here...",
-						"Ennoia be with you, it's a bit too dark..."
-					)
-					to_chat(src, SPAN_WARNING(pick(assunzione_messages)))
+			T = loc
+			if(prob(2) && T.get_lumcount() < 0.2)
+				var/list/assunzione_messages = list(
+					"You feel a bit afraid...",
+					"You feel somewhat nervous...",
+					"You could use a little light here...",
+					"Ennoia be with you, it's a bit too dark..."
+				)
+				to_chat(src, SPAN_WARNING(pick(assunzione_messages)))
 
+		// People sensitive to light get eye strain.
 		if(HAS_TRAIT(src, TRAIT_ORIGIN_LIGHT_SENSITIVE))
-			if(T.get_lumcount() > 0.8)
-				if(prob(1))
-					if(prob(5))
+			T = loc
+			// From testing, this generally leaves several minutes between each message.
+			if(prob(1) && T.get_lumcount() > 0.8)
+				// If you have this trait, your default flash protection is -1; check for ANY protection.
+				var/mob/living/carbon/human/self = src
+				var/flash_protection = self.get_flash_protection()
+				if(!flash_protection)
+					var/obj/item/organ/eyes = self.get_eyes()
+					if(istype(eyes))
+						self.eye_blurry = max(self.eye_blurry, 6)
+						eyes.take_damage(1, TRUE)
 						var/list/eye_sensitivity_messages = list(
-							"Your eyes tire a bit.",
-							"Your eyes sting a little.",
-							"Your vision feels a bit strained."
+							"Your eyes tire a bit from the brightness.",
+							"Your eyes sting a little; it's too bright.",
+							"The bright light leaves your vision strained."
 						)
 						to_chat(src, SPAN_WARNING(pick(eye_sensitivity_messages)))
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1215,27 +1215,34 @@
 			if(T.get_lumcount() < 0.05)	// give a little bit of tolerance for near-dark areas.
 				playsound(null, pick(GLOB.scarySounds), 50, TRUE)
 
-		// People who are afraid of the dark (Assunzionii) get anxious.
+		// People who are afraid of the dark get anxious.
 		if(HAS_TRAIT(src, TRAIT_ORIGIN_DARK_AFRAID))
 			T = loc
 			if(prob(2) && T.get_lumcount() < 0.2)
-				var/list/assunzione_messages = list(
+				var/list/afraid_of_the_dark_messages = list(
 					"You feel a bit afraid...",
 					"You feel somewhat nervous...",
 					"You could use a little light here...",
-					"Ennoia be with you, it's a bit too dark..."
+					"It's dark enough that you feel a little anxious..."
 				)
-				to_chat(src, SPAN_WARNING(pick(assunzione_messages)))
+				to_chat(src, SPAN_WARNING(pick(afraid_of_the_dark_messages)))
 
 		// People sensitive to light get eye strain.
 		if(HAS_TRAIT(src, TRAIT_ORIGIN_LIGHT_SENSITIVE))
 			T = loc
 			// From testing, this generally leaves several minutes between each message.
 			if(prob(1) && T.get_lumcount() > 0.8)
-				// If you have this trait, your default flash protection is -1; check for ANY protection.
 				var/mob/living/carbon/human/self = src
+
+				// If you have this trait, your default flash protection is -1; check for ANY protection.
 				var/flash_protection = self.get_flash_protection()
-				if(!flash_protection)
+
+				// I hate this. We removed flash protection from basic sunglasses for 'powergaming concerns.'
+				// Check if we're wearing the stupid fake loadout sunglasses.
+				// Yes this is stupid. Remove this when we rebalance flash protection to be a 0-100 threshold.
+				var/fakesunglasses = istype(self?.glasses, /obj/item/clothing/glasses/fakesunglasses)
+
+				if(!flash_protection && !fakesunglasses)
 					var/obj/item/organ/eyes = self.get_eyes()
 					if(istype(eyes))
 						self.eye_blurry = max(self.eye_blurry, 6)

--- a/html/changelogs/Bat-LightSensitivity.yml
+++ b/html/changelogs/Bat-LightSensitivity.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - bugfix: "Fixes light and dark sensitivity trait behaviors being locked behind an unrelated rare prob event."

--- a/html/changelogs/Bat-LightSensitivity.yml
+++ b/html/changelogs/Bat-LightSensitivity.yml
@@ -3,3 +3,4 @@ delete-after: True
 changes:
   - bugfix: "Fixes light and dark sensitivity trait behaviors being locked behind an unrelated rare prob event."
   - balance: "Makes light sensitivity apply the basic low-level flash effect when triggered (trivial eye damage that immediately heals, very brief translucent grey overlay)."
+  - balance: "Makes minor+ flash protection (basic sunglasses etc.) protect against bright lights for affected characters."

--- a/html/changelogs/Bat-LightSensitivity.yml
+++ b/html/changelogs/Bat-LightSensitivity.yml
@@ -2,3 +2,4 @@ author: Batrachophrenoboocosmomachia
 delete-after: True
 changes:
   - bugfix: "Fixes light and dark sensitivity trait behaviors being locked behind an unrelated rare prob event."
+  - balance: "Makes light sensitivity apply the basic low-level flash effect when triggered (trivial eye damage that immediately heals, very brief translucent grey overlay)."


### PR DESCRIPTION
Light sensitivity traits (either to excess of light or absence of light) were not firing, because they were tucked behind a 0.1% chance prob for an unrelated spooky noise proc if you're in pitch black.

Did some testing and found a prob value that was infrequent but not absent. Also added a little visual effect for the light-sensitive one (similar to v minor flash, which is 1 eye dmg that immediately heals & a very brief translucent grey overlay).