### PR TITLE
Tenacity Skill

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -518,6 +518,7 @@
 #include "code\datums\components\skills\combat\armed_combat_skill_component.dm"
 #include "code\datums\components\skills\combat\firearms_skill_component.dm"
 #include "code\datums\components\skills\combat\leadership_skill_component.dm"
+#include "code\datums\components\skills\combat\tenacity_skill_component.dm"
 #include "code\datums\components\skills\combat\unarmed_combat_skill_component.dm"
 #include "code\datums\components\skills\engineering\atmospherics_systems_skill_component.dm"
 #include "code\datums\components\skills\engineering\electrical_engineering_skill_component.dm"

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -27,6 +27,7 @@
 #define PHARMACOLOGY_SKILL_COMPONENT /datum/component/skill/pharmacology
 #define SURGERY_SKILL_COMPONENT /datum/component/skill/surgery
 #define CAROUSING_SKILL_COMPONENT /datum/component/skill/carousing
+#define TENACITY_SKILL_COMPONENT /datum/component/skill/tenacity
 
 /**
  * Trinary-Boolean helper that either returns null, or the skill level of a given skill component(which can be zero).

--- a/code/datums/components/skills/combat/tenacity_skill_component.dm
+++ b/code/datums/components/skills/combat/tenacity_skill_component.dm
@@ -1,0 +1,62 @@
+/**
+ * Component used for the Tenacity skill. Ranks placed in this skill affect how long a character can survive in critical condition before permanently dying.
+ * It does not make them any tougher to actual combat damage.
+ **/
+/datum/component/skill/tenacity
+	/**
+	 * Bonus to a character's "minimum heart efficiency" per rank in this skill, which determines the floor of how effective a character's blood volume transfers oxygen when the heart isn't beating correctly.
+	 * This only has an affect on a character that is both in crit, and not receiving CPR.
+	 **/
+	var/bonus_min_efficiency_per_rank = 0.1
+
+	/**
+	 * A character's "effective blood volume" per crit threshold calculation is increased by this amount per rank in the skill.
+	 * It's a rather small amount since Brainmed's balancing is really delicate.
+	 **/
+	var/bonus_effective_bv_per_rank = 1.25
+
+	/**
+	 * Bonus to a character's "heart efficiency" per rank in this skill, which is used to calculate a character's effective blood volume.
+	 * This factors into the percentage thresholds of blood loss at which a character's rate of dying changes.
+	 * Also a very small amount, since Brainmed balancing is quite delicate.
+	 **/
+	var/bonus_pulse_mod_per_rank = 0.05
+
+	/// How much of a modifier to a character's bleed resistance is provided by this component.
+	var/bonus_bleed_resist_per_rank = 0.075
+
+	/// How much of a modifier to a character's Arterial bleed resistance is provided by this component.
+	var/bonus_arterial_resist_per_rank = 0.0375
+
+/datum/component/skill/tenacity/Initialize()
+	. = ..()
+	if (!parent)
+		return
+
+	RegisterSignal(parent, COMSIG_HEART_PUMP_EVENT, PROC_REF(stabilize_circulation))
+	RegisterSignal(parent, COMSIG_HEART_BLEED_EVENT, PROC_REF(reduce_bloodloss))
+
+/datum/component/skill/tenacity/Destroy()
+	if (!parent)
+		return ..()
+
+	UnregisterSignal(parent, COMSIG_HEART_PUMP_EVENT)
+	UnregisterSignal(parent, COMSIG_HEART_BLEED_EVENT)
+	return ..()
+
+/datum/component/skill/tenacity/proc/stabilize_circulation(owner, obj/item/organ/internal/heart/heart, blood_volume, recent_pump, pulse_mod, min_efficiency)
+	SIGNAL_HANDLER
+	// Bonus per this skill starts at rank 2 rather than 1, they simply won't have this component at rank 1.
+	var/offset_skill = skill_level - 1
+
+	*min_efficiency = *min_efficiency * (1 + (bonus_min_efficiency_per_rank * offset_skill))
+	*blood_volume = *blood_volume + (bonus_effective_bv_per_rank * offset_skill)
+	*pulse_mod = *pulse_mod * (1 + (bonus_pulse_mod_per_rank * offset_skill))
+
+/datum/component/skill/tenacity/proc/reduce_bloodloss(owner, blood_volume, cut_bloodloss_modifier, arterial_bloodloss_modifier)
+	SIGNAL_HANDLER
+	// Bonus per this skill starts at rank 2 rather than 1, they simply won't have this component at rank 1.
+	var/offset_skill = skill_level - 1
+
+	*cut_bloodloss_modifier = *cut_bloodloss_modifier * (1 - (offset_skill * bonus_bleed_resist_per_rank))
+	*arterial_bloodloss_modifier = *arterial_bloodloss_modifier * (1 - (offset_skill * bonus_arterial_resist_per_rank))

--- a/code/datums/skills/combat/combat.dm
+++ b/code/datums/skills/combat/combat.dm
@@ -78,3 +78,23 @@
 // 	required = TRUE
 // 	component_type = LEADERSHIP_SKILL_COMPONENT
 
