### PR TITLE
Remove Changeling Processing From Life

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -84,12 +84,12 @@
 /datum/mind/proc/transfer_to(mob/living/new_character)
 	if(!istype(new_character))
 		log_world("ERROR: ## DEBUG: transfer_to(): Some idiot has tried to transfer_to( a non mob/living mob. Please inform Carn")
-	var/datum/changeling/changeling = antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = antag_datums[MODE_CHANGELING]
 	var/datum/vampire/vampire = antag_datums[MODE_VAMPIRE]
 	if(current)					//remove ourself from our old body's mind variable
 		if(changeling)
 			current.remove_changeling_powers()
-			remove_verb(current, /datum/changeling/proc/EvolutionMenu)
+			remove_verb(current, /datum/component/changeling/proc/EvolutionMenu)
 		if(vampire)
 			current.remove_vampire_powers()
 		current.mind = null

--- a/code/game/antagonist/station/changeling/changeling.dm
+++ b/code/game/antagonist/station/changeling/changeling.dm
@@ -32,7 +32,7 @@ GLOBAL_DATUM(changelings, /datum/antagonist/changeling)
 	GLOB.changelings = src
 
 /datum/antagonist/changeling/get_special_objective_text(var/datum/mind/player)
-	var/datum/changeling/changeling = player.antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = player.antag_datums[MODE_CHANGELING]
 	return "<br><b>Changeling ID:</b> [changeling.changelingID].<br><b>Genomes Absorbed:</b> [changeling.absorbedcount]"
 
 /datum/antagonist/changeling/update_antag_mob(var/datum/mind/player)
@@ -99,7 +99,7 @@ GLOBAL_DATUM(changelings, /datum/antagonist/changeling)
 /datum/antagonist/changeling/remove_antagonist(var/datum/mind/player, var/show_message = TRUE, var/implanted)
 	. = ..()
 	if(.)
-		remove_verb(player.current, /datum/changeling/proc/EvolutionMenu)
+		remove_verb(player.current, /datum/component/changeling/proc/EvolutionMenu)
 		for(var/datum/power/changeling/P in powerinstances)
 			remove_verb(player.current, P.verbpath)
 

--- a/code/game/gamemodes/changeling/helpers/_framework.dm
+++ b/code/game/gamemodes/changeling/helpers/_framework.dm
@@ -23,6 +23,14 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 	/// if they've entered stasis before, then we don't want to give them stasis again
 	var/has_entered_stasis = FALSE
 
+/datum/component/changeling/Initialize()
+	. = ..()
+	START_PROCESSING(SSprocessing, src)
+
+/datum/component/changeling/Destroy(force)
+	STOP_PROCESSING(SSprocessing, src)
+	return ..()
+
 /datum/component/changeling/process(seconds_per_tick)
 	var/mob/living/carbon/human/human = parent
 	if (QDELING(human) || !istype(human) || human.stat == DEAD)

--- a/code/game/gamemodes/changeling/helpers/_framework.dm
+++ b/code/game/gamemodes/changeling/helpers/_framework.dm
@@ -1,6 +1,6 @@
 GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa","Lambda","Mu","Nu","Xi","Omicron","Pi","Rho","Sigma","Tau","Upsilon","Phi","Chi","Psi","Omega"))
 
-/datum/changeling //stores changeling powers, changeling recharge thingie, changeling absorbed DNA and changeling ID (for changeling hivemind)
+/datum/component/changeling //stores changeling powers, changeling recharge thingie, changeling absorbed DNA and changeling ID (for changeling hivemind)
 	var/list/datum/absorbed_dna/absorbed_dna = list()
 	var/list/absorbed_languages = list()
 	var/list/hivemind_members = list()
@@ -23,8 +23,15 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 	/// if they've entered stasis before, then we don't want to give them stasis again
 	var/has_entered_stasis = FALSE
 
-/datum/changeling/New(var/gender=FEMALE)
-	..()
+/datum/component/changeling/process(seconds_per_tick)
+	var/mob/living/carbon/human/human = parent
+	if (QDELING(human) || !istype(human) || human.stat == DEAD)
+		return
+
+	regenerate()
+
+/datum/component/changeling/New(var/gender=FEMALE)
+	. = ..()
 	var/honorific = (gender == FEMALE) ? "Ms." : "Mr."
 	if(GLOB.possible_changeling_IDs.len)
 		changelingID = pick(GLOB.possible_changeling_IDs)
