### PR TITLE
Airlock repair

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1882,19 +1882,6 @@ About the new airlock wires panel:
 					else
 						to_chat(user, SPAN_WARNING("You need to be wielding \the [attacking_item] to do that."))
 		return TRUE
-	else if(attacking_item.tool_behaviour == TOOL_HAMMER)
-		if(locked && user.a_intent != I_HURT)
-			to_chat(user, SPAN_NOTICE("The airlock's bolts prevent it from being forced."))
-		else if(user.a_intent == I_HURT)
-			..()
-		else if(arePowerSystemsOn())
-			to_chat(user, SPAN_NOTICE("The airlock's motors resist your efforts to force it."))
-		else if(!welded && !operating)
-			if(density)
-				open(1)
-			else
-				close(1)
-		return TRUE
 	else if(density && istype(attacking_item, /obj/item/material/twohanded/chainsaw))
 		var/obj/item/material/twohanded/chainsaw/ChainSawVar = attacking_item
 		if(!ChainSawVar.wielded)

--- a/html/changelogs/Bat-AirlockRepair.yml
+++ b/html/changelogs/Bat-AirlockRepair.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoobocosmomachia
+delete-after: True
+changes:
+  - bugfix: "Airlocks can again be repaired by using hammers on them with an appropriate stack of materials in your offhand."


### PR DESCRIPTION
changes:
  - bugfix: "Airlocks can again be repaired by using hammers on them with an appropriate stack of materials in your offhand."