### PR TITLE
Atmos Control app remote air panel access fix

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -965,6 +965,13 @@ pixel_x = 10;
 			apply_mode()
 			return TRUE
 
+/// Snowflake proc to make it so users of the Atmosphere Control app (having the UI open) have full access to an alarm.
+/obj/machinery/alarm/ui_status(mob/user)
+	for(var/datum/tgui/open_tgui in user.tgui_open_uis)
+		if(open_tgui.interface == "AtmosAlarmControl")
+			return UI_INTERACTIVE
+	return ..()
+
 /**
  * Resets the area atmospheric alarm. Called by ui_act and directly by atmos_alert computers.
  */

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -715,16 +715,13 @@ pixel_x = 10;
 		wires.interact(user)
 
 /obj/machinery/alarm/ui_interact(mob/user, datum/tgui/ui)
-	to_chat(world, "in ui_interact")
 	if(buildstage != 2)
-		to_chat(world, "buildstage != 2")
 		return
 	if(aidisabled && isAI(user))
 		to_chat(user, SPAN_WARNING("AI control for \the [src] interface has been disabled."))
 		return
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		to_chat(world, "!ui")
 		ui = new(user, src, "AirAlarm")
 		ui.open()
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -59,6 +59,7 @@
 		ALARM_GET_DANGER_LEVEL(co2_dangerlevel, environment.gas[GAS_CO2]*partial_pressure, TLV[GAS_CO2]);\
 		ALARM_GET_DANGER_LEVEL(phoron_dangerlevel, environment.gas[GAS_PHORON]*partial_pressure, TLV[GAS_PHORON]);\
 		ALARM_GET_DANGER_LEVEL(hydrogen_dangerlevel, environment.gas[GAS_HYDROGEN]*partial_pressure, TLV[GAS_HYDROGEN]);\
+		ALARM_GET_DANGER_LEVEL(chlorine_dangerlevel, environment.gas[GAS_CHLORINE]*partial_pressure, TLV[GAS_CHLORINE]);\
 		ALARM_GET_DANGER_LEVEL(temperature_dangerlevel, environment.temperature, TLV["temperature"]);\
 		ALARM_GET_DANGER_LEVEL(other_dangerlevel, other_moles*partial_pressure, TLV["other"]);\
 		\
@@ -68,6 +69,7 @@
 		co2_dangerlevel,\
 		phoron_dangerlevel,\
 		hydrogen_dangerlevel,\
+		chlorine_dangerlevel,\
 		other_dangerlevel,\
 		temperature_dangerlevel\
 		);\
@@ -152,6 +154,7 @@ pixel_x = 10;
 	var/co2_dangerlevel = 0
 	var/phoron_dangerlevel = 0
 	var/hydrogen_dangerlevel = 0
+	var/chlorine_dangerlevel = 0
 	var/temperature_dangerlevel = 0
 	var/other_dangerlevel = 0
 
@@ -418,6 +421,7 @@ pixel_x = 10;
 	TLV[GAS_CO2] = 				list(-1.0, -1.0, 5, 10) // Partial pressure, kpa
 	TLV[GAS_PHORON] =			list(-1.0, -1.0, 0.2, 0.5) // Partial pressure, kpa
 	TLV[GAS_HYDROGEN] =			list(-1.0, -1.0, 0.2, 0.5) // Partial pressure, kpa
+	TLV[GAS_CHLORINE] =			list(-1.0, -1.0, 0.2, 0.5) // Partial pressure, kpa
 	TLV["other"] =			list(-1.0, -1.0, 0.5, 1.0) // Partial pressure, kpa
 	TLV["pressure"] =		list(ONE_ATMOSPHERE*0.80,ONE_ATMOSPHERE*0.90,ONE_ATMOSPHERE*1.10,ONE_ATMOSPHERE*1.20) /* kpa */
 	TLV["temperature"] =	list(T0C-26, T0C, T0C+40, T0C+66) // K
@@ -711,13 +715,16 @@ pixel_x = 10;
 		wires.interact(user)
 
 /obj/machinery/alarm/ui_interact(mob/user, datum/tgui/ui)
+	to_chat(world, "in ui_interact")
 	if(buildstage != 2)
+		to_chat(world, "buildstage != 2")
 		return
 	if(aidisabled && isAI(user))
 		to_chat(user, SPAN_WARNING("AI control for \the [src] interface has been disabled."))
 		return
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
+		to_chat(world, "!ui")
 		ui = new(user, src, "AirAlarm")
 		ui.open()
 
