### PR TITLE
Stops job uniforms and suits from being put in players

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -311,7 +311,6 @@ SUBSYSTEM_DEF(jobs)
 		EquipCustom(H, job, H.client.prefs, custom_equip_leftovers, spawn_in_storage, custom_equip_slots)
 
 		job.equip(H)
-		UniformReturn(H, H.client.prefs, job)
 
 		spawn_in_storage += EquipCustomDeferred(H, H.client.prefs, custom_equip_leftovers, custom_equip_slots)
 	else
@@ -888,21 +887,4 @@ SUBSYSTEM_DEF(jobs)
 		C.screen -= T
 	qdel(T)
 
-/datum/controller/subsystem/jobs/proc/UniformReturn(mob/living/carbon/human/H, datum/preferences/prefs, datum/job/job)
-	var/uniform = job.get_outfit(H)
-	if(!uniform) // silicons don't have uniforms or gear
-		return
-	var/obj/outfit/U = new uniform
-	var/spawned_uniform = FALSE
-	var/spawned_suit = FALSE
-	for(var/item in prefs.gear)
-		var/datum/gear/L = GLOB.gear_datums[item]
-		if(L.slot == slot_w_uniform)
-			if(U.uniform && !spawned_uniform && !istype(H.w_uniform, U.uniform))
-				H.equip_or_collect(new U.uniform(H), H.back)
-				spawned_uniform = TRUE
-		if(L.slot == slot_wear_suit)
-			if(U.suit && !spawned_suit && !istype(H.wear_suit, U.suit))
-				H.equip_or_collect(new U.suit(H), H.back)
-				spawned_suit = TRUE
 #undef Debug

--- a/html/changelogs/UniformRemoval.yml
+++ b/html/changelogs/UniformRemoval.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscdel: "Job uniforms and suits replaced by loadout items, no longer spawn in bags."


### PR DESCRIPTION
Before, job uniforms and suits would be placed in a player's bag if they had loadout items that replaced them. This prevent that. If players want the job uniform despite using loadout equipment, there are lockers and drobes for almost all jobs.