### PR TITLE
Bugfix persistence of items in inventories and persistent charge card location

### DIFF
--- a/code/controllers/subsystems/persistence/persistence_objects.dm
+++ b/code/controllers/subsystems/persistence/persistence_objects.dm
@@ -57,8 +57,6 @@
 		var/turf/T = get_turf(track)
 		if(!T || !is_station_level(T.z)) // The persistence system only supports objects from the main map levels for multiple reasons, e.g. Z level value, mapping support
 			objectsDeregisterTrack(track)
-		if(astype(track, /obj/item)?.in_inventory) // Objects that are held by players won't become persistent
-			objectsDeregisterTrack(track)
 
 	var/created = 0
 	var/updated = 0

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -495,7 +495,7 @@
 	if(!persistency_considered_trash)
 		return
 
-	if(in_storage) // Items getting moved into storages (lunchboxes, backpacks) triggers the dropped handler and requires no persistency as a result
+	if(in_storage || in_inventory) // Items getting moved into storages (lunchboxes, backpacks) triggers the dropped handler and requires no persistency as a result
 		SSpersistence.objectsDeregisterTrack(src)
 		return
 
@@ -543,6 +543,7 @@
 		addtimer(CALLBACK(src, PROC_REF(check_maptext)), 1) // invoke async does not work here
 	in_inventory = TRUE
 	do_pickup_animation(user)
+	try_make_persistent_trash()
 
 // called when this item is removed from a storage item, which is passed on as S. The loc variable is already set to the new destination before this is called.
 /obj/item/proc/on_exit_storage(obj/item/storage/S as obj)

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -355,7 +355,7 @@
 	if(A && istype(A, /area/horizon/command))
 		target_area = A // Command areas are deemed safe
 	else
-		target_area = locate(/area/horizon/command/heads/om) in GLOB.areas // Non safe area - Operations manager office as fallback
+		target_area = locate(/area/horizon/command/heads/xo) in GLOB.areas // Non safe area - XO office as fallback
 
 	var/obj/structure/table/T = locate(/obj/structure/table) in target_area // Put it on a table
 	if(T)

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -344,9 +344,24 @@
 	initial_worth = isnull(content["initial_worth"]) ? 0 : content["initial_worth"]
 	worth = isnull(content["worth"]) ? 0 : content["worth"]
 	owner_name = isnull(content["owner_name"]) ? src.owner_name : content["owner_name"]
+
 	src.x = x
 	src.y = y
 	src.z = z
+
+	// While the item features a persistent location, we want to return it to a safe spot if it is not in acceptable areas
+	var/area/target_area
+	var/area/A = get_area(src)
+	if(A && istype(A, /area/horizon/command))
+		target_area = A // Command areas are deemed safe
+	else
+		target_area = locate(/area/horizon/command/heads/om) in GLOB.areas // Non safe area - Operations manager office as fallback
+
+	var/obj/structure/table/T = locate(/obj/structure/table) in target_area // Put it on a table
+	if(T)
+		src.x = T.x
+		src.y = T.y
+		src.z = T.z
 
 /obj/item/spacecash/ewallet/persistent_charge_card/Destroy()
 	log_and_message_admins("Persistent charge card ([src.name]) at [src] was destroyed!", null, get_turf(src))

--- a/html/changelogs/fabiank3-persistent-supplies-return-location.yml
+++ b/html/changelogs/fabiank3-persistent-supplies-return-location.yml
@@ -1,0 +1,7 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed trash in inventory persistence prevention disallowing any items to be persistent on character locations."
+  - bugfix: "Fixed persistent charge card location on new round start."


### PR DESCRIPTION
# Summary

This PR fixes two bugs with persistent items, trash and the persistent charge card.

## Changes

- Fixed the prevention of trash in inventories becoming persistent also preventing any items on characters becoming persistent.
- Fixed persistent charge card location on init. If the card is not in an command area, it will be moved into the XO office, if it is in a command area, it will stay there.