### PR TITLE
Emp Damage Hotfix

### DIFF
--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -167,7 +167,7 @@
 		take_damage(owner.chem_effects[toxin_type] * seconds_per_tick)
 
 	handle_regeneration(seconds_per_tick)
-	tick_surge_damage() //Yes, this is intentional.
+	tick_surge_damage(seconds_per_tick) //Yes, this is intentional.
 
 /obj/item/organ/internal/proc/handle_regeneration(seconds_per_tick)
 	SHOULD_CALL_PARENT(TRUE)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -783,7 +783,7 @@ This function completely restores a damaged organ to perfect condition.
 		return TRUE
 	return FALSE
 
-/obj/item/organ/external/process()
+/obj/item/organ/external/process(seconds_per_tick)
 	if(owner)
 		//Specialized handling for tesla limbs. Checks if the limb currently has an associated tesla spine. Else, will disable the emissive and active overlays
 		if(is_tesla)
@@ -815,7 +815,7 @@ This function completely restores a damaged organ to perfect condition.
 			N.handle_nymph(src)
 
 		if(surge_damage && (status & ORGAN_ASSISTED))
-			tick_surge_damage() //Yes, this being here is intentional since this proc does not call ..() unless the owner is null.
+			tick_surge_damage(seconds_per_tick) //Yes, this being here is intentional since this proc does not call ..() unless the owner is null.
 
 		//Infections
 		update_germs()

--- a/html/changelogs/hellfirejag-emp-damage-hotfix.yml
+++ b/html/changelogs/hellfirejag-emp-damage-hotfix.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed EMP damage not ticking down on prosthetics."


### PR DESCRIPTION
Some of the prosthetics weren't ticking down EMP damage, which was because they had overrides of Process() that weren't correctly passing in the SPT value needed by the tick_surge_damage(seconds_per_tick) proc.