### PR TITLE
Nerfs projectile piercing and makes it's chance based more on armour piercing than damage.

### DIFF
--- a/code/modules/overmap/ship_weaponry/_ship_ammunition.dm
+++ b/code/modules/overmap/ship_weaponry/_ship_ammunition.dm
@@ -225,6 +225,7 @@
 	impact_sounds = list(BULLET_IMPACT_MEAT = SOUNDS_BULLET_MEAT, BULLET_IMPACT_METAL = SOUNDS_BULLET_METAL)
 	accuracy = 100
 	projectile_piercing = PASSMOB|PASSDOORS|PASSGLASS|PASSCLOSEDTURF|PASSWINDOW|PASSMACHINE|PASSBLOB|PASSFLAPS|PASSVEHICLE //It's a ship weapon let it try to penetrate everything.
+	pierce_decay_damage = 0.95  //Ship weapon projectiles don't lose much damage on pierce by default, but this can be set per projectile.
 	var/obj/item/ship_ammunition/ammo
 	var/primed = FALSE
 	var/hit_target = FALSE //First target we hit. Used to report if a hit was successful.

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -656,7 +656,7 @@
 	if(projectile_piercing & A.pass_flags_self)
 		if (penetrating > pierces)
 			if(prob(min(100, (pierce_chance + (damage/4) + armor_penetration) * anti_materiel_potential))) //Base pierce_chance is 0. This gives the STS a 30% chance to pierce once.
-				damage *= piercing_decay_damage
+				damage *= pierce_decay_damage
 				penetrating--
 				last_hit_pierced = TRUE
 				return PROJECTILE_PIERCE_HIT

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -76,6 +76,8 @@
 	var/pierces = 0
 	///The base chance that a projectile capable of piercing will actually pierce.
 	var/pierce_chance = 0
+	/// 0-1 multiplier, the projectile's damage is modified by multiplying this after each pierce.
+	var/pierce_decay_damage = 0.7
 	///Used to determine whether or not to apply embed chances on hit.
 	var/last_hit_pierced = FALSE
 	/// If objects are below this layer, we pass through them.
@@ -654,6 +656,7 @@
 	if(projectile_piercing & A.pass_flags_self)
 		if (penetrating > pierces)
 			if(prob(min(100, (pierce_chance + (damage/4) + armor_penetration) * anti_materiel_potential))) //Base pierce_chance is 0. This gives the STS a 30% chance to pierce once.
+				damage *= piercing_decay_damage
 				penetrating--
 				last_hit_pierced = TRUE
 				return PROJECTILE_PIERCE_HIT

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -653,7 +653,7 @@
 		return PROJECTILE_PIERCE_PHASE
 	if(projectile_piercing & A.pass_flags_self)
 		if (penetrating > pierces)
-			if(damage > 20 && prob(pierce_chance + damage))
+			if(prob(min(100, (pierce_chance + (damage/4) + armor_penetration) * anti_materiel_potential))) //Base pierce_chance is 0. This gives the STS a 30% chance to pierce once.
 				penetrating--
 				last_hit_pierced = TRUE
 				return PROJECTILE_PIERCE_HIT

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -313,6 +313,7 @@
 	hitscan = 1 //so the PTR isn't useless as a sniper weapon
 	maim_rate = 3
 	anti_materiel_potential = 2
+	pierce_decay_damage = 0.9
 
 /obj/projectile/bullet/rifle/kumar_super
 	damage = 40

--- a/html/changelogs/FenodyreePiercingBalance.yml
+++ b/html/changelogs/FenodyreePiercingBalance.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Fenodyree
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Adjusts piercing chance to be based more on armour piercing than damage. This nerfs the STS from 55% pierce chance to 30%"
+  - balance: "Multiplies piercing chance by anti-material potential. This gives the PEAC 100% pierce chance."
+  - balance: "Projectile damage is now reduced by default 30% on every pierce. This can be set per projectile. Ship weapons only lose 5% damage."


### PR DESCRIPTION
- Projectiles now lose 30% of their damage for every pierce they go through by default.

- Ship weapons only lose 5% damage on pierce. 
  
- The default chance was changed from (Pierce Chance (20%) + Damage, to Pierce Chance (0%) + Damage / 4 + Armour Piercing.
This means the merc's STS, went from 55% chance to pierce, down to 30%, with reduced damage when it does.

- Specialist anti-tank weapons, such as the PEAC, now have their pierce chance multiplied by their anti-material potential.
This gives the PEAC 100% piercing chance.


<img width="327" height="261" alt="image" src="https://github.com/user-attachments/assets/661904ec-3957-4116-a10b-e8a8fc14cd2d" />
