### PR TITLE
Custodial Fixes

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -360,6 +360,7 @@
 	door_color = "#6f8751"
 
 /obj/machinery/door/airlock/service/custodial // Custodial Airlock
+	icon_state = "custodial"
 	paintable = AIRLOCK_PAINTABLE_MAIN | AIRLOCK_PAINTABLE_STRIPE
 	door_color = "#6f8751"
 	stripe_color = COLOR_PURPLE_GRAY
@@ -374,6 +375,7 @@
 	close_sound_powered = 'sound/machines/airlock/hall3c.ogg'
 
 /obj/machinery/door/airlock/glass_service/custodial // Custodial Airlock (Glass)
+	icon_state = "custodial_glass"
 	paintable = AIRLOCK_PAINTABLE_MAIN | AIRLOCK_PAINTABLE_STRIPE
 	door_color = "#6f8751"
 	stripe_color = COLOR_PURPLE_GRAY

--- a/code/game/objects/structures/carts/janicart.dm
+++ b/code/game/objects/structures/carts/janicart.dm
@@ -90,7 +90,7 @@
 	if(istype(mopbucket, /obj/structure/mopbucket) && !my_bucket && do_after(user, 20))
 		mopbucket.forceMove(src)
 		my_bucket = mopbucket
-		to_chat(user, "You mount the [mopbucket] on the janicart.")
+		to_chat(user, SPAN_NOTICE("You mount \the [mopbucket] on \the [src]."))
 		get_storage_contents_list()
 	else
 		..()

--- a/html/changelogs/SleepyGemmy-custodial_fixes.yml
+++ b/html/changelogs/SleepyGemmy-custodial_fixes.yml
@@ -1,0 +1,7 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed custodial airlocks not having the correct preview sprite set."
+  - bugfix: "Fixed a message when putting a mop bucket on a custodial cart."


### PR DESCRIPTION
fixes missing stripes on the custodial airlock mapping preview and a message when you put a mop bucket on a custodial cart.