### PR TITLE
Telepad's Set GPS Memory actually functions now

### DIFF
--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -520,7 +520,7 @@
 	if(href_list["setMemory"])
 		if(last_target && inserted_gps)
 			inserted_gps.locked_location = last_target
-			temp_msg = "Location saved.<BR>([inserted_gps.locked_location.x], [inserted_gps.locked_location.y])"
+			temp_msg = "Location saved.<BR>Target Location: ([inserted_gps.locked_location.x], [inserted_gps.locked_location.y])"
 		else
 			temp_msg = "ERROR!<BR>No data was stored."
 

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -520,7 +520,7 @@
 	if(href_list["setMemory"])
 		if(last_target && inserted_gps)
 			inserted_gps.locked_location = last_target
-			temp_msg = "Location saved."
+			temp_msg = "Location saved.<BR>([inserted_gps.locked_location.x], [inserted_gps.locked_location.y])"
 		else
 			temp_msg = "ERROR!<BR>No data was stored."
 

--- a/html/changelogs/diggiez - displayGPSMemory.yml
+++ b/html/changelogs/diggiez - displayGPSMemory.yml
@@ -1,0 +1,11 @@
+author: diggiez
+
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Set GPS Memory in the Telepad Control Console finally, actually functions and displays the last target coordinates."


### PR DESCRIPTION
This has been a clickable button on the telepad control console for literally over a decade with its own variable within GPSes, and I think the original coder just forgot to have it display. It's going down as a bugfix because of this, var/locked_location is literally never used otherwise.

Telescience was reworked to use portals years ago specifically so using GPSes isn't risk-free, but portals make having a valid destination _mandatory_, so this won't really remove risk as it just removes tedium. For the other 4 telescientists, rejoice.
<img width="583" height="490" alt="image" src="https://github.com/user-attachments/assets/db7e2be4-9b08-419a-b50c-7cef1922ff8c" />
