### PR TITLE
Long-range cameras

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -43,6 +43,10 @@
 
 	var/affected_by_emp_until = 0
 
+	/// This variable means that a camera is always accessible, no matter the z-level. This is used for integrated cameras in helmets, integrated circuits, etc.
+	/// In the future, this would be more logically tied to telecomms range on the overmap, but for now this is for playability.
+	var/long_range = FALSE
+
 /obj/machinery/camera/Initialize()
 	wires = new(src)
 	assembly = new(src)

--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -25,6 +25,7 @@
 	camera = new(src)
 	camera.c_tag = channel
 	camera.status = FALSE
+	camera.long_range = TRUE
 	radio = new(src)
 	radio.get_frequency(FALSE)
 	radio.set_frequency(ENT_FREQ)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -87,6 +87,7 @@
 	if(ispath(camera))
 		camera = new camera(src)
 		camera.set_status(0)
+		camera.long_range = TRUE
 
 	if(camera)
 		camera.set_status(!camera.status)

--- a/code/modules/heavy_vehicle/mecha.dm
+++ b/code/modules/heavy_vehicle/mecha.dm
@@ -236,6 +236,7 @@
 		camera = new /obj/machinery/camera(src, 0, TRUE, TRUE)
 		camera.c_tag = name
 		camera.replace_networks(list(NETWORK_MECHS))
+		camera.long_range = TRUE
 
 	// Create HUD.
 	instantiate_hud()

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -258,6 +258,7 @@
 /obj/item/integrated_circuit/output/video_camera/Initialize()
 	. = ..()
 	camera = new(src, 0, TRUE, TRUE)
+	camera.long_range = TRUE
 	on_data_written()
 
 /obj/item/integrated_circuit/output/video_camera/Destroy()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -164,6 +164,7 @@
 	if(!camera)
 		camera = new /obj/machinery/camera(src, 0, TRUE, TRUE)
 		camera.c_tag = real_name
+		camera.long_range = TRUE
 		if(!scrambled_codes)
 			camera.replace_networks(list(NETWORK_STATION, NETWORK_ROBOTS))
 		else

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -66,6 +66,7 @@
 	camera = new /obj/machinery/camera(src, 0, TRUE, TRUE)
 	camera.c_tag = "spiderbot-[real_name]"
 	camera.replace_networks(list("SS13"))
+	camera.long_range = TRUE
 
 /mob/living/simple_animal/spiderbot/Destroy()
 	eject_brain()

--- a/code/modules/modular_computers/file_system/programs/security/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/security/camera.dm
@@ -157,7 +157,7 @@
 		A.client.eye = A.eyeobj
 		return TRUE
 
-	if(!is_contact_area(get_area(C)))
+	if(!is_contact_area(get_area(C)) && !C.long_range)
 		to_chat(user, SPAN_NOTICE("This camera is too far away to connect to!"))
 		return FALSE
 

--- a/html/changelogs/Bat-RemoteCameras.yml
+++ b/html/changelogs/Bat-RemoteCameras.yml
@@ -2,3 +2,5 @@ author: Batrachophrenoboocosmomachia
 delete-after: True
 changes:
   - qol: "Embedded cameras (basically every video camera EXCEPT those which are installed on walls) can now be viewed from any z-level, not just connected ones."
+  - rscadd: "Adds several public camera monitor consoles to the Horizon (near where public sensor grid feed consoles already exist)."
+  - rscadd: "Adds some spare camera console boards to Horizon technical storage."

--- a/html/changelogs/Bat-RemoteCameras.yml
+++ b/html/changelogs/Bat-RemoteCameras.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - qol: "Embedded cameras (basically every video camera EXCEPT those which are installed on walls) can now be viewed from any z-level, not just connected ones."


### PR DESCRIPTION
changes:
  - qol: "Embedded cameras (basically every video camera EXCEPT those which are installed on walls) can now be viewed from any z-level, not just connected ones."
  - rscadd: "Adds several public camera monitor consoles to the Horizon (near where public sensor grid feed consoles already exist)."
  - rscadd: "Adds some spare camera console boards to Horizon technical storage."

This addresses the issue of people with circuit kits, helmet cams, etc., getting wired up with video feeds for offship excursions, only for everyone to learn that they can't see anything through the cameras as soon as they've left the Horizon.

A few public monitor consoles have also been added to encourage the use of this mechanic by making it more widely available to the crew at large.