### PR TITLE
Fixes some missing objects on the SFA patrol ship

### DIFF
--- a/html/changelogs/SFAFix.yml
+++ b/html/changelogs/SFAFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed some mapped objects that no longer existed being mapped on the SFA patrol ship."

--- a/maps/away/ships/sol/sol_pirate/sfa_patrol_ship.dmm
+++ b/maps/away/ships/sol/sol_pirate/sfa_patrol_ship.dmm
@@ -4409,7 +4409,7 @@
 /obj/item/clothing/suit/storage/toggle/leather_jacket/military/old,
 /obj/item/clothing/suit/storage/toggle/leather_jacket/flight,
 /obj/item/clothing/head/beanie/random,
-/obj/item/clothing/head/bucket/boonie/blue,
+/obj/item/clothing/head/bucket/boonie,
 /obj/item/clothing/under/dressshirt/silversun/random,
 /obj/item/clothing/under/dressshirt/silversun/random,
 /turf/simulated/floor/wood,
@@ -7149,7 +7149,7 @@
 	desc = "A rectangular steel footlocker.";
 	name = "footlocker"
 	},
-/obj/item/clothing/accessory/badge/passcard/sol/cytherean,
+/obj/item/clothing/accessory/badge/passcard/sol,
 /obj/item/reagent_containers/syringe{
 	desc = "A syringe of nightlife. Unfortunately this one is empty."
 	},


### PR DESCRIPTION
The objects in question had been removed, so I changed them to their closest parent type for now.