### PR TITLE
Light Sensitivity Refactor

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -546,6 +546,8 @@
 #include "code\datums\elements\empprotection.dm"
 #include "code\datums\elements\light_blocking.dm"
 #include "code\datums\elements\temporary.dm"
+#include "code\datums\elements\traits\dark_afraid.dm"
+#include "code\datums\elements\traits\light_sensitivity.dm"
 #include "code\datums\ert\corporate.dm"
 #include "code\datums\ert\outsider.dm"
 #include "code\datums\ert\responseteam.dm"

--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -57,3 +57,6 @@
 
 /// Signal raised at the end of a mob's vision update to check if signals wish to supplement their own huds.
 #define COMSIG_MOB_UPDATE_VISION "mob_update_vision"
+
+/// Signal raised when a mob checks for their flash protection.
+#define COMSIG_GET_FLASH_PROTECTION_MODIFIERS "get_flash_protection_modifiers"

--- a/code/__DEFINES/origin_traits.dm
+++ b/code/__DEFINES/origin_traits.dm
@@ -1,13 +1,12 @@
 // A set of traits used to determine which origin quirks to apply to characters.
+// These should all eventually be fully replaced with ECS methods.
 #define TRAIT_ORIGIN_IGNORE_CAPSAICIN "ignore_capsaicin"
 #define TRAIT_ORIGIN_ALCOHOL_RESISTANCE "alcohol_resistance"
 #define TRAIT_ORIGIN_DRUG_RESISTANCE "drug_resistance"
-#define TRAIT_ORIGIN_DARK_AFRAID "dark_sensitivity"
 #define TRAIT_ORIGIN_TOX_RESISTANCE "toxin_resistance"
 #define TRAIT_ORIGIN_COLD_RESISTANCE "cold_resistance"
 #define TRAIT_ORIGIN_HOT_RESISTANCE "hot_resistance"
 #define TRAIT_ORIGIN_NO_ANIMAL_PROTEIN "no_animal_protein"
-#define TRAIT_ORIGIN_LIGHT_SENSITIVE "light_sensitive"
 #define TRAIT_ORIGIN_STAMINA_BONUS "stamina_bonus"
 #define TRAIT_ORIGIN_PAIN_RESISTANCE "pain_resistance"
 

--- a/code/datums/elements/traits/dark_afraid.dm
+++ b/code/datums/elements/traits/dark_afraid.dm
@@ -1,0 +1,25 @@
+/datum/element/dark_afraid
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
+
+	/// The set of messages to draw from for characters with the Nyctophobia trait.
+	var/list/afraid_of_the_dark_messages = list(
+		"You feel a bit afraid...",
+		"You feel somewhat nervous...",
+		"You could use a little light here...",
+		"It's dark enough that you feel a little anxious..."
+	)
+
+/datum/element/dark_afraid/Attach(datum/target)
+	. = ..()
+	RegisterSignal(target, COMSIG_MOB_UPDATE_VISION, PROC_REF(handle_vision_update))
+
+/datum/element/dark_afraid/Detach(datum/target)
+	. = ..()
+	UnregisterSignal(target, COMSIG_MOB_UPDATE_VISION)
+
+/datum/element/dark_afraid/proc/handle_vision_update(mob/living/carbon/human/human)
+	SIGNAL_HANDLER
+	if (!prob(2) || astype(get_turf(human), /turf)?.get_lumcount() >= 0.2)
+		return
+
+	to_chat(human, SPAN_WARNING(pick(afraid_of_the_dark_messages)))

--- a/code/datums/elements/traits/dark_afraid.dm
+++ b/code/datums/elements/traits/dark_afraid.dm
@@ -14,6 +14,9 @@
 		"It's dark enough that you feel a little anxious..."
 	)
 
+	/// How much this trait modifies morale when triggering.
+	var/morale_modifier = -10.0
+
 /datum/element/dark_afraid/Attach(datum/target)
 	. = ..()
 	RegisterSignal(target, COMSIG_MOB_UPDATE_VISION, PROC_REF(handle_vision_update))
