### PR TITLE
Fixed Spammy Pointless Signals Runtime Error

### DIFF
--- a/code/datums/signals.dm
+++ b/code/datums/signals.dm
@@ -13,7 +13,7 @@
  * * proctype The proc to call back when the signal is emitted
  * * override If a previous registration exists you must explicitly set this
  */
-/datum/proc/RegisterSignal(datum/target, signal_type, proctype, override = FALSE)
+/datum/proc/RegisterSignal(datum/target, signal_type, proctype, override = TRUE)
 	if(QDELETED(src) || QDELETED(target))
 		return
 
@@ -53,7 +53,7 @@
 		looked_up += src
 
 /// Registers multiple signals to the same proc.
-/datum/proc/RegisterSignals(datum/target, list/signal_types, proctype, override = FALSE)
+/datum/proc/RegisterSignals(datum/target, list/signal_types, proctype, override = TRUE)
 	for (var/signal_type in signal_types)
 		RegisterSignal(target, signal_type, proctype, override)
 

--- a/html/changelogs/hellfirejag-signals-runtime-nonsense.yml
+++ b/html/changelogs/hellfirejag-signals-runtime-nonsense.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed a spammy nonsense runtime error related to signals."


### PR DESCRIPTION
<img width="1233" height="377" alt="image" src="https://github.com/user-attachments/assets/6e267bec-cf6a-4c8b-8371-e0347068d7eb" />

Literally pointless runtime error, except this time I'm disabling it without making it harder to port stuff from TG. 