### PR TITLE
Engineering washroom, maint fixes, area rename

### DIFF
--- a/html/changelogs/fabiank3-engineering-bathroom.yml
+++ b/html/changelogs/fabiank3-engineering-bathroom.yml
@@ -1,0 +1,9 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - rscadd: "Added a washroom to engineering."
+  - qol: "Refactored the multilevel maint between engineering and medical."
+  - qol: "Renamed engineering EVA to engineering equipment. Area name change, doors and cameras were already correct."
+  - bugfix: "Fixed camera in supermatter monitoring belonging to the wrong network."

--- a/html/changelogs/fabiank3-engineering-bathroom.yml
+++ b/html/changelogs/fabiank3-engineering-bathroom.yml
@@ -7,3 +7,4 @@ changes:
   - qol: "Refactored the multilevel maint between engineering and medical."
   - qol: "Renamed engineering EVA to engineering equipment. Area name change, doors and cameras were already correct."
   - bugfix: "Fixed camera in supermatter monitoring belonging to the wrong network."
+  - bugfix: "Removed the left-over unconnected vents in security meeting room."

--- a/maps/sccv_horizon/areas/horizon_areas_engineering.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_engineering.dm
@@ -25,10 +25,16 @@
 	horizon_deck = 1
 	lightswitch = FALSE
 
-/area/horizon/engineering/storage_eva
-	name = "EVA Storage"
+/area/horizon/engineering/equipment
+	name = "Equipment"
 	icon_state = "engineering_storage"
 	horizon_deck = 2
+
+/area/horizon/engineering/washroom
+	name = "Washroom"
+	sound_environment = SOUND_AREA_SMALL_ENCLOSED
+	horizon_deck = 2
+	area_blurb = "The air in here not only smells like aggresive cleaning reagents, but everything you find around the whole department, oil, paint and other highly flammable chemicals... Unfortunately."
 
 /area/horizon/engineering/break_room
 	name = "Break Room"


### PR DESCRIPTION
# Summary

This PR adds a washroom to the engineering department - *Why does the dirtiest department not have a washroom?*  
Refactoring of nearby maints.

## Changes

- Engineering washroom
- Refactore fore maint, added vents (the maint is too large to not have them, multi-level Z too)
- Signs
- Renamed "EVA storage" to engineering "Equipment"
- Fixed wrong camera network in SM monitoring
- Removed left-over vents in sec meeting room.