### PR TITLE
Brings back representative objectives

### DIFF
--- a/code/game/jobs/faction/hephaestus.dm
+++ b/code/game/jobs/faction/hephaestus.dm
@@ -61,6 +61,25 @@
 		"Operations Personnel" = /obj/outfit/job/hangar_tech/event/hephaestus
 	)
 
+/datum/faction/hephaestus_industries/get_corporate_objectives(var/mission_level)
+	var/objective
+	switch(mission_level)
+		if(REPRESENTATIVE_MISSION_HIGH)
+			objective = pick("Recruit a crew member to disperse physical or radio material besmirching the image of Zavodskoi Interstellar",
+						"Support Hephaestus employees involved in disputes with Zavodskoi Interstellar contractors",
+						"Identify and document Zavodskoi Interstellar employees with disfavourable views towards Zavodskoi")
+		if(REPRESENTATIVE_MISSION_MEDIUM)
+			objective = pick("Identify the seeds of unionisation among Hephaestus employees. Report union representatives",
+						"Have a Hephaestus employee sign a contract extension",
+						"Emphasise how relatable Titanius Aeson is to the common worker")
+		else
+			objective = pick("Conduct a survey on Hephaestus Industries employee morale",
+						"Evaluate crew opinions on Hephaestus industrial synthetics",
+						"Survey unathi crew members on their views of Hephaestus Industries",
+						"Identify and resolve a complaint of a Hephaestus Industries employee")
+
+	return objective
+
 /obj/outfit/job/hangar_tech/hephaestus
 	name = "Hangar Technician - Hephaestus"
 

--- a/code/game/jobs/faction/hephaestus.dm
+++ b/code/game/jobs/faction/hephaestus.dm
@@ -62,23 +62,21 @@
 	)
 
 /datum/faction/hephaestus_industries/get_corporate_objectives(var/mission_level)
