### PR TITLE
Asynchronous Mapping Initialization

### DIFF
--- a/code/controllers/subsystems/ghostroles.dm
+++ b/code/controllers/subsystems/ghostroles.dm
@@ -36,10 +36,6 @@ SUBSYSTEM_DEF(ghostroles)
 		if(!G.short_name || !G.name || !G.desc)
 			log_subsystem_ghostroles("Spawner [G.type] got removed from selection because of missing data")
 			continue
-		//Check if we have a spawnpoint on the current map
-		if(!G.select_spawnlocation(FALSE) && G.loc_type == GS_LOC_POS)
-			log_subsystem_ghostroles("Spawner [G.type] got removed from selection because of missing spawnpoint")
-			continue
 		spawners[G.short_name] = G
 
 	for (var/identifier in spawnpoints)
@@ -51,6 +47,14 @@ SUBSYSTEM_DEF(ghostroles)
 		spawn_atom[spawn_type] = list()
 
 	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/ghostroles/proc/prune_spawners()
+	set waitfor = FALSE
+	for(var/s in spawners)
+		var/datum/ghostspawner/G = spawners[s]
+		if(!G.select_spawnlocation(FALSE) && G.loc_type == GS_LOC_POS)
+			log_subsystem_ghostroles("Spawner [G.type] got removed from selection because of missing spawnpoint after map gen")
+			spawners -= s
 
 //Adds a spawnpoint to the spawnpoint list
 /datum/controller/subsystem/ghostroles/proc/add_spawnpoints(var/obj/effect/ghostspawpoint/P)

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -35,11 +35,19 @@ SUBSYSTEM_DEF(mapping)
 	if(!GLOB.config.fastboot || GLOB.config.exoplanets["enable_loading"] || GLOB.config.awaysites["enable_loading"])
 		// Load templates and build away sites.
 		preloadTemplates()
-
-		SSatlas.current_map.build_away_sites()
-		SSatlas.current_map.build_exoplanets()
+		build_extra_sites()
 
 	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/mapping/proc/build_extra_sites()
+	set waitfor = FALSE
+	SSatlas.current_map.build_away_sites()
+	SSatlas.current_map.build_exoplanets()
+
+	while(!SSghostroles.initialized)
+		sleep(wait)
+
+	SSghostroles.prune_spawners()
 
 /datum/controller/subsystem/mapping/Recover()
 	flags |= SS_NO_INIT

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -11,7 +11,7 @@
 
 	var/datum/map_template/template = SSmapping.map_templates[map]
 	template.lazy_load_size()
-	
+
 	var/turf/T = get_turf(usr)
 	if(!T)
 		return

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -10,7 +10,8 @@
 		return
 
 	var/datum/map_template/template = SSmapping.map_templates[map]
-
+	template.lazy_load_size()
+	
 	var/turf/T = get_turf(usr)
 	if(!T)
 		return

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -33,10 +33,12 @@
 	. = ..()
 	if(path)
 		mappath = path
-	if(mappath)
-		preload_size(mappath, cache)
 	if(rename)
 		name = rename
+
+/datum/map_template/proc/lazy_load_size()
+	if(!width || !height)
+		preload_size()
 
 /datum/map_template/proc/preload_size(path)
 	var/list/bounds = list(1.#INF, 1.#INF, 1.#INF, -1.#INF, -1.#INF, -1.#INF)
@@ -52,6 +54,7 @@
 	return bounds
 
 /datum/map_template/proc/load_new_z(var/no_changeturf = TRUE)
+	lazy_load_size()
 	var/x = round((world.maxx - width)/2)
 	var/y = round((world.maxy - height)/2)
 
@@ -173,6 +176,7 @@
 			T.static_lighting_build_overlay()
 
 /datum/map_template/proc/load(turf/T, centered = FALSE)
+	lazy_load_size()
 	if(centered)
 		T = locate(T.x - round(width / 2) , T.y - round(height / 2) , T.z)
 	if(!T)

--- a/code/modules/mapping/ruins.dm
+++ b/code/modules/mapping/ruins.dm
@@ -139,6 +139,8 @@ GLOBAL_LIST_EMPTY(banned_ruin_ids)
 	if(budget && (ruin.spawn_cost > budget))
 		return
 
+	ruin.lazy_load_size()
+
 	var/width = TRANSITIONEDGE + RUIN_MAP_EDGE_PAD + round(ruin.width / 2)
 	var/height = TRANSITIONEDGE + RUIN_MAP_EDGE_PAD + round(ruin.height / 2)
 
@@ -164,6 +166,7 @@ GLOBAL_LIST_EMPTY(banned_ruin_ids)
 /proc/load_ruin(turf/central_turf, datum/map_template/template)
 	if(!template)
 		return FALSE
+	template.lazy_load_size()
 	for(var/i in template.get_affected_turfs(central_turf, 1))
 		var/turf/T = i
 		for(var/mob/living/simple_animal/monster in T)

--- a/html/changelogs/hellfirejag-async-map-init.yml
+++ b/html/changelogs/hellfirejag-async-map-init.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - refactor: "Refactored the Mapping subsystem to initialize EXTREMELY FAST."


### PR DESCRIPTION
Mapping init time on live server:

<img width="409" height="60" alt="image" src="https://github.com/user-attachments/assets/9b6aba6c-7e86-40b9-9c69-f643b22e010f" />

Mapping init time on my home computer (No changes, fastboot disabled):

<img width="364" height="25" alt="image" src="https://github.com/user-attachments/assets/eda373aa-e5a4-4ec5-8863-24a721532f55" />

with Lazyloading:

<img width="363" height="25" alt="image" src="https://github.com/user-attachments/assets/f40d2d43-eb7d-4ff4-b7a7-6ee8e70fe904" />

Lazyloading + Asynchronous map initialization

<img width="341" height="22" alt="image" src="https://github.com/user-attachments/assets/90812697-0a92-4d2b-b2ea-a1541bab0af7" />

I have actually tested this locally.

<img width="1917" height="1024" alt="image" src="https://github.com/user-attachments/assets/bca5d0d6-5e32-4fcb-bad7-42ad534d259a" />

I think the screenshots speak for themselves.

To clarify what's going on, the Asynchronous mapping init isn't actually a real time saving. The mapping subsystem initializes "instantly" purely because it's telling the other subsystems to go ahead before it's done. The time it would have spent pausing all other inits is instead an equal amount of time where the server is "slightly laggier". If the server would have taken 200s to initialize Mapping, the next 200s after the start of Mapinit are instead slightly laggier.

The real time savings (about 40% in testing) come from Lazyloading the maps. Normally the mapping system has to parse every possible map that could spawn during init in order to check how large it is, which requires fetching the map files from storage (SLOW), and then parsing the files for their attributes. By instead moving this operation to the actual loading of the maps themselves, only the maps being spawned during initialization have to be read from disk. 

There is a theoretical tradeoff that this would make is *a little bit slower* to load maps by admin command, but we already don't do that normally by convention, so the time savings during server init (which we must always pay every time the server starts) are far more substantial than the relatively small time losses during live. 