### PR TITLE
BST Hard Dels

### DIFF
--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -130,6 +130,7 @@ ABSTRACT_TYPE(/obj/item/implant)
 	if(part)
 		part.implants.Remove(src)
 		part = null
+	imp_in = null
 	STOP_PROCESSING(SSprocessing, src)
 	GLOB.implants -= src
 	return ..()

--- a/code/modules/admin/verbs/bluespacetech.dm
+++ b/code/modules/admin/verbs/bluespacetech.dm
@@ -41,7 +41,7 @@
 	var/T = get_turf(usr)
 	var/mob/living/carbon/human/bst/bst = new(T)
 	if(istype(mob, /mob/living))
-		bst.original_mob = mob
+		bst.original_mob = WEAKREF(mob)
 
 	bst.anchored = 1
 	bst.ckey = usr.ckey
@@ -138,7 +138,7 @@
 	status_flags = GODMODE|NOFALL
 
 	/// The BST's original mob. Moved here from /datum/holder to support storytellers.
-	var/mob/original_mob
+	var/datum/weakref/original_mob
 
 /mob/living/carbon/human/bst/Destroy(force)
 	original_mob = null
@@ -174,8 +174,10 @@
 	QDEL_IN(src, 10)
 	animate(src, alpha = 0, time = 9, easing = QUAD_EASING)
 	if(key)
-		if(original_mob)
-			client.key = key
+		var/mob/living/origin = original_mob?.resolve()
+		if(origin)
+			origin.key = key
+			original_mob = null
 			client.init_verbs()
 		else
 			var/mob/abstract/ghost/observer/ghost = new(src, src)	//Transfer safety to observer spawning proc.
@@ -326,12 +328,13 @@
 	set desc = "Jump into bluespace and continue wherever you left off. Deletes the BSTech and returns to your original mob if you have one."
 	set category = "BST"
 
-	if(original_mob)
-		if(original_mob.key)//Thanks for kicking Tish off the Server Meow, wouldn't have spotted this otherwise.
+	var/mob/living/origin = original_mob?.resolve()
+	if(origin)
+		if(origin.key)//Thanks for kicking Tish off the Server Meow, wouldn't have spotted this otherwise.
 			//suicide()
 			return
 
-		original_mob.key = key
+		origin.key = key
 		original_mob = null
 	suicide()
 

--- a/html/changelogs/hellfirejag-bst-tweaks.yml
+++ b/html/changelogs/hellfirejag-bst-tweaks.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Tweaked bluespace techs to hold a weakref to their original mob instead of a real reference, in order to mitigate race condition hard deletes."


### PR DESCRIPTION
Another PR for Bluespace Techs, this time swapping them to hold a weakref to their original mob. There's a ton of code in BSTs that can create race conditions with all their associated Destroy() procs, so swapping them to weakref methods should significantly cut down on that. 