@@ -32,5 +35,5 @@
 	if (!morale_comp)
 		return
 
-	var/datum/moodlet/nyctophobia_moodlet = morale_comp.load_moodlet(/datum/moodlet/dark_afraid, -10.0)
+	var/datum/moodlet/nyctophobia_moodlet = morale_comp.load_moodlet(/datum/moodlet/dark_afraid, morale_modifier)
 	nyctophobia_moodlet.refresh_moodlet()

--- a/code/datums/elements/traits/dark_afraid.dm
+++ b/code/datums/elements/traits/dark_afraid.dm
@@ -14,8 +14,8 @@
 	RegisterSignal(target, COMSIG_MOB_UPDATE_VISION, PROC_REF(handle_vision_update))
 
 /datum/element/dark_afraid/Detach(datum/target)
-	. = ..()
 	UnregisterSignal(target, COMSIG_MOB_UPDATE_VISION)
+	return ..()
 
 /datum/element/dark_afraid/proc/handle_vision_update(mob/living/carbon/human/human)
 	SIGNAL_HANDLER

--- a/code/datums/elements/traits/dark_afraid.dm
+++ b/code/datums/elements/traits/dark_afraid.dm
@@ -1,3 +1,8 @@
+/// Moodlet spawned by the Nyctophobia trait
+/datum/moodlet/dark_afraid
+	duration = 2 MINUTES
+
+/// Element used by the Nyctophobia trait.
 /datum/element/dark_afraid
 	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
 
@@ -23,3 +28,9 @@
 		return
 
 	to_chat(human, SPAN_WARNING(pick(afraid_of_the_dark_messages)))
+	var/datum/component/morale/morale_comp = human.GetComponent(MORALE_COMPONENT)
+	if (!morale_comp)
+		return
+
+	var/datum/moodlet/nyctophobia_moodlet = morale_comp.load_moodlet(/datum/moodlet/dark_afraid, -10.0)
+	nyctophobia_moodlet.refresh_moodlet()

--- a/code/datums/elements/traits/light_sensitivity.dm
+++ b/code/datums/elements/traits/light_sensitivity.dm
@@ -13,6 +13,9 @@
 		"The bright light leaves your vision strained."
 	)
 
+	/// How much this trait modifies morale when triggering.
+	var/morale_modifier = -10.0
+
 /datum/element/light_sensitivity/Attach(datum/target)
 	. = ..()
 	RegisterSignal(target, COMSIG_MOB_UPDATE_VISION, PROC_REF(handle_vision_update))
@@ -41,7 +44,7 @@
 	to_chat(human, SPAN_WARNING(pick(eye_sensitivity_messages)))
 	var/datum/component/morale/morale_comp = human.GetComponent(MORALE_COMPONENT)
 	if (morale_comp)
-		var/datum/moodlet/photosensitivity_moodlet = morale_comp.load_moodlet(/datum/moodlet/light_sensitivity, -10.0)
+		var/datum/moodlet/photosensitivity_moodlet = morale_comp.load_moodlet(/datum/moodlet/light_sensitivity, morale_modifier)
 		photosensitivity_moodlet.refresh_moodlet()
 
 	if(!prob(20))

--- a/code/datums/elements/traits/light_sensitivity.dm
+++ b/code/datums/elements/traits/light_sensitivity.dm
@@ -1,3 +1,8 @@
+/// Moodlet spawned by the Photosensitivity trait.
+/datum/moodlet/light_sensitivity
+	duration = 2 MINUTES
+
+/// Element used by the Photosensitivity trait.
 /datum/element/light_sensitivity
 	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
 
@@ -34,6 +39,11 @@
 
 	human.eye_blurry = max(human.eye_blurry, 6)
 	to_chat(human, SPAN_WARNING(pick(eye_sensitivity_messages)))
