### PR TITLE
Fixes the citizenship check for factions

### DIFF
--- a/code/game/jobs/faction/faction.dm
+++ b/code/game/jobs/faction/faction.dm
@@ -10,7 +10,9 @@
 
 	var/list/allowed_role_types
 	var/list/allowed_species_types
-	var/list/job_species_blacklist //will override the normal job species list for a member of this faction
+	//will override the normal job species list for a member of this faction
+	var/list/job_species_blacklist
+	/// The nation types not allowed to be a faction. To be set as nation datums.
 	var/list/blacklisted_citizenship_types
 
 	var/is_default = FALSE
@@ -65,6 +67,22 @@
 			. += role
 
 /datum/faction/proc/get_selection_error(datum/preferences/prefs, mob/user)
+	var/result
+
+	result = check_citizenship(prefs, user)
+	if(result)
+		return result
+
+	result = check_species(prefs, user)
+	if(result)
+		return result
+
+	if(!is_visible(user))
+		return "This faction is not available to you"
+
+	return null
+
+/datum/faction/proc/check_species(datum/preferences/prefs, mob/user)
 	if(length(allowed_species_types))
 		var/datum/species/S = prefs.get_species_datum()
 
@@ -74,6 +92,9 @@
 		if(!is_type_in_typecache(S, allowed_species_types))
 			return "Invalid species"
 
+	return null
+
+/datum/faction/proc/check_citizenship(datum/preferences/prefs, mob/user)
 	if(length(blacklisted_citizenship_types))
 		var/datum/citizenship/C = SSrecords.citizenships[prefs.citizenship]
 
@@ -82,9 +103,6 @@
 
 		if(is_type_in_typecache(C, blacklisted_citizenship_types))
 			return "Invalid nation"
-
-	if(!is_visible(user))
-		return "This faction is not available to you"
 
 	return null
 

--- a/code/modules/tgui/modules/faction_select.dm
+++ b/code/modules/tgui/modules/faction_select.dm
@@ -29,6 +29,8 @@
 	// Set `viewed_faction` to the `get_faction()` result from it, since that double checks that it's actually valid.
 	data["viewed_faction"] = faction_datum.name
 	data["viewed_selection_error"] = faction_datum.get_selection_error(occupation.pref, user)
+	data["citizenship_allowed"] = faction_datum.check_citizenship(occupation.pref, user)
+	data["culture_allowed"] = faction_datum.check_species(occupation.pref, user)
 
 	return data
 

--- a/html/changelogs/FactionSelectFix.yml
+++ b/html/changelogs/FactionSelectFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed some things regarding the nation blacklist check for factions."

--- a/tgui/packages/tgui/interfaces/FactionSelect.tsx
+++ b/tgui/packages/tgui/interfaces/FactionSelect.tsx
@@ -18,6 +18,8 @@ export type FactionSelectData = {
   chosen_faction: string;
   viewed_faction: string;
   viewed_selection_error: string;
+  citizenship_allowed: boolean;
+  culture_allowed: boolean;
   factions: Faction[];
   wiki_url: string;
 };
@@ -230,11 +232,10 @@ const FactionPanel = (props: { currentFaction: Faction }, context) => {
           <Stack.Item fontFamily="Tahoma" fontSize={1.05}>
             <LabeledList>
               <LabeledList.Item label="Citizenship Check">
-                {Checkmark(true)}
-                {/* NYI (/datum/faction/var/blacklisted_citizenship_types) */}
+                {Checkmark(!data.citizenship_allowed)}
               </LabeledList.Item>
               <LabeledList.Item label="Cultural Check">
-                {Checkmark(!data.viewed_selection_error)}
+                {Checkmark(!data.culture_allowed)}
               </LabeledList.Item>
             </LabeledList>
           </Stack.Item>


### PR DESCRIPTION
Now the new faction window will properly display if a nation can't be selected due to the citizenship of a char.