### PR TITLE
Random Produce Fix

### DIFF
--- a/code/game/objects/random/produce.dm
+++ b/code/game/objects/random/produce.dm
@@ -64,7 +64,7 @@
 		"cucumber" = 0.25,
 		"lime" = 0.25,
 		"lemon" = 0.5,
-		"chickpeas" = 0.1,
+		"chickpea" = 0.1,
 		"banana" = 0.1,
 		"plumphelmet" = 0.1,
 		"orange" = 0.1,

--- a/html/changelogs/SleepyGemmy-random_produce_fix.yml
+++ b/html/changelogs/SleepyGemmy-random_produce_fix.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed chickpeas being unable to spawn in the random produce boxes due to a typo."


### PR DESCRIPTION
fixes chickpeas being unable to spawn in random produce boxes.