### PR TITLE
Death and Unconscious Messages

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -28,6 +28,8 @@
 	if(stat == DEAD)
 		return
 
+	to_chat(src, EXAMINE_BLOCK_RED(SPAN_DANGER(FONT_LARGE("<i>You have died.</i>"))))
+
 	vr_disconnect()
 
 	BITSET(hud_updateflag, HEALTH_HUD)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -834,11 +834,11 @@
 		if(paralysis || sleeping || InStasis())
 			blinded = TRUE
 			if(sleeping && !stat)
-				species.sleep_msg(src)
 				set_stat(UNCONSCIOUS)
+				species.sleep_msg(src)
 				if(!sleeping_msg_debounce)
 					sleeping_msg_debounce = TRUE
-					to_chat(src, SPAN_NOTICE(FONT_LARGE("You are now unconscious.<br>You will not remember anything you \"see\" happening around you until you regain consciousness.")))
+					to_chat(src, EXAMINE_BLOCK_BLUE(SPAN_NOTICE(FONT_LARGE("You are now unconscious. You will not remember anything you see, hear, or feel happening around you until you regain consciousness."))))
 
 			adjustHalLoss(-3)
 			if (species.tail)

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -252,7 +252,7 @@
 	if(!owner)
 		return
 	to_chat(owner, "<span class = 'notice'><font size=4><B>What happened...?</B></font></span>")
-	alert(owner.find_mob_consciousness(), "You have taken massive brain damage! You will not be able to remember the events leading up to your injury.", "Brain Damaged")
+	to_chat(owner, EXAMINE_BLOCK_RED(SPAN_NOTICE(FONT_LARGE("You have taken massive brain damage. You will not be able to remember the events leading up to your injury."))))
 
 /obj/item/organ/internal/brain/proc/handle_damage_effects()
 	if(owner.stat)

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -242,16 +242,16 @@
 /obj/item/organ/internal/brain/proc/handle_severe_brain_damage()
 	set waitfor = FALSE
 	healed_threshold = 0
-	to_chat(owner, "<span class = 'notice'><font size=4><B>Where am I...?</B></font></span>")
+	to_chat(owner, SPAN_NOTICE(FONT_LARGE("<b>Where am I...?</b>")))
 	owner.Paralyse(20)
 	sleep(5 SECONDS)
 	if(!owner)
 		return
-	to_chat(owner, "<span class = 'notice'><font size=4><B>What's going on...?</B></font></span>")
+	to_chat(owner, SPAN_NOTICE(FONT_LARGE("<b>What is going on...?</b>")))
 	sleep(10 SECONDS)
 	if(!owner)
 		return
-	to_chat(owner, "<span class = 'notice'><font size=4><B>What happened...?</B></font></span>")
+	to_chat(owner, SPAN_NOTICE(FONT_LARGE("<b>What happened...?</b>")))
 	to_chat(owner, EXAMINE_BLOCK_RED(SPAN_NOTICE(FONT_LARGE("You have taken massive brain damage. You will not be able to remember the events leading up to your injury."))))
 
 /obj/item/organ/internal/brain/proc/handle_damage_effects()

--- a/html/changelogs/SleepyGemmy-death.yml
+++ b/html/changelogs/SleepyGemmy-death.yml
@@ -1,0 +1,7 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - rscadd: "Added a death message."
+  - rscadd: "Changed the unconscious and brain damage messages to use the chat examine boxes."


### PR DESCRIPTION
adds a death message, changes the brain damage message to output in the chat, and tweaks the unconscious message to display in a chat examine box.

death
<img width="820" height="38" alt="image" src="https://github.com/user-attachments/assets/caff6bf0-1f8f-49fa-a763-98b7c8b0afc6" />

brain damage
<img width="820" height="58" alt="image" src="https://github.com/user-attachments/assets/94eb57a5-244f-4f89-81ba-24923214ee0d" />

unconscious
<img width="820" height="58" alt="image" src="https://github.com/user-attachments/assets/2e384f8a-86a9-4624-ae57-138d85747846" />