### PR TITLE
Fix Watches and Add Ashtrays Examine Hint

### DIFF
--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -134,6 +134,10 @@
 		update_icon()
 	return ..()
 
+/obj/item/material/ashtray/mechanics_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "Use help intent to empty into a disposal. Use harm intent to put into a disposal."
+
 /obj/item/material/ashtray/plastic/Initialize(newloc, material_key)
 	. = ..(newloc, MATERIAL_PLASTIC)
 

--- a/code/modules/clothing/wrists/watches.dm
+++ b/code/modules/clothing/wrists/watches.dm
@@ -96,8 +96,8 @@
 
 	if(wired && screwed)
 		to_chat(usr, SPAN_NOTICE("You check your watch, spotting a digital collection of numbers reading '[worldtime2text()]'. Today's date is '[time2text(world.time, "Month DD")]. [GLOB.game_year]'."))
-		if (GLOB.evacuation_controller.get_status_panel_eta())
-			to_chat(usr, SPAN_WARNING("Time until Bluespace Jump: [GLOB.evacuation_controller.get_status_panel_eta()]."))
+		if(GLOB.evacuation_controller.get_status_panel_eta())
+			to_chat(usr, SPAN_WARNING("Time until shift end: [GLOB.evacuation_controller.get_status_panel_eta()]."))
 	else if(wired && !screwed)
 		to_chat(usr, SPAN_NOTICE("You check your watch, realising it's still open."))
 	else

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -263,7 +263,7 @@
 
 	user.drop_from_inventory(attacking_item, src)
 
-	user.visible_message("<b>[user]</b> places \the [attacking_item] into \the [src].", SPAN_NOTICE("You place \the [attacking_item] into the [src]."), range = 3)
+	user.visible_message("<b>[user]</b> places \the [attacking_item] into \the [src].", SPAN_NOTICE("You place \the [attacking_item] into \the [src]."), range = 3)
 	update()
 
 /**

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -210,10 +210,12 @@
 		update()
 		return TRUE
 
-	else if (istype (attacking_item, /obj/item/material/ashtray) && user.a_intent != I_HURT)
+	else if(istype(attacking_item, /obj/item/material/ashtray) && user.a_intent != I_HURT) // If attacked with ashtray on harm intent.
 		var/obj/item/material/ashtray/A = attacking_item
-		if(A.emptyout(src))
-			user.visible_message("<b>[user]</b> pours [attacking_item] out into [src].", SPAN_NOTICE("You pour [attacking_item] out into [src]."))
+		if(A.emptyout(src)) // Ashtray has contents.
+			user.visible_message("<b>[user]</b> pours \the [attacking_item] out into \the [src].", SPAN_NOTICE("You pour \the [attacking_item] out into \the [src]."))
+		else // Ashtray has no contents.
+			to_chat(user, SPAN_NOTICE("\The [attacking_item] is empty."))
 		return TRUE
 
 	else if (istype (attacking_item, /obj/item/lightreplacer))

--- a/html/changelogs/SleepyGemmy-fixes.yml
+++ b/html/changelogs/SleepyGemmy-fixes.yml
@@ -1,0 +1,7 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed watches referring to bluespace transfer during the round end timer."
+  - bugfix: "Fixed ashtrays not having a examine hint about emptying vs putting it into a disposal."

--- a/html/changelogs/SleepyGemmy-fixes.yml
+++ b/html/changelogs/SleepyGemmy-fixes.yml
@@ -5,4 +5,4 @@ delete-after: True
 changes:
   - bugfix: "Fixed watches referring to bluespace transfer during the round end timer."
   - bugfix: "Fixed ashtrays not having a examine hint about emptying vs putting it into a disposal."
-  - bugfix: "Fixed ashtrays not giving a feedback message when trying to empty a empty one"
+  - bugfix: "Fixed ashtrays not giving a feedback message when trying to empty a empty one."

--- a/html/changelogs/SleepyGemmy-fixes.yml
+++ b/html/changelogs/SleepyGemmy-fixes.yml
@@ -6,3 +6,4 @@ changes:
   - bugfix: "Fixed watches referring to bluespace transfer during the round end timer."
   - bugfix: "Fixed ashtrays not having a examine hint about emptying vs putting it into a disposal."
   - bugfix: "Fixed ashtrays not giving a feedback message when trying to empty a empty one."
+  - bugfix: "Fixed a duplicate \"the\" when putting something inside a disposal."

--- a/html/changelogs/SleepyGemmy-fixes.yml
+++ b/html/changelogs/SleepyGemmy-fixes.yml
@@ -5,3 +5,4 @@ delete-after: True
 changes:
   - bugfix: "Fixed watches referring to bluespace transfer during the round end timer."
   - bugfix: "Fixed ashtrays not having a examine hint about emptying vs putting it into a disposal."
+  - bugfix: "Fixed ashtrays not giving a feedback message when trying to empty a empty one"


### PR DESCRIPTION
fixes watches referring to bluespace during the roundend timer, ashtrays not having a examine hint about emptying vs putting it into a disposal, and ashtrays not giving a feedback message when trying to empty a empty one.

fixes #22209 and fixes #22215.