@@ -33,20 +40,20 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 	else
 		changelingID = "[honorific] [rand(1,999)]"
 
-/datum/changeling/proc/regenerate()
+/datum/component/changeling/proc/regenerate()
 	chem_charges = min(max(0, chem_charges + chem_recharge_rate), chem_storage)
 	geneticdamage = max(0, geneticdamage - 1)
 
-/datum/changeling/proc/GetDNA(var/dna_owner)
+/datum/component/changeling/proc/GetDNA(var/dna_owner)
 	for(var/datum/absorbed_dna/DNA in absorbed_dna)
 		if(dna_owner == DNA.name)
 			return DNA
 
-/datum/changeling/proc/use_charges(var/charges_used)
+/datum/component/changeling/proc/use_charges(var/charges_used)
 	chem_charges = max(0, chem_charges - charges_used)
 
 /mob/proc/absorbDNA(var/datum/absorbed_dna/newDNA)
-	var/datum/changeling/changeling = null
+	var/datum/component/changeling/changeling = null
 	if(mind)
 		changeling = mind.antag_datums[MODE_CHANGELING]
 	if(!changeling)
@@ -67,9 +74,9 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 	if(!changeling_mind)
 		return
 	if(!changeling_mind.antag_datums[MODE_CHANGELING])
-		changeling_mind.antag_datums[MODE_CHANGELING] = new /datum/changeling(gender)
+		changeling_mind.antag_datums[MODE_CHANGELING] = new /datum/component/changeling(gender)
 
-	add_verb(src, /datum/changeling/proc/EvolutionMenu)
+	add_verb(src, /datum/component/changeling/proc/EvolutionMenu)
 	add_language(LANGUAGE_CHANGELING)
 
 	var/lesser_form = !ishuman(src)
@@ -78,7 +85,7 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 		for(var/P in powers)
 			powerinstances += new P()
 
-	var/datum/changeling/changeling = changeling_mind.antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = changeling_mind.antag_datums[MODE_CHANGELING]
 
 	// Code to auto-purchase free powers.
 	for(var/datum/power/changeling/P in powerinstances)
@@ -111,7 +118,7 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
  * Resets a changeling to the point where they were when they first became a changeling.
  */
 /mob/proc/changeling_respec()
-	var/datum/changeling/changeling = null
+	var/datum/component/changeling/changeling = null
 	if(mind)
 		changeling = mind.antag_datums[MODE_CHANGELING]
 	if(!changeling)
@@ -132,7 +139,7 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
  * Removes a changeling's abilities
  */
 /mob/proc/remove_changeling_powers(reset_powers = FALSE)
-	var/datum/changeling/changeling
+	var/datum/component/changeling/changeling
 	if(mind)
 		changeling = mind.antag_datums[MODE_CHANGELING]
 	if(!changeling)
@@ -161,7 +168,7 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 	if(!iscarbon(src))
 		return
 
-	var/datum/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
 	if(!changeling)
 		return
 	if(src.stat > max_stat)
@@ -191,7 +198,7 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 	set category = "Changeling"
 	set name = "Re-evolve"
 
-	var/datum/changeling/changeling
+	var/datum/component/changeling/changeling
 	if(mind)
 		changeling = mind.antag_datums[MODE_CHANGELING]
 	if(!changeling)
@@ -275,7 +282,7 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 		to_chat(H, SPAN_WARNING("You don't have any changeling potential."))
 		return
 
-	var/datum/changeling/changeling = H.mind.antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = H.mind.antag_datums[MODE_CHANGELING]
 	if(changeling)
 		to_chat(H, SPAN_WARNING("You've already awakened your changeling potential!"))
 		return

--- a/code/game/gamemodes/changeling/helpers/_store.dm
+++ b/code/game/gamemodes/changeling/helpers/_store.dm
@@ -287,11 +287,11 @@ var/list/datum/power/changeling/powerinstances = list()
 // Modularchangling, totally stolen from the new player panel.  YAYY
 //I'm too afraid to touch this, you win this time, oldcode - Geeves
 // After an HTML course, I finally conquered this. Convert into TGUI eventually. - Geeves
-/datum/changeling/proc/EvolutionMenu()//The new one
+/datum/component/changeling/proc/EvolutionMenu()//The new one
 	set category = "Changeling"
 	set desc = "Buy new abilities.."
 