+	var/datum/component/morale/morale_comp = human.GetComponent(MORALE_COMPONENT)
+	if (morale_comp)
+		var/datum/moodlet/photosensitivity_moodlet = morale_comp.load_moodlet(/datum/moodlet/light_sensitivity, -10.0)
+		photosensitivity_moodlet.refresh_moodlet()
+
 	if(!prob(20))
 		return
 

--- a/code/datums/elements/traits/light_sensitivity.dm
+++ b/code/datums/elements/traits/light_sensitivity.dm
@@ -1,0 +1,47 @@
+/datum/element/light_sensitivity
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
+
+	/// The set of messages to draw from for characters with the Photosensitivity trait.
+	var/list/eye_sensitivity_messages = list(
+		"Your eyes tire a bit from the brightness.",
+		"Your eyes sting a little; it's too bright.",
+		"The bright light leaves your vision strained."
+	)
+
+/datum/element/light_sensitivity/Attach(datum/target)
+	. = ..()
+	RegisterSignal(target, COMSIG_MOB_UPDATE_VISION, PROC_REF(handle_vision_update))
+
+/datum/element/light_sensitivity/Detach(datum/target)
+	. = ..()
+	UnregisterSignal(target, COMSIG_MOB_UPDATE_VISION)
+
+/datum/element/light_sensitivity/proc/handle_vision_update(mob/living/carbon/human/human)
+	SIGNAL_HANDLER
+	// First check the light level every once in awhile
+	if (!prob(0.5) || astype(get_turf(human), /turf)?.get_lumcount() <= 0.95)
+		return
+
+	// Then check if they've got protection from bright lights
+	if (human.get_flash_protection() <= 0 || !istype(human.glasses, /obj/item/clothing/glasses/fakesunglasses))
+		return
+
+	// And check if someone cut their eyes out.
+	if(!human.get_eyes())
+		return
+
+	human.eye_blurry = max(human.eye_blurry, 6)
+	to_chat(human, SPAN_WARNING(pick(eye_sensitivity_messages)))
+	if(!prob(20))
+		return
+
+	// If your eyes are covered, people can see you squinting.
+	var/list/protection = list(human.head, human.glasses, human.wear_mask)
+	var/eyes_covered = FALSE
+	for(var/obj/item/I in protection)
+		if(I?.body_parts_covered & EYES)
+			eyes_covered = TRUE
+	if(eyes_covered)
+		return
+
+	human.visible_message("[human] squints in discomfort.")

--- a/code/datums/elements/traits/light_sensitivity.dm
+++ b/code/datums/elements/traits/light_sensitivity.dm
@@ -37,11 +37,8 @@
 
 	// If your eyes are covered, people can see you squinting.
 	var/list/protection = list(human.head, human.glasses, human.wear_mask)
-	var/eyes_covered = FALSE
 	for(var/obj/item/I in protection)
 		if(I?.body_parts_covered & EYES)
-			eyes_covered = TRUE
-	if(eyes_covered)
-		return
+			return
 
 	human.visible_message("[human] squints in discomfort.")

--- a/code/datums/elements/traits/light_sensitivity.dm
+++ b/code/datums/elements/traits/light_sensitivity.dm
@@ -11,10 +11,12 @@
 /datum/element/light_sensitivity/Attach(datum/target)
 	. = ..()
 	RegisterSignal(target, COMSIG_MOB_UPDATE_VISION, PROC_REF(handle_vision_update))
+	RegisterSignal(target, COMSIG_GET_FLASH_PROTECTION_MODIFIERS, PROC_REF(handle_flash_protection))
 
 /datum/element/light_sensitivity/Detach(datum/target)
-	. = ..()
 	UnregisterSignal(target, COMSIG_MOB_UPDATE_VISION)
+	UnregisterSignal(target, COMSIG_GET_FLASH_PROTECTION_MODIFIERS)
+	return ..()
 
 /datum/element/light_sensitivity/proc/handle_vision_update(mob/living/carbon/human/human)
 	SIGNAL_HANDLER
