### PR TITLE
Anatomy Skill

### DIFF
--- a/code/datums/skills/occupational/medical.dm
+++ b/code/datums/skills/occupational/medical.dm
@@ -66,12 +66,39 @@
 
 /singleton/skill/anatomy
 	name = "Anatomy"
-	description = "Not currently implemented."
+	description = "Governs the speed at which you can check yourself for injuries, as well as the quality of the information obtained when doing so."
 	maximum_level = SKILL_LEVEL_PROFESSIONAL
-	uneducated_skill_cap = SKILL_LEVEL_TRAINED
+	uneducated_skill_cap = SKILL_LEVEL_PROFESSIONAL
 	category =  /singleton/skill_category/occupational
 	subcategory = SKILL_SUBCATEGORY_MEDICAL
 	component_type = ANATOMY_SKILL_COMPONENT
+	skill_level_descriptions = alist(
+		SKILL_LEVEL_UNFAMILIAR = "You have zero training or knowledge of anatomy.<br>" \
+			+ " - You can only distinguish visible damage like cuts and burns.",
+		SKILL_LEVEL_FAMILIAR = "You have minimal training on the basics of anatomy. This is equivalent to a fresh med school graduate, or a military corpsman.<br>" \
+			+ "You can diagnose the following conditions: <br>" \
+			+ " - External injuries.<br>" \
+			+ " - Limb dislocation.<br>" \
+			+ " - Broken bones.<br>" \
+			+ " - Simple bleeds.",
+		SKILL_LEVEL_TRAINED = "You have years of formal training and experience with anatomy. This is equivalent to a fully licensed surgeon.<br>" \
+			+ "You can diagnose the following conditions: <br>" \
+			+ " - External injuries at a high level of detail.<br>" \
+			+ " - Limb dislocation.<br>" \
+			+ " - Broken bones.<br>" \
+			+ " - Simple bleeds.<br>" \
+			+ " - Limb necrosis.<br>" \
+			+ " - Tag injuries by triage priority.",
+		SKILL_LEVEL_PROFESSIONAL = "You are a world class physician with decades worth of training and experience.<br>" \
+			+ "You can diagnose the following conditions at the highest level of detail: <br>" \
+			+ " - External injuries at a high level of detail.<br>" \
+			+ " - Limb dislocation.<br>" \
+			+ " - Broken bones.<br>" \
+			+ " - Distinguish between simple bleeds and severed arteries.<br>" \
+			+ " - Limb necrosis.<br>" \
+			+ " - Tag injuries by triage priority."
+	)
+	required = TRUE
 
 /singleton/skill/forensics
 	name = "Forensics"