-	var/datum/changeling/changeling = usr.mind.antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = usr.mind.antag_datums[MODE_CHANGELING]
 	if(!usr || !usr.mind || !changeling)
 		return
 	src = changeling
@@ -536,7 +536,7 @@ var/list/datum/power/changeling/powerinstances = list()
 	power_win.open()
 
 
-/datum/changeling/Topic(href, href_list)
+/datum/component/changeling/Topic(href, href_list)
 	..()
 	if(!ismob(usr))
 		return
@@ -546,12 +546,12 @@ var/list/datum/power/changeling/powerinstances = list()
 		if(!istype(M))
 			return
 		purchasePower(M, href_list["P"])
-		call(/datum/changeling/proc/EvolutionMenu)()
+		call(/datum/component/changeling/proc/EvolutionMenu)()
 
 
 
-/datum/changeling/proc/purchasePower(var/datum/mind/M, var/power_name, var/remake_verbs = 1)
-	var/datum/changeling/changeling = M.antag_datums[MODE_CHANGELING]
+/datum/component/changeling/proc/purchasePower(var/datum/mind/M, var/power_name, var/remake_verbs = 1)
+	var/datum/component/changeling/changeling = M.antag_datums[MODE_CHANGELING]
 	if(!M || !changeling)
 		return
 

--- a/code/game/gamemodes/changeling/helpers/sting_click.dm
+++ b/code/game/gamemodes/changeling/helpers/sting_click.dm
@@ -2,7 +2,7 @@
 	SHOULD_NOT_SLEEP(TRUE)
 
 	if(isliving(target) && holder.a_intent == I_HURT && holder.mind)
-		var/datum/changeling/changeling = holder.mind.antag_datums[MODE_CHANGELING]
+		var/datum/component/changeling/changeling = holder.mind.antag_datums[MODE_CHANGELING]
 		if(changeling && changeling.prepared_sting)
 			if(changeling.prepared_sting.can_sting(target))
 				changeling.prepared_sting.do_sting(target)

--- a/code/game/gamemodes/changeling/implements/hivemind.dm
+++ b/code/game/gamemodes/changeling/implements/hivemind.dm
@@ -14,7 +14,7 @@
 	set desc = "Relinquish your life and enter the land of the dead."
 
 	announce_ghost_joinleave(ghostize(1, 0))
-	var/datum/changeling/changeling = changeling_mob.mind.antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = changeling_mob.mind.antag_datums[MODE_CHANGELING]
 	changeling.hivemind_members -= src
 	relay_hivemind(SPAN_NOTICE("[src] has left our hivemind to join the living dead."), changeling_mob)
 
@@ -28,7 +28,7 @@
 		ckey = original_body.ckey
 		changeling_mob = ling
 	if(changeling_mob)
-		var/datum/changeling/changeling = changeling_mob.mind.antag_datums[MODE_CHANGELING]
+		var/datum/component/changeling/changeling = changeling_mob.mind.antag_datums[MODE_CHANGELING]
 		changeling.hivemind_members[name] = src
 		introduction(changeling_mob)
 
@@ -65,7 +65,7 @@
 	M.ckey = ckey
 	GLOB.morphs.add_antagonist(M.mind, TRUE, TRUE, FALSE, TRUE, TRUE)
 
-	var/datum/changeling/changeling = changeling_mob.mind.antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = changeling_mob.mind.antag_datums[MODE_CHANGELING]
 	changeling.hivemind_members -= src
 
 	qdel(src)

--- a/code/game/gamemodes/changeling/implements/items.dm
+++ b/code/game/gamemodes/changeling/implements/items.dm
@@ -145,7 +145,7 @@
 	if(!proximity)
 		return
 
-	var/datum/changeling/changeling = user.changeling_power(10)
+	var/datum/component/changeling/changeling = user.changeling_power(10)
 	if(!changeling)
 		return
 

--- a/code/game/gamemodes/changeling/implements/powers/body.dm
+++ b/code/game/gamemodes/changeling/implements/powers/body.dm
@@ -3,7 +3,7 @@
 	set category = "Changeling"
 	set name = "Transform (5)"
 
-	var/datum/changeling/changeling = changeling_power(5, 1, 0)
+	var/datum/component/changeling/changeling = changeling_power(5, 1, 0)
 	if(!changeling)
 		return
 
@@ -45,7 +45,7 @@
 		var/newSpecies = chosen_dna.speciesName
 		H.set_species(newSpecies, 1)
 		if(mind) //likely transfomration sting on ghosted corpse if no mind