@@ -42,3 +44,7 @@
 			return
 
 	human.visible_message("[human] squints in discomfort.")
+
+/datum/element/light_sensitivity/proc/handle_flash_protection(mob/living/carbon/human/human, base_flash_protection)
+	SIGNAL_HANDLER
+	*base_flash_protection = *base_flash_protection - 1

--- a/code/game/objects/items/devices/lighting/flashlight.dm
+++ b/code/game/objects/items/devices/lighting/flashlight.dm
@@ -208,7 +208,7 @@
 
 		var/mob/living/carbon/human/H = target_mob	//mob has protective eyewear
 		if(istype(H))
-			if(H.get_flash_protection() >= FLASH_PROTECTION_NONE)
+			if(H.get_flash_protection() > FLASH_PROTECTION_NONE)
 				to_chat(user, SPAN_WARNING("You're going to need to remove \the [H]'s eye protection first."))
 				return
 

--- a/code/game/objects/items/devices/lighting/flashlight.dm
+++ b/code/game/objects/items/devices/lighting/flashlight.dm
@@ -208,7 +208,7 @@
 
 		var/mob/living/carbon/human/H = target_mob	//mob has protective eyewear
 		if(istype(H))
-			if(H.get_flash_protection())
+			if(H.get_flash_protection() >= FLASH_PROTECTION_NONE)
 				to_chat(user, SPAN_WARNING("You're going to need to remove \the [H]'s eye protection first."))
 				return
 

--- a/code/modules/background/origins/origins/human/coalition.dm
+++ b/code/modules/background/origins/origins/human/coalition.dm
@@ -28,8 +28,12 @@
 	possible_accents = list(ACCENT_HIMEO)
 	possible_citizenships = CITIZENSHIPS_COALITION
 	possible_religions = RELIGIONS_COALITION
-	origin_traits = list(TRAIT_ORIGIN_COLD_RESISTANCE, TRAIT_ORIGIN_LIGHT_SENSITIVE)
+	origin_traits = list(TRAIT_ORIGIN_COLD_RESISTANCE)
 	origin_traits_descriptions = list("are more acclimatised to the cold.", "are more sensitive to bright lights")
+
+/singleton/origin_item/origin/himeo/on_apply(mob/living/carbon/human/H)
+	. = ..()
+	H.AddElement(/datum/element/light_sensitivity)
 
 /singleton/origin_item/origin/vysoka
 	name = "Free System of Vysoka"
@@ -96,8 +100,11 @@
 	possible_accents = list(ACCENT_ASSUNZIONE)
 	possible_citizenships = CITIZENSHIPS_COALITION
 	possible_religions = list(RELIGION_LUCEISM)
-	origin_traits = list(TRAIT_ORIGIN_DARK_AFRAID)
 	origin_traits_descriptions = list("tend to feel nervous in the dark")
+
+/singleton/origin_item/origin/assunzione/on_apply(mob/living/carbon/human/H)
+	. = ..()
+	H.AddElement(/datum/element/dark_afraid)
 
 /singleton/origin_item/origin/ncf
 	name = "Non-Coalition Frontier"

--- a/code/modules/background/origins/origins/human/sol.dm
+++ b/code/modules/background/origins/origins/human/sol.dm
@@ -92,8 +92,12 @@
 	possible_accents = list(ACCENT_EUROPA)
 	possible_citizenships = CITIZENSHIPS_SOLARIAN
 	possible_religions = RELIGIONS_SOLARIAN
-	origin_traits = list(TRAIT_ORIGIN_COLD_RESISTANCE, TRAIT_ORIGIN_LIGHT_SENSITIVE)
+	origin_traits = list(TRAIT_ORIGIN_COLD_RESISTANCE)
 	origin_traits_descriptions = list("are more acclimatised to the cold.", "are more sensitive to bright lights")
