### PR TITLE
Tajaran Cigarettes Fix

### DIFF
--- a/code/game/objects/items/tajara.dm
+++ b/code/game/objects/items/tajara.dm
@@ -27,7 +27,7 @@
 	cigarette_to_spawn = /obj/item/clothing/mask/smokable/cigarette/adhomai
 
 /obj/item/storage/box/fancy/cigarettes/nka
-	name = "\improper Gato Royales cigarette packet"
+	name = "\improper Gato Royales menthol cigarette packet"
 	desc = "Popular with the aristocrats of the New Kingdom of Adhomai for its mild menthol flavor."
 	desc_extended = "Imported from the New Kingdom of Adhomai."
 	icon_state = "nkapacket"

--- a/code/modules/client/preference_setup/loadout/items/drugs_meds.dm
+++ b/code/modules/client/preference_setup/loadout/items/drugs_meds.dm
@@ -55,12 +55,16 @@
 	cigarettes["Trans-Stellar Duty Free cigarette packet"] = /obj/item/storage/box/fancy/cigarettes
 	cigarettes["DromedaryCo cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/dromedaryco
 	cigarettes["Nico-Tine cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/nicotine
-	cigarettes["Working Tajara cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/pra
-	cigarettes["Shastar Leaves cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/dpra
-	cigarettes["Royal Choice cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/nka
+
+	cigarettes["Labourer's Choice cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/pra
+	cigarettes["Shastar List'ya cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/dpra
+	cigarettes["Gato Royales menthol cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/nka
+
 	cigarettes["Eriuyushi Sunset cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/federation
 	cigarettes["Xaqixal Dyn Fields cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/dyn
+
 	cigarettes["Natural Vysokan Soothsayer oracle cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/oracle
+
 	cigarettes["Ha'zana Corsair Afterburners cigarette packet"] = /obj/item/storage/box/fancy/cigarettes/koko
 	gear_tweaks += new /datum/gear_tweak/path(cigarettes)
 

--- a/html/changelogs/SleepyGemmy-gato_royales.yml
+++ b/html/changelogs/SleepyGemmy-gato_royales.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed the tajaran cigarettes being named differently in the loadout."


### PR DESCRIPTION
fixes the tajaran cigarettes being named differently in the loadout. also makes the menthol variant more clearly named.