### PR TITLE
Implanted HUD Flicker Fix

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -54,3 +54,6 @@
 
 /// For when the players intent changes
 #define COMSIG_INTENT_CHANGE "intent_change"
+
+/// Signal raised at the end of a mob's vision update to check if signals wish to supplement their own huds.
+#define COMSIG_MOB_UPDATE_VISION "mob_update_vision"

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -72,6 +72,8 @@
 		if(istype(back,/obj/item/rig))
 			process_rig(back)
 
+	SEND_SIGNAL(src, COMSIG_MOB_UPDATE_VISION)
+
 /mob/living/carbon/human/proc/process_glasses(var/obj/item/clothing/glasses/G)
 	if(G && G.active)
 		equipment_darkness_modifier += G.darkness_view

--- a/code/modules/organs/subtypes/augment/augments/eye_sensors.dm
+++ b/code/modules/organs/subtypes/augment/augments/eye_sensors.dm
@@ -15,17 +15,38 @@
 
 	var/selected_hud = "disabled"
 
-/obj/item/organ/internal/augment/eye_sensors/attack_self(var/mob/user)
+/obj/item/organ/internal/augment/eye_sensors/Initialize()
+	. = ..()
+	if(!owner)
+		return
+
+	RegisterSignal(owner, COMSIG_MOB_UPDATE_VISION, PROC_REF(handle_vision_update))
+
+/obj/item/organ/internal/augment/eye_sensors/replaced(mob/living/carbon/human/target)
+	. = ..()
+	if(!owner)
+		return
+
+	RegisterSignal(owner, COMSIG_MOB_UPDATE_VISION, PROC_REF(handle_vision_update))
+
+/obj/item/organ/internal/augment/eye_sensors/removed()
+	if(!owner)
+		return ..()
+
+	UnregisterSignal(owner, COMSIG_MOB_UPDATE_VISION)
+	return ..()
+
+/obj/item/organ/internal/augment/eye_sensors/attack_self(mob/user)
 	. = ..()
 
 	if(!.)
 		return FALSE
 
-/obj/item/organ/internal/augment/eye_sensors/process()
-	..()
+	// Update HUD immediately on toggle
+	handle_vision_update()
 
-	if(!owner)
-		return
+/obj/item/organ/internal/augment/eye_sensors/proc/handle_vision_update(mob/living/carbon/human/H)
+	SIGNAL_HANDLER
 
 /obj/item/organ/internal/augment/eye_sensors/emp_act(severity)
 	. = ..()
@@ -36,14 +57,14 @@
 
 	E.take_damage(5)
 
-/obj/item/organ/internal/augment/eye_sensors/proc/check_hud(var/hud)
+/obj/item/organ/internal/augment/eye_sensors/proc/check_hud(hud)
 	return (hud == active_hud)
 
 /obj/item/organ/internal/augment/eye_sensors/security
 	name = "integrated security HUD sensors"
 	action_button_name = "Toggle Security Sensors"
 
-/obj/item/organ/internal/augment/eye_sensors/security/attack_self(var/mob/user)
+/obj/item/organ/internal/augment/eye_sensors/security/attack_self(mob/user)
 	. = ..()
 
 	if(selected_hud == "disabled")
@@ -53,11 +74,12 @@
 		selected_hud = "disabled"
 		to_chat(user, SPAN_NOTICE("You deactivate \the [src]."))
 
-/obj/item/organ/internal/augment/eye_sensors/security/process()
-	..()
+/obj/item/organ/internal/augment/eye_sensors/security/handle_vision_update(mob/living/carbon/human/H)
+	SIGNAL_HANDLER
+	if(!owner)
+		return
 
 	switch(selected_hud)
-
 		if(SEC_HUDTYPE)
 			req_access = list(ACCESS_SECURITY)
 			if(allowed(owner))
@@ -72,7 +94,7 @@
 	name = "integrated medical HUD sensors"
 	action_button_name = "Toggle Medical Sensors"
 
-/obj/item/organ/internal/augment/eye_sensors/medical/attack_self(var/mob/user)
+/obj/item/organ/internal/augment/eye_sensors/medical/attack_self(mob/user)
 	. = ..()
 
 	if(selected_hud == "disabled")
@@ -82,8 +104,10 @@
 		selected_hud = "disabled"
 		to_chat(user, SPAN_NOTICE("You deactivate \the [src]."))
 
-/obj/item/organ/internal/augment/eye_sensors/medical/process()
-	..()
+/obj/item/organ/internal/augment/eye_sensors/medical/handle_vision_update(mob/living/carbon/human/H)
+	SIGNAL_HANDLER
+	if(!owner)
+		return
 
 	switch(selected_hud)
 

--- a/code/modules/organs/subtypes/augment/augments/eye_sensors.dm
+++ b/code/modules/organs/subtypes/augment/augments/eye_sensors.dm
@@ -75,7 +75,6 @@
 		to_chat(user, SPAN_NOTICE("You deactivate \the [src]."))
 
 /obj/item/organ/internal/augment/eye_sensors/security/handle_vision_update(mob/living/carbon/human/H)
-	SIGNAL_HANDLER
 	if(!owner)
 		return
 
@@ -105,7 +104,6 @@
 		to_chat(user, SPAN_NOTICE("You deactivate \the [src]."))
 
 /obj/item/organ/internal/augment/eye_sensors/medical/handle_vision_update(mob/living/carbon/human/H)
-	SIGNAL_HANDLER
 	if(!owner)
 		return
 

--- a/code/modules/organs/subtypes/augment/augments/phalanx_facial_plate.dm
+++ b/code/modules/organs/subtypes/augment/augments/phalanx_facial_plate.dm
@@ -30,7 +30,6 @@
 		return
 
 /obj/item/organ/internal/augment/eye_sensors/phalanx/handle_vision_update(mob/living/carbon/human/H)
-	SIGNAL_HANDLER
 	if(!owner)
 		return
 

--- a/code/modules/organs/subtypes/augment/augments/phalanx_facial_plate.dm
+++ b/code/modules/organs/subtypes/augment/augments/phalanx_facial_plate.dm
@@ -29,8 +29,10 @@
 		to_chat(user, "You deactivate \the [src].")
 		return
 
-/obj/item/organ/internal/augment/eye_sensors/phalanx/process()
-	..()
+/obj/item/organ/internal/augment/eye_sensors/phalanx/handle_vision_update(mob/living/carbon/human/H)
+	SIGNAL_HANDLER
+	if(!owner)
+		return
 
 	switch(selected_hud)
 		if(SEC_HUDTYPE)

--- a/html/changelogs/hellfirejag-implant-hud-fix.yml
+++ b/html/changelogs/hellfirejag-implant-hud-fix.yml
@@ -1,0 +1,5 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed implanted medical and security huds flickering."
+  - rscadd: "Components and Implants can now add hud elements via signals."


### PR DESCRIPTION
closes #22079 
closes #21945

This bug was also my fault, and it happened when I decoupled organ processing from the life() tick to prevent organs being processed twice. Since Huds were generated during the Life() tick, but implants were adding the Hud during Process(), a flicker occured whenever they fired out of sync, with the Life() tick erasing the hud and Process() adding it back. To significantly cut down on the time complexity of having to iterate and fire every HUD producing implant and component during Life(), I've instead reworked it into a Signal that permits the HUD implants to inject hud elements into the Life() codepath dynamically. 

Here is the fix in action now.

https://github.com/user-attachments/assets/18ccc80d-cb5f-4fd7-9ad5-28c91acf6ca5