+
+/singleton/origin_item/origin/jupiter_eur/on_apply(mob/living/carbon/human/H)
+	. = ..()
+	H.AddElement(/datum/element/light_sensitivity)
 
 /singleton/origin_item/origin/saturn
 	name = "Saturn"

--- a/code/modules/mob/abstract/new_player/character_traits.dm
+++ b/code/modules/mob/abstract/new_player/character_traits.dm
@@ -4,63 +4,63 @@
 	var/name = "Enigma"
 	var/desc = "This trait was not meant to be seen by mortal minds."
 
-/datum/character_disabilities/proc/apply_self(var/mob/living/carbon/human/H)
+/datum/character_disabilities/proc/apply_self(mob/living/carbon/human/H)
 	return
 
 /datum/character_disabilities/nearsighted
 	name = "Nearsightedness"
 	desc = "Without prescription glasses your vision is impaired."
 
-/datum/character_disabilities/nearsighted/apply_self(var/mob/living/carbon/human/H)
+/datum/character_disabilities/nearsighted/apply_self(mob/living/carbon/human/H)
 	H.disabilities |= NEARSIGHTED
 
 /datum/character_disabilities/stutter
 	name = "Stuttering"
 	desc = "You have a chronic case of stuttering, repeating sounds involuntarily."
 
-/datum/character_disabilities/stutter/apply_self(var/mob/living/carbon/human/H)
+/datum/character_disabilities/stutter/apply_self(mob/living/carbon/human/H)
 	H.disabilities |= STUTTERING
 
 /datum/character_disabilities/deuteranomaly
 	name = "Deuteranopia"
 	desc = "You have difficulty perceiving green."
 
-/datum/character_disabilities/deuteranomaly/apply_self(var/mob/living/carbon/human/H)
+/datum/character_disabilities/deuteranomaly/apply_self(mob/living/carbon/human/H)
 	H.add_client_color(/datum/client_color/deuteranopia, TRUE)
 
 /datum/character_disabilities/protanopia
 	name = "Protanopia"
 	desc = "You have difficulty perceiving red."
 
-/datum/character_disabilities/protanopia/apply_self(var/mob/living/carbon/human/H)
+/datum/character_disabilities/protanopia/apply_self(mob/living/carbon/human/H)
 	H.add_client_color(/datum/client_color/protanopia, TRUE)
 
 /datum/character_disabilities/tritanopia
 	name = "Tritanopia"
 	desc = "You have difficulty perceiving green and yellow."
 
-/datum/character_disabilities/tritanopia/apply_self(var/mob/living/carbon/human/H)
+/datum/character_disabilities/tritanopia/apply_self(mob/living/carbon/human/H)
 	H.add_client_color(/datum/client_color/tritanopia, TRUE)
 
 /datum/character_disabilities/total_colorblind
 	name = "Total Colorblindness"
 	desc = "You cannot see color, only black, white, and shades of gray."
 
-/datum/character_disabilities/total_colorblind/apply_self(var/mob/living/carbon/human/H)
+/datum/character_disabilities/total_colorblind/apply_self(mob/living/carbon/human/H)
 	H.add_client_color(/datum/client_color/monochrome, TRUE)
 
 /datum/character_disabilities/deaf
 	name = "Deafness"
 	desc = "You are unable to percieve sound."
 
-/datum/character_disabilities/deaf/apply_self(var/mob/living/carbon/human/H)
+/datum/character_disabilities/deaf/apply_self(mob/living/carbon/human/H)
 	H.sdisabilities |= DEAF
 
 /datum/character_disabilities/asthma
 	name = "Asthma"
 	desc = "You are prone to inflammation in the lungs."
 
-/datum/character_disabilities/asthma/apply_self(var/mob/living/carbon/human/H)
+/datum/character_disabilities/asthma/apply_self(mob/living/carbon/human/H)
 	H.disabilities |= ASTHMA
 	if(H.max_stamina)
 		H.max_stamina *= 0.8
