### PR TITLE
Status Displays show ship time by default at round start

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -24,8 +24,8 @@
 	idle_power_usage = 10
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 	var/hears_arrivals = FALSE
-	var/mode = STATUS_DISPLAY_TRANSFER_SHUTTLE_TIME
-	var/last_mode = STATUS_DISPLAY_TRANSFER_SHUTTLE_TIME
+	var/mode = STATUS_DISPLAY_TIME
+	var/last_mode = STATUS_DISPLAY_TIME
 
 	var/picture_state	// icon_state of alert picture
 

--- a/html/changelogs/Bat-StatusDisplay.yml
+++ b/html/changelogs/Bat-StatusDisplay.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - bugfix: "Status Displays correctly display time on round start rather than attempting to display arrivals shuttle (and remaining blank until changed)."


### PR DESCRIPTION
See title. Status displays still attempt to provide arrivals shuttle timer on init, resulting in blank screens; this PR fixes that.