### PR TITLE
Wearing Shaper gear removes Hive name and color from Hivenet.

### DIFF
--- a/code/game/objects/items/weapons/vaurca_items.dm
+++ b/code/game/objects/items/weapons/vaurca_items.dm
@@ -33,7 +33,6 @@
 	icon = 'icons/obj/vaurca_items.dmi'
 	icon_state = "shaper_helmet"
 	item_state = "shaper_helmet"
-	flags_inv = HIDEFACE
 	contained_sprite = TRUE
 	sprite_sheets = list(
 		BODYTYPE_VAURCA_BULWARK = 'icons/mob/species/bulwark/head.dmi'
@@ -43,7 +42,7 @@
 
 /obj/item/clothing/head/shaper/mechanics_hints(mob/user, distance, is_adjacent)
 	. += ..()
-	. += "Wearing this will remove your Hive name from physical messages."
+	. += "Wearing this will remove your Hive name and color from Hivenet messages."
 
 /obj/item/clothing/head/expression
 	name = "human expression mask"

--- a/code/game/objects/items/weapons/vaurca_items.dm
+++ b/code/game/objects/items/weapons/vaurca_items.dm
@@ -33,6 +33,7 @@
 	icon = 'icons/obj/vaurca_items.dmi'
 	icon_state = "shaper_helmet"
 	item_state = "shaper_helmet"
+	flags_inv = HIDEFACE
 	contained_sprite = TRUE
 	sprite_sheets = list(
 		BODYTYPE_VAURCA_BULWARK = 'icons/mob/species/bulwark/head.dmi'
@@ -42,7 +43,7 @@
 
 /obj/item/clothing/head/shaper/mechanics_hints(mob/user, distance, is_adjacent)
 	. += ..()
-	. += "Wearing this will remove your Hive name specifically while speaking. Visible emotes, normal examine, and similar are unaffected. *-based audio emotes and even !-based audible emote macros that would otherwise work fine manually, are also unaffected"
+	. += "Wearing this will remove your Hive name from physical messages."
 
 /obj/item/clothing/head/expression
 	name = "human expression mask"

--- a/code/game/objects/items/weapons/vaurca_items.dm
+++ b/code/game/objects/items/weapons/vaurca_items.dm
@@ -40,6 +40,10 @@
 	species_restricted = list(BODYTYPE_VAURCA, BODYTYPE_VAURCA_BULWARK)
 	body_parts_covered = HEAD|EYES
 
+/obj/item/clothing/head/shaper/mechanics_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "Wearing this will remove your Hive name specifically while speaking. Visible emotes, normal examine, and similar are unaffected. *-based audio emotes and even !-based audible emote macros that would otherwise work fine manually, are also unaffected"
+
 /obj/item/clothing/head/expression
 	name = "human expression mask"
 	desc = "A mask that allows emotively challenged aliens to convey facial expressions. This one depicts a human."

--- a/code/modules/clothing/suits/xeno/vaurca.dm
+++ b/code/modules/clothing/suits/xeno/vaurca.dm
@@ -24,13 +24,17 @@
 
 /obj/item/clothing/suit/vaurca/shaper
 	name = "shaper robes"
-	desc = "Commonly worn by Preimmients, these robes are meant to catch pheromones, obfuscating hive affiliation."
+	desc = "Commonly worn by Preimminents, these robes are meant to catch pheromones, obfuscating hive affiliation."
 	icon_state = "shaper_robes"
 	item_state = "shaper_robes"
 	sprite_sheets = list(
 		BODYTYPE_VAURCA_BULWARK = 'icons/mob/species/bulwark/suit.dmi'
 	)
 	species_restricted = list(BODYTYPE_VAURCA, BODYTYPE_VAURCA_BULWARK)
+
+/obj/item/clothing/suit/vaurca/shaper/mechanics_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "Wearing this will remove your Hive name and color from Hivenet."
 
 /obj/item/clothing/suit/vaurca/breeder
 	name = "zo'ra representative clothes"

--- a/code/modules/clothing/suits/xeno/vaurca.dm
+++ b/code/modules/clothing/suits/xeno/vaurca.dm
@@ -34,7 +34,7 @@
 
 /obj/item/clothing/suit/vaurca/shaper/mechanics_hints(mob/user, distance, is_adjacent)
 	. += ..()
-	. += "Wearing this will remove your Hive name and color from Hivenet."
+	. += "Wearing this will remove your Hive name from physical messages."
 
 /obj/item/clothing/suit/vaurca/breeder
 	name = "zo'ra representative clothes"

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -235,10 +235,10 @@
 	log_say("[key_name(speaker)] : ([name]) [message]")
 
 	var/mob/living/carbon/human/H = speaker //Check for Preimminent Shaper robes, which obscure Hive affiliation
-	var/obj/item/clothing/suit/vaurca/shaper/wornrobes = H.get_equipped_item(slot_wear_suit)
+	var/obj/item/clothing/head/shaper/helmet = H.get_equipped_item(slot_head)
 	if(!speaker_mask)
 		speaker_mask = speaker.real_name
-		if(istype(wornrobes)) //Then remove their Hive name from Hivenet
+		if(istype(helmet)) //Then remove their Hive name from Hivenet
 			var/list/speaker_surname = splittext(speaker_mask, " ")
 			speaker_mask = speaker_surname[1]
 

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -234,11 +234,16 @@
 /datum/language/bug/broadcast(var/mob/living/speaker,var/message,var/speaker_mask)
 	log_say("[key_name(speaker)] : ([name]) [message]")
 
+	var/mob/living/carbon/human/H = speaker //Check for Preimminent Shaper robes, which obscure Hive affiliation
+	var/obj/item/clothing/suit/vaurca/shaper/wornrobes = H.get_equipped_item(slot_wear_suit)
 	if(!speaker_mask)
 		speaker_mask = speaker.real_name
+		if(istype(wornrobes)) //Then remove their Hive name from Hivenet
+			var/list/speaker_surname = splittext(speaker_mask, " ")
+			speaker_mask = speaker_surname[1]
 
-	var/msg = "<i><span class='game say'>[name], <span class='name'>[speaker_mask]</span>[format_message(message, get_spoken_verb(message), speaker_mask)]</span></i>"
-	var/encrypted_msg =  "<i><span class='game say'>[name], <span class='name'>[speaker_mask]</span>[format_message("!a surge of encrypted data", get_spoken_verb(message), speaker_mask)]</span></i>"
+	var/msg = "<i><span class='game say'>[name], <span class='name'>[speaker_mask]</span>[format_message(message, get_spoken_verb(message), speaker_mask, speaker)]</span></i>"
+	var/encrypted_msg =  "<i><span class='game say'>[name], <span class='name'>[speaker_mask]</span>[format_message("!a surge of encrypted data", get_spoken_verb(message), speaker_mask, speaker)]</span></i>"
 
 	if(isvaurca(speaker))
 		speaker.custom_emote(VISIBLE_MESSAGE, "[pick("twitches their antennae", "twitches their antennae rhythmically")].")
@@ -281,19 +286,25 @@
 				continue
 			to_chat(player, msg)
 
-/datum/language/bug/format_message(message, verb, speaker_mask)
+/datum/language/bug/format_message(message, verb, speaker_mask, speaker)
 	var/message_color = colour
 	var/list/speaker_surname = splittext(speaker_mask, " ")
+	var/mob/living/carbon/human/H = speaker //Check for Preimminent Shaper robes, which obscure Hive affiliation
+	var/obj/item/clothing/suit/vaurca/shaper/wornrobes = H.get_equipped_item(slot_wear_suit)
 	if(length(speaker_surname) > 1)
-		switch(speaker_surname[2])
+		switch(speaker_surname[2]) //Then prevent Hive colors
 			if("Zo'ra")
-				message_color = "vaurca_zora"
+				if(!istype(wornrobes))
+					message_color = "vaurca_zora"
 			if("C'thur")
-				message_color = "vaurca_cthur"
+				if(!istype(wornrobes))
+					message_color = "vaurca_cthur"
 			if("K'lax")
-				message_color = "vaurca_klax"
+				if(!istype(wornrobes))
+					message_color = "vaurca_klax"
 			if("Lii'dra")
-				message_color = "vaurca_liidra"
+				if(!istype(wornrobes))
+					message_color = "vaurca_liidra"
 	if(copytext(message, 1, 2) == "!")
 		return " projects <span class='message'><span class='[message_color]'>[copytext(message, 2)]</span></span>"
 	return "[verb], <span class='message'><span class='[message_color]'>\"[capitalize(message)]\"</span></span>"

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -289,22 +289,16 @@
 /datum/language/bug/format_message(message, verb, speaker_mask, speaker)
 	var/message_color = colour
 	var/list/speaker_surname = splittext(speaker_mask, " ")
-	var/mob/living/carbon/human/H = speaker //Check for Preimminent Shaper robes, which obscure Hive affiliation
-	var/obj/item/clothing/suit/vaurca/shaper/wornrobes = H.get_equipped_item(slot_wear_suit)
 	if(length(speaker_surname) > 1)
-		switch(speaker_surname[2]) //Then prevent Hive colors
+		switch(speaker_surname[2])
 			if("Zo'ra")
-				if(!istype(wornrobes))
-					message_color = "vaurca_zora"
+				message_color = "vaurca_zora"
 			if("C'thur")
-				if(!istype(wornrobes))
-					message_color = "vaurca_cthur"
+				message_color = "vaurca_cthur"
 			if("K'lax")
-				if(!istype(wornrobes))
-					message_color = "vaurca_klax"
+				message_color = "vaurca_klax"
 			if("Lii'dra")
-				if(!istype(wornrobes))
-					message_color = "vaurca_liidra"
+				message_color = "vaurca_liidra"
 	if(copytext(message, 1, 2) == "!")
 		return " projects <span class='message'><span class='[message_color]'>[copytext(message, 2)]</span></span>"
 	return "[verb], <span class='message'><span class='[message_color]'>\"[capitalize(message)]\"</span></span>"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -484,10 +484,10 @@
 	if( wear_mask && (wear_mask.flags_inv&HIDEFACE) )	//Wearing a mask which hides our face, use id-name if possible
 		return get_id_name("Unknown")
 	if( head && (head.flags_inv&HIDEFACE) )
-		if(istype(head, /obj/item/clothing/head/shaper)) //Check for Preimminent Shaper helmet which obscures Hive affiliation
-			var/list/hiveless_name = splittext(real_name, " ") //then remove Hive surname, ignore ID for obvious reason.
-			return hiveless_name[1]
 		return get_id_name("Unknown")		//Likewise for hats
+	if(istype(wear_suit, /obj/item/clothing/suit/vaurca/shaper)) //Check for Preimminent Shaper helmet which obscures Hive affiliation
+		var/list/hiveless_name = splittext(real_name, " ") //then remove Hive surname, ignore ID for obvious reason.
+		return hiveless_name[1]
 	var/face_name = get_face_name()
 	var/id_name = get_id_name("")
 	if(id_name && (id_name != face_name))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -484,6 +484,9 @@
 	if( wear_mask && (wear_mask.flags_inv&HIDEFACE) )	//Wearing a mask which hides our face, use id-name if possible
 		return get_id_name("Unknown")
 	if( head && (head.flags_inv&HIDEFACE) )
+		if(istype(head, /obj/item/clothing/head/shaper)) //Check for Preimminent Shaper helmet which obscures Hive affiliation
+			var/list/hiveless_name = splittext(real_name, " ") //then remove Hive surname, ignore ID for obvious reason.
+			return hiveless_name[1]
 		return get_id_name("Unknown")		//Likewise for hats
 	var/face_name = get_face_name()
 	var/id_name = get_id_name("")

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -87,6 +87,10 @@
 				voice_sub = changer.voice
 	if(voice_sub)
 		return voice_sub
+	var/obj/item/clothing/head/shaper/helmet = src.get_equipped_item(slot_head)
+	if(istype(helmet)) //Check for Preimminent Shaper helmet which obscures Hive affiliation, then remove Hive surname when speaking
+		var/list/hiveless_name = splittext(real_name, " ")
+		return hiveless_name[1]
 	var/obj/item/organ/external/head/face = organs_by_name[BP_HEAD]
 	if(face?.disfigured) // if your face is ruined, your ability to vocalize is also ruined
 		return "Unknown" // above ling voice mimicing so they don't get caught out immediately

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -87,9 +87,8 @@
 				voice_sub = changer.voice
 	if(voice_sub)
 		return voice_sub
-	var/obj/item/clothing/head/shaper/helmet = src.get_equipped_item(slot_head)
-	if(istype(helmet)) //Check for Preimminent Shaper helmet which obscures Hive affiliation, then remove Hive surname when speaking
-		var/list/hiveless_name = splittext(real_name, " ")
+	if(istype(wear_suit, /obj/item/clothing/suit/vaurca/shaper)) //Check for Preimminent Shaper robes which obscures Hive affiliation
+		var/list/hiveless_name = splittext(real_name, " ") // then remove Hive surname when speaking
 		return hiveless_name[1]
 	var/obj/item/organ/external/head/face = organs_by_name[BP_HEAD]
 	if(face?.disfigured) // if your face is ruined, your ability to vocalize is also ruined

--- a/html/changelogs/diggiez - DecoloredShaperHivenet.yml
+++ b/html/changelogs/diggiez - DecoloredShaperHivenet.yml
@@ -9,5 +9,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Wearing Shaper robes now removes Hive name and color from Hivenet. The helmet will also remove Hive name from physical messages."
+  - rscadd: "Wearing Shaper robes now removes Hive name from physical messages. The helmet will remove Hive name from Hivenet messages."
   - spellcheck: "Preimminent misspelling on the robe corrected."

--- a/html/changelogs/diggiez - DecoloredShaperHivenet.yml
+++ b/html/changelogs/diggiez - DecoloredShaperHivenet.yml
@@ -9,5 +9,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Wearing Shaper robes now removes Hive name and color from Hivenet. The helmet will also remove Hive name when physically speaking."
+  - rscadd: "Wearing Shaper robes now removes Hive name and color from Hivenet. The helmet will also remove Hive name from physical messages."
   - spellcheck: "Preimminent misspelling on the robe corrected."

--- a/html/changelogs/diggiez - DecoloredShaperHivenet.yml
+++ b/html/changelogs/diggiez - DecoloredShaperHivenet.yml
@@ -1,0 +1,13 @@
+author: diggiez
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Wearing Shaper robes now removes Hive name and color from Hivenet."
+  - spellcheck: "Preimminent misspelling on the robe corrected."

--- a/html/changelogs/diggiez - DecoloredShaperHivenet.yml
+++ b/html/changelogs/diggiez - DecoloredShaperHivenet.yml
@@ -9,5 +9,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Wearing Shaper robes now removes Hive name and color from Hivenet."
+  - rscadd: "Wearing Shaper robes now removes Hive name and color from Hivenet. The helmet will also remove Hive name when physically speaking."
   - spellcheck: "Preimminent misspelling on the robe corrected."


### PR DESCRIPTION
Mechanically representing its pre-existing lore and description. Mechanical description added on the item too.

<img width="416" height="97" alt="image" src="https://github.com/user-attachments/assets/e70da937-30ab-42f3-bf85-5a8da5accddf" />

NEW:
Shaper Helmet now also removes Hive name when physically speaking.
<img width="330" height="65" alt="image" src="https://github.com/user-attachments/assets/a56af02c-0494-4589-bf15-4d59f6d0767e" />

NEWER: Helmet affects visible name and messages. It ignores worn ID for obvious reasons, but some Shapers may hide their ID while talking to other Vaurcae.
<img width="533" height="225" alt="image" src="https://github.com/user-attachments/assets/da85914d-52bc-4036-9616-66e479794fa3" />

Full Preimminent Shapers should wear robes and helmet with TTS accent to be as anonymized as possible. Parts of your carapace that peek through can be easily hidden as well.

NEWEST: Robes and helmet functionality have been swapped, as it makes more sense for the robes that cover you up to remove from physical messages.