@@ -72,7 +72,7 @@
 	/// This takes a TRAIT_DISABILITY_* type trait, and assigns it to the character on apply_self
 	var/trait_type = TRAIT_DISABILITY_HEMOPHILIA
 
-/datum/character_disabilities/hemophilia/apply_self(var/mob/living/carbon/human/H)
+/datum/character_disabilities/hemophilia/apply_self(mob/living/carbon/human/H)
 	ADD_TRAIT(H, trait_type, DISABILITY_TRAIT)
 
 /datum/character_disabilities/hemophilia/major
@@ -85,7 +85,7 @@ ABSTRACT_TYPE(/datum/character_disabilities/organ_scarring)
 	name = "Organ Scarring"
 	var/affected_organ
 
-/datum/character_disabilities/organ_scarring/apply_self(var/mob/living/carbon/human/target)
+/datum/character_disabilities/organ_scarring/apply_self(mob/living/carbon/human/target)
 	var/obj/item/organ/internal/affecting = target.internal_organs_by_name[affected_organ]
 	if(affecting)
 		affecting.set_max_damage(initial(affecting.max_damage) * 0.5)
@@ -111,7 +111,7 @@ ABSTRACT_TYPE(/datum/character_disabilities/broken)
 	name = "Bruised Limb"
 	var/affected_limb
 
-/datum/character_disabilities/broken/apply_self(var/mob/living/carbon/human/target)
+/datum/character_disabilities/broken/apply_self(mob/living/carbon/human/target)
 	var/obj/item/organ/external/affecting = target.get_organ(affected_limb)
 	if(affecting)
 		affecting.fracture(silent = TRUE)
@@ -141,7 +141,7 @@ BROKEN_DISABILITY(right_foot, "Right Foot", BP_R_FOOT)
 		+ "Though this does not grant any psychic abilities, a character with this trait is counted as being psychic for a variety of effects." \
 		+ "For example, having the ability to distinguish the source of telepathic signals, but also taking bonus damage from anything that deals bonus damage to psychics."
 
-/datum/character_disabilities/high_psi_sensitivity/apply_self(var/mob/living/carbon/human/H)
+/datum/character_disabilities/high_psi_sensitivity/apply_self(mob/living/carbon/human/H)
 	H.AddComponent(HIGH_PSI_SENSITIVITY_COMPONENT)
 
 /datum/character_disabilities/low_psi_sensitivity
@@ -151,5 +151,20 @@ BROKEN_DISABILITY(right_foot, "Right Foot", BP_R_FOOT)
 		+ "For example, losing the ability to distinguish the source of telepathic signals, or taking brain damage when having their mind read." \
 		+ "On the opposite end of the spectrum, anything that deals bonus damage to psychics will also deal reduced damage to you."
 
-/datum/character_disabilities/low_psi_sensitivity/apply_self(var/mob/living/carbon/human/H)
+/datum/character_disabilities/low_psi_sensitivity/apply_self(mob/living/carbon/human/H)
 	H.AddComponent(LOW_PSI_SENSITIVITY_COMPONENT)
+
+/datum/character_disabilities/photosensitivity
+	name = "Photosensitivity"
+	desc = "You are highly sensitive to bright lights. " \
+		+ "Characters with this trait suffer from painful sensations and degraded vision when standing in brightly lit areas without eye protection. "
+
+/datum/character_disabilities/photosensitivity/apply_self(mob/living/carbon/human/H)
+	H.AddElement(/datum/element/light_sensitivity)
+
+/datum/character_disabilities/nyctophobia
+	name = "Nyctophobia"
+	desc = "You have a fear of the dark."
+
+/datum/character_disabilities/nyctophobia/apply_self(mob/living/carbon/human/H)
+	H.AddElement(/datum/element/dark_afraid)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -914,6 +914,7 @@
 	var/base_flash_protection = flash_protection
 
 	// Fetch flash protection modifiers via ECS methods.
