### PR TITLE
Bioaug Hard Del Fix

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -595,6 +595,12 @@ GLOBAL_LIST_INIT(gear_datums, list())
 			qdel(replaced_organ)
 
 	var/item = new spawn_path(spawn_location)
+	if(istype(item, /obj/item/organ/internal) && ishuman(H))
+		var/obj/item/organ/internal/I = item
+		var/obj/item/organ/external/E = H.get_organ(I.parent_organ)
+		if(E)
+			I.replaced(H, E)
+
 	for(var/datum/gear_tweak/gt in gear_tweaks)
 		if(metadata["[gt]"])
 			gt.tweak_item(item, metadata["[gt]"], H)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -82,6 +82,8 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 
 /obj/item/organ/Destroy()
 	STOP_PROCESSING(SSprocessing, src)
+	QDEL_NULL(dna)
+
 	if(!owner)
 		return ..()
 
@@ -90,14 +92,15 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 			owner.internal_organs -= src
 		if(istype(owner, /mob/living/carbon/human))
 			if(owner.internal_organs_by_name)
-				owner.internal_organs_by_name -= src
+				owner.internal_organs_by_name[organ_tag] = null
+				owner.internal_organs_by_name -= organ_tag
 			if(owner.organs)
 				owner.organs -= src
 			if(owner.organs_by_name)
-				owner.organs_by_name -= src
+				owner.organs_by_name[organ_tag] = null
+				owner.organs_by_name -= organ_tag
 
 	owner = null
-	QDEL_NULL(dna)
 
 	return ..()
 

--- a/html/changelogs/hellfirejag-bioaugs-hard-del-fix.yml
+++ b/html/changelogs/hellfirejag-bioaugs-hard-del-fix.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed a hard del related to any form of direct organ replacement via loadouts (such as bioaugs)."


### PR DESCRIPTION
This PR fixes a hard del related to any kind of direct organ replacement via loadouts, which it turns out all of them were doing. But it was most commonly showing up with bioaugs because the boosted heart and boosted liver are the only organs besides custom items that replace an internal organ during loadouts spawning.