### PR TITLE
Fixes weapon racks not displaying stored guns roundstart

### DIFF
--- a/code/game/objects/structures/weapons_rack.dm
+++ b/code/game/objects/structures/weapons_rack.dm
@@ -147,7 +147,7 @@
 #define INTER_OFFSET_RIFLE_SLOT 7
 /obj/structure/weapons_rack/update_icon()
 	. = ..()
-	visual_holder.overlays.Cut()
+	visual_holder.ClearOverlays()
 	ClearOverlays()
 
 	for(var/i in 1 to length(src.contents))
@@ -162,7 +162,7 @@
 		var/mutable_appearance/weapon_appearance = mutable_appearance(G.icon, G.icon_state, plane = src.plane, layer = G.layer)
 		weapon_appearance.transform = transform_matrix
 
-		visual_holder.overlays += weapon_appearance
+		visual_holder.AddOverlays(weapon_appearance)
 
 	if(locked)
 		AddOverlays(image(src.icon, "locked_overlay", layer = ABOVE_OBJ_LAYER))

--- a/html/changelogs/kano-dot-where-are-my-weapons!.yml
+++ b/html/changelogs/kano-dot-where-are-my-weapons!.yml
@@ -1,0 +1,6 @@
+author: Kano
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed weapon racks not displaying the guns stored inside upon roundstart."


### PR DESCRIPTION
## About PR

Instead of directly poking the `overlays` list, uses overlay helper procs to queue the icons properly. Can't really fathom why this became an issue in the first place

I didn't observe any layer changes upon testing, it works as it should

<img width="401" height="200" alt="Screenshot_45" src="https://github.com/user-attachments/assets/15ecbf15-4e87-4f4e-b90a-e838db453677" />