+	// Anything in this proc that doesn't hook into this signal should eventually be replaced with signal registry methods for simplicity.
 	SEND_SIGNAL(src, COMSIG_GET_FLASH_PROTECTION_MODIFIERS, &base_flash_protection)
 
 	if (!ignore_inherent)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -893,6 +893,8 @@
 /// Returns a number between -1 to 2
 /mob/living/carbon/human/get_flash_protection(ignore_inherent = FALSE)
 
+	// Handle all the exits first before we do the standard method.
+
 	//Ling
 	var/datum/changeling/changeling = changeling_power(0, 0, 0)
 	if(changeling && changeling.using_thermals)
@@ -905,13 +907,16 @@
 	if (I && I.status & ORGAN_CUT_AWAY)
 		return FLASH_PROTECTION_MAJOR
 
-	if (!ignore_inherent && species.inherent_eye_protection)
-		. = max(species.inherent_eye_protection, flash_protection)
-	else
-		return flash_protection
+	// Standard method, sum of modifiers.
+	var/base_flash_protection = flash_protection
 
-	if(HAS_TRAIT(src, TRAIT_ORIGIN_LIGHT_SENSITIVE))
-		return max(. - 1, FLASH_PROTECTION_REDUCED)
+	// Fetch flash protection modifiers via ECS methods.
+	SEND_SIGNAL(src, COMSIG_GET_FLASH_PROTECTION_MODIFIERS, &base_flash_protection)
+
+	if (!ignore_inherent)
+		base_flash_protection += species.inherent_eye_protection
+
+	return base_flash_protection
 
 /mob/living/carbon/human/flash_act(intensity = FLASH_PROTECTION_MODERATE, override_blindness_check = FALSE, affect_silicon = FALSE, ignore_inherent = FALSE, type = /atom/movable/screen/fullscreen/flash, length = 2.5 SECONDS)
 	if(..())

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -890,7 +890,10 @@
 	return
 
 
-/// Returns a number between -1 to 2
+/**
+ * Returns a numerical value between -INFINITY and +INFINITY representing a user's flash protection value.
+ * As a friendly reminder, do not use the == operator on this proc, use >= or <= instead.
+ */
 /mob/living/carbon/human/get_flash_protection(ignore_inherent = FALSE)
 
 	// Handle all the exits first before we do the standard method.
@@ -923,7 +926,7 @@
 		var/obj/item/organ/E = get_eyes(no_synthetic = !affect_silicon)
 		if(istype(E))
 			return E.flash_act(intensity, override_blindness_check, affect_silicon, ignore_inherent, type, length)
-	else if(intensity == get_flash_protection(ignore_inherent))
+	else if(intensity >= get_flash_protection(ignore_inherent))
 		if(prob(20))
 			to_chat(src, SPAN_NOTICE("Something bright flashes in the corner of your vision!"))
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1271,53 +1271,6 @@
 			if(T.get_lumcount() < 0.05)	// give a little bit of tolerance for near-dark areas.
 				playsound(null, pick(GLOB.scarySounds), 50, TRUE)
 
