### PR TITLE
Light Sensitivity - Offship Accommodation

### DIFF
--- a/html/changelogs/Bat-LightSensitivityShips.yml
+++ b/html/changelogs/Bat-LightSensitivityShips.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - qol: "Gadpathur and Himeo offship maps now have night mode light controls to accommodate for those origins' light sensitivity traits."

--- a/maps/away/ships/coc/gadpathur_patrol/gadpathur_patrol_areas.dm
+++ b/maps/away/ships/coc/gadpathur_patrol/gadpathur_patrol_areas.dm
@@ -5,6 +5,8 @@
 	no_light_control = FALSE
 	base_turf = /turf/space
 	area_flags = AREA_FLAG_RAD_SHIELDED
+	no_light_control = FALSE
+	allow_nightmode = TRUE
 
 /area/ship/gadpathur_patrol/exterior
 	name = "Gadpathurian Corvette - Exterior"

--- a/maps/away/ships/himeo/himeo_patrol_ship_areas.dm
+++ b/maps/away/ships/himeo/himeo_patrol_ship_areas.dm
@@ -3,6 +3,7 @@
 	icon_state = "hallC"
 	requires_power = TRUE
 	no_light_control = FALSE
+	allow_nightmode = TRUE
 	area_flags = AREA_FLAG_RAD_SHIELDED
 	ambience = AMBIENCE_ENGINEERING
 


### PR DESCRIPTION
More light sensitivity-related balance and QoL as items are found. Himean and Gadpathurian offship maps have had night mode enabled on them to accommodate for those characters' origin traits. How cruel, to station photosensitive people on ships and not let them turn down the lights!