### PR TITLE
Fixes projectile accuracy checks

### DIFF
--- a/code/datums/components/skills/combat/firearms_skill_component.dm
+++ b/code/datums/components/skills/combat/firearms_skill_component.dm
@@ -7,7 +7,7 @@
 	 * Accuracy modifier to fired guns per point of "Skill Diff".
 	 * As an "Effective increase" in tiles to the target being shot.
 	 */
-	var/accuracy_per_skill_diff = 2
+	var/accuracy_per_skill_diff = 0.5
 
 	/**
 	 * Dispersion modifier to fired guns per point of "Skill Diff".

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -422,6 +422,9 @@
 	if(ismob(A))
 		var/miss_modifier = max(15*(distance-1) - round(25*accuracy), 0)
 		def_zone = get_zone_with_miss_chance(def_zone, A, miss_modifier, (distance > 1 || original != A), point_blank)
+		if (!def_zone)
+			A.visible_message(SPAN_NOTICE("\The [src] misses [A] narrowly!"))
+			return FALSE
 	else
 		def_zone = ran_zone(def_zone, clamp(accurate_range - (accuracy_falloff * distance), 5, 100)) //Lower accurancy/longer range tradeoff. 7 is a balanced number to use.
 

--- a/html/changelogs/ProjectileAccuracyFix-Fenodyree.yml
+++ b/html/changelogs/ProjectileAccuracyFix-Fenodyree.yml
@@ -1,0 +1,6 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes projectile accuracy checks not working. Shots can now miss again."


### PR DESCRIPTION
Fixes projectiles always hitting.

When a projectile rolled a 'miss', and returned Null as it's bodypart to hit, it was being defaulted to hit the torso.

This meant that a low accuracy weapon, was not more likely to miss than a high accuracy one.
In fact, low accuracy was a significant buff, because it made your shots scatter to random limbs 30% of the time.
There was also no reason ever to aim for the torso, shooting the head or hands was mechanically correct.

This is why mercs one handing the STS in burst mode were breaking so many hands.

<img width="386" height="226" alt="image" src="https://github.com/user-attachments/assets/a0c2992f-ca5b-41cb-84c9-c6a3f74e09d0" />
This is the table of the chance to hit the torso, after this fix.

Point blank shots (range 1 and 2) always hit.

Almost all lasers have 2 accuracy (when wielded, if they are 2 handed)
Almost all ballistics have 1 accuracy (likewise when wielded, if possible)

Snipers have up to 4 accuracy. (When scoped)

Burst fire imposes an accuracy malus, the STS-35 is the heaviest malus outside of admin spawn guns like the L6 SAW.

burst=5, burst_accuracy=list(1,0,0,-1,-1)

This means the first shot of the burst is accuracy 1, then it falls off.

If you aim for a different body part, these are the base chances to miss:
	BP_HEAD = 70,
	BP_CHEST = 10,
	BP_GROIN = 20,
	BP_L_LEG = 40,
	BP_R_LEG = 40,
	BP_L_ARM = 40,
	BP_R_ARM = 40,
	BP_L_HAND = 60,
	BP_R_HAND = 60,
	BP_L_FOOT = 60,
	BP_R_FOOT = 60

There is a minimum 30% chance to hit, regardless of any modifiers.