### PR TITLE
Fix Ancient IIS Module Bug

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -269,6 +269,16 @@
 					data += list(list("Hardsuit Modules", "[SRM.module.interface_name]", "[SRM]", REF(SRM)))
 	return data
 
+/mob/living/silicon/get_actions_for_statpanel()
+	var/list/data = ..()
+	var/obj/item/rig/R = get_rig()
+	if(istype(R))
+		for(var/obj/item/rig_module/module in R.installed_modules)
+			for(var/stat_rig_module/SRM in module.stat_modules)
+				if(SRM.CanUse())
+					data += list(list("Hardsuit Modules", "[SRM.module.interface_name]", "[SRM]", REF(SRM)))
+	return data
+
 /stat_rig_module
 	parent_type = /atom/movable
 	var/module_mode = ""

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -612,18 +612,30 @@
 		return cell
 	return ..()
 
-/obj/item/rig/proc/check_suit_access(var/mob/living/carbon/human/user)
+/obj/item/rig/proc/is_integrated_rig_ai(var/mob/living/user)
+	if(!user)
+		return FALSE
+	for(var/obj/item/rig_module/ai_container/module in installed_modules)
+		if(module.integrated_ai == user)
+			return TRUE
+	return FALSE
+
+/obj/item/rig/proc/check_suit_access(var/mob/living/user)
 
 	if(!security_check_enabled || !locked)
 		return 1
 
-	if(istype(user))
-		if(malfunction_check(user))
+	if(is_integrated_rig_ai(user))
+		return 1
+
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(malfunction_check(H))
 			return 0
-		if(user.back != src)
+		if(H.back != src)
 			return 0
-		else if(!src.allowed(user))
-			to_chat(user, SPAN_DANGER("Unauthorized user. Access denied."))
+		else if(!src.allowed(H))
+			to_chat(H, SPAN_DANGER("Unauthorized user. Access denied."))
 			return 0
 
 	else if(!ai_override_enabled)
@@ -912,7 +924,7 @@
 			to_chat(wearer, SPAN_WARNING("The [source] has damaged your [dam_module.interface_name]!"))
 	dam_module.deactivate()
 
-/obj/item/rig/proc/malfunction_check(var/mob/living/carbon/human/user)
+/obj/item/rig/proc/malfunction_check(var/mob/living/user)
 	if(malfunction_delay)
 		if(offline)
 			to_chat(user, SPAN_DANGER("The suit is completely unresponsive."))

--- a/html/changelogs/hellfirejag-fix-IIS-module.yml
+++ b/html/changelogs/hellfirejag-fix-IIS-module.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed the IIS module not allowing a PAI to actually do anything with a hardsuit."


### PR DESCRIPTION
closes #2951

Oh my god this was the oldest confirmed still active bug in the entire issue tracker, and it's 9 years old. This bug was reported originally in 2017 and was never fixed. Uhhh. Hell.

This makes it so that pAIs can actually control a hardsuit via an installed IIS Module. The thing that module was meant to do 9 years ago.