### PR TITLE
Fixes one handed firing dispersion penalties

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -648,6 +648,12 @@ ABSTRACT_TYPE(/obj/item/gun)
 		F = firemodes[sel_mode]
 	if(one_hand_fa_penalty > 2 && !wielded && F?.name == "full auto") // todo: make firemode names defines
 		P.accuracy -= one_hand_fa_penalty * 0.5
+		P.spread -= one_hand_fa_penalty * 0.5 //Adds 6 degrees of spread on all rifles. Not very significant.
+	if(one_hand_fa_penalty > 2 && !wielded && F?.name == "short burst")
+		P.accuracy -= one_hand_fa_penalty * 0.5
+		P.spread -= one_hand_fa_penalty * 0.5
+	if(one_hand_fa_penalty > 2 && !wielded && F?.name == "3 round burst")
+		P.accuracy -= one_hand_fa_penalty * 0.5
 		P.spread -= one_hand_fa_penalty * 0.5
 
 //does the actual launching of the projectile

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -23,7 +23,7 @@
 		list(mode_name="semiauto",       can_autofire=0, burst=1, fire_delay=ROF_SMG),
 		list(mode_name="3-round bursts", can_autofire=0, burst=3, burst_accuracy=list(1,0,0), dispersion=list(0, 10, 15)),
 		list(mode_name="short bursts",   can_autofire=0, burst=5, burst_accuracy=list(1,0,,-1,-1), dispersion=list(5, 10, 15, 20)),
-		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=5, fire_delay_wielded=2, one_hand_fa_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(5, 10, 15, 20, 25))
+		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=5, fire_delay_wielded=2, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(5, 10, 15, 20, 25)) //Guns that can't be wielded shouldn't get a one handed penalty.
 		)
 
 //Submachine guns and personal defence weapons, go.
@@ -180,7 +180,7 @@
 	firemodes = list(
 		list(mode_name="semiauto",       burst=1, fire_delay=ROF_RIFLE),
 		list(mode_name="short bursts",   burst=5, burst_accuracy=list(1,0,0,-1,-1), dispersion=list(5, 5, 15)),
-		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=5, fire_delay_wielded=2, one_hand_fa_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(5, 10, 15, 20, 25)),
+		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=5, fire_delay_wielded=2, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(5, 10, 15, 20, 25)),
 		)
 
 /obj/item/gun/projectile/automatic/konyang_pirate/update_icon()
@@ -212,8 +212,8 @@ ABSTRACT_TYPE(/obj/item/gun/projectile/automatic/rifle)
 
 	firemodes = list(
 		list(mode_name="semiauto",       burst=1, fire_delay=ROF_RIFLE),
-		list(mode_name="3-round bursts", burst=3, burst_accuracy=list(1,0,0),       dispersion=list(0, 5, 10)),
-		list(mode_name="short bursts",   burst=5, burst_accuracy=list(1,0,0,-1,-1), dispersion=list(5, 5, 15)),
+		list(mode_name="3-round bursts", burst=3, burst_accuracy=list(1,0,0), one_hand_fa_penalty=12, dispersion=list(0, 5, 10)),
+		list(mode_name="short bursts",   burst=5, burst_accuracy=list(1,0,0,-1,-1), one_hand_fa_penalty=12, dispersion=list(5, 5, 15)),
 		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=5, fire_delay_wielded=2, one_hand_fa_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(5, 10, 15, 20, 25)),
 		)
 

--- a/html/changelogs/Fenodyree-OneHandedPenaltyFix.yml
+++ b/html/changelogs/Fenodyree-OneHandedPenaltyFix.yml
@@ -1,0 +1,8 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes one handed only guns having a one handed firing penalty."
+  - bugfix: "Fixes the one handed firing penalty not applying to short and 3 round bursts."
+


### PR DESCRIPTION
Fixes One Handed Dispersion & Accuracy penalties only applying to full auto.
Removes one handed penalty from guns that can only be fired one handed.

<img width="903" height="201" alt="image" src="https://github.com/user-attachments/assets/5306410b-6ecf-43fe-bf5c-f7a2d407ca27" />
<img width="904" height="201" alt="image" src="https://github.com/user-attachments/assets/9e9d243c-5daa-410e-89f7-aad23b1256bc" />

The STS dispersion penalty (the worst, except for the light machine gun) is 5, 5, 15.
So short bursts from the STS one handed have: 
79%, 79%, 41%, 41%, 41% chance to hit at 7 tiles.
Down from:
100%, 100%, 58%, 58%, 58% chance to hit at 7 tiles.

As the first 2 shots of your burst are still 100% accurate, this gives a very tiny reason to actually wield your STS, if you're shooting bursts at max range.