### PR TITLE
Binary atmos devices alt-click toggle fix, space heater feedback text fix

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -161,7 +161,7 @@
 		return
 	switch(action)
 		if("powerToggle")
-			balloon_alert_to_viewers("turned [on ? "on" : "off"]")
+			balloon_alert_to_viewers("turned [on ? "off" : "on"]")
 			on = !on
 			active = 0
 			power_change()

--- a/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
+++ b/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
@@ -136,8 +136,17 @@
 /obj/machinery/atmospherics/binary/AltClick(var/mob/user)
 	if(src.anchored)
 		if(!allowed(user))
-			to_chat(user, SPAN_WARNING("Access denied."))
-			return
-		Topic(src, list("power" = "1"))
+			balloon_alert(user, "Access denied.")
+			return FALSE
+		else if(stat && NOPOWER)
+			balloon_alert(user, "No power!")
+			return FALSE
+		else if(stat && BROKEN)
+			balloon_alert(user, "Broken!")
+			return FALSE
+		else
+			update_use_power(!use_power)
+			update_icon()
+			return TRUE
 	else
 		. = ..()

--- a/html/changelogs/Bat-AirPumpToggle.yml
+++ b/html/changelogs/Bat-AirPumpToggle.yml
@@ -1,0 +1,5 @@
+author: Batrachophrenoobocosmomachia
+delete-after: True
+changes:
+  - bugfix: "Binary atmos devices are again able to be toggled on/off by alt-clicking them."
+  - bugfix: "Temp control units now display correct 'turned on/off' balloon text when toggled."


### PR DESCRIPTION
Fixes https://github.com/Aurorastation/Aurora.3/issues/22246
changes:
  - bugfix: "Binary atmos devices are again able to be toggled on/off by alt-clicking them."
  - bugfix: "Temp control units now display correct 'turned on/off' balloon text when toggled."