### PR TITLE
A bunch of ops mapping changes

### DIFF
--- a/code/game/objects/random/weapon.dm
+++ b/code/game/objects/random/weapon.dm
@@ -30,7 +30,7 @@
 /obj/random/ammo
 	name = "random ammunition"
 	desc = "This is some random ammunition."
-	icon_state = "needsprite"
+	icon_state = "need-sprite"
 	problist = list(
 		/obj/item/storage/box/shells/beanbags = 6,
 		/obj/item/storage/box/shells/slugs = 2,
@@ -206,7 +206,7 @@
 /obj/random/vault_weapon
 	name = "random vault weapon"
 	desc = "This is a random vault weapon."
-	icon_state = "needsprite"
+	icon_state = "kinetic"
 	spawnlist = list(
 		/obj/item/gun/custom_ka/frameA/prebuilt = 1,
 		/obj/item/gun/custom_ka/frameB/prebuilt = 0.5,

--- a/code/game/objects/structures/crates_lockers/closets/secure/operations.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/operations.dm
@@ -54,6 +54,7 @@
 	new /obj/item/flashlight/marshallingwand(src)
 	new /obj/item/flashlight/marshallingwand(src)
 	new /obj/item/paint_sprayer(src)
+	new /obj/item/storage/toolbox/mechanical(src)
 
 // Machinist
 /obj/structure/closet/secure_closet/machinist

--- a/html/changelogs/CargoMapping.yml
+++ b/html/changelogs/CargoMapping.yml
@@ -1,0 +1,12 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed a large number of overlapping wall objects in operations."
+  - bugfix: "Tool storage is now on the same grid as the hallway, rather than on the ops grid."
+  - rscadd: "Gave hangar techs a blue toolbox in their lockers to do their job with."
+  - rscadd: "Added a sheet snatcher to ops."
+  - rscadd: "Moved miner and OM spawn to the ops break room."
+  - rscadd: "Made the conveyor on the cargo elevator one shorter, to avoid loose items being shuffled off the elevator."
+  - bugfix: "Fixed two sprites mainly seen when mapping random object spawns."


### PR DESCRIPTION
A bunch of overlapping wall objects, primarily cameras and lights, were moved to avoid overlap within operations.
Tool storage was put on the civilian grid instead of the operations grid.
Hangar techs have been given a blue toolbox in their locker. This is because they need tools for taking care of the shuttles, such as for refueling.
A sheet snatcher was added to ops near the mining output.
Miners and OM now spawn in the ops break room, so there is a bit more team to the starting instead of them being separate, and to match some of the other department starts. Machinists were not moved due to the distance to their workshop.
The conveyor on the cargo elevator was made one shorter so it stops overspilling loose items behind the elevator.
Mapping sprites for two random spawn objects were fixed, alongside the sprite for the doors to the ship ammunition storage. This only affects mapping and was not visible ingame.