### PR TITLE
Signals Runtime Nonsense

### DIFF
--- a/code/controllers/subsystems/spatial_gridmap.dm
+++ b/code/controllers/subsystems/spatial_gridmap.dm
@@ -134,7 +134,7 @@ SUBSYSTEM_DEF(spatial_grid)
 
 ///add a movable to the pre init queue for whichever type is specified so that when the subsystem initializes they get added to the grid
 /datum/controller/subsystem/spatial_grid/proc/enter_pre_init_queue(atom/movable/waiting_movable, type)
-	RegisterSignal(waiting_movable, COMSIG_QDELETING, PROC_REF(queued_item_deleted), override = TRUE)
+	RegisterSignal(waiting_movable, COMSIG_QDELETING, PROC_REF(queued_item_deleted))
 	//override because something can enter the queue for two different types but that is done through unrelated procs that shouldnt know about eachother
 	waiting_to_add_by_type[type] += waiting_movable
 

--- a/code/datums/components/leanable.dm
+++ b/code/datums/components/leanable.dm
@@ -69,7 +69,7 @@
 		return COMPONENT_CANCEL_MOUSEDROPPED_ONTO
 	leaner.start_leaning(source, leaning_offset)
 	LAZYADD(leaning_mobs, leaner)
-	RegisterSignals(leaner, list(COMSIG_LIVING_STOPPED_LEANING, COMSIG_QDELETING), PROC_REF(stopped_leaning), override = TRUE)
+	RegisterSignals(leaner, list(COMSIG_LIVING_STOPPED_LEANING, COMSIG_QDELETING), PROC_REF(stopped_leaning))
 	return COMPONENT_CANCEL_MOUSEDROPPED_ONTO
 
 /**

--- a/code/datums/components/psionics/psi_sensitivity.dm
+++ b/code/datums/components/psionics/psi_sensitivity.dm
@@ -25,7 +25,7 @@
 	// When this component is given to a datum via AddComponent(), such as on a player character
 	// the component tells the datum it wishes to do something when this signal happens to the datum.
 	// When SendSignal() is later activated on that character, this component will react with its prepared proc.
-	RegisterSignal(parent, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity), override = TRUE)
+	RegisterSignal(parent, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity))
 
 /datum/component/psi_sensitivity/Destroy()
 	if (!parent)

--- a/code/datums/components/psionics/psi_suppression.dm
+++ b/code/datums/components/psionics/psi_suppression.dm
@@ -16,8 +16,8 @@
 	if (!parent)
 		return
 
-	RegisterSignal(parent, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity), override = TRUE)
-	RegisterSignal(parent, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power), override = TRUE)
+	RegisterSignal(parent, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity))
+	RegisterSignal(parent, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power))
 
 /datum/component/psi_suppression/Destroy()
 	if (!parent)

--- a/code/datums/elements/_element.dm
+++ b/code/datums/elements/_element.dm
@@ -32,7 +32,7 @@
 		return ELEMENT_INCOMPATIBLE
 	SEND_SIGNAL(target, COMSIG_ELEMENT_ATTACH, src)
 	if(element_flags & ELEMENT_DETACH_ON_HOST_DESTROY)
-		RegisterSignal(target, COMSIG_QDELETING, PROC_REF(OnTargetDelete), override = TRUE)
+		RegisterSignal(target, COMSIG_QDELETING, PROC_REF(OnTargetDelete))
 
 /datum/element/proc/OnTargetDelete(datum/source)
 	SIGNAL_HANDLER

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -14,7 +14,7 @@
 
 	src.connections = connections
 
-	RegisterSignal(listener, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved), override = TRUE)
+	RegisterSignal(listener, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
 	update_signals(listener)
 
 /datum/element/connect_loc/Detach(atom/movable/listener)
@@ -29,7 +29,7 @@
 
 	for (var/signal in connections)
 		//override=TRUE because more than one connect_loc element instance tracked object can be on the same loc
-		listener.RegisterSignal(listener_loc, signal, connections[signal], override=TRUE)
+		listener.RegisterSignal(listener_loc, signal, connections[signal])
 
 /datum/element/connect_loc/proc/unregister_signals(datum/listener, atom/old_loc)
 	if(isnull(old_loc))

--- a/code/datums/signals.dm
+++ b/code/datums/signals.dm
@@ -13,7 +13,7 @@
  * * proctype The proc to call back when the signal is emitted
  * * override If a previous registration exists you must explicitly set this
  */