-			var/datum/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
+			var/datum/component/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
 			if(changeling && !changeling.mimicing)
 				changeling.mimiced_accent = chosen_dna.accent
 		H.dna = chosen_dna.dna
@@ -67,7 +67,7 @@
 	set category = "Changeling"
 	set name = "Lesser Form (1)"
 
-	var/datum/changeling/changeling = changeling_power(1, 0, 0)
+	var/datum/component/changeling/changeling = changeling_power(1, 0, 0)
 	if(!changeling)
 		return
 
@@ -129,7 +129,7 @@
 	set category = "Changeling"
 	set name = "Transform (1)"
 
-	var/datum/changeling/changeling = changeling_power(1, 1, 0)
+	var/datum/component/changeling/changeling = changeling_power(1, 1, 0)
 	if(!changeling)
 		return
 
@@ -211,7 +211,7 @@
 	set category = "Changeling"
 	set name = "Regenerative Stasis (20)"
 
-	var/datum/changeling/changeling = changeling_power(20, 1, 100, UNCONSCIOUS)
+	var/datum/component/changeling/changeling = changeling_power(20, 1, 100, UNCONSCIOUS)
 	if(!changeling)
 		return
 
@@ -244,7 +244,7 @@
 		to_chat(src, SPAN_HIGHDANGER("We died while regenerating! Our last resort is detaching our head now..."))
 		return
 
-	var/datum/changeling/changeling = changeling_power(20, 1, 100, UNCONSCIOUS)
+	var/datum/component/changeling/changeling = changeling_power(20, 1, 100, UNCONSCIOUS)
 	if(!changeling)
 		return
 
@@ -275,7 +275,7 @@
 	set category = "Changeling"
 	set name = "Emergency Transform (1)"
 
-	var/datum/changeling/changeling = changeling_power(1, 0, 100, DEAD)
+	var/datum/component/changeling/changeling = changeling_power(1, 0, 100, DEAD)
 	if(!changeling)
 		return
 
@@ -335,7 +335,7 @@
 	set name = "Adrenaline Sacs (30)"
 	set desc = "Removes all manner of stuns, as well as producing painkillers and stimulants."
 
-	var/datum/changeling/changeling = changeling_power(30, 0, 100, UNCONSCIOUS)
+	var/datum/component/changeling/changeling = changeling_power(30, 0, 100, UNCONSCIOUS)
 	if(!changeling)
 		return FALSE
 	changeling.use_charges(30)
@@ -362,7 +362,7 @@
 	set name = "Toggle Digital Camouflage"
 	set desc = "The AI can no longer track us, but we will look uncanny if examined. Has a constant cost while active."
 
-	var/datum/changeling/changeling = changeling_power()
+	var/datum/component/changeling/changeling = changeling_power()
 	if(!changeling)
 		return FALSE
 
@@ -389,7 +389,7 @@
 	set name = "Rapid Regeneration (30)"
 	set desc = "We begin rapidly regenerating ourselves. Does not affect stuns or chemicals."
 
-	var/datum/changeling/changeling = changeling_power(30, 0, 100, UNCONSCIOUS)
+	var/datum/component/changeling/changeling = changeling_power(30, 0, 100, UNCONSCIOUS)
 	if(!changeling)
 		return FALSE
 	changeling.use_charges(30)
@@ -416,7 +416,7 @@
 	set name = "Mimic Voice"
 	set desc = "Shape our vocal glands to form a voice of anyone we choose."
 
-	var/datum/changeling/changeling = changeling_power()
+	var/datum/component/changeling/changeling = changeling_power()
 	if(!changeling)
 		return
 
@@ -455,7 +455,7 @@
 	set name = "Form Blades (20)"
 	set desc = "Rupture the flesh and mend the bone of your hand into a deadly blade."
 
-	var/datum/changeling/changeling = changeling_power(20, 0, 0)
+	var/datum/component/changeling/changeling = changeling_power(20, 0, 0)
 	if(!changeling)
 		return FALSE
 	changeling.use_charges(20)
@@ -493,7 +493,7 @@
 	set name = "Form Shield (20)"
 	set desc = "Bend the flesh and bone of your hand into a grotesque shield."
 
-	var/datum/changeling/changeling = changeling_power(20,0,0)
+	var/datum/component/changeling/changeling = changeling_power(20,0,0)
 	if(!changeling)
 		return FALSE
 	changeling.use_charges(20)
