### PR TITLE
Stop Sheet Snatcher Spam

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -152,8 +152,6 @@
 
 /obj/item/storage/bag/sheetsnatcher/can_be_inserted(obj/item/W as obj, stop_messages = 0)
 	if(!istype(W,/obj/item/stack/material))
-		if(!stop_messages)
-			to_chat(usr, "The snatcher does not accept [W].")
 		return 0
 	var/current = 0
 	for(var/obj/item/stack/material/S in contents)

--- a/html/changelogs/example copy.yml
+++ b/html/changelogs/example copy.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscdel: "Sheet Snatchers no longer flood your chat with messages."


### PR DESCRIPTION
There's like 8 different items in the game that go in a sheet snatcher. If the intended purpose of the Sheet Snatcher is to grab all of the material sheets from a giant pile of random crap in the warehouse, then it spamming the chat is apparently incredibly useless. This PR was requested to me by some warehouse mains.

<img width="425" height="85" alt="image" src="https://github.com/user-attachments/assets/427c2426-6784-4377-8d59-1aa8d7469409" />
