### PR TITLE
Mob Human Timers Cleanup

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -219,7 +219,7 @@
 	seizure()
 	custom_pain(SPAN_DANGER(FONT_LARGE("[pick(psi_operancy_messages)]")), 25)
 	sleep(30)
-	addtimer(CALLBACK(psi, TYPE_PROC_REF(/datum/psi_complexus, check_psionic_trigger), 100, source, TRUE), 4.5 SECONDS)
+	addtimer(CALLBACK(psi, TYPE_PROC_REF(/datum/psi_complexus, check_psionic_trigger), 100, source, TRUE), 4.5 SECONDS, TIMER_STOPPABLE|TIMER_DELETE_ME)
 
 /mob/living/carbon/human/get_resist_power()
 	return species.resist_mod

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -663,7 +663,7 @@
 
 	src.set_light(4,-20)
 
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, set_light), 0), 30 SECONDS)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, set_light), 0), 30 SECONDS, TIMER_STOPPABLE|TIMER_DELETE_ME)
 
 /mob/living/carbon/human/proc/darkness_eyes()
 	set category = "Abilities"
@@ -784,7 +784,7 @@
 		playsound(src,'sound/mecha/mechstep.ogg',25,1)
 		if (brokesomething)
 			src.visible_message(SPAN_DANGER("[src.name] breaks through!"))
-		addtimer(CALLBACK(src, PROC_REF(trampling)), 1)
+		addtimer(CALLBACK(src, PROC_REF(trampling)), 1, TIMER_STOPPABLE|TIMER_DELETE_ME)
 
 	else
 		target = get_step(src, dir)

--- a/code/modules/mob/living/carbon/human/species/station/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/station/golem.dm
@@ -825,7 +825,7 @@ GLOBAL_LIST_INIT(golem_types, list(
 	if(turn_into_materials)
 		//This is because otherwise the removal of vital organs in the gibbing will call death again, which calls this again, creating a neverending
 		//server death loop
-		addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living/carbon/human, gib)), 1 SECONDS)
+		addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living/carbon/human, gib)), 1 SECONDS, TIMER_STOPPABLE|TIMER_DELETE_ME)
 
 /datum/species/golem/homunculus/handle_environment_special(var/mob/living/carbon/human/H)
 	if(prob(25))

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
@@ -268,7 +268,7 @@
 /datum/species/machine/handle_death(var/mob/living/carbon/human/H)
 	..()
 	H.f_style = ""
-	addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living/carbon/human, update_hair)), 100)
+	addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living/carbon/human, update_hair)), 100, TIMER_STOPPABLE|TIMER_DELETE_ME)
 
 /datum/species/machine/sanitize_name(var/new_name)
 	return sanitizeName(new_name, allow_numbers = 1)

--- a/code/modules/mob/living/carbon/human/species/station/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/station/slime.dm
@@ -53,4 +53,4 @@
 
 /datum/species/slime/handle_death(var/mob/living/carbon/human/H)
 	if(H)
-		addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living/carbon/human, gib)),  1)
+		addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living/carbon/human, gib)),  1, TIMER_STOPPABLE|TIMER_DELETE_ME)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1409,7 +1409,7 @@ There are several things that need to be remembered:
 
 	tail_overlay = set_tail_state(mob_state)
 	if(tail_overlay)
-		addtimer(CALLBACK(src, PROC_REF(end_animate_tail_once), tail_overlay), 20, TIMER_CLIENT_TIME)
+		addtimer(CALLBACK(src, PROC_REF(end_animate_tail_once), tail_overlay), 20, TIMER_CLIENT_TIME|TIMER_STOPPABLE|TIMER_DELETE_ME)
 
 /mob/living/carbon/human/proc/end_animate_tail_once(image/tail_overlay)
 	//check that the animation hasn't changed in the meantime

--- a/html/changelogs/hellfirejag-cleanup-some-human-timers.yml
+++ b/html/changelogs/hellfirejag-cleanup-some-human-timers.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Cleaned up some mob human timers that might sometimes hard del."


### PR DESCRIPTION
Just cleaning up some Mob Human related timers that occasionally hard del(). Fixing the /mob/living/carbon/human hard del completely is proving to be a challenge because there's just so many damn things that could possibly cause it that there's really no definitive source for it without having the reference logging enabled.