### PR TITLE
Revenge Of The Pants

### DIFF
--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -145,7 +145,9 @@ Path adjustment
 	return "Type: [metadata]"
 
 /datum/gear_tweak/path/get_default()
-	return valid_paths[1]
+	for(var/key in valid_paths)
+		return key
+	return null
 
 /datum/gear_tweak/path/get_random()
 	return pick(valid_paths)
@@ -154,9 +156,15 @@ Path adjustment
 	return tgui_input_list(user, "Choose a type.", "Character Preference", valid_paths, metadata)
 
 /datum/gear_tweak/path/tweak_gear_data(var/metadata, var/datum/gear_data/gear_data)
-	if(!(metadata in valid_paths))
+	if(metadata in valid_paths)
+		gear_data.path = valid_paths[metadata]
 		return
-	gear_data.path = valid_paths[metadata]
+
+	// Fallback for when metadata is actually the path (value) instead of the name (key)
+	for(var/key in valid_paths)
+		if(valid_paths[key] == metadata)
+			gear_data.path = metadata
+			return
 
 /*
 Faction-based Path adjustment
@@ -164,10 +172,17 @@ Same as the adjustment above, but the associated value is a list with the first 
 */
 
 /datum/gear_tweak/path/faction/tweak_gear_data(var/metadata, var/datum/gear_data/gear_data)
-	if(!(metadata in valid_paths))
+	if(metadata in valid_paths)
+		gear_data.path = valid_paths[metadata][1]
+		gear_data.faction_requirement = valid_paths[metadata][2]
 		return
-	gear_data.path = valid_paths[metadata][1]
-	gear_data.faction_requirement = valid_paths[metadata][2]
+
+	// Fallback for when metadata is actually the path (value) instead of the name (key)
+	for(var/key in valid_paths)
+		if(valid_paths[key][1] == metadata)
+			gear_data.path = metadata
+			gear_data.faction_requirement = valid_paths[key][2]
+			return
 
 /*
 Content adjustment

--- a/code/modules/client/preference_setup/loadout/items/pants.dm
+++ b/code/modules/client/preference_setup/loadout/items/pants.dm
@@ -5,7 +5,7 @@ ABSTRACT_TYPE(/datum/gear/pants)
 /datum/gear/pants/trousers
 	display_name = "pants and shorts selection"
 	description = "A selection of pants and shorts."
-	path = /obj/item/clothing/pants
+	path = /obj/item/clothing/pants/black
 
 /datum/gear/pants/trousers/New()
 	..()

--- a/code/modules/client/preference_setup/loadout/items/xeno/tajara.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/tajara.dm
@@ -5,7 +5,7 @@ ABSTRACT_TYPE(/datum/gear/shoes/tajara)
 /datum/gear/shoes/tajara/boots
 	display_name = "tajaran boots selection"
 	description = "A selection of shoes and boots fitted for Tajara."
-	path = /obj/item/clothing/shoes/tajara
+	path = /obj/item/clothing/shoes/jackboots/tajara
 	whitelisted = list(SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI)
 	sort_category = "Xenowear - Tajara"
 

--- a/html/changelogs/hellfirejag-final-pants-fix.yml
+++ b/html/changelogs/hellfirejag-final-pants-fix.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Finally fixed the pants memory leak. It is no longer possible to accidentally put Abstract (not real) pants in your loadout."


### PR DESCRIPTION
I have actually tested this PR to verify it. Thanks to Sentry for finally giving me the data point needed to figure out where the hell the bug was coming from. It turns out the culprit for The Pants Hard Delete was people accidentally saving Abstract Pants in their loadout, which would immediately produce a runtime error when the game attempts to add them to the chargen dummy.

<img width="655" height="560" alt="image" src="https://github.com/user-attachments/assets/6b4028a2-0661-4479-a9a5-03cc7157e5f7" />