@@ -739,6 +746,7 @@ pixel_x = 10;
 			environment_data += list(list("name" = "Carbon Dioxide",  "value" = environment.gas[GAS_CO2] / total * 100,    "unit" = "%",   "danger_level" = co2_dangerlevel))
 			environment_data += list(list("name" = "Phoron",          "value" = environment.gas[GAS_PHORON] / total * 100, "unit" = "%",   "danger_level" = phoron_dangerlevel))
 			environment_data += list(list("name" = "Hydrogen",        "value" = environment.gas[GAS_HYDROGEN] / total * 100,"unit" = "%",  "danger_level" = hydrogen_dangerlevel))
+			environment_data += list(list("name" = "Chlorine",        "value" = environment.gas[GAS_CHLORINE] / total * 100,"unit" = "%",  "danger_level" = chlorine_dangerlevel))
 			environment_data += list(list("name" = "Temperature",     "value" = environment.temperature,                   "unit" = "K",   "danger_level" = temperature_dangerlevel))
 	data["environment"] = environment_data
 	data["total_danger"] = danger_level
@@ -795,7 +803,8 @@ pixel_x = 10;
 				list("name" = "Carbon Dioxide", "command" = "co2_scrub", "val" = info["filter_co2"]),
 				list("name" = "Phoron",         "command" = "tox_scrub", "val" = info["filter_phoron"]),
 				list("name" = "Hydrogen",       "command" = "h2_scrub",  "val" = info["filter_h"]),
-				list("name" = "Nitrous Oxide",  "command" = "n2o_scrub", "val" = info["filter_n2o"])
+				list("name" = "Nitrous Oxide",  "command" = "n2o_scrub", "val" = info["filter_n2o"]),
+				list("name" = "Chlorine",       "command" = "cl_scrub",  "val" = info["filter_cl"])
 			)
 		)
 		scrubbers += list(scrubber)
@@ -808,6 +817,7 @@ pixel_x = 10;
 		GAS_CO2      = "CO\u2082",
 		GAS_PHORON   = "Phoron",
 		GAS_HYDROGEN = "Hydrogen",
+		GAS_CHLORINE = "Chlorine",
 		"other"      = "Other"
 	)
 	for(var/g in gas_names)
@@ -890,6 +900,7 @@ pixel_x = 10;
 					"tox_scrub",
 					"h2_scrub",
 					"n2o_scrub",
+					"cl_scrub",
 					"panic_siphon",
 					"scrubbing")
 					signal[command] = text2num(params["val"])

--- a/code/modules/modular_computers/file_system/programs/engineering/atmoscontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/atmoscontrol.dm
@@ -47,8 +47,11 @@
 	switch(action)
 		// Opens the interface for the given air alarm.
 		if("alarm")
+			to_chat(world, "alarm")
 			var/obj/machinery/alarm/alarm = locate(params["alarm"]) in (monitored_alarms.len ? monitored_alarms : SSmachinery.processing)
+			to_chat(world, "[alarm]")
 			if(alarm)
+				to_chat(world, "trying to interact")
 				alarm.ui_interact(usr)
 			return TRUE
 		// Manually clear and repopulate the alarm list.

--- a/code/modules/modular_computers/file_system/programs/engineering/atmoscontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/atmoscontrol.dm
@@ -47,11 +47,8 @@
 	switch(action)
 		// Opens the interface for the given air alarm.
 		if("alarm")
-			to_chat(world, "alarm")
 			var/obj/machinery/alarm/alarm = locate(params["alarm"]) in (monitored_alarms.len ? monitored_alarms : SSmachinery.processing)
-			to_chat(world, "[alarm]")
 			if(alarm)
-				to_chat(world, "trying to interact")
 				alarm.ui_interact(usr)
 			return TRUE
 		// Manually clear and repopulate the alarm list.

--- a/html/changelogs/Bat-RemoteAirAlarmFix.yml
+++ b/html/changelogs/Bat-RemoteAirAlarmFix.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - bugfix: "Air panels again able to be accessed remotely through Atmosphere Control app."

--- a/html/changelogs/Bat-RemoteAirAlarmFix.yml
+++ b/html/changelogs/Bat-RemoteAirAlarmFix.yml
@@ -2,3 +2,4 @@ author: Batrachophrenoboocosmomachia
 delete-after: True
 changes:
   - bugfix: "Air panels again able to be accessed remotely through Atmosphere Control app."
+  - bugfix: "Missing chlorine detection added to air panels."


### PR DESCRIPTION
changes:
  - bugfix: "Air panels again able to be accessed remotely through Atmosphere Control app."
  - bugfix: "Missing chlorine detection added to air panels."