### PR TITLE
Materials And Stack Harddel

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -62,6 +62,10 @@
 	if (src && usr && usr.machine == src)
 		usr << browse(null, "window=stack")
 		usr.unset_machine()
+
+	recipes = null
+	build_type = null
+	synths = null
 	return ..()
 
 /obj/item/stack/update_icon()

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -50,6 +50,10 @@
 
 	matter = material.get_matter()
 
+/obj/item/stack/material/Destroy()
+	material = null
+	return ..()
+
 /obj/item/stack/material/get_material()
 	return material
 

--- a/html/changelogs/hellfirejag-materials-hard-del.yml
+++ b/html/changelogs/hellfirejag-materials-hard-del.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."

--- a/html/changelogs/hellfirejag-materials-hard-del.yml
+++ b/html/changelogs/hellfirejag-materials-hard-del.yml
@@ -1,4 +1,4 @@
 author: Hellfirejag
 delete-after: True
 changes:
-  - bugfix: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
+  - bugfix: "Removed a hard del related to material stacks."


### PR DESCRIPTION
To clarify I have recently cancelled my subscription to google's coding agents, so this is my first hard del PR in several weeks that was done completely by hand. This PR fixes a hard del on Materials (and their parent Stacks), which was being caused by up to 4 different vars potentially containing references that were not being cleared during their Destroy() procs.

I have also tested this by hand, by spawning and deleting stacks, then waiting to see if the hard del triggers or not.