### PR TITLE
Posibrain Fixes

### DIFF
--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -57,7 +57,7 @@
 
 	brainmob.client.init_verbs()
 
-	return src
+	return brainmob
 
 /obj/item/mmi/digital/posibrain/update_name()
 	var/new_name = tgui_input_text(brainmob, "Choose your name.", "Name Selection", brainmob.real_name, MAX_NAME_LEN)

--- a/code/modules/organs/internal/species/machine/posibrain.dm
+++ b/code/modules/organs/internal/species/machine/posibrain.dm
@@ -140,6 +140,7 @@
 		stored_mmi.forceMove(get_turf(src))
 		if(owner.mind)
 			owner.mind.transfer_to(stored_mmi.brainmob)
+		stored_mmi = null
 
 	. = ..()
 

--- a/html/changelogs/hellfirejag-posibrain-fixes.yml
+++ b/html/changelogs/hellfirejag-posibrain-fixes.yml
@@ -1,0 +1,5 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed surgically removing a positronic brain deleting it and ghosting the player, you now correctly get a sentient cube."
+  - bugfix: "Fixed posibrains despawning instantly when joined as a ghostrole. They have souls, this is proof!"


### PR DESCRIPTION
closes #21982
closes #21705

<img width="465" height="394" alt="image" src="https://github.com/user-attachments/assets/6ae35510-73c5-46e8-b624-a83e71dca603" />

This PR fixes the longstanding IPC med rework bug whereby surgically removing a posibrain would just delete it. Also fixes a bug where it wasn't possible to join as a posibrain ghost role. 