@@ -531,7 +531,7 @@
 	set name = "Horror Form (50)"
 	set desc = "Tear apart your human disguise, revealing your true form."
 
-	var/datum/changeling/changeling = changeling_power(50,0,0)
+	var/datum/component/changeling/changeling = changeling_power(50,0,0)
 	if(!changeling)
 		return FALSE
 
@@ -593,7 +593,7 @@
 	set name = "Resonant Shriek (30)"
 	set desc = "Emit a powerful screech which shatters glass within a seven-tile radius, and disorients hearers."
 
-	var/datum/changeling/changeling = changeling_power(30,0,0)
+	var/datum/component/changeling/changeling = changeling_power(30,0,0)
 	if(!changeling)
 		return FALSE
 
@@ -654,7 +654,7 @@
 	set name = "Dissonant Shriek (30)"
 	set desc = "Emit a moderate sized EMP."
 
-	var/datum/changeling/changeling = changeling_power(30,0,0)
+	var/datum/component/changeling/changeling = changeling_power(30,0,0)
 	if(!changeling)
 		return FALSE
 
@@ -669,7 +669,7 @@
 	set name = "Enable Heat Receptors (5)"
 	set desc = "Toggles our thermal vision."
 
-	var/datum/changeling/changeling = changeling_power(5,0,0)
+	var/datum/component/changeling/changeling = changeling_power(5,0,0)
 	if(!changeling)
 		return FALSE
 
@@ -695,7 +695,7 @@
 	set name = "Electric Lockpick (5 + 10/use)"
 	set desc = "Bruteforces open most electrical locking systems, at 10 chemicals per use."
 
-	var/datum/changeling/changeling = changeling_power(5,0,100,CONSCIOUS)
+	var/datum/component/changeling/changeling = changeling_power(5,0,100,CONSCIOUS)
 
 	var/mob/living/carbon/human/H = src
 

--- a/code/game/gamemodes/changeling/implements/powers/fabricate_clothing.dm
+++ b/code/game/gamemodes/changeling/implements/powers/fabricate_clothing.dm
@@ -1,5 +1,5 @@
 /mob/proc/changeling_equip_clothing(var/list/stuff_to_equip, var/cost)
-	var/datum/changeling/changeling = changeling_power(cost,1,100,CONSCIOUS)
+	var/datum/component/changeling/changeling = changeling_power(cost,1,100,CONSCIOUS)
 	if(!changeling)
 		return
 

--- a/code/game/gamemodes/changeling/implements/powers/hivemind.dm
+++ b/code/game/gamemodes/changeling/implements/powers/hivemind.dm
@@ -4,7 +4,7 @@
 	set name = "Hivemind Eject"
 	set desc = "Ejects a member of our internal hivemind."
 
-	var/datum/changeling/changeling = changeling_power()
+	var/datum/component/changeling/changeling = changeling_power()
 	if(!changeling)
 		return
 	var/chosen_player = tgui_input_list(src, "Choose a hivemind member to eject.", "Eject", changeling.hivemind_members)
@@ -26,7 +26,7 @@
 	return TRUE
 
 /mob/proc/relay_hivemind(var/message, var/mob/ling)
-	var/datum/changeling/changeling = ling.mind.antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = ling.mind.antag_datums[MODE_CHANGELING]
 	if(changeling)
 		for(var/H in changeling.hivemind_members) // tell the others in the hivemind
 			var/mob/M = changeling.hivemind_members[H]
@@ -41,7 +41,7 @@
 	set name = "Hivemind Release Morph"
 	set desc = "Releases a member of our internal hivemind as a morph, at the cost of one of our limbs."
 
-	var/datum/changeling/changeling = changeling_power()
+	var/datum/component/changeling/changeling = changeling_power()
 	if(!changeling)
 		return
 

--- a/code/game/gamemodes/changeling/implements/powers/resources.dm
+++ b/code/game/gamemodes/changeling/implements/powers/resources.dm
@@ -1,12 +1,12 @@
 //Speeds up chemical regeneration
 /mob/proc/changeling_fastchemical()
-	var/datum/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
 	changeling.chem_recharge_rate *= 2.5
 	return TRUE
 
 //Increases maximum chemical storage
 /mob/proc/changeling_engorgedglands()
-	var/datum/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
 	changeling.chem_storage += 50
 	return TRUE
 