-	var/objective
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
-			objective = pick("Recruit a crew member to disperse physical or radio material besmirching the image of Zavodskoi Interstellar",
+			return pick("Recruit a crew member to disperse physical or radio material besmirching the image of Zavodskoi Interstellar",
 						"Support Hephaestus employees involved in disputes with Zavodskoi Interstellar contractors",
 						"Identify and document Zavodskoi Interstellar employees with disfavourable views towards Zavodskoi")
-		if(REPRESENTATIVE_MISSION_MEDIUM)
-			objective = pick("Identify the seeds of unionisation among Hephaestus employees. Report union representatives",
+		else if(REPRESENTATIVE_MISSION_MEDIUM)
+			return pick("Identify the seeds of unionisation among Hephaestus employees. Report union representatives",
 						"Have a Hephaestus employee sign a contract extension",
 						"Emphasise how relatable Titanius Aeson is to the common worker")
 		else
-			objective = pick("Conduct a survey on Hephaestus Industries employee morale",
+			return pick("Conduct a survey on Hephaestus Industries employee morale",
 						"Evaluate crew opinions on Hephaestus industrial synthetics",
 						"Survey unathi crew members on their views of Hephaestus Industries",
 						"Identify and resolve a complaint of a Hephaestus Industries employee")
 
-	return objective
 
 /obj/outfit/job/hangar_tech/hephaestus
 	name = "Hangar Technician - Hephaestus"

--- a/code/game/jobs/faction/hephaestus.dm
+++ b/code/game/jobs/faction/hephaestus.dm
@@ -67,7 +67,7 @@
 			return pick("Recruit a crew member to disperse physical or radio material besmirching the image of Zavodskoi Interstellar",
 						"Support Hephaestus employees involved in disputes with Zavodskoi Interstellar contractors",
 						"Identify and document Zavodskoi Interstellar employees with disfavourable views towards Zavodskoi")
-		else if(REPRESENTATIVE_MISSION_MEDIUM)
+		if(REPRESENTATIVE_MISSION_MEDIUM)
 			return pick("Identify the seeds of unionisation among Hephaestus employees. Report union representatives",
 						"Have a Hephaestus employee sign a contract extension",
 						"Emphasise how relatable Titanius Aeson is to the common worker")

--- a/code/game/jobs/faction/idris.dm
+++ b/code/game/jobs/faction/idris.dm
@@ -76,7 +76,7 @@
 		if(REPRESENTATIVE_MISSION_HIGH)
 			return pick("Recruit economically disadvantaged crew to inform on inter-megacorporate conflict aboard the [station_name()]",
 						"Identify crew members with severe financial difficulties and refer them to Idris Incorporated's financial aide services")
-		else if(REPRESENTATIVE_MISSION_MEDIUM)
+		if(REPRESENTATIVE_MISSION_MEDIUM)
 			return pick("Renew an Idris Incorporated employee's Non-Disclosure Agreement concerning all internal Idris operations",
 						"Have an Idris Incorporated sign a contract extension in exchange for discounted Le Soleil Royal purchases",
 						"Ensure owned Idris Incorporated synthetics are maintaining brand standards")

--- a/code/game/jobs/faction/idris.dm
+++ b/code/game/jobs/faction/idris.dm
@@ -71,6 +71,24 @@
 		"Service Personnel" = /obj/outfit/job/bartender/idris
 	)
 
+/datum/faction/idris_incorporated/get_corporate_objectives(var/mission_level)
+	var/objective
+	switch(mission_level)
+		if(REPRESENTATIVE_MISSION_HIGH)
+			objective = pick("Recruit economically disadvantaged crew to inform on inter-megacorporate conflict aboard the [station_name()]",
+						"Identify crew members with severe financial difficulties and refer them to Idris Incorporated's financial aide services")
+		if(REPRESENTATIVE_MISSION_MEDIUM)
+			objective = pick("Renew an Idris Incorporated employee's Non-Disclosure Agreement concerning all internal Idris operations",
+						"Have an Idris Incorporated sign a contract extension in exchange for discounted Le Soleil Royal purchases",
+						"Ensure owned Idris Incorporated synthetics are maintaining brand standards")
+		else
+			objective = pick("Conduct a survey on Idris Incorporated employee morale",
+						"Evaluate the cost of Idris Incorporated operations aboard the [station_name()] against the completion of SCC and/or Idris agenda goals",
+						"Evaluate crew opinions on Le Soleil Royal products",
+						"Identify and resolve a complaint of an Idris Incorporated employee")
+
+	return objective
+
 /obj/outfit/job/officer/idris
 	name = "Security Officer - Idris"
 

--- a/code/game/jobs/faction/idris.dm
+++ b/code/game/jobs/faction/idris.dm
@@ -72,22 +72,20 @@
 	)
 
 /datum/faction/idris_incorporated/get_corporate_objectives(var/mission_level)
-	var/objective
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
-			objective = pick("Recruit economically disadvantaged crew to inform on inter-megacorporate conflict aboard the [station_name()]",
+			return pick("Recruit economically disadvantaged crew to inform on inter-megacorporate conflict aboard the [station_name()]",
 						"Identify crew members with severe financial difficulties and refer them to Idris Incorporated's financial aide services")
-		if(REPRESENTATIVE_MISSION_MEDIUM)
-			objective = pick("Renew an Idris Incorporated employee's Non-Disclosure Agreement concerning all internal Idris operations",
+		else if(REPRESENTATIVE_MISSION_MEDIUM)
+			return pick("Renew an Idris Incorporated employee's Non-Disclosure Agreement concerning all internal Idris operations",
 						"Have an Idris Incorporated sign a contract extension in exchange for discounted Le Soleil Royal purchases",
 						"Ensure owned Idris Incorporated synthetics are maintaining brand standards")
 		else
-			objective = pick("Conduct a survey on Idris Incorporated employee morale",
+			return pick("Conduct a survey on Idris Incorporated employee morale",
 						"Evaluate the cost of Idris Incorporated operations aboard the [station_name()] against the completion of SCC and/or Idris agenda goals",
 						"Evaluate crew opinions on Le Soleil Royal products",
 						"Identify and resolve a complaint of an Idris Incorporated employee")
 
-	return objective
 
 /obj/outfit/job/officer/idris
 	name = "Security Officer - Idris"

--- a/code/game/jobs/faction/nanotrasen.dm
+++ b/code/game/jobs/faction/nanotrasen.dm
@@ -41,21 +41,19 @@
 	var/objective
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
-			objective = pick("Obtain 2000 moles of gaseous Phoron or 20x Phoron Crystals for shipping to NanoTrasen Corporation.",
+			return pick("Obtain 2000 moles of gaseous Phoron or 20x Phoron Crystals for shipping to NanoTrasen Corporation.",
 						"Identify and report SCC command staff who are overtly favouring their origin state or company (IE. displaying origin state/corporation iconography) in breach of Conglomerate ideals",
 						"Identify and report any acts of inter-SCC conflict or espionage")
-		if(REPRESENTATIVE_MISSION_MEDIUM)
-			objective = pick("Have any crew member enroll onto a paid NanoTrasen Academy online learning course",
+		else if(REPRESENTATIVE_MISSION_MEDIUM)
+			return pick("Have any crew member enroll onto a paid NanoTrasen Academy online learning course",
 						"Have a NanoTrasen employee sign a contract extension",
 						"Evaluate crew opinions on GetMore Corporation products available on the [station_name()]",
 						"Ensure Hazel! Limited positronics are compliant with brand standards",
 						"Evaluate crew opinions on Ingi Usang Entertainment Company products and brands")
 		else
-			objective = pick("Conduct a survey on NanoTrasen Corporation employee morale",
+			return pick("Conduct a survey on NanoTrasen Corporation employee morale",
 						"Identify and resolve a complaint of a NanoTrasen Corporation employee",
 						"Emphasise the importance of phoronic technologies aboard the [station_name()] and around the Orion Spur")
-
-	return objective
 
 /obj/outfit/job/visitor/nanotrasen
 	name = "Off-Duty Crew Member - NanoTrasen"

--- a/code/game/jobs/faction/nanotrasen.dm
+++ b/code/game/jobs/faction/nanotrasen.dm
@@ -41,7 +41,7 @@
 	var/objective
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
-			objective = pick("Have the [station_name()] Operations Department set aside 2000 moles of gaseous Phoron or 20x Phoron Crystals for shipping to NanoTrasen Corporation.",
+			objective = pick("Obtain 2000 moles of gaseous Phoron or 20x Phoron Crystals for shipping to NanoTrasen Corporation.",
 						"Identify and report SCC command staff who are overtly favouring their origin state or company (IE. displaying origin state/corporation iconography) in breach of Conglomerate ideals",
 						"Identify and report any acts of inter-SCC conflict or espionage")
 		if(REPRESENTATIVE_MISSION_MEDIUM)

--- a/code/game/jobs/faction/nanotrasen.dm
+++ b/code/game/jobs/faction/nanotrasen.dm
@@ -38,7 +38,6 @@
 	allowed_role_types = NT_ROLES
 
 /datum/faction/nano_trasen/get_corporate_objectives(var/mission_level)
-	var/objective
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
 			return pick("Obtain 2000 moles of gaseous Phoron or 20x Phoron Crystals for shipping to NanoTrasen Corporation.",

--- a/code/game/jobs/faction/nanotrasen.dm
+++ b/code/game/jobs/faction/nanotrasen.dm
@@ -43,7 +43,7 @@
 			return pick("Obtain 2000 moles of gaseous Phoron or 20x Phoron Crystals for shipping to NanoTrasen Corporation.",
 						"Identify and report SCC command staff who are overtly favouring their origin state or company (IE. displaying origin state/corporation iconography) in breach of Conglomerate ideals",
 						"Identify and report any acts of inter-SCC conflict or espionage")
-		else if(REPRESENTATIVE_MISSION_MEDIUM)
+		if(REPRESENTATIVE_MISSION_MEDIUM)
 			return pick("Have any crew member enroll onto a paid NanoTrasen Academy online learning course",
 						"Have a NanoTrasen employee sign a contract extension",
 						"Evaluate crew opinions on GetMore Corporation products available on the [station_name()]",

--- a/code/game/jobs/faction/nanotrasen.dm
+++ b/code/game/jobs/faction/nanotrasen.dm
@@ -41,17 +41,19 @@
 	var/objective
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
-			objective = pick("Have [rand(1,4)] crewmember sign NT apprenticeship contracts",
-						"Make sure that the [station_name()] fullfils [rand(4,12)] cargo bounties",
-						"Make sure that the [station_name()] raises [rand(5000,12000)] credits by the end of the shift")
+			objective = pick("Have the [station_name()] Operations Department set aside 2000 moles of gaseous Phoron or 20x Phoron Crystals for shipping to NanoTrasen Corporation.",
+						"Identify and report SCC command staff who are overtly favouring their origin state or company (IE. displaying origin state/corporation iconography) in breach of Conglomerate ideals",
+						"Identify and report any acts of inter-SCC conflict or espionage")
 		if(REPRESENTATIVE_MISSION_MEDIUM)
-			objective = pick("Have [rand(2,5)] crewmembers sign contract extensions",
-						"Have [rand(2,5)] crewmembers buy Odin real estate",
-						"[rand(3,10)] crewmember must buy Getmore products from the vendors")
+			objective = pick("Have any crew member enroll onto a paid NanoTrasen Academy online learning course",
+						"Have a NanoTrasen employee sign a contract extension",
+						"Evaluate crew opinions on GetMore Corporation products available on the [station_name()]",
+						"Ensure Hazel! Limited positronics are compliant with brand standards",
+						"Evaluate crew opinions on Ingi Usang Entertainment Company products and brands")
 		else
-			objective = pick("Conduct and present a survey on crew morale and content",
-						"Make sure that [rand(2,4)] complaints are solved on the [station_name()]",
-						"Have [rand(3,10)] crewmembers buy Getmore products from the vendors")
+			objective = pick("Conduct a survey on NanoTrasen Corporation employee morale",
+						"Identify and resolve a complaint of a NanoTrasen Corporation employee",
+						"Emphasise the importance of phoronic technologies aboard the [station_name()] and around the Orion Spur")
 
 	return objective
 

--- a/code/game/jobs/faction/orion_express.dm
+++ b/code/game/jobs/faction/orion_express.dm
@@ -64,7 +64,7 @@
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
 			return pick("Identify and document Orion Express employees slowing or impeding company operations (IE. inadequate mining yields; slow order deliveries; slow service catering)")
-		else if(REPRESENTATIVE_MISSION_MEDIUM)
+		if(REPRESENTATIVE_MISSION_MEDIUM)
 			return pick("Promote competitiveness and the setting personal of goals among Orion Express employees",
 						"Ensure all outbound Orion Express packages aboard the [station_name()] are delivered",
 						"Evaluate crew opinions on Quick-E-Burger catering aboard the [station_name()]")

--- a/code/game/jobs/faction/orion_express.dm
+++ b/code/game/jobs/faction/orion_express.dm
@@ -60,6 +60,22 @@
 		"Service Personnel" = /obj/outfit/job/bartender/orion
 	)
 
+/datum/faction/orion_express/get_corporate_objectives(var/mission_level)
+	var/objective
+	switch(mission_level)
+		if(REPRESENTATIVE_MISSION_HIGH)
+			objective = pick("Identify and document Orion Express employees slowing or impeding company operations (IE. inadequate mining yields; slow order deliveries; slow service catering)")
+		if(REPRESENTATIVE_MISSION_MEDIUM)
+			objective = pick("Promote competitiveness and the setting personal of goals among Orion Express employees",
+						"Ensure all outbound Orion Express packages aboard the [station_name()] are delivered",
+						"Evaluate crew opinions on Quick-E-Burger catering aboard the [station_name()]")
+		else
+			objective = pick("Conduct a survey on Orion Express employee morale",
+						"Survey crew members on their typical package delivery times",
+						"Identify and resolve a complaint of an Orion Express employee")
+
+	return objective
+
 /obj/outfit/job/hangar_tech/orion
 	name = "Hangar Technician - Orion Express"
 

--- a/code/game/jobs/faction/orion_express.dm
+++ b/code/game/jobs/faction/orion_express.dm
@@ -61,20 +61,18 @@
 	)
 
 /datum/faction/orion_express/get_corporate_objectives(var/mission_level)
-	var/objective
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
-			objective = pick("Identify and document Orion Express employees slowing or impeding company operations (IE. inadequate mining yields; slow order deliveries; slow service catering)")
-		if(REPRESENTATIVE_MISSION_MEDIUM)
-			objective = pick("Promote competitiveness and the setting personal of goals among Orion Express employees",
+			return pick("Identify and document Orion Express employees slowing or impeding company operations (IE. inadequate mining yields; slow order deliveries; slow service catering)")
+		else if(REPRESENTATIVE_MISSION_MEDIUM)
+			return pick("Promote competitiveness and the setting personal of goals among Orion Express employees",
 						"Ensure all outbound Orion Express packages aboard the [station_name()] are delivered",
 						"Evaluate crew opinions on Quick-E-Burger catering aboard the [station_name()]")
 		else
-			objective = pick("Conduct a survey on Orion Express employee morale",
+			return pick("Conduct a survey on Orion Express employee morale",
 						"Survey crew members on their typical package delivery times",
 						"Identify and resolve a complaint of an Orion Express employee")
 
-	return objective
 
 /obj/outfit/job/hangar_tech/orion
 	name = "Hangar Technician - Orion Express"

--- a/code/game/jobs/faction/pmc.dm
+++ b/code/game/jobs/faction/pmc.dm
@@ -60,18 +60,16 @@
 	)
 
 /datum/faction/pmc/get_corporate_objectives(var/mission_level)
-	var/objective
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
-			objective = pick("Ensure PMCG contractors are integrating properly into the [station_name()]'s corporate environment")
-		if(REPRESENTATIVE_MISSION_MEDIUM)
-			objective = pick("Encourage team-building exercises between PMCG subcontractors",
+			return pick("Ensure PMCG contractors are integrating properly into the [station_name()]'s corporate environment")
+		else if(REPRESENTATIVE_MISSION_MEDIUM)
+			return pick("Encourage team-building exercises between PMCG subcontractors",
 						"Have a PMCG employee sign a contract extension")
 		else
-			objective = pick("Conduct a survey on Private Military Contracting Group employee morale",
+			return pick("Conduct a survey on Private Military Contracting Group employee morale",
 						"Identify and resolve a complaint of a Private Military Contracting Group employee [station_name()]")
 
-	return objective
 
 /obj/outfit/job/officer/pmc
 	name = "Security Officer - PMC"

--- a/code/game/jobs/faction/pmc.dm
+++ b/code/game/jobs/faction/pmc.dm
@@ -63,7 +63,7 @@
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
 			return pick("Ensure PMCG contractors are integrating properly into the [station_name()]'s corporate environment")
-		else if(REPRESENTATIVE_MISSION_MEDIUM)
+		if(REPRESENTATIVE_MISSION_MEDIUM)
 			return pick("Encourage team-building exercises between PMCG subcontractors",
 						"Have a PMCG employee sign a contract extension")
 		else

--- a/code/game/jobs/faction/pmc.dm
+++ b/code/game/jobs/faction/pmc.dm
@@ -59,6 +59,20 @@
 		"Medical Personnel" = /obj/outfit/job/med_tech/event/pmc
 	)
 
+/datum/faction/pmc/get_corporate_objectives(var/mission_level)
+	var/objective
+	switch(mission_level)
+		if(REPRESENTATIVE_MISSION_HIGH)
+			objective = pick("Ensure PMCG contractors are integrating properly into the [station_name()]'s corporate environment")
+		if(REPRESENTATIVE_MISSION_MEDIUM)
+			objective = pick("Encourage team-building exercises between PMCG subcontractors",
+						"Have a PMCG employee sign a contract extension")
+		else
+			objective = pick("Conduct a survey on Private Military Contracting Group employee morale",
+						"Identify and resolve a complaint of a Private Military Contracting Group employee [station_name()]")
+
+	return objective
+
 /obj/outfit/job/officer/pmc
 	name = "Security Officer - PMC"
 

--- a/code/game/jobs/faction/zavodskoi.dm
+++ b/code/game/jobs/faction/zavodskoi.dm
@@ -82,6 +82,24 @@
 		"Science Personnel" = /obj/outfit/job/scientist/event/zavodskoi
 	)
 
+/datum/faction/zavodskoi_interstellar/get_corporate_objectives(var/mission_level)
+	var/objective
+	switch(mission_level)
+		if(REPRESENTATIVE_MISSION_HIGH)
+			objective = pick("Recruit a crew member to inform Hephaestus Industries contractors of their poor benefits, unsupportive company, and need to unionise.",
+						"Support Zavodskoi employees involved in disputes with Hephaestus Industries contractors",
+						"Identify and document Hephaestus Industries employees with disfavourable views towards Hephaestus")
+		if(REPRESENTATIVE_MISSION_MEDIUM)
+			objective = pick("Identify and rectify Zavodskoi Interstellar employees not compliant with company image standards or otherwise damaging company optics",
+						"Identify and rectify aberrant behaviour in Zavodskoi Interstellar synthetics.",
+						"Have a Zavodskoi employee sign a contract extension in exchange for a nearly-all-paid, 3-day holiday to a destination of choice on Moroz")
+		else
+			objective = pick("Conduct a survey on Zavodskoi Interstellar employee morale",
+						"Evaluate crew opinions on Zavodskoi Interstellar's company image",
+						"Identify and resolve a complaint of a Zavodskoi Interstellar employee")
+
+	return objective
+
 /obj/outfit/job/officer/zavodskoi
 	name = "Security Officer - Zavodskoi Interstellar"
 

--- a/code/game/jobs/faction/zavodskoi.dm
+++ b/code/game/jobs/faction/zavodskoi.dm
@@ -88,7 +88,7 @@
 			return pick("Recruit a crew member to inform Hephaestus Industries contractors of their poor benefits, unsupportive company, and need to unionise.",
 						"Support Zavodskoi employees involved in disputes with Hephaestus Industries contractors",
 						"Identify and document Hephaestus Industries employees with disfavourable views towards Hephaestus")
-		else if(REPRESENTATIVE_MISSION_MEDIUM)
+		if(REPRESENTATIVE_MISSION_MEDIUM)
 			return pick("Identify and rectify Zavodskoi Interstellar employees not compliant with company image standards or otherwise damaging company optics",
 						"Identify and rectify aberrant behaviour in Zavodskoi Interstellar synthetics.",
 						"Have a Zavodskoi employee sign a contract extension in exchange for a nearly-all-paid, 3-day holiday to a destination of choice on Moroz")

--- a/code/game/jobs/faction/zavodskoi.dm
+++ b/code/game/jobs/faction/zavodskoi.dm
@@ -83,22 +83,20 @@
 	)
 
 /datum/faction/zavodskoi_interstellar/get_corporate_objectives(var/mission_level)
-	var/objective
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
-			objective = pick("Recruit a crew member to inform Hephaestus Industries contractors of their poor benefits, unsupportive company, and need to unionise.",
+			return pick("Recruit a crew member to inform Hephaestus Industries contractors of their poor benefits, unsupportive company, and need to unionise.",
 						"Support Zavodskoi employees involved in disputes with Hephaestus Industries contractors",
 						"Identify and document Hephaestus Industries employees with disfavourable views towards Hephaestus")
-		if(REPRESENTATIVE_MISSION_MEDIUM)
-			objective = pick("Identify and rectify Zavodskoi Interstellar employees not compliant with company image standards or otherwise damaging company optics",
+		else if(REPRESENTATIVE_MISSION_MEDIUM)
+			return pick("Identify and rectify Zavodskoi Interstellar employees not compliant with company image standards or otherwise damaging company optics",
 						"Identify and rectify aberrant behaviour in Zavodskoi Interstellar synthetics.",
 						"Have a Zavodskoi employee sign a contract extension in exchange for a nearly-all-paid, 3-day holiday to a destination of choice on Moroz")
 		else
-			objective = pick("Conduct a survey on Zavodskoi Interstellar employee morale",
+			return pick("Conduct a survey on Zavodskoi Interstellar employee morale",
 						"Evaluate crew opinions on Zavodskoi Interstellar's company image",
 						"Identify and resolve a complaint of a Zavodskoi Interstellar employee")
 
-	return objective
 
 /obj/outfit/job/officer/zavodskoi
 	name = "Security Officer - Zavodskoi Interstellar"

--- a/code/game/jobs/faction/zeng_hu.dm
+++ b/code/game/jobs/faction/zeng_hu.dm
@@ -67,22 +67,20 @@
 	)
 
 /datum/faction/zeng_hu/get_corporate_objectives(var/mission_level)
-	var/objective
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
-			objective = pick("Obtain copies of research documentation from the [station_name()] Science Department",
+			return pick("Obtain copies of research documentation from the [station_name()] Science Department",
 						"Identify veteran NanoTrasen Corporation employees willing to seek employment with Zeng-Hu Pharmaceuticals in exchange for transhuman benefits",
 						"Obtain research prototypes or pharmaceutical products produced by NanoTrasen Corporation employees for analysis")
-		if(REPRESENTATIVE_MISSION_MEDIUM)
-			objective = pick("Have a Zeng-Hu Pharmaceuticals employee sign a contract extension in exchange for company-covered cyber- or bio-augmentation",
+		else if(REPRESENTATIVE_MISSION_MEDIUM)
+			return pick("Have a Zeng-Hu Pharmaceuticals employee sign a contract extension in exchange for company-covered cyber- or bio-augmentation",
 						"Award a seniority or veterancy plate to Zeng-Hu—loaned command personnel. If refused, identify and report why",
 						"Evaluate crew opinions on keiretsu member products and brands")
 		else
-			objective = pick("Conduct a survey on Zeng-Hu Pharmaceuticals employee morale",
+			return pick("Conduct a survey on Zeng-Hu Pharmaceuticals employee morale",
 						"Evaluate crew views towards transhumanity, and preferences towards bioaugmentation or cyberaugmentation",
 						"Identify and resolve a complaint of a Zeng-Hu Pharmaceuticals employee")
 
-	return objective
 
 /obj/outfit/job/doctor/zeng_hu
 	name = "Physician - Zeng-Hu"

--- a/code/game/jobs/faction/zeng_hu.dm
+++ b/code/game/jobs/faction/zeng_hu.dm
@@ -66,6 +66,24 @@
 		"Medical Personnel" = /obj/outfit/job/med_tech/event/zeng_hu
 	)
 
+/datum/faction/zeng_hu/get_corporate_objectives(var/mission_level)
+	var/objective
+	switch(mission_level)
+		if(REPRESENTATIVE_MISSION_HIGH)
+			objective = pick("Obtain copies of research documentation from the [station_name()] Science Department",
+						"Identify veteran NanoTrasen Corporation employees willing to seek employment with Zeng-Hu Pharmaceuticals in exchange for transhuman benefits",
+						"Obtain research prototypes or pharmaceutical products produced by NanoTrasen Corporation employees for analysis")
+		if(REPRESENTATIVE_MISSION_MEDIUM)
+			objective = pick("Have a Zeng-Hu Pharmaceuticals employee sign a contract extension in exchange for company-covered cyber- or bio-augmentation",
+						"Award a seniority or veterancy plate to Zeng-Hu—loaned command personnel. If refused, identify and report why",
+						"Evaluate crew opinions on keiretsu member products and brands")
+		else
+			objective = pick("Conduct a survey on Zeng-Hu Pharmaceuticals employee morale",
+						"Evaluate crew views towards transhumanity, and preferences towards bioaugmentation or cyberaugmentation",
+						"Identify and resolve a complaint of a Zeng-Hu Pharmaceuticals employee")
+
+	return objective
+
 /obj/outfit/job/doctor/zeng_hu
 	name = "Physician - Zeng-Hu"
 

--- a/code/game/jobs/faction/zeng_hu.dm
+++ b/code/game/jobs/faction/zeng_hu.dm
@@ -72,7 +72,7 @@
 			return pick("Obtain copies of research documentation from the [station_name()] Science Department",
 						"Identify veteran NanoTrasen Corporation employees willing to seek employment with Zeng-Hu Pharmaceuticals in exchange for transhuman benefits",
 						"Obtain research prototypes or pharmaceutical products produced by NanoTrasen Corporation employees for analysis")
-		else if(REPRESENTATIVE_MISSION_MEDIUM)
+		if(REPRESENTATIVE_MISSION_MEDIUM)
 			return pick("Have a Zeng-Hu Pharmaceuticals employee sign a contract extension in exchange for company-covered cyber- or bio-augmentation",
 						"Award a seniority or veterancy plate to Zeng-Hu—loaned command personnel. If refused, identify and report why",
 						"Evaluate crew opinions on keiretsu member products and brands")

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -163,19 +163,19 @@
 /obj/outfit/job/representative/proc/send_representative_mission(var/mob/living/carbon/human/H)
 	var/papertext
 
-	papertext += "<center><br><h2><br><b>Office Directives Notice</h2></b></FONT size><HR></center>"
+	papertext += "<hr><center><h2><b>Office Directives Notice</h2></b></FONT size><HR></center>"
 	papertext += "<center><small>This document is confidential and may contain protected internal operation or personnel information. \
 	Any unauthorised review, copying, sharing, or retention of this document may result in legal action. If you are not the \
 	recipient, stop reading, inform the [name] Office, and destroy this document immediately.</small></center><hr>"
 	papertext += "<b><font face='Courier New'>[name], the following directives have been issued to the [station_name()] Office:</font></b><br><ul>"
 
 	papertext += "<li>[get_objectives(H, REPRESENTATIVE_MISSION_LOW)].</li>"
-	if(prob(50))
+	if(prob(66))
 		papertext += "<li>[get_objectives(H, REPRESENTATIVE_MISSION_MEDIUM)].</li>"
-	if(prob(25))
+	if(prob(33))
 		papertext += "<li>[get_objectives(H, REPRESENTATIVE_MISSION_HIGH)].</li>"
 
-	papertext += "<br><b><font face='Courier New'>Please report back if any directives are completed during your shift.</font></b><br><ul>"
+	papertext += "</ul><br><b><font face='Courier New'>Please report back if any directives are completed during your shift.</font></b><br>"
 
 	var/obj/item/paper/P = new /obj/item/paper()
 	P.name = "[name] - Directives"

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -157,27 +157,42 @@
 /obj/outfit/job/representative/post_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()
 	if(H && !visualsOnly)
-		addtimer(CALLBACK(src, PROC_REF(send_representative_mission), H), 5 MINUTES)
+		send_representative_mission(H)
 	return TRUE
 
 /obj/outfit/job/representative/proc/send_representative_mission(var/mob/living/carbon/human/H)
-	var/faxtext = "<center><br><h2><br><b>Directives Report</h2></b></FONT size><HR></center>"
-	faxtext += "<b><font face='Courier New'>Attention [name], the following directives are to be fulfilled during your stay on the [station_name()]:</font></b><br><ul>"
+	var/papertext
 
-	faxtext += "<li>[get_objectives(H, REPRESENTATIVE_MISSION_LOW)].</li>"
+	papertext += "<center><br><h2><br><b>Office Directives Notice</h2></b></FONT size><HR></center>"
+	papertext += "<center><small>This document is confidential and may contain protected internal operation or personnel information. \
+	Any unauthorised review, copying, sharing, or retention of this document may result in legal action. If you are not the \
+	recipient, stop reading, inform the [name] Office, and destroy this document immediately.</small></center><hr>"
+	papertext += "<b><font face='Courier New'>[name], the following directives have been issued to the [station_name()] Office:</font></b><br><ul>"
 
+	papertext += "<li>[get_objectives(H, REPRESENTATIVE_MISSION_LOW)].</li>"
 	if(prob(50))
-		faxtext += "<li>[get_objectives(H, REPRESENTATIVE_MISSION_MEDIUM)].</li>"
-
+		papertext += "<li>[get_objectives(H, REPRESENTATIVE_MISSION_MEDIUM)].</li>"
 	if(prob(25))
-		faxtext += "<li>[get_objectives(H, REPRESENTATIVE_MISSION_HIGH)].</li>"
+		papertext += "<li>[get_objectives(H, REPRESENTATIVE_MISSION_HIGH)].</li>"
 
-	for (var/obj/machinery/photocopier/faxmachine/F in GLOB.allfaxes)
-		if (F.department == fax_department)
-			var/obj/item/paper/P = new /obj/item/paper(get_turf(F))
-			P.name = "[name] - Directives"
-			P.info = faxtext
-			P.update_icon()
+	papertext += "<br><b><font face='Courier New'>Please report back if any directives are completed during your shift.</font></b><br><ul>"
+
+	var/obj/item/paper/P = new /obj/item/paper()
+	P.name = "[name] - Directives"
+	P.info = papertext
+
+	//stamp the paper
+	var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
+	stampoverlay.icon_state = "paper_stamp-leland_stamp"
+	if(!P.stamped)
+		P.stamped = new
+	P.stamped += /obj/item/stamp
+	P.overlays += stampoverlay
+	P.stamps += "<hr><i>This paper has been stamped as \"CONFIDENTIAL-SECRET\".</i>"
+
+	P.update_icon()
+	H.put_in_hands(P)
+
 	return
 
 /obj/outfit/job/representative/proc/get_objectives(var/mob/living/carbon/human/H, var/mission_level)

--- a/code/modules/background/citizenship/human.dm
+++ b/code/modules/background/citizenship/human.dm
@@ -24,38 +24,33 @@
 	)
 
 /datum/citizenship/tau_ceti/get_objectives(mission_level, var/mob/living/carbon/human/H)
-	var/rep_objectives
-
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
 			if(isvaurca(H))
-				rep_objectives = pick("Investigate and report suspicious individuals who might harbour anti-Republic sentiments",
+				return pick("Investigate and report suspicious individuals who might harbour anti-Republic sentiments",
 								"Collect evidence of the [SSatlas.current_map.boss_name] being unfair or bigoted to Vaurca employees, to be used as leverage in future hive labor negotiations",
 								"Convince the command of the [SSatlas.current_map.station_name] of the utility of Bound labor over similar alternatives such as cyborgs or owned synthetics")
 			else
-				rep_objectives = pick("Investigate and report suspicious individuals who might harbour anti-Republic sentiments",
+				return pick("Investigate and report suspicious individuals who might harbour anti-Republic sentiments",
 								"Identify and document command personnel with non-favourable views towards NanoTrasen Corporation")
 
-		if(REPRESENTATIVE_MISSION_MEDIUM)
+		else if(REPRESENTATIVE_MISSION_MEDIUM)
 			if(isvaurca(H))
-				rep_objectives = pick("Highlight the failures of the Solarian Alliance and promote the Republic of Biesel's successes",
+				return pick("Highlight the failures of the Solarian Alliance and promote the Republic of Biesel's successes",
 								"Refer a non-Republic citizen to citizenship opportunities in the Tau Ceti Armed Forces",
 								"Promote Zo'rane products such as Zo'ra Soda to the crew")
 			else
-				rep_objectives = pick("Highlight the failures of the Solarian Alliance and promote the Republic of Biesel's successes",
+				return pick("Highlight the failures of the Solarian Alliance and promote the Republic of Biesel's successes",
 								"Refer a non-Republic citizen to citizenship opportunities in the Tau Ceti Armed Forces")
-		else
+		else (REPRESENTATIVE_MISSION_LOW)
 			if(isvaurca(H))
-				rep_objectives = pick("Survey Republic citizens views of the Tau Ceti Armed Forces post-Peacekeeper Mandate.",
+				return pick("Survey Republic citizens views of the Tau Ceti Armed Forces post-Peacekeeper Mandate.",
 								"Question non-Vaurca employees about their Vaurca coworkers, looking for areas of improvement.",
 								"Protect and promote the public image of the Zo'ra Hive to all [SSatlas.current_map.boss_name] employees.")
 			else
-				rep_objectives = pick("Survey Republic citizens views of the Tau Ceti Armed Forces post-Peacekeeper Mandate.",
+				return pick("Survey Republic citizens views of the Tau Ceti Armed Forces post-Peacekeeper Mandate.",
 								"Survey Republic citizen views of the Republic of Biesel's multiculturalism.",
 								"Have a Republic citizen re-affirm their pledge of loyalty to the Republic of Biesel")
-
-
-	return rep_objectives
 
 /obj/outfit/job/representative/consular/ceti
 	name = "Tau Ceti Consular Officer"

--- a/code/modules/background/citizenship/human.dm
+++ b/code/modules/background/citizenship/human.dm
@@ -34,7 +34,7 @@
 				return pick("Investigate and report suspicious individuals who might harbour anti-Republic sentiments",
 								"Identify and document command personnel with non-favourable views towards NanoTrasen Corporation")
 
-		else if(REPRESENTATIVE_MISSION_MEDIUM)
+		if(REPRESENTATIVE_MISSION_MEDIUM)
 			if(isvaurca(H))
 				return pick("Highlight the failures of the Solarian Alliance and promote the Republic of Biesel's successes",
 								"Refer a non-Republic citizen to citizenship opportunities in the Tau Ceti Armed Forces",
@@ -42,7 +42,7 @@
 			else
 				return pick("Highlight the failures of the Solarian Alliance and promote the Republic of Biesel's successes",
 								"Refer a non-Republic citizen to citizenship opportunities in the Tau Ceti Armed Forces")
-		else (REPRESENTATIVE_MISSION_LOW)
+		else
 			if(isvaurca(H))
 				return pick("Survey Republic citizens views of the Tau Ceti Armed Forces post-Peacekeeper Mandate.",
 								"Question non-Vaurca employees about their Vaurca coworkers, looking for areas of improvement.",

--- a/code/modules/background/citizenship/human.dm
+++ b/code/modules/background/citizenship/human.dm
@@ -29,29 +29,30 @@
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
 			if(isvaurca(H))
-				rep_objectives = pick("Compile and report and audit [rand(1,3)] suspicious indivduals who might be spies or otherwise act hostile against the Republic.",
-								"Collect evidence of the [SSatlas.current_map.boss_name] being unfair or bigoted to Vaurca employees, to be used as leverage in future hive labor negotiations.",
-								"Convince the command of the [SSatlas.current_map.station_name] of the utility of Bound labor over similar alternatives such as cyborgs or owned synthetics.")
+				rep_objectives = pick("Investigate and report suspicious individuals who might harbour anti-Republic sentiments",
+								"Collect evidence of the [SSatlas.current_map.boss_name] being unfair or bigoted to Vaurca employees, to be used as leverage in future hive labor negotiations",
+								"Convince the command of the [SSatlas.current_map.station_name] of the utility of Bound labor over similar alternatives such as cyborgs or owned synthetics")
 			else
-				rep_objectives = pick("Compile and report and audit [rand(1,3)] suspicious indivduals who might be spies or otherwise act hostile against the Republic.",
-								"Have [rand(2,6)] crewmembers sign a pledge of loyalty to the Republic.")
+				rep_objectives = pick("Investigate and report suspicious individuals who might harbour anti-Republic sentiments",
+								"Identify and document command personnel with non-favourable views towards NanoTrasen Corporation")
 
 		if(REPRESENTATIVE_MISSION_MEDIUM)
 			if(isvaurca(H))
-				rep_objectives = pick("Promote the superiority of the Republic of Biesel over the Sol Alliance.",
-								"Encourage non-citizens to seek citizenship in the Republic via enlistment in the Tau Ceti Foreign Legion.",
-								"Promote Zo'rane products such as Zo'ra Soda to the crew.")
+				rep_objectives = pick("Highlight the failures of the Solarian Alliance and promote the Republic of Biesel's successes",
+								"Refer a non-Republic citizen to citizenship opportunities in the Tau Ceti Armed Forces",
+								"Promote Zo'rane products such as Zo'ra Soda to the crew")
 			else
-				rep_objectives = pick("Convince [rand(2,4)] Tau Ceti crewmembers who are not a part of Command or Security to join the Tau Ceti Foreign Legion.",
-								"Convince [rand(3,6)] crewmembers of Tau Ceti superiority over the Sol Alliance.")
+				rep_objectives = pick("Highlight the failures of the Solarian Alliance and promote the Republic of Biesel's successes",
+								"Refer a non-Republic citizen to citizenship opportunities in the Tau Ceti Armed Forces")
 		else
 			if(isvaurca(H))
-				rep_objectives = pick("Run a questionanaire on Tau Ceti citizens' views on Vaurca citizenship.",
+				rep_objectives = pick("Survey Republic citizens views of the Tau Ceti Armed Forces post-Peacekeeper Mandate.",
 								"Question non-Vaurca employees about their Vaurca coworkers, looking for areas of improvement.",
 								"Protect and promote the public image of the Zo'ra Hive to all [SSatlas.current_map.boss_name] employees.")
 			else
-				rep_objectives = pick("Run a questionnaire on Tau Ceti citizens' views on synthetic citizenship.",
-								"Run a questionnaire on Tau Ceti citizens' views on vaurca citizenship.")
+				rep_objectives = pick("Survey Republic citizens views of the Tau Ceti Armed Forces post-Peacekeeper Mandate.",
+								"Survey Republic citizen views of the Republic of Biesel's multiculturalism.",
+								"Have a Republic citizen re-affirm their pledge of loyalty to the Republic of Biesel")
 
 
 	return rep_objectives

--- a/html/changelogs/kermit-representative-objectives-fix.yml
+++ b/html/changelogs/kermit-representative-objectives-fix.yml
@@ -1,0 +1,7 @@
+author: kermit
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes representative objectives not being sent. They will now appear in-hand on-spawning"
+  - rscadd: "Redoes all megacorporate objectives and Republic of Biesel objectives"


### PR DESCRIPTION
fixes representative objectives not being sent after dual representative offices were added. they now appear in-hand, instead of being faxed, bc i am not adding a claim system to the offices

additionally, reformats the objectives letter and includes a confidential notice

while I was here, I also re-did all of the Megacorp / Biesel objectives