### PR TITLE
Another Turf Hand Fix

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -24,6 +24,9 @@
 	/// Turning this off prevents awkward zone geometry in places like medbay lobby, for example.
 	block_air_zones = 0
 
+	/// Blast doors don't respond to hand interaction, so don't intercept clicks on their turf.
+	turf_hand_priority = 0
+
 	/// Icon states for different shutter types. Simply change this instead of rewriting the update_icon proc.
 	var/icon_state_open = null
 	var/icon_state_opening = null

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -24,7 +24,7 @@
 	/// Turning this off prevents awkward zone geometry in places like medbay lobby, for example.
 	block_air_zones = 0
 
-	/// Blast doors don't respond to hand interaction, so don't intercept clicks on their turf.
+	// Blast doors don't respond to hand interaction, so don't intercept clicks on their turf.
 	turf_hand_priority = 0
 
 	/// Icon states for different shutter types. Simply change this instead of rewriting the update_icon proc.

--- a/html/changelogs/hellfirejag-shutters-turf-hand-fix.yml
+++ b/html/changelogs/hellfirejag-shutters-turf-hand-fix.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed doors with shutters not responding to clicking the tile underneath them."


### PR DESCRIPTION
<img width="385" height="397" alt="image" src="https://github.com/user-attachments/assets/fa4d574e-74dc-4cb1-b2a9-d06bce6bde3f" />

Blast doors are counted as doors, and so were capable of intercepting the turf hand click, even though they have no hand interaction. This meant that most doors which had shutters sharing their tile could not be closed via clicking the tile underneath them. There's a simple fix to that, and it's exempting shutters  from turf hand (which you can't close them by clicking on them anyway)