### PR TITLE
Add accent flavor text

### DIFF
--- a/code/modules/client/preference_setup/general/06_flavor.dm
+++ b/code/modules/client/preference_setup/general/06_flavor.dm
@@ -12,6 +12,7 @@
 	S["flavor_texts_hands"]   >> pref.flavor_texts["hands"]
 	S["flavor_texts_legs"]    >> pref.flavor_texts["legs"]
 	S["flavor_texts_feet"]    >> pref.flavor_texts["feet"]
+	S["flavor_texts_accent"]  >> pref.flavor_texts["accent"]
 
 	//Flavour text for robots.
 	S["flavour_texts_robot_Default"] >> pref.flavour_texts_robot["Default"]
@@ -31,6 +32,7 @@
 	S["flavor_texts_hands"]   << pref.flavor_texts["hands"]
 	S["flavor_texts_legs"]    << pref.flavor_texts["legs"]
 	S["flavor_texts_feet"]    << pref.flavor_texts["feet"]
+	S["flavor_texts_accent"]  << pref.flavor_texts["account"]
 
 	S["flavour_texts_robot_Default"] << pref.flavour_texts_robot["Default"]
 	for(var/module in GLOB.robot_module_types)
@@ -50,6 +52,7 @@
 		"flavour_hands" = "flavor_texts/hands",
 		"flavour_legs" = "flavor_texts/legs",
 		"flavour_feet" = "flavor_texts/feet",
+		"flavour_accent" = "flavor_texts/accent",
 		"robot_default" = "flavour_texts_robot/Default",
 		"signature" = "signature",
 		"signature_font" = "signfont"
@@ -79,6 +82,7 @@
 		"flavour_hands",
 		"flavour_legs",
 		"flavour_feet",
+		"flavour_accent",
 		"robot_default",
 		"signature",
 		"signature_font",
@@ -102,6 +106,7 @@
 		"flavour_hands" = pref.flavor_texts["hands"],
 		"flavour_legs" = pref.flavor_texts["legs"],
 		"flavour_feet" = pref.flavor_texts["feet"],
+		"flavour_accent" = pref.flavor_texts["accent"],
 		"robot_default" = pref.flavour_texts_robot["Default"],
 		"signature" = pref.signature,
 		"signature_font" = pref.signfont
@@ -241,6 +246,9 @@
 	HTML += "<br>"
 	HTML += "<a href='byond://?src=[REF(src)];flavor_text=feet'>Feet:</a> "
 	HTML += TextPreview(pref.flavor_texts["feet"])
+	HTML += "<br>"
+	HTML += "<a href='byond://?src=[REF(src)];flavor_text=accent'>Accent:</a> "
+	HTML += TextPreview(pref.flavor_texts["accent"])
 	HTML += "<br>"
 	HTML += "<hr />"
 	HTML += "<tt>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -435,6 +435,7 @@ GLOBAL_LIST_EMPTY_TYPED(preferences_datums, /datum/preferences)
 	character.flavor_texts["hands"] = flavor_texts["hands"]
 	character.flavor_texts["legs"] = flavor_texts["legs"]
 	character.flavor_texts["feet"] = flavor_texts["feet"]
+	character.flavor_texts["accent"] = flavor_texts["accent"]
 	character.character_id = current_character
 
 	character.med_record = med_record

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -41,6 +41,9 @@
 	HTML += "<a href='byond://?src=[REF(src)];flavor_change=feet'>Feet:</a> "
 	HTML += TextPreview(flavor_texts["feet"])
 	HTML += "<br>"
+	HTML += "<a href='byond://?src=[REF(src)];flavor_change=accent'>Accent:</a> "
+	HTML += TextPreview(flavor_texts["accent"])
+	HTML += "<br>"
 	HTML += "<hr />"
 	HTML +="<a href='byond://?src=[REF(src)];flavor_change=done'>\[Done\]</a>"
 	HTML += "<tt>"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1804,7 +1804,7 @@
 	flavor_text = ""
 	for (var/T in flavor_texts)
 		if(flavor_texts[T] && flavor_texts[T] != "")
-			if((T == "general") || (T == BP_HEAD && head_exposed) || (T == "face" && face_exposed) || (T == BP_EYES && eyes_exposed) || (T == "torso" && torso_exposed) || (T == "arms" && arms_exposed) || (T == "hands" && hands_exposed) || (T == "legs" && legs_exposed) || (T == "feet" && feet_exposed))
+			if((T == "general") || (T == BP_HEAD && head_exposed) || (T == "face" && face_exposed) || (T == BP_EYES && eyes_exposed) || (T == "torso" && torso_exposed) || (T == "arms" && arms_exposed) || (T == "hands" && hands_exposed) || (T == "legs" && legs_exposed) || (T == "feet" && feet_exposed) || (T == "accent"))
 				flavor_text += flavor_texts[T]
 				flavor_text += "\n\n"
 	if(!shrink)

--- a/html/changelogs/sierrakomodo-accent-flavor-text.yml
+++ b/html/changelogs/sierrakomodo-accent-flavor-text.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: SierraKomodo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a flavor text category for accents and speech mannerisms."


### PR DESCRIPTION
Adds a flavor text category for accents, to better describe how your character talks beyond just the existing accent tags.

Separate PR will be made for adding an indicator to the chat accent tags and adding the text to the accent information popup, once I figure out some technical difficulties and balance stuff pertaining to mimicked accents.


## TODO
- [ ] Fix the accent flavor text not saving and reloading properly. (Please help me figure out why this doesn't work, there's no error messages or runtimes. It just doesn't seem to actually save.)