### PR TITLE
Spark Shutters Access Fix

### DIFF
--- a/html/changelogs/SleepyGemmy-spark_access_fix.yml
+++ b/html/changelogs/SleepyGemmy-spark_access_fix.yml
@@ -3,5 +3,5 @@ author: SleepyGemmy
 delete-after: True
 
 changes:
-  - bugfix: "Fixed the shuttles' access shutters not allowing the Quark and Spark accesses."
+  - bugfix: "Fixed the shuttles' access shutters not allowing the Spark and Canary accesses."
   - bugfix: "Fixed the Spark's access shutters not having mining access."

--- a/html/changelogs/SleepyGemmy-spark_access_fix.yml
+++ b/html/changelogs/SleepyGemmy-spark_access_fix.yml
@@ -1,0 +1,7 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed the shuttles' access shutters not allowing the Quark and Spark accesses."
+  - bugfix: "Fixed the Spark access shutters not having mining access."

--- a/html/changelogs/SleepyGemmy-spark_access_fix.yml
+++ b/html/changelogs/SleepyGemmy-spark_access_fix.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
   - bugfix: "Fixed the shuttles' access shutters not allowing the Quark and Spark accesses."
-  - bugfix: "Fixed the Spark access shutters not having mining access."
+  - bugfix: "Fixed the Spark's access shutters not having mining access."


### PR DESCRIPTION
fixes the shuttles' access shutters not allowing Spark and Canary accesses and the Spark's access shutters not having mining access.

fixes #22222.