### PR TITLE
Fix Light Sensitivity Proc

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1240,7 +1240,6 @@
 					var/obj/item/organ/eyes = self.get_eyes()
 					if(istype(eyes))
 						self.eye_blurry = max(self.eye_blurry, 6)
-						eyes.take_damage(1, TRUE)
 						var/list/eye_sensitivity_messages = list(
 							"Your eyes tire a bit from the brightness.",
 							"Your eyes sting a little; it's too bright.",

--- a/html/changelogs/Bat-LightSensitivity2.yml
+++ b/html/changelogs/Bat-LightSensitivity2.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - bugfix: "Removes superficial eye damage from light sensitivity proc."


### PR DESCRIPTION
Guess how many people play characters with the Light Sensitive trait who also have mechanical eyes? At least one, me.

Well it turns out my original implementation ends with your augs poisoning you because it didn't check for whether your eyes autoheal.

Removed the 1 damage from the fluorescents being too bright.