### PR TITLE
Latex/nitrile gloves no longer leave fingerprints

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -61,7 +61,6 @@
 	siemens_coefficient = 1.0 //thin latex gloves, much more conductive than fabric gloves (basically a capacitor for AC)
 	permeability_coefficient = 0.01
 	germ_level = 0
-	fingerprint_chance = 75
 	drop_sound = 'sound/items/drop/rubber.ogg'
 	pickup_sound = 'sound/items/pickup/rubber.ogg'
 	var/balloon = /obj/item/toy/balloon/latex

--- a/html/changelogs/Bat-GloveFingerprints.yml
+++ b/html/changelogs/Bat-GloveFingerprints.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - balance: "Latex gloves (including nitrile and all other child types) no longer have a chance to leave fingerprints."


### PR DESCRIPTION
Latex gloves (and by extension, nitrile and all other child items) had a 75% chance to leave fingerprints. This reduces that chance to zero. While some impressions can be left by these gloves in real life, it is a counterintuitive behavior for the purposes of the game (and we have enough of those to memorize elsewhere anyways).