### PR TITLE
Water Hard Del Fix

### DIFF
--- a/code/game/objects/effects/chem/water.dm
+++ b/code/game/objects/effects/chem/water.dm
@@ -9,9 +9,6 @@
 	. = ..()
 	QDEL_IN(src, 15 SECONDS)	// In case whatever made it forgets to delete it
 
-/obj/effect/effect/water/Destroy()
-	reagents = null
-	return ..()
 
 /obj/effect/effect/water/proc/set_color() // Call it after you move reagents to it
 	if(!reagents)

--- a/html/changelogs/hellfirejag-water-hard-del fix.yml
+++ b/html/changelogs/hellfirejag-water-hard-del fix.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed a hard delete in water effects."


### PR DESCRIPTION
Small mistake that makes fire extinguishers cause a hard delete. Water effects were nulling the effect reagents before calling their parent, but then their parent attempts to QDEL_NULL(reagents) a reference that it can no longer correctly cleanup. The simple solution was to get rid of the Destroy() override on effect/water since it wasn't needed.