--- a/code/datums/skills/occupational/medical.dm
+++ b/code/datums/skills/occupational/medical.dm
@@ -75,13 +75,13 @@
 	skill_level_descriptions = alist(
 		SKILL_LEVEL_UNFAMILIAR = "You have zero training or knowledge of anatomy.<br>" \
 			+ " - You can only distinguish visible damage like cuts and burns.",
-		SKILL_LEVEL_FAMILIAR = "You have minimal training on the basics of anatomy. This is equivalent to a fresh med school graduate, or a military corpsman.<br>" \
+		SKILL_LEVEL_FAMILIAR = "You have minimal training on the basics of anatomy.<br>" \
 			+ "You can diagnose the following conditions: <br>" \
 			+ " - External injuries.<br>" \
 			+ " - Limb dislocation.<br>" \
 			+ " - Broken bones.<br>" \
 			+ " - Simple bleeds.",
-		SKILL_LEVEL_TRAINED = "You have years of formal training and experience with anatomy. This is equivalent to a fully licensed physician.<br>" \
+		SKILL_LEVEL_TRAINED = "You have years of formal training and experience with anatomy.<br>" \
 			+ "You can diagnose the following conditions: <br>" \
 			+ " - External injuries at a high level of detail.<br>" \
 			+ " - Limb dislocation.<br>" \
@@ -89,7 +89,7 @@
 			+ " - Simple bleeds.<br>" \
 			+ " - Limb necrosis.<br>" \
 			+ " - Tag injuries by triage priority.",
-		SKILL_LEVEL_PROFESSIONAL = "You are a world class physician with decades worth of training and experience.<br>" \
+		SKILL_LEVEL_PROFESSIONAL = "You have extensive training and experience with anatomy.<br>" \
 			+ "You can diagnose the following conditions at the highest level of detail: <br>" \
 			+ " - External injuries at a high level of detail.<br>" \
 			+ " - Limb dislocation.<br>" \

--- a/code/datums/skills/occupational/medical.dm
+++ b/code/datums/skills/occupational/medical.dm
@@ -81,7 +81,7 @@
 			+ " - Limb dislocation.<br>" \
 			+ " - Broken bones.<br>" \
 			+ " - Simple bleeds.",
-		SKILL_LEVEL_TRAINED = "You have years of formal training and experience with anatomy. This is equivalent to a fully licensed surgeon.<br>" \
+		SKILL_LEVEL_TRAINED = "You have years of formal training and experience with anatomy. This is equivalent to a fully licensed physician.<br>" \
 			+ "You can diagnose the following conditions: <br>" \
 			+ " - External injuries at a high level of detail.<br>" \
 			+ " - Limb dislocation.<br>" \

--- a/code/datums/skills/occupational/medical.dm
+++ b/code/datums/skills/occupational/medical.dm
@@ -86,7 +86,7 @@
 			+ " - External injuries at a high level of detail.<br>" \
 			+ " - Limb dislocation.<br>" \
 			+ " - Broken bones.<br>" \
-			+ " - Simple bleeds.<br>" \
+			+ " - Distinguish between simple bleeds and severed arteries.<br>" \
 			+ " - Limb necrosis.<br>" \
 			+ " - Tag injuries by triage priority.",
 		SKILL_LEVEL_PROFESSIONAL = "You have extensive training and experience with anatomy.<br>" \

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -215,48 +215,90 @@
 			var/mob/living/carbon/human/H = src
 			src.visible_message(
 				SPAN_NOTICE("[src] examines [src.get_pronoun("himself")]."), \
-				SPAN_NOTICE("You check yourself for injuries.") \
+				SPAN_NOTICE("You start checking yourself for injuries.") \
 				)
+
+			var/anatomy = GET_SKILL_LEVEL(M, ANATOMY_SKILL_COMPONENT)
+			if (!do_after(M, 5 SECONDS * (1 / (anatomy ? anatomy : 1))))
+				to_chat(M, SPAN_WARNING("You must stand still to examine yourself for injuries."))
+				return
+
+			// Set to vanilla-equivalent for people without the skill.
+			if(!anatomy)
+				anatomy = 2
 
 			for(var/obj/item/organ/external/org in H.organs)
 				var/list/status = list()
 				var/brutedamage = org.brute_dam
 				var/burndamage = org.burn_dam
+
+				// Anatomy 1: All the obvious stuff
 				switch(brutedamage)
-					if(1 to 20)
-						status += "bruised"
-					if(20 to 40)
-						status += "wounded"
-					if(40 to INFINITY)
-						status += "mangled"
+					if(1 to 10)
+						status += (anatomy < 3 ? "bruised" : "superficial cuts")
+					if(10 to 25)
+						status += (anatomy < 3 ? "wounded" : "moderate physical trauma")
+					if(25 to 50)
+						status += (anatomy < 3 ? "badly injured" : "significant physical trauma")
+					if(50 to 75)
+						status += (anatomy < 3 ? "severely injured" : "YELLOW TAGGED physical trauma")
+					if(75 to 100)
+						status += (anatomy < 3 ? "extremely injured" : "RED TAGGED physical injury, loss of limb is imminent")
+					if(100 to INFINITY)
+						status += (anatomy < 3 ? "critically injured" : "BLACK TAGGED physical injury, the limb is beyond saving")
 
 				switch(burndamage)
 					if(1 to 10)
-						status += "numb"
-					if(10 to 40)
-						status += "blistered"
-					if(40 to INFINITY)
-						status += "peeling away"
+						status += (anatomy < 3 ? "numb" : "superficially burned")
+					if(10 to 25)
+						status += (anatomy < 3 ? "blistered" : "moderately burned")
+					if(25 to 50)
+						status += (anatomy < 3 ? "peeling away" : "notable 3rd degree burns")
+					if(50 to 75)
+						status += (anatomy < 3 ? "visibly charred" : "YELLOW TAGGED 3rd degree burns")
+					if(75 to 100)
+						status += (anatomy < 3 ? "black leather" : "RED TAGGED burn injury, loss of limb is imminent")
+					if(100 to INFINITY)
+						status += (anatomy < 3 ? "like charcoal" : "BLACK TAGGED burn injury, the limb is beyond saving")
 
 				if(org.is_stump())
 					status += SPAN_DANGER("MISSING")
 				if(org.status & ORGAN_MUTATED)
 					status += "weirdly shapen"
-				if(org.dislocated == 2)
-					status += "dislocated"
-				if(org.status & ORGAN_BROKEN)
-					status += "hurts when touched"
-				if(org.status & ORGAN_DEAD)
-					status += "is necrotic"
 				if(!org.is_usable())
 					status += "dangling uselessly"
-				if(org.status & ORGAN_BLEEDING)
-					status += SPAN_DANGER("bleeding")
+				// End of Anatomy 1.
+
+				// Anatomy 2: Slightly harder.
+				if(anatomy >= 2)
+					if(org.dislocated == 2)
+						status += "dislocated"
+					if(org.status & ORGAN_BROKEN)
+						status += (anatomy < 3 ? "hurts when touched" : "broken")
+					// Anatomy 2 and 3 can't distinguish between regular bleeding and arterial.
+					if(anatomy < 4 && ((org.status & ORGAN_BLEEDING) || (org.status & ORGAN_ARTERY_CUT)))
+						status += "bleeding"
+				// End of Anatomy 2.
+
+				// Anatomy 3: Descriptions start to get more medical.
+				if(anatomy >= 3)
+					if(org.status & ORGAN_DEAD)
+						status += (anatomy < 4 ? "possibly necrotic" : "visible discoloration of skin that indicates tissue necrosis")
+					if(org.status & ORGAN_BLEEDING)
+						status += "bandage-ably cut"
+				// End of Anatomy 3
+
+				// Anatomy 4:
+				if(anatomy >= 4)
+					if(org.status & ORGAN_ARTERY_CUT)
+						status += "spraying blood from a severed artery"
+				// End of Anatomy 4
+
 				var/output = ""
 				if(length(status))
 					output = "My [org.name] is [SPAN_WARNING("[english_list(status)].")]"
 				else
-					output = "My [org.name] feels [SPAN_NOTICE("OK.")]"
+					output = (anatomy < 3 ? "My [org.name] feels [SPAN_NOTICE("OK.")]" : "My [org.name] has no visible signs of injuries.")
 				if(length(org.implants))
 					output += " [SPAN_WARNING("I can feel something inside it.")]"
 				to_chat(src, output)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -284,15 +284,11 @@
 				if(anatomy >= 3)
 					if(org.status & ORGAN_DEAD)
 						status += (anatomy < 4 ? "possibly necrotic" : "visible discoloration of skin that indicates tissue necrosis")
-					if(org.status & ORGAN_BLEEDING)
-						status += "bandage-ably cut"
-				// End of Anatomy 3
-
-				// Anatomy 4:
-				if(anatomy >= 3)
 					if(org.status & ORGAN_ARTERY_CUT)
 						status += "spraying blood from a severed artery"
-				// End of Anatomy 4
+					else if(org.status & ORGAN_BLEEDING)
+						status += "bandage-ably cut"
+				// End of Anatomy 3
 
 				var/output = ""
 				if(length(status))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -289,7 +289,7 @@
 				// End of Anatomy 3
 
 				// Anatomy 4:
-				if(anatomy >= 4)
+				if(anatomy >= 3)
 					if(org.status & ORGAN_ARTERY_CUT)
 						status += "spraying blood from a severed artery"
 				// End of Anatomy 4

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -275,8 +275,8 @@
 						status += "dislocated"
 					if(org.status & ORGAN_BROKEN)
 						status += (anatomy < 3 ? "hurts when touched" : "broken")
-					// Anatomy 2 and 3 can't distinguish between regular bleeding and arterial.
-					if(anatomy < 4 && ((org.status & ORGAN_BLEEDING) || (org.status & ORGAN_ARTERY_CUT)))
+					// Anatomy 2 can't distinguish between regular bleeding and arterial.
+					if(anatomy < 3 && ((org.status & ORGAN_BLEEDING) || (org.status & ORGAN_ARTERY_CUT)))
 						status += "bleeding"
 				// End of Anatomy 2.
 

--- a/html/changelogs/hellfirejag-anatomy-skill.yml
+++ b/html/changelogs/hellfirejag-anatomy-skill.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "Implemented the Anatomy skill. Anatomy determines the quality of information received when medically examining your own injuries."


### PR DESCRIPTION
This PR provides a relatively simple first implementation for the Anatomy skill, which I have intended to be more broadly useful for any character, beyond just medical characters. The first use of Anatomy skill is for when examining your own injuries, your ranks in the skill determine both the time it takes to self-examine, as well as the quality of the information provided. Previously the injury check was instantaneous, now it takes 5 seconds to perform at its baseline, and all the way down to 1.25 seconds at maximum rank in the skill.

No ranks in Anatomy:

<img width="368" height="198" alt="image" src="https://github.com/user-attachments/assets/fd8a40f3-466d-4fb0-bd6c-99691bae9be5" />

High ranks in Anatomy:

<img width="621" height="216" alt="image" src="https://github.com/user-attachments/assets/3bb30cd4-0698-4ff1-8886-f2f0567d8594" />
