### PR TITLE
Another Observer Hard Del Fix

### DIFF
--- a/code/modules/mob/abstract/ghost/observer/observer.dm
+++ b/code/modules/mob/abstract/ghost/observer/observer.dm
@@ -85,7 +85,12 @@
 	real_name = name
 
 /mob/abstract/ghost/observer/Destroy()
+	if(client)
+		for(var/image/I in client.images)
+			if(I.loc == src)
+				qdel(I)
 	QDEL_NULL(hud)
+	mind = null
 	return ..()
 
 /mob/abstract/ghost/observer/proc/initialise_postkey(set_timers = TRUE)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -7,6 +7,7 @@
 	GLOB.mob_list -= src
 	GLOB.dead_mob_list -= src
 	GLOB.living_mob_list -= src
+	GLOB.player_list -= src
 	unset_machine()
 	QDEL_NULL(hud_used)
 

--- a/html/changelogs/hellfirejag-another-observer-harddel.yml
+++ b/html/changelogs/hellfirejag-another-observer-harddel.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed another harddel related to observers."


### PR DESCRIPTION
Another and hopefully my last fix for the Observer hard dels. This probably but might not also clear the Storyteller harddel since they're an observer child. But I dunno. I have actually tested this.

<img width="670" height="435" alt="image" src="https://github.com/user-attachments/assets/41e75448-211d-429b-b694-43b9d025e996" />
