### PR TITLE
Firing Range Fixes

### DIFF
--- a/html/changelogs/SleepyGemmy-firing_range_fixes.yml
+++ b/html/changelogs/SleepyGemmy-firing_range_fixes.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed missing practice shotgun shells and practice revolver speedloaders in the security firing range."


### PR DESCRIPTION
fixes the security firing range not having practice shells- and speedloaders.

fixes #22363.