-/datum/proc/RegisterSignal(datum/target, signal_type, proctype, override = FALSE)
+/datum/proc/RegisterSignal(datum/target, signal_type, proctype)
 	if(QDELETED(src) || QDELETED(target))
 		return
 
@@ -26,7 +26,7 @@
 			known_failures[message] = TRUE
 			stack_trace("[target] [message]")
 
-		RegisterSignals(target, signal_type, proctype, override)
+		RegisterSignals(target, signal_type, proctype)
 		return
 
 	var/list/procs = (_signal_procs ||= list())
@@ -37,13 +37,6 @@
 	target_procs[signal_type] = proctype
 
 	if(exists)
-		if(!override)
-			// This is stupid. It does literally nothing but pointlessly nuke garbage collection.
-			// The signal registry duplication is already cleanly and safely prevented by the if (exists) return, there is no need to throw a runtime error.
-
-			// var/override_message = "[signal_type] overridden. Use override = TRUE to suppress this warning.\nTarget: [target] ([target.type]) Existing Proc: [exists] New Proc: [proctype]"
-			// log_signal(override_message)
-			// stack_trace(override_message)
 		return
 
 	var/list/looked_up = lookup[signal_type]
@@ -56,9 +49,9 @@
 		looked_up += src
 
 /// Registers multiple signals to the same proc.
-/datum/proc/RegisterSignals(datum/target, list/signal_types, proctype, override = FALSE)
+/datum/proc/RegisterSignals(datum/target, list/signal_types, proctype)
 	for (var/signal_type in signal_types)
