### PR TITLE
Public Navigation Consoles can be used without skills

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -338,6 +338,15 @@
 	can_pass_under = FALSE
 	light_power_on = 1
 
+/obj/machinery/computer/ship/navigation/attack_hand(mob/user)
+	if(use_check_and_message(user))
+		return
+	if(!emagged && !allowed(user))
+		to_chat(user, SPAN_WARNING("Access denied."))
+		return FALSE
+	user.set_machine(src)
+	ui_interact(user)
+
 /obj/machinery/computer/ship/navigation/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)

--- a/html/changelogs/Bat-NavConsoleUse.yml
+++ b/html/changelogs/Bat-NavConsoleUse.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - bugfix: "Makes the navigation consoles scattered around the public spaces on the Horizon (that only display nearby starmap) able to be viewed again without any piloting skills."


### PR DESCRIPTION
Makes Navigation Consoles (the ones scattered around the public spaces of the Horizon that only let you view the nearby starmap) able to be viewed again without having piloting skills.