### PR TITLE
Fixes flashlight lighting direction mismatch when dropped

### DIFF
--- a/code/game/objects/items/devices/lighting/flashlight.dm
+++ b/code/game/objects/items/devices/lighting/flashlight.dm
@@ -38,8 +38,6 @@
 	var/always_on = FALSE
 	/// How efficient the flashlight is at producing light compared to baseline
 	var/efficiency_modifier = 1.0
-	/// A way for mappers to force which way a flashlight faces upon spawning
-	var/spawn_dir
 
 /obj/item/flashlight/mechanics_hints(mob/user, distance, is_adjacent)
 	. += ..()
@@ -81,6 +79,11 @@
 	STOP_PROCESSING(SSprocessing, src)
 	QDEL_NULL(cell)
 	return ..()
+
+/obj/item/flashlight/dropped(mob/user)
+	. = ..()
+	if(user?.dir)
+		set_dir(user.dir)
 
 /obj/item/flashlight/get_cell()
 	return cell

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -24,6 +24,11 @@
 	drop_sound = 'sound/items/drop/helm.ogg'
 	pickup_sound = 'sound/items/pickup/helm.ogg'
 
+/obj/item/clothing/head/hardhat/dropped(mob/user)
+	. = ..()
+	if(user?.dir)
+		set_dir(user.dir)
+
 /obj/item/clothing/head/hardhat/orange
 	icon_state = "hardhat_orange"
 	item_state = "hardhat_orange"

--- a/html/changelogs/kano-dot-light-directions.yml
+++ b/html/changelogs/kano-dot-light-directions.yml
@@ -1,0 +1,6 @@
+author: Kano
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed flashlights not lighting the direction they're supposed to when dropped."


### PR DESCRIPTION
## About PR

Makes it so lighting system recognizes the direction flashlight is facing when dropped, so it no longer defaults to south

The reasoning behind this method is,

https://github.com/Aurorastation/Aurora.3/blob/38a5988115e33594fcc9e9fafd08d474bbf76967/code/datums/components/overlay_lighting.dm#L503-L509

items don't update their directions when held and carried around, and `set_dir()` is where the signal is sent which system listens to

also removes an unused var
