### PR TITLE
Stasis Bed Nerf

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -20,7 +20,7 @@
 	var/obj/item/reagent_containers/glass/beaker = null
 	var/filtering = FALSE
 	var/pump = FALSE
-	var/list/stasis_settings = list(1, 2, 5, 10)
+	var/list/stasis_settings = list(1, 2, 4)
 	var/stasis = 1
 	var/allow_occupant_types = list(/mob/living/carbon/human)
 	var/disallow_occupant_types = list()

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -20,7 +20,7 @@
 	var/obj/item/reagent_containers/glass/beaker = null
 	var/filtering = FALSE
 	var/pump = FALSE
-	var/list/stasis_settings = list(1, 2, 4)
+	var/list/stasis_settings = list(1, 2, 4, 8)
 	var/stasis = 1
 	var/allow_occupant_types = list(/mob/living/carbon/human)
 	var/disallow_occupant_types = list()

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -20,7 +20,7 @@
 	var/obj/item/reagent_containers/glass/beaker = null
 	var/filtering = FALSE
 	var/pump = FALSE
-	var/list/stasis_settings = list(1, 2, 4, 8)
+	var/list/stasis_settings = list(1, 2, 4)
 	var/stasis = 1
 	var/allow_occupant_types = list(/mob/living/carbon/human)
 	var/disallow_occupant_types = list()

--- a/code/game/machinery/stasis_bed.dm
+++ b/code/game/machinery/stasis_bed.dm
@@ -20,7 +20,7 @@
 	var/stasis_can_toggle = 0
 
 	/// The amount of Stasis Value that this machine provides to an occupant.
-	var/stasis_power = 10
+	var/stasis_power = 6
 
 	/**
 	 * The type of stasis this machine provides to an occupant.

--- a/html/changelogs/Bat-NerfStasisBeds.yml
+++ b/html/changelogs/Bat-NerfStasisBeds.yml
@@ -2,4 +2,4 @@ author: Batrachophrenoboocosmomachia
 delete-after: True
 changes:
   - balance: "Nerfs stasis beds to provide 6x stasis per part level, down from 10x stasis."
-  - balance: "Nerfs sleeper stasis settings options to 1x,2x,4x, down from 1x,2x,5x,10x."
+  - balance: "Nerfs sleeper stasis settings options to 1x,2x,4x,8x, down from 1x,2x,5x,10x."

--- a/html/changelogs/Bat-NerfStasisBeds.yml
+++ b/html/changelogs/Bat-NerfStasisBeds.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - balance: "Nerfs stasis beds to provide 6x stasis per part level, down from 10x stasis."

--- a/html/changelogs/Bat-NerfStasisBeds.yml
+++ b/html/changelogs/Bat-NerfStasisBeds.yml
@@ -2,3 +2,4 @@ author: Batrachophrenoboocosmomachia
 delete-after: True
 changes:
   - balance: "Nerfs stasis beds to provide 6x stasis per part level, down from 10x stasis."
+  - balance: "Nerfs sleeper stasis settings options to 1x,2x,4x, down from 1x,2x,5x,10x."

--- a/html/changelogs/Bat-NerfStasisBeds.yml
+++ b/html/changelogs/Bat-NerfStasisBeds.yml
@@ -2,4 +2,4 @@ author: Batrachophrenoboocosmomachia
 delete-after: True
 changes:
   - balance: "Nerfs stasis beds to provide 6x stasis per part level, down from 10x stasis."
-  - balance: "Nerfs sleeper stasis settings options to 1x,2x,4x,8x, down from 1x,2x,5x,10x."
+  - balance: "Nerfs sleeper stasis settings options to 1x,2x,4x, down from 1x,2x,5x,10x."


### PR DESCRIPTION
Stasis beds are a little too good at keeping people alive. Reduces default stasis levels for both stasis beds and sleepers. Both should be tools for a given situation with comparable usefulness, with stasis beds remaining able to be upgraded to become Very Powerful.

changes:
  - balance: "Nerfs stasis beds to provide 6x stasis per part level, down from 10x stasis."
  - balance: "Nerfs sleeper stasis settings options to 1x,2x,4x, down from 1x,2x,5x,10x."