-		// People who are afraid of the dark get anxious.
-		if(HAS_TRAIT(src, TRAIT_ORIGIN_DARK_AFRAID))
-			T = loc
-			if(prob(2) && T.get_lumcount() < 0.2)
-				var/list/afraid_of_the_dark_messages = list(
-					"You feel a bit afraid...",
-					"You feel somewhat nervous...",
-					"You could use a little light here...",
-					"It's dark enough that you feel a little anxious..."
-				)
-				to_chat(src, SPAN_WARNING(pick(afraid_of_the_dark_messages)))
-
-		// People sensitive to light get eye strain.
-		if(HAS_TRAIT(src, TRAIT_ORIGIN_LIGHT_SENSITIVE))
-			T = loc
-			// From testing, this generally leaves several minutes between each message.
-			if(prob(0.5) && T.get_lumcount() > 0.95)
-				var/mob/living/carbon/human/self = src
-
-				// If you have this trait, your default flash protection is -1; check for ANY protection.
-				var/flash_protection = self.get_flash_protection()
-
-				// I hate this. We removed flash protection from basic sunglasses for 'powergaming concerns.'
-				// Check if we're wearing the stupid fake loadout sunglasses.
-				// Yes this is stupid. Remove this when we rebalance flash protection to be a 0-100 threshold.
-				var/fakesunglasses = istype(self?.glasses, /obj/item/clothing/glasses/fakesunglasses)
-
-				if(!flash_protection && !fakesunglasses)
-					var/obj/item/organ/eyes = self.get_eyes()
-					if(istype(eyes))
-						self.eye_blurry = max(self.eye_blurry, 6)
-						var/list/eye_sensitivity_messages = list(
-							"Your eyes tire a bit from the brightness.",
-							"Your eyes sting a little; it's too bright.",
-							"The bright light leaves your vision strained."
-						)
-						to_chat(src, SPAN_WARNING(pick(eye_sensitivity_messages)))
-						if(prob(20))
-							// If your eyes are covered, people can see you squinting.
-							var/list/protection = list(self.head, self.glasses, self.wear_mask)
-							var/eyes_covered = FALSE
-							for(var/obj/item/I in protection)
-								if(I?.body_parts_covered & EYES)
-									eyes_covered = TRUE
-							if(!eyes_covered)
-								self.visible_message("[self] squints in discomfort.")
-
 /mob/living/carbon/human/proc/handle_changeling()
 	if(mind)
 		var/datum/changeling/changeling = mind.antag_datums[MODE_CHANGELING]

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1251,9 +1251,6 @@
 	return "EAST[coord_col]:[coord_col_offset],NORTH[coord_row]:[coord_row_offset]"
 
 /mob/living/carbon/human/handle_random_events()
-	if(InStasis())
-		return
-
 	// Puke if toxloss is too high
 	if(!stat)
 		if (getToxLoss() >= 45 && !lastpuke)

--- a/html/changelogs/hellfirejag-light-sensitivity-refactor.yml
+++ b/html/changelogs/hellfirejag-light-sensitivity-refactor.yml
@@ -1,0 +1,5 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - refactor: "Refactored light sensitivity and dark phobia traits to cut down on Life() performance costs by making them elements instead of hardcoded checks for every mob."
+  - rscadd: "Added disability selections for Photosensitivity and Nyctophobia"

--- a/html/changelogs/hellfirejag-light-sensitivity-refactor.yml
+++ b/html/changelogs/hellfirejag-light-sensitivity-refactor.yml
@@ -3,3 +3,4 @@ delete-after: True
 changes:
   - refactor: "Refactored light sensitivity and dark phobia traits to cut down on Life() performance costs by making them elements instead of hardcoded checks for every mob."
   - rscadd: "Added disability selections for Photosensitivity and Nyctophobia"
+  - rscadd: "Photosensitivity and Nyctopyobia now also apply a short duration negative morale modifier in addition to displaying their flavor text when activating."


### PR DESCRIPTION
The last time the Light Sensitivity code was changed, I remarked in a review that "This should probably be a component so that its code isn't being run on every mob forever". Well I've gotten around to doing that myself, except I figured out it's even better off as an Element in this situation rather than a Component. So this is now my first time adding Elements to the repo. It turns out they're really awesome when paired with signals.

This PR removes the hardcoded check for the light senstivity and dark phobia traits from the Life() path, replacing them instead with two Elements which hook into the pre-existing signal used to handle vision updates for human mobs. I've mainly done this to help cut down on the overwhelmingly high cost of the Life() codepath, which is currently one of the most expensive paths we have.

While I was at it with refactoring these two, I noticed that there wasn't a trait selection for either of them, so I added selections for both traits to the disabilities tab so that players can opt-in to being light sensitive or afraid of the dark!

<img width="318" height="336" alt="image" src="https://github.com/user-attachments/assets/a1e60e83-d899-44df-8ea3-0cd5a87c231c" />
