### PR TITLE
Job Skill Reqkoning

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -363,8 +363,7 @@
 	blacklisted_species = list(SPECIES_TAJARA_MSAI, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_ATTENDANT, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER)
 
 	skill_requirements = alist(
-		/singleton/skill/pilot_spacecraft = SKILL_LEVEL_FAMILIAR,
-		/singleton/skill/pilot_mechs = SKILL_LEVEL_FAMILIAR
+		/singleton/skill/pilot_spacecraft = SKILL_LEVEL_FAMILIAR
 	)
 
 /obj/outfit/job/operations_manager
@@ -418,10 +417,6 @@
 	outfit = /obj/outfit/job/hangar_tech
 
 	blacklisted_species = list(SPECIES_VAURCA_BREEDER)
-
-	skill_requirements = alist(
-		/singleton/skill/pilot_mechs = SKILL_LEVEL_FAMILIAR
-	)
 
 /obj/outfit/job/hangar_tech
 	name = "Hangar Technician"

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -78,6 +78,14 @@
 
 	/**
 	 * Associated list of /singleton/skill/skill_name = skill_level that this job requires.
+	 * This should only be used for skills that have "Mechanical Hard Requirements"
+	 * EG: Surgery is literally impossible without the skill,
+	 * Thus a surgeon would be actually unplayable if they lacked it.
+	 * This is only intended to prevent situations where a player forgets to set a skill a job NEEDS
+	 * And then tries to join a round as a surgeon who can't do surgery.
+	 *
+	 * If a skill is "hard required" but later gets reworked to only have "soft requirements"
+	 * Then every job listing it should have the requirement removed.
 	 */
 	var/alist/skill_requirements = alist()
 

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -35,10 +35,6 @@
 
 	blacklisted_species = list(SPECIES_TAJARA_MSAI, SPECIES_TAJARA_ZHAN, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_ATTENDANT, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER)
 
-	skill_requirements = alist(
-		/singleton/skill/medicine = SKILL_LEVEL_TRAINED
-	)
-
 /obj/outfit/job/cmo
 	name = "Chief Medical Officer"
 	jobtype = /datum/job/cmo
@@ -88,9 +84,7 @@
 	outfit = /obj/outfit/job/doctor
 	blacklisted_species = list(SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER)
 	skill_requirements = alist(
-		/singleton/skill/surgery = SKILL_LEVEL_TRAINED,
-		/singleton/skill/medicine = SKILL_LEVEL_PROFESSIONAL,
-		/singleton/skill/anatomy = SKILL_LEVEL_TRAINED
+		/singleton/skill/surgery = SKILL_LEVEL_TRAINED
 	)
 
 /datum/job/surgeon
@@ -117,9 +111,7 @@
 	outfit = /obj/outfit/job/doctor/surgeon
 	blacklisted_species = list(SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER)
 	skill_requirements = alist(
-		/singleton/skill/surgery = SKILL_LEVEL_PROFESSIONAL,
-		/singleton/skill/medicine = SKILL_LEVEL_TRAINED,
-		/singleton/skill/anatomy = SKILL_LEVEL_TRAINED
+		/singleton/skill/surgery = SKILL_LEVEL_PROFESSIONAL
 	)
 
 /obj/outfit/job/doctor
@@ -186,11 +178,6 @@
 	minimal_access = list(ACCESS_MEDICAL, ACCESS_MEDICAL_EQUIP, ACCESS_PHARMACY, ACCESS_VIROLOGY)
 	outfit = /obj/outfit/job/pharmacist
 	blacklisted_species = list(SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER)
-	skill_requirements = alist(
-		/singleton/skill/pharmacology = SKILL_LEVEL_PROFESSIONAL,
-		/singleton/skill/medicine = SKILL_LEVEL_TRAINED,
-		/singleton/skill/anatomy = SKILL_LEVEL_TRAINED
-	)
 
 /obj/outfit/job/pharmacist
 	name = "Pharmacist"
@@ -302,9 +289,7 @@
 
 	blacklisted_species = list(SPECIES_DIONA, SPECIES_DIONA_COEUS, SPECIES_IPC_G2, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER)
 	skill_requirements = alist(
-		/singleton/skill/surgery = SKILL_LEVEL_FAMILIAR,
-		/singleton/skill/medicine = SKILL_LEVEL_TRAINED,
-		/singleton/skill/anatomy = SKILL_LEVEL_TRAINED
+		/singleton/skill/surgery = SKILL_LEVEL_FAMILIAR
 	)
 
 /obj/outfit/job/med_tech
