### PR TITLE
Openspace mimics stop lingering

### DIFF
--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -131,12 +131,12 @@
 			deltimer(destruction_timer)
 			destruction_timer = null
 	else if (!destruction_timer)
-		destruction_timer = addtimer(CALLBACK(src, TYPE_PROC_REF(/datum, qdel_self)), 10 SECONDS, TIMER_STOPPABLE)
+		destruction_timer = addtimer(CALLBACK(src, TYPE_PROC_REF(/datum, qdel_self)), 1, TIMER_STOPPABLE)
 
 // Called when the turf we're on is deleted/changed.
 /atom/movable/openspace/mimic/proc/owning_turf_changed()
 	if (!destruction_timer)
-		destruction_timer = addtimer(CALLBACK(src, TYPE_PROC_REF(/datum, qdel_self)), 10 SECONDS, TIMER_STOPPABLE)
+		destruction_timer = addtimer(CALLBACK(src, TYPE_PROC_REF(/datum, qdel_self)), 1, TIMER_STOPPABLE)
 
 // -- TURF PROXY --
 

--- a/html/changelogs/Bat-ZCopyTimer.yml
+++ b/html/changelogs/Bat-ZCopyTimer.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - bugfix: "Reduces openspace mimic destruction timers from 10 seconds to 0.1 second to remove persistent ghosting when changing z-levels (such as using stairs or ladders)."


### PR DESCRIPTION
Fixes https://github.com/Aurorastation/Aurora.3/issues/22296

This appears to have been caused by an excessively long timer delay in the destruction of the 'mimic' object created when an AM is viewable from above through an openspace turf. Now, when transitioning up a staircase or ladder to a higher z-level, mimics of yourself and any objects you may have been pulling are no longer still visible for 10 seconds.

I do not know exactly why the original timer was set for so long.

I did not detect any performance issues or harddels when testing it (knocking a bunch of random holes in the the 2nd floor of runtime and setting a bunch of greimorians loose on the 1st floor so that their openspace mimics would be continually created and destroyed.