-		RegisterSignal(target, signal_type, proctype, override)
+		RegisterSignal(target, signal_type, proctype)
 
 /**
  * Stop listening to a given signal from target

--- a/code/datums/signals.dm
+++ b/code/datums/signals.dm
@@ -38,9 +38,12 @@
 
 	if(exists)
 		if(!override)
-			var/override_message = "[signal_type] overridden. Use override = TRUE to suppress this warning.\nTarget: [target] ([target.type]) Existing Proc: [exists] New Proc: [proctype]"
-			log_signal(override_message)
-			stack_trace(override_message)
+			// This is stupid. It does literally nothing but pointlessly nuke garbage collection.
+			// The signal registry duplication is already cleanly and safely prevented by the if (exists) return, there is no need to throw a runtime error.
+
+			// var/override_message = "[signal_type] overridden. Use override = TRUE to suppress this warning.\nTarget: [target] ([target.type]) Existing Proc: [exists] New Proc: [proctype]"
+			// log_signal(override_message)
+			// stack_trace(override_message)
 		return
 
 	var/list/looked_up = lookup[signal_type]

--- a/code/game/objects/items/weapons/implants/implants/mindshield.dm
+++ b/code/game/objects/items/weapons/implants/implants/mindshield.dm
@@ -25,8 +25,8 @@
 <b>Integrity:</b> Implant will last so long as the nanobots are inside the bloodstream."}
 
 /obj/item/implant/mindshield/implanted(mob/M)
-	RegisterSignal(M, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity), override = TRUE)
-	RegisterSignal(M, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power), override = TRUE)
+	RegisterSignal(M, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity))
+	RegisterSignal(M, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power))
 	to_chat(M, SPAN_GOOD("You feel your mind steel against external suggestion!"))
 	if(istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M

--- a/code/game/objects/structures/large.dm
+++ b/code/game/objects/structures/large.dm
@@ -109,7 +109,7 @@
 		C.part_of = src
 		C.color = color
 		grouped_structures += C
-		RegisterSignal(T, COMSIG_ATOM_ENTERED, PROC_REF(structure_entered), override = TRUE)
+		RegisterSignal(T, COMSIG_ATOM_ENTERED, PROC_REF(structure_entered))
 
 /datum/large_structure/proc/disassemble(var/time_per_structure, var/mob/user)
 	if(user in interacting)
@@ -151,7 +151,7 @@
 /datum/large_structure/proc/structure_entered(var/turf/entry_point, var/atom/movable/entering)
 	if(!(isliving(entering) || isobserver(entering)))
 		return FALSE
-	RegisterSignal(entering, COMSIG_MOVABLE_MOVED, PROC_REF(mob_moved), override = TRUE)
+	RegisterSignal(entering, COMSIG_MOVABLE_MOVED, PROC_REF(mob_moved))
 	return TRUE
 
 /datum/large_structure/proc/mob_moved(var/mob/mover)

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -1047,7 +1047,7 @@ All custom items with worn sprites must follow the contained sprite system: http
 	. = ..()
 	if(!owner)
 		return
-	RegisterSignal(owner, COMSIG_BEGIN_SURGERY, PROC_REF(negate_healing), override = TRUE)
+	RegisterSignal(owner, COMSIG_BEGIN_SURGERY, PROC_REF(negate_healing))
 	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 	parent.fracture(TRUE)
 
@@ -1055,7 +1055,7 @@ All custom items with worn sprites must follow the contained sprite system: http
 	. = ..()
 	if(!owner)
 		return
-	RegisterSignal(owner, COMSIG_BEGIN_SURGERY, PROC_REF(negate_healing), override = TRUE)
+	RegisterSignal(owner, COMSIG_BEGIN_SURGERY, PROC_REF(negate_healing))
 	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 	parent.fracture(TRUE)
 

--- a/code/modules/organs/subtypes/augment/augments/auxiliary_heart.dm
+++ b/code/modules/organs/subtypes/augment/augments/auxiliary_heart.dm
@@ -12,14 +12,14 @@
 	if(!owner)
 		return
 
-	RegisterSignal(owner, COMSIG_HEART_PUMP_EVENT, PROC_REF(stabilize_circulation), override = TRUE)
+	RegisterSignal(owner, COMSIG_HEART_PUMP_EVENT, PROC_REF(stabilize_circulation))
 
 /obj/item/organ/internal/augment/bioaug/auxiliary_heart/replaced()
 	. = ..()
 	if(!owner)
 		return
 
-	RegisterSignal(owner, COMSIG_HEART_PUMP_EVENT, PROC_REF(stabilize_circulation), override = TRUE)
+	RegisterSignal(owner, COMSIG_HEART_PUMP_EVENT, PROC_REF(stabilize_circulation))
 
 /obj/item/organ/internal/augment/bioaug/auxiliary_heart/removed()
 	if(!owner)

--- a/code/modules/organs/subtypes/augment/augments/gravity_adaptations.dm
+++ b/code/modules/organs/subtypes/augment/augments/gravity_adaptations.dm
@@ -11,14 +11,14 @@
 	if(!owner)
 		return
 
-	RegisterSignal(owner, COMSIG_GRAVITY_WEAKNESS_EVENT, PROC_REF(negate_weakness), override = TRUE)
+	RegisterSignal(owner, COMSIG_GRAVITY_WEAKNESS_EVENT, PROC_REF(negate_weakness))
 
 /obj/item/organ/internal/augment/bioaug/gravity_adaptations/replaced()
 	. = ..()
 	if(!owner)
 		return
 
-	RegisterSignal(owner, COMSIG_GRAVITY_WEAKNESS_EVENT, PROC_REF(negate_weakness), override = TRUE)
+	RegisterSignal(owner, COMSIG_GRAVITY_WEAKNESS_EVENT, PROC_REF(negate_weakness))
 
 /obj/item/organ/internal/augment/bioaug/gravity_adaptations/removed()
 	if(!owner)

--- a/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
+++ b/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
@@ -12,16 +12,16 @@
 	if(!owner)
 		return
 
-	RegisterSignal(owner, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power), override = TRUE)
-	RegisterSignal(owner, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity), override = TRUE)
+	RegisterSignal(owner, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power))
+	RegisterSignal(owner, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity))
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker/replaced()
 	. = ..()
 	if(!owner)
 		return
 
-	RegisterSignal(owner, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power), override = TRUE)
-	RegisterSignal(owner, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity), override = TRUE)
+	RegisterSignal(owner, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power))
+	RegisterSignal(owner, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity))
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker/removed()
 	if(!owner)
@@ -63,16 +63,16 @@
 	if(!owner)
 		return
 
-	RegisterSignal(owner, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power_lethal), override = TRUE)
-	RegisterSignal(owner, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity), override = TRUE)
+	RegisterSignal(owner, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power_lethal))
+	RegisterSignal(owner, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity))
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker_lethal/replaced()
 	. = ..()
 	if(!owner)
 		return
 
-	RegisterSignal(owner, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power_lethal), override = TRUE)
-	RegisterSignal(owner, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity), override = TRUE)
+	RegisterSignal(owner, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power_lethal))
+	RegisterSignal(owner, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity))
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker_lethal/removed()
 	. = ..()

--- a/code/modules/organs/subtypes/augment/augments/platelet_factories.dm
+++ b/code/modules/organs/subtypes/augment/augments/platelet_factories.dm
@@ -12,16 +12,16 @@
 	if(!owner)
 		return
 
-	RegisterSignal(owner, COMSIG_HEART_PUMP_EVENT, PROC_REF(stroke_risk), override = TRUE)
-	RegisterSignal(owner, COMSIG_HEART_BLEED_EVENT, PROC_REF(reduce_bloodloss), override = TRUE)
+	RegisterSignal(owner, COMSIG_HEART_PUMP_EVENT, PROC_REF(stroke_risk))
+	RegisterSignal(owner, COMSIG_HEART_BLEED_EVENT, PROC_REF(reduce_bloodloss))
 
 /obj/item/organ/internal/augment/bioaug/platelet_factories/replaced()
 	. = ..()
 	if(!owner)
 		return
 
-	RegisterSignal(owner, COMSIG_HEART_PUMP_EVENT, PROC_REF(stroke_risk), override = TRUE)
-	RegisterSignal(owner, COMSIG_HEART_BLEED_EVENT, PROC_REF(reduce_bloodloss), override = TRUE)
+	RegisterSignal(owner, COMSIG_HEART_PUMP_EVENT, PROC_REF(stroke_risk))
+	RegisterSignal(owner, COMSIG_HEART_BLEED_EVENT, PROC_REF(reduce_bloodloss))
 
 /obj/item/organ/internal/augment/bioaug/platelet_factories/removed()
 	if(!owner)

--- a/code/modules/organs/subtypes/augment/augments/psi_receiver.dm
+++ b/code/modules/organs/subtypes/augment/augments/psi_receiver.dm
@@ -24,14 +24,14 @@
 	if(!owner)
 		return
 
-	RegisterSignal(owner, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity), override = TRUE)
+	RegisterSignal(owner, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity))
 
 /obj/item/organ/internal/augment/bioaug/psi/replaced()
 	. = ..()
 	if(!owner)
 		return
 
-	RegisterSignal(owner, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity), override = TRUE)
+	RegisterSignal(owner, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity))
 
 /obj/item/organ/internal/augment/bioaug/psi/removed()
 	if(!owner)

--- a/html/changelogs/helfirejag-signals-runtime.yml
+++ b/html/changelogs/helfirejag-signals-runtime.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Removed a pointless forced runtime error in signal registries."


### PR DESCRIPTION
<img width="1226" height="356" alt="image" src="https://github.com/user-attachments/assets/29408dfe-4a8c-47a3-9c57-3b0c100e496a" />

This is dumb and pointless, the signals code already cleanly and safely handles prevention of duplicate registries for the same source registry, there's no need to produce a runtime error. In fact failing to put override = TRUE would change literally nothing about how signals register, except that it would mean every signal registry will automatically trigger a forced runtime error that serves no purpose. 

Stop this, get some help.