@@ -383,9 +368,7 @@
 	outfit = /obj/outfit/job/intern_med
 	blacklisted_species = list(SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER)
 	skill_requirements = alist(
-		/singleton/skill/surgery = SKILL_LEVEL_FAMILIAR,
-		/singleton/skill/medicine = SKILL_LEVEL_FAMILIAR,
-		/singleton/skill/anatomy = SKILL_LEVEL_FAMILIAR
+		/singleton/skill/surgery = SKILL_LEVEL_FAMILIAR
 	)
 
 /obj/outfit/job/intern_med

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -35,11 +35,6 @@
 
 	blacklisted_species = list(SPECIES_TAJARA_ZHAN, SPECIES_DIONA, SPECIES_DIONA_COEUS, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_ATTENDANT, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER)
 
-	// Make sure security at bare minimum won't footgun themselves...
-	skill_requirements = alist(
-		/singleton/skill/firearms = SKILL_LEVEL_TRAINED
-	)
-
 /obj/outfit/job/hos
 	name = "Head of Security"
 	jobtype = /datum/job/hos
@@ -106,11 +101,6 @@
 
 	blacklisted_species = list(SPECIES_IPC_XION_REMOTE, SPECIES_VAURCA_BULWARK, SPECIES_DIONA_COEUS, SPECIES_VAURCA_BREEDER)
 
-	// Make sure security at bare minimum won't footgun themselves...
-	skill_requirements = alist(
-		/singleton/skill/firearms = SKILL_LEVEL_TRAINED
-	)
-
 /obj/outfit/job/warden
 	name = "Warden"
 	jobtype = /datum/job/warden
@@ -175,9 +165,7 @@
 	outfit = /obj/outfit/job/forensics
 	blacklisted_species = list(SPECIES_IPC_XION_REMOTE, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER)
 	skill_requirements = alist(
-		/singleton/skill/surgery = SKILL_LEVEL_TRAINED,
-		/singleton/skill/anatomy = SKILL_LEVEL_FAMILIAR,
-		/singleton/skill/forensics = SKILL_LEVEL_PROFESSIONAL
+		/singleton/skill/surgery = SKILL_LEVEL_TRAINED
 	)
 
 /obj/outfit/job/forensics
@@ -238,11 +226,6 @@
 	outfit = /obj/outfit/job/officer
 
 	blacklisted_species = list(SPECIES_IPC_XION_REMOTE, SPECIES_VAURCA_BULWARK, SPECIES_DIONA_COEUS, SPECIES_VAURCA_BREEDER)
-
-	// Make sure security at bare minimum won't footgun themselves...
-	skill_requirements = alist(
-		/singleton/skill/firearms = SKILL_LEVEL_TRAINED
-	)
 
 /obj/outfit/job/officer
 	name = "Security Officer"
@@ -310,11 +293,6 @@
 	)
 
 	blacklisted_species = list(SPECIES_IPC_XION_REMOTE, SPECIES_VAURCA_BULWARK, SPECIES_DIONA_COEUS, SPECIES_VAURCA_BREEDER)
-
-	// Make sure security at bare minimum won't footgun themselves...
-	skill_requirements = alist(
-		/singleton/skill/firearms = SKILL_LEVEL_TRAINED
-	)
 
 /obj/outfit/job/intern_sec
 	name = "Security Cadet"

--- a/html/changelogs/hellfirejag-job-skill-reqkoning.yml
+++ b/html/changelogs/hellfirejag-job-skill-reqkoning.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscdel: "Removed all job skill requirements that weren't actually mechanically necessary."


### PR DESCRIPTION
Job skill requirements are really not meant to be used as hard requirements where not actually appropriate. This caused a great deal of player friction as these are really meant to only be used for skills that have "Mechanical Hard Requirements" such as Surgery, Robotics, Engineering, Pilot Spacecraft, where if you attempted to join a round as a surgeon who lacks the surgery skill, you would immediately find the game literally unplayable. 

It's extremely poorly suited for the use case of skills that are built for "soft requirement", where they're intended that lacking the skill makes you mechanically bad at doing it, but you aren't prevented outright from doing that thing. For example, the medicine skill doesn't prevent you from bandaging people, having a low rank in it just makes you worse at it. Players have extremely consistent frictional problems with the system where it prevents them from making characters that are "mechanically bad at their job" even in situations where they could otherwise still perform the job anyways. 

Hard requirements in general are a very poor use and implementation for skills.