### PR TITLE
Professional electrical skill reveals wires

### DIFF
--- a/code/datums/skills/occupational/engineering.dm
+++ b/code/datums/skills/occupational/engineering.dm
@@ -1,12 +1,19 @@
 /singleton/skill/electrical_engineering
 	name = "Electrical Engineering"
-	description = "Not currently implemented"
+	description = "Electrical engineering covers usage and maintenance of various electrical systems, such as wiring."
 	maximum_level = SKILL_LEVEL_PROFESSIONAL
 	uneducated_skill_cap = SKILL_LEVEL_FAMILIAR
 	category =  /singleton/skill_category/occupational
 	subcategory = SKILL_SUBCATEGORY_ENGINEERING
 	required = TRUE
 	component_type = ELECTRICAL_ENGINEERING_SKILL_COMPONENT
+	skill_level_descriptions = alist(
+		SKILL_LEVEL_UNFAMILIAR = "You have little to no experience working with electrical systems.",
+		SKILL_LEVEL_FAMILIAR = "You have some experience working with electrical systes, though are not formally trained.",
+		SKILL_LEVEL_TRAINED = "You have formal training in electrical engineering concepts, equivalent to a Bachelor's Degree.",
+		SKILL_LEVEL_PROFESSIONAL = "You have many years of training in electrical related Engineering concepts, equivalent to a Master's Degree or better.<br>" \
+			+ " - You can tell what most machinery and airlock wires do just by looking at them." \
+	)
 
 /singleton/skill/mechanical_engineering
 	name = "Mechanical Engineering"

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -300,9 +300,13 @@ GLOBAL_LIST_INIT(wire_name_directory, list())
 	var/reveal_wires = can_reveal_wires(user)
 
 	for(var/color in colors)
+		var/wire_label = null
+		if (reveal_wires || always_reveal_wire(color))
+			wire_label = is_dud_color(color) ? "None" : get_wire(color)
+
 		payload.Add(list(list(
 			"color" = color,
-			"wire" = (((reveal_wires || always_reveal_wire(color)) && !is_dud_color(color)) ? get_wire(color) : null),
+			"wire" = wire_label,
 			"cut" = is_color_cut(color),
 			"attached" = is_attached(color)
 		)))

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -251,8 +251,16 @@ GLOBAL_LIST_INIT(wire_name_directory, list())
 	if(isghost(user) && check_rights(R_MOD, FALSE, user))
 		return TRUE
 
-	// Station blueprints do that too, but only if the wires are not randomized.
-	if(istype(user.get_active_hand(), /obj/item/blueprints) && !random)
+	// The following checks only apply for non-randomized wires.
+	if (random)
+		return FALSE
+
+	// Station blueprints do that too
+	if(istype(user.get_active_hand(), /obj/item/blueprints))
+		return TRUE
+
+	// Max electrical engineering skill grants this as a perk
+	if (GET_SKILL_LEVEL(user, ELECTRICAL_ENGINEERING_SKILL_COMPONENT) >= SKILL_LEVEL_PROFESSIONAL)
 		return TRUE
 
 	return FALSE

--- a/html/changelogs/SierraKomodo-electrical-skill-examine-wires.yml
+++ b/html/changelogs/SierraKomodo-electrical-skill-examine-wires.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: SierraKomodo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Electrical Engineering skill of Professional now allows you to see the purpose of non-randomized wires, without needing to have blueprints or fancy tools."

--- a/html/changelogs/SierraKomodo-electrical-skill-examine-wires.yml
+++ b/html/changelogs/SierraKomodo-electrical-skill-examine-wires.yml
@@ -56,3 +56,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscadd: "Electrical Engineering skill of Professional now allows you to see the purpose of non-randomized wires, without needing to have blueprints or fancy tools."
+  - rscadd: "Dud wires (Wires that do nothing) now appear as 'None' in the wire panel UI if wire purposes are revealed."


### PR DESCRIPTION
Professional level in the Electrical Engineering skill now reveals (non randomized) wire functions to mobs. Basically just takes the existing functionality applied to having blueprints, and lets them see this without needing said blueprints.

Inspired by a similar mechanic present on Baystation.

Also added a tweak to display 'None' for dud wires instead of leaving the field blank, because empty field made me think there was a bug.