### PR TITLE
Fixes human shields

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -413,6 +413,8 @@
  * Also, we select_target to find what to process_hit first.
  */
 /obj/projectile/proc/Impact(atom/A)
+	if(QDELETED(src))
+		return TRUE
 	if(!trajectory)
 		qdel(src)
 		return FALSE
@@ -424,8 +426,6 @@
 		var/datum/weakref/original_ref = A.weak_reference
 		impacted[original_ref] = TRUE
 		process_hit(T, shield_target, A)
-		if(QDELETED(src))
-			return TRUE
 		impacted -= original_ref
 	var/datum/point/point_cache = trajectory.copy_to()
 	if(ricochets < ricochets_max && check_ricochet_flag(A) && check_ricochet(A))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -376,6 +376,25 @@
 	beam_index = point_cache
 	beam_segments[beam_index] = null
 
+/obj/projectile/proc/check_human_shield(atom/A)
+	if(!isliving(A) || !starting)
+		return FALSE
+
+	var/mob/living/M = A
+	if(!(M.dir & get_dir(M, starting)))
+		return FALSE
+
+	if(point_blank)
+		return FALSE
+
+	for(var/obj/item/grab/G in list(M.l_hand, M.r_hand))
+		if(!G?.affecting || G.state < GRAB_NECK || G.affecting.lying)
+			continue
+		M.visible_message(SPAN_DANGER("\The [M] uses [G.affecting] as a shield!"))
+		return G.affecting
+
+	return FALSE
+
 /obj/projectile/Collide(atom/A)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_BUMP, A)
 	if(!can_hit_target(A, A == original, TRUE, TRUE))
@@ -399,8 +418,16 @@
 		return FALSE
 	if(impacted[A.weak_reference]) // NEVER doublehit
 		return FALSE
-	var/datum/point/point_cache = trajectory.copy_to()
 	var/turf/T = get_turf(A)
+	var/atom/shield_target = check_human_shield(A)
+	if(shield_target)
+		var/datum/weakref/original_ref = A.weak_reference
+		impacted[original_ref] = TRUE
+		process_hit(T, shield_target, A)
+		if(QDELETED(src))
+			return TRUE
+		impacted -= original_ref
+	var/datum/point/point_cache = trajectory.copy_to()
 	if(ricochets < ricochets_max && check_ricochet_flag(A) && check_ricochet(A))
 		ricochets++
 		if(A.handle_ricochet(src))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -381,10 +381,7 @@
 		return FALSE
 
 	var/mob/living/M = A
-	if(!(M.dir & get_dir(M, starting)))
-		return FALSE
-
-	if(point_blank)
+	if(point_blank || !(M.dir & get_dir(M, starting)))
 		return FALSE
 
 	for(var/obj/item/grab/G in list(M.l_hand, M.r_hand))

--- a/html/changelogs/HumanShieldFix-Fenodyree.yml
+++ b/html/changelogs/HumanShieldFix-Fenodyree.yml
@@ -1,0 +1,6 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes human shields not working. If you are redgrabbing someone and facing the direction the shot comes from, the shot will hit your hostage instead of you. Point-blank shots ignore this. Piercing shots can hit both."


### PR DESCRIPTION
Fixes #22107, human shields not working.
The code that handled humans shields got removed in the projectile refactor, this restores it exactly as it was.

- If you are facing the shooter, with someone in a neck grab, the shots will hit your hostage.
- Point blank shots will ignore the hostage.
- Piercing shots can go through the hostage and hit you.

I think here or Collide is the best place for this check to happen. I tried placing it further down the chain, but couldn't get it working without much bigger changes.


https://github.com/user-attachments/assets/f79a62d4-f7f3-450f-8a83-51e7133c063b