+/singleton/skill/tenacity
+	name = "Tenacity"
+	description = "Tenacity represents a character's \"Will to Live\". It affects a character's ability to cling to life when in critical condition, effectively allowing them to live for a little bit longer before medics can reach them. " \
+		+ "It does not affect a character's overall toughness and difficulty to take down in a fight, only how much time they have to be saved when they do go down. "
+	maximum_level = SKILL_LEVEL_PROFESSIONAL
+	category = /singleton/skill_category/combat
+	subcategory = SKILL_SUBCATEGORY_SUPPORT
+	component_type = TENACITY_SKILL_COMPONENT
+	skill_level_descriptions = alist(
+		SKILL_LEVEL_UNFAMILIAR = "You have no modifiers from Tenacity.",
+		SKILL_LEVEL_FAMILIAR = "You take slightly longer to die while in critical condition.",
+		SKILL_LEVEL_TRAINED = "You take a little bit longer to die while in critical condition.",
+		SKILL_LEVEL_PROFESSIONAL = "You take longer to die while in critical condition."
+	)
+	skill_cost_map = alist(
+		SKILL_LEVEL_UNFAMILIAR = 0,
+		SKILL_LEVEL_FAMILIAR = 1,
+		SKILL_LEVEL_TRAINED = 2,
+		SKILL_LEVEL_PROFESSIONAL = 4
+	)

--- a/code/modules/organs/subtypes/augment/augments/auxiliary_heart.dm
+++ b/code/modules/organs/subtypes/augment/augments/auxiliary_heart.dm
@@ -28,7 +28,7 @@
 	UnregisterSignal(owner, COMSIG_HEART_PUMP_EVENT)
 	return ..()
 
-/obj/item/organ/internal/augment/bioaug/auxiliary_heart/proc/stabilize_circulation(var/implantee, var/obj/item/organ/internal/heart/heart, var/blood_volume, var/recent_pump, var/pulse_mod, var/min_efficiency)
+/obj/item/organ/internal/augment/bioaug/auxiliary_heart/proc/stabilize_circulation(implantee, obj/item/organ/internal/heart/heart, blood_volume, recent_pump, pulse_mod, min_efficiency)
 	SIGNAL_HANDLER
-	*min_efficiency *= 1.5
-	*blood_volume += 2.5 // This doesn't affect actual blood volume, only the "effective" volume used for calculating thresholds.
+	*min_efficiency = *min_efficiency * 1.5
+	*blood_volume = *blood_volume + 2.5 // This doesn't affect actual blood volume, only the "effective" volume used for calculating thresholds.

--- a/code/modules/organs/subtypes/augment/augments/platelet_factories.dm
+++ b/code/modules/organs/subtypes/augment/augments/platelet_factories.dm
@@ -31,12 +31,12 @@
 	UnregisterSignal(owner, COMSIG_HEART_BLEED_EVENT)
 	return ..()
 
-/obj/item/organ/internal/augment/bioaug/platelet_factories/proc/stroke_risk(var/implantee, var/obj/item/organ/internal/heart/heart, var/blood_volume, var/recent_pump, var/pulse_mod, var/min_efficiency)
+/obj/item/organ/internal/augment/bioaug/platelet_factories/proc/stroke_risk(implantee, obj/item/organ/internal/heart/heart, blood_volume, recent_pump, pulse_mod, min_efficiency)
 	SIGNAL_HANDLER
-	*min_efficiency *= 0.85
-	*pulse_mod *= 0.95
+	*min_efficiency = *min_efficiency * 0.85
+	*pulse_mod = *pulse_mod * 0.95
 
-/obj/item/organ/internal/augment/bioaug/platelet_factories/proc/reduce_bloodloss(var/implantee, var/blood_volume, var/cut_bloodloss_modifier, var/arterial_bloodloss_modifier)
+/obj/item/organ/internal/augment/bioaug/platelet_factories/proc/reduce_bloodloss(implantee, blood_volume, cut_bloodloss_modifier, arterial_bloodloss_modifier)
 	SIGNAL_HANDLER
-	*cut_bloodloss_modifier *= 0.1
-	*arterial_bloodloss_modifier *= 0.25
+	*cut_bloodloss_modifier = *cut_bloodloss_modifier * 0.1
+	*arterial_bloodloss_modifier = *arterial_bloodloss_modifier * 0.25

--- a/html/changelogs/hellfirejag-tenacity-skill.yml
+++ b/html/changelogs/hellfirejag-tenacity-skill.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "Added Tenacity to the Combat skills category. Ranks in tenacity allow a character to survive longer while in critical condition."


### PR DESCRIPTION
This PR adds a new Combat skill largely designed for non-combat characters called Tenacity. It's fairly analagous to traits like Will to Live from Shadowrun. Ranks in this skill make a character take a little bit longer to "bleed out in crit", but do nothing to actually change how hard they are to take down in combat. Effectively this means that ranks put in this skill give you a little bit more of a buffer of time to be picked up by a paramedic and rescued.

For actual combat characters it's very undesireable since it does nothing to actually help win you fights, so this skill is largely more to serve as an option for characters outside of security who don't actually want to spend any points on direct combat capabilities. All of the numerical modifiers from the skill are rather small, and make use of pre-existing signal hooks that I've made previously for Brainmed to allow component based modifiers to organ code.

<img width="1069" height="243" alt="image" src="https://github.com/user-attachments/assets/92d6c19a-a0f2-4cc8-b490-df4538fd2b3d" />
