### PR TITLE
Thermite sprite replacement

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -143,8 +143,8 @@ ABSTRACT_TYPE(/obj/effect/decal/cleanable/greenglow/radioactive)
 	icon_state = "cobweb2"
 
 /obj/effect/decal/cleanable/molten_item
-	name = "gooey grey mass"
-	desc = "It looks like a melted... something."
+	name = "melted grey mass"
+	desc = "It looks like a gooey melted... something."
 	density = FALSE
 	anchored = TRUE
 	layer = OBJ_LAYER

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -182,8 +182,9 @@
 	if(!can_melt())
 		return
 
-	new /obj/effect/overlay/burnt_wall(get_turf(src), name, material, reinf_material)
 	src.ChangeTurf(under_turf)
+	// Create a gooey mass of slag.
+	new /obj/effect/decal/cleanable/molten_item(src)
 
 	if(do_message)
 		visible_message(SPAN_DANGER("\The [src] spontaneously combusts!")) //!!OH SHIT!!

--- a/html/changelogs/Bat-ThermiteRemnants.yml
+++ b/html/changelogs/Bat-ThermiteRemnants.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - bugfix: "After using thermite, replaces the ancient pre-3/4s thermite burnt wall sprite left over with a bubbling mass of molten slag on the floor."


### PR DESCRIPTION
Fixes https://github.com/Aurorastation/Aurora.3/issues/22000

Replaces the ancient burnt wall sprite that thermite leaves behind with bubbling grey goo as slag (cleanable decal).