### PR TITLE
Spawn Blurb and Status Fixes

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -860,7 +860,7 @@ SUBSYSTEM_DEF(jobs)
 	set waitfor = 0
 
 	var/style = "font-family: 'Fixedsys'; -dm-text-outline: 1 black; font-size: 11px;"
-	var/text = "[worlddate2text()], [worldtime2text()]\n[station_name()], [SSatlas.current_sector.name]"
+	var/text = "[worlddate2text()] [worldtime2text()]\n[station_name()], [SSatlas.current_sector.name]"
 	text = uppertext(text)
 
 	var/obj/effect/overlay/T = new()

--- a/code/controllers/subsystems/statpanel.dm
+++ b/code/controllers/subsystems/statpanel.dm
@@ -22,8 +22,6 @@ SUBSYSTEM_DEF(statpanels)
 /datum/controller/subsystem/statpanels/fire(resumed = FALSE)
 	if (!resumed)
 		num_fires++
-		var/current_month = text2num(time2text(world.realtime, "MM"))
-		var/current_day = text2num(time2text(world.realtime, "DD"))
 		var/eta_status = "No ETA"
 		if(GLOB.evacuation_controller)
 			eta_status = GLOB.evacuation_controller.get_status_panel_eta()
@@ -31,7 +29,7 @@ SUBSYSTEM_DEF(statpanels)
 			"Map: [SSatlas.current_map.name]",
 			"Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]",
 			"Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]",
-			"Current Date: [GLOB.game_year]-[current_month]-[current_day]",
+			"Current Date: [worlddate2text()]",
 			"Round Time: [get_round_duration_formatted()]",
 			"Ship Time: [worldtime2text()]",
 			"Current Space Sector: [SSatlas.current_sector.name]",

--- a/html/changelogs/SleepyGemmy-location_blurb.yml
+++ b/html/changelogs/SleepyGemmy-location_blurb.yml
@@ -1,0 +1,7 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed an extra comma in the spawn date and time screen message."
+  - bugfix: "Fixed the month number not being prefixed correctly in the status tab."


### PR DESCRIPTION
fixes an extra comma in the spawn date and time blurb and the month number in the status tab not being prefixed correctly.