### PR TITLE
Ho'taki rifle in raider prep now has correct ammo caliber available

### DIFF
--- a/html/changelogs/Bat-RaiderRifleAmmo.yml
+++ b/html/changelogs/Bat-RaiderRifleAmmo.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - bugfix: "Ho'taki marksman rifle in Raider prep area now has correct caliber ammunition available next to it."


### PR DESCRIPTION
Fixes https://github.com/Aurorastation/Aurora.3/issues/22216

Ammo on the table next to it were two magazines of 10 rounds of 7.62. Replaced with same of 6.8.

I don't know why StrongDMM decided that there's no longer a definition for tile ydS according to changed files, but nothing has been modified on the main Horizon map.