### PR TITLE
Simple Hostile HardDel Cleanup

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -28,8 +28,6 @@ ABSTRACT_TYPE(/mob/living/simple_animal/hostile)
 	var/destroy_surroundings = 1
 	a_intent = I_HURT
 	hunger_enabled = 0//Until automated eating mechanics are enabled, disable hunger for hostile mobs
-	var/shuttletarget = null
-	var/enroute = 0
 	var/obj/effect/landmark/mob_waypoint/target_waypoint = null // The waypoint mobs that are spawned by mapped in spawners move to
 
 	// Vars to help find targets
@@ -54,10 +52,13 @@ ABSTRACT_TYPE(/mob/living/simple_animal/hostile)
 	setup_target_type_validators()
 
 /mob/living/simple_animal/hostile/Destroy()
-	friends = null
+	GLOB.move_manager.stop_looping(src)
 	unset_last_found_target()
-	targets = null
-	target_type_validator_map = null
+	friends.Cut()
+	target_waypoint = null
+	targets.Cut()
+	target_type_validator_map.Cut()
+	tolerated_types.Cut()
 	return ..()
 
 /mob/living/simple_animal/hostile/proc/setup_target_type_validators()

--- a/code/modules/mob/living/simple_animal/hostile/ipc_zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ipc_zombie.dm
@@ -56,6 +56,10 @@
 	AddOverlays(emissive_overlay)
 	set_light(MINIMUM_USEFUL_LIGHT_RANGE, 2, LIGHT_COLOR_TUNGSTEN)
 
+/mob/living/simple_animal/hostile/ipc_zombie/Destroy()
+	QDEL_NULL(screen_overlay)
+	return ..()
+
 /mob/living/simple_animal/hostile/ipc_zombie/update_icon()
 	ClearOverlays()
 	if(screen && stat != DEAD)

--- a/code/modules/mob/living/simple_animal/hostile/rogue_maint_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/rogue_maint_drone.dm
@@ -33,6 +33,10 @@
 	eye_overlay.appearance_flags = KEEP_APART
 	AddOverlays(eye_overlay)
 
+/mob/living/simple_animal/hostile/rogue_drone/Destroy()
+	QDEL_NULL(eye_overlay)
+	return ..()
+
 /mob/living/simple_animal/hostile/rogue_drone/CanPass(atom/movable/mover, turf/target, height, air_group)
 	. = ..()
 	if(.)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -251,6 +251,7 @@
 
 /mob/living/simple_animal/Destroy()
 	CutOverlays(blood_overlay)
+	QDEL_NULL(blood_overlay)
 	lostMovementTarget()
 	QDEL_NULL(udder)
 

--- a/html/changelogs/hellfirejag-hostile-mob-fixes.yml
+++ b/html/changelogs/hellfirejag-hostile-mob-fixes.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed numerous hard dels that were universal to all hostile mobs."


### PR DESCRIPTION
<img width="1919" height="985" alt="image" src="https://github.com/user-attachments/assets/f10f6e84-65e3-4a73-b977-4017aca5169a" />

I have also actually tested this PR. This PR cleans up Hostile Mob code, removing **several** hard del conditions that were universal across all hostile mobs, as well as a few individually specific simple mobs that weren't cleaning up overlay images correctly. While I was at it, I removed some verifiably unused vars from hostile mobs.