### PR TITLE
Exploding Mob Hard Del

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot.dm
@@ -108,7 +108,7 @@
 
 	var/turf/current_turf = get_turf(src)
 	if(!current_turf)
-		qdel(src)
+		QDEL_IN(src, 0)
 		return
 
 	var/robot_gib_type = /obj/effect/decal/cleanable/blood/gibs/robot
@@ -120,7 +120,7 @@
 
 	spark(current_turf, 1, GLOB.alldirs)
 
-	qdel(src)
+	QDEL_IN(src, 0)
 
 /mob/living/simple_animal/hostile/hivebot/think()
 	. =..()

--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_beacon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_beacon.dm
@@ -214,7 +214,7 @@
 	var/T = get_turf(src)
 	new /obj/effect/gibspawner/robot(T)
 	spark(T, 3, GLOB.alldirs)
-	qdel(src)
+	QDEL_IN(src, 0)
 	return
 
 /mob/living/simple_animal/hostile/hivebotbeacon/think()
@@ -280,6 +280,9 @@
 		do_teleport(src, random_turf)
 
 /mob/living/simple_animal/hostile/hivebotbeacon/proc/wakeup()
+	if(QDELETED(src))
+		return
+
 	change_stance(HOSTILE_STANCE_IDLE)
 	activated = 0
 	activate_beacon()
@@ -289,7 +292,7 @@
 		visible_message(SPAN_DANGER("[src] disappears in a cloud of smoke!"))
 		playsound(src.loc, 'sound/effects/teleport.ogg', 25, 1)
 		new /obj/effect/decal/cleanable/greenglow(src.loc)
-		qdel(src)
+		QDEL_IN(src, 0)
 		return
 
 	if(activated == -1)

--- a/code/modules/mob/living/simple_animal/hostile/icarus_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/icarus_drone.dm
@@ -238,10 +238,11 @@
 
 /mob/living/simple_animal/hostile/icarus_drone/death()
 	..(null, "suddenly breaks apart.")
-	qdel(src)
+	QDEL_IN(src, 0)
 
 /mob/living/simple_animal/hostile/icarus_drone/Destroy()
 	QDEL_NULL(ion_trail)
+	patrol_target = null
 	//some random debris left behind
 	if(has_loot)
 		spark(src, 3, GLOB.alldirs)

--- a/code/modules/mob/living/simple_animal/hostile/rogue_maint_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/rogue_maint_drone.dm
@@ -48,7 +48,7 @@
 	var/T = get_turf(src)
 	new /obj/effect/gibspawner/robot(T)
 	spark(T, 1, GLOB.alldirs)
-	qdel(src)
+	QDEL_IN(src, 0)
 
 /mob/living/simple_animal/hostile/rogue_drone/validator_living(var/mob/living/L, var/atom/current)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/viscerator.dm
+++ b/code/modules/mob/living/simple_animal/hostile/viscerator.dm
@@ -39,7 +39,7 @@
 	var/T = get_turf(src)
 	new /obj/effect/gibspawner/robot(T)
 	spark(T, 3, GLOB.alldirs)
-	qdel(src)
+	QDEL_IN(src, 0)
 
 /mob/living/simple_animal/hostile/viscerator/CanPass(atom/movable/mover, turf/target, height, air_group)
 	. = ..()
@@ -48,6 +48,9 @@
 			return FALSE
 
 /mob/living/simple_animal/hostile/viscerator/proc/wakeup()
+	if(QDELETED(src))
+		return
+
 	change_stance(HOSTILE_STANCE_IDLE)
 
 /mob/living/simple_animal/hostile/viscerator/emp_act(severity)
@@ -65,3 +68,4 @@
 /mob/living/simple_animal/hostile/viscerator/lube/death()
 	reagents.splash(get_turf(src), 30)
 	..()
+

--- a/html/changelogs/hellfirejag-drone-harddels.yml
+++ b/html/changelogs/hellfirejag-drone-harddels.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed a hard del related to mechanical mobs that explode on death such as maintenance drones."


### PR DESCRIPTION
This PR fixes a hard del related to mobs that explode into scrap on death, such as maintenance drones, icarus drones, and hivebots. I have actually tested this.

<img width="1409" height="693" alt="image" src="https://github.com/user-attachments/assets/9daf9bff-45f3-44ef-8940-08d3bee13726" />

And all this work, but I'm now scraping the barrel of hard deletes, and this would have only saved 5 seconds of lag during the most recent odyssey round.

<img width="479" height="905" alt="image" src="https://github.com/user-attachments/assets/e819e520-1f51-4c0e-9d99-0de6773b265c" />
