### PR TITLE
Remove light sensitivity from Gadpathurians

### DIFF
--- a/code/modules/background/origins/origins/human/coalition.dm
+++ b/code/modules/background/origins/origins/human/coalition.dm
@@ -61,8 +61,7 @@
 	possible_accents = list(ACCENT_GADPATHUR)
 	possible_citizenships = list(CITIZENSHIP_COALITION)
 	possible_religions = list(RELIGION_NONE, RELIGION_CHRISTIANITY, RELIGION_ISLAM, RELIGION_BUDDHISM, RELIGION_HINDU, RELIGION_TAOISM, RELIGION_JUDAISM, RELIGION_SIKHISM, RELIGION_OTHER)
-	origin_traits = list(TRAIT_ORIGIN_LIGHT_SENSITIVE)
-	origin_traits_descriptions = list("have a small resistance to radiation", "are more sensitive to bright lights")
+	origin_traits_descriptions = list("have a small resistance to radiation")
 
 /singleton/origin_item/origin/gadpathur/on_apply(var/mob/living/carbon/human/H)
 	. = ..()

--- a/code/modules/background/origins/origins/human/coalition.dm
+++ b/code/modules/background/origins/origins/human/coalition.dm
@@ -78,8 +78,7 @@
 	possible_accents = list(ACCENT_GADPATHUR)
 	possible_citizenships = list(CITIZENSHIP_COALITION, CITIZENSHIP_BIESEL)
 	possible_religions = RELIGIONS_COALITION
-	origin_traits = list(TRAIT_ORIGIN_LIGHT_SENSITIVE)
-	origin_traits_descriptions = list("have a small resistance to radiation", "are more sensitive to bright lights")
+	origin_traits_descriptions = list("have a small resistance to radiation")
 
 /singleton/origin_item/origin/gadpathur_exile/on_apply(var/mob/living/carbon/human/H)
 	. = ..()

--- a/html/changelogs/GeneralCamo - Gadpathurian Fix.yml
+++ b/html/changelogs/GeneralCamo - Gadpathurian Fix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Gadpathurians no longer have light sensitivity."


### PR DESCRIPTION
<img width="556" height="81" alt="image" src="https://github.com/user-attachments/assets/bf5ef9e3-9c83-4aea-a2a4-de04a78b4c59" />
This shouldn't have been added in the first place. This resolves it since Gadpathurians don't make sense to have it.