### PR TITLE
Revert "Materials And Stack Harddel"

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -62,10 +62,6 @@
 	if (src && usr && usr.machine == src)
 		usr << browse(null, "window=stack")
 		usr.unset_machine()
-
-	recipes = null
-	build_type = null
-	synths = null
 	return ..()
 
 /obj/item/stack/update_icon()

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -50,10 +50,6 @@
 
 	matter = material.get_matter()
 
-/obj/item/stack/material/Destroy()
-	material = null
-	return ..()
-
 /obj/item/stack/material/get_material()
 	return material
 


### PR DESCRIPTION
Reverts Aurorastation/Aurora.3#22313

Somehow made a race condition that causes the protolathe to delete stacks if and only if the stack would have been "finished" by fully placing the stack in the protolathe. 