@@ -33,7 +33,7 @@ GLOBAL_LIST_INIT_TYPED(hivemind_bank, /datum/absorbed_dna, list())
 	set name = "Hive Channel (10)"
 	set desc = "Allows you to channel DNA in the airwaves to allow other changelings to absorb it."
 
-	var/datum/changeling/changeling = changeling_power(10,1)
+	var/datum/component/changeling/changeling = changeling_power(10,1)
 	if(!changeling)
 		return
 
@@ -70,7 +70,7 @@ GLOBAL_LIST_INIT_TYPED(hivemind_bank, /datum/absorbed_dna, list())
 	set name = "Hive Absorb (20)"
 	set desc = "Allows you to absorb DNA that is being channeled in the airwaves."
 
-	var/datum/changeling/changeling = changeling_power(20, 1)
+	var/datum/component/changeling/changeling = changeling_power(20, 1)
 	if(!changeling)
 		return
 

--- a/code/game/gamemodes/changeling/implements/powers/stings.dm
+++ b/code/game/gamemodes/changeling/implements/powers/stings.dm
@@ -18,7 +18,7 @@
 
 	if(!target || !owner.mind)
 		return FALSE
-	var/datum/changeling/changeling = owner.mind.antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = owner.mind.antag_datums[MODE_CHANGELING]
 	if(!changeling)
 		return FALSE
 	if(!(target in view(changeling.sting_range)))
@@ -37,7 +37,7 @@
 /datum/changeling_sting/proc/do_sting(mob/living/target)
 	SHOULD_NOT_SLEEP(TRUE)
 
-	var/datum/changeling/changeling = owner.mind.antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = owner.mind.antag_datums[MODE_CHANGELING]
 	changeling.use_charges(required_chems)
 	changeling.sting_range = 1
 	remove_verb(owner, verb_path)
@@ -61,7 +61,7 @@
 	feedback_add_details("changeling_powers", feedback_tag)
 
 /mob/proc/changeling_sting(var/required_chems = 0, var/verb_path, var/datum_path, var/stealthy = FALSE)
-	var/datum/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
 	if(istype(changeling.prepared_sting, datum_path))
 		to_chat(src, SPAN_NOTICE("You unprepare the <b>[changeling.prepared_sting.name]</b>."))
 		QDEL_NULL(changeling.prepared_sting)
@@ -164,7 +164,7 @@
 	set name = "Transformation Sting (40)"
 	set desc = "Causes the target to permanently transform into a collected DNA subject."
 
-	var/datum/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
 	if(!length(changeling.absorbed_dna))
 		to_chat(src, SPAN_WARNING("You have no DNA to load this sting with!"))
 		return
@@ -265,7 +265,7 @@
 	set name = "Ranged Sting (10)"
 	set desc = "Your next sting ability can be used against targets 2 squares away."
 
-	var/datum/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
 	if(changeling.sting_range > 1)
 		to_chat(src, SPAN_WARNING("The range of your sting has already been boosted!"))
 		return

--- a/code/game/gamemodes/changeling/implements/powers/suck.dm
+++ b/code/game/gamemodes/changeling/implements/powers/suck.dm
@@ -2,7 +2,7 @@
 	set category = "Changeling"
 	set name = "Absorb DNA"
 
-	var/datum/changeling/changeling = changeling_power(0, 0, 100)
+	var/datum/component/changeling/changeling = changeling_power(0, 0, 100)
 	if(!changeling)
 		return
 
@@ -81,7 +81,7 @@
 	var/datum/absorbed_dna/newDNA = new(T.real_name, T.dna, T.species.get_cloning_variant(), T.languages, T.height, T.gender, T.pronouns, T.accent, newGradient)
 	absorbDNA(newDNA)
 
-	var/datum/changeling/changeling_check = T.get_antag_datum(MODE_CHANGELING)
+	var/datum/component/changeling/changeling_check = T.get_antag_datum(MODE_CHANGELING)
 	if(changeling_check)
 		if(changeling_check.absorbed_dna)
 			for(var/datum/absorbed_dna/dna_data in changeling_check.absorbed_dna)	//steal all their loot

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -603,7 +603,7 @@ GLOBAL_LIST_EMPTY(process_objectives)
 				n_p ++
 	else if (SSticker.current_state == GAME_STATE_PLAYING)
 		for(var/mob/living/carbon/human/P in GLOB.player_list)
-			var/datum/changeling/changeling = P.mind.antag_datums[MODE_CHANGELING]
+			var/datum/component/changeling/changeling = P.mind.antag_datums[MODE_CHANGELING]
 			if(P.client && !changeling && P.mind != owner)
 				n_p ++
 	target_amount = min(target_amount, n_p)
@@ -612,7 +612,7 @@ GLOBAL_LIST_EMPTY(process_objectives)
 	return target_amount
 
 /datum/objective/absorb/check_completion()
-	var/datum/changeling/changeling = owner.antag_datums[MODE_CHANGELING]
+	var/datum/component/changeling/changeling = owner.antag_datums[MODE_CHANGELING]
 	if(owner && changeling?.absorbed_dna && (changeling.absorbedcount >= target_amount))
 		return 1
 	else

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -9,7 +9,7 @@
 
 /datum/language/ling/broadcast(var/mob/living/speaker,var/message,var/speaker_mask)
 	if(speaker.mind)
-		var/datum/changeling/changeling = speaker.mind.antag_datums[MODE_CHANGELING]
+		var/datum/component/changeling/changeling = speaker.mind.antag_datums[MODE_CHANGELING]
 		if(changeling)
 			..(speaker,message, changeling.changelingID)
 			return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -274,7 +274,7 @@
 		if(vampire)
 			. += "Usable Blood [vampire.blood_usable]"
 			. += "Total Blood [vampire.blood_total]"
-		var/datum/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
+		var/datum/component/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
 		if(changeling)
 			. += "Chemical Storage: [changeling.chem_charges]"
 			. += "Genetic Damage Time: [changeling.geneticdamage]"
@@ -894,7 +894,7 @@
 /mob/living/carbon/human/get_flash_protection(ignore_inherent = FALSE)
 
 	//Ling
-	var/datum/changeling/changeling = changeling_power(0, 0, 0)
+	var/datum/component/changeling/changeling = changeling_power(0, 0, 0)
 	if(changeling && changeling.using_thermals)
 		return FLASH_PROTECTION_REDUCED
 
@@ -2172,7 +2172,7 @@
 	var/used_accent = accent //starts with the mob's default accent
 
 	if(mind)
-		var/datum/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
+		var/datum/component/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
 		if(changeling?.mimiced_accent)
 			used_accent = changeling.mimiced_accent
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -62,7 +62,7 @@
 
 	var/turf/T = get_turf(src)
 	if(T) // changelings don't get movement costs
-		var/datum/changeling/changeling
+		var/datum/component/changeling/changeling
 		if(mind)
 			changeling = mind.antag_datums[MODE_CHANGELING]
 		if(!changeling)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -78,9 +78,6 @@
 
 	//No need to update all of these procs if the guy is dead or in stasis
 	if(stat != DEAD && !InStasis())
-		//Updates the number of stored chemicals for powers
-		handle_changeling()
-
 		//Organs
 		handle_organs(seconds_per_tick)
 		stabilize_body_temperature(seconds_per_tick) //Body temperature adjusts itself (self-regulation)
@@ -1317,12 +1314,6 @@
 									eyes_covered = TRUE
 							if(!eyes_covered)
 								self.visible_message("[self] squints in discomfort.")
-
-/mob/living/carbon/human/proc/handle_changeling()
-	if(mind)
-		var/datum/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
-		if(changeling)
-			changeling.regenerate()
 
 /**
  * This proc assumes that if traumatic_shock = null, then a shock value was NOT passed in, and thus it calculates it itself.

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -91,7 +91,7 @@
 	if(face?.disfigured) // if your face is ruined, your ability to vocalize is also ruined
 		return "Unknown" // above ling voice mimicing so they don't get caught out immediately
 	if(mind)
-		var/datum/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
+		var/datum/component/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
 		if(changeling?.mimicing)
 			return changeling.mimicing
 	if(GetSpecialVoice())

--- a/html/changelogs/hellfirejag-remove-ling-from-life.yml
+++ b/html/changelogs/hellfirejag-remove-ling-from-life.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - refactor: "Refactored changeling code to no longer require every mob checks on every tick if it's a changeling."


### PR DESCRIPTION
All of this effort to make Life() no longer need to check every mob on every tick if it's a changeling.

I tested to make sure changeling still works. 

<img width="1916" height="1031" alt="image" src="https://github.com/user-attachments/assets/13911846-873b-49e1-a2a6-2cb8f93dd9fd" />
