### PR TITLE
Fix persistent supplies

### DIFF
--- a/code/controllers/subsystems/persistence/persistence_objects_public.dm
+++ b/code/controllers/subsystems/persistence/persistence_objects_public.dm
@@ -9,10 +9,6 @@
 	if(new_track.persistent_objects_track_active) // Prevent multiple registers per object and removes the need to check the register if it's already in there
 		return
 
-	var/turf/T = get_turf(new_track)
-	if(!T || !is_station_level(T.z) || SSatlas.current_map.path != "sccv_horizon") // The persistence system only supports objects from the main map levels for multiple reasons, e.g. Z level value, mapping support
-		return
-
 	new_track.persistent_objects_track_active = TRUE
 	new_track.persistent_objects_author_ckey = ckey
 	GLOB.persistence_object_track_register += new_track

--- a/code/modules/cargo/delivery/package.dm
+++ b/code/modules/cargo/delivery/package.dm
@@ -36,6 +36,31 @@ ABSTRACT_TYPE(/obj/item/package)
 /obj/item/package/too_heavy_to_throw()
 	return TRUE
 
+/obj/item/package/do_additional_pickup_checks(var/mob/living/carbon/human/user)
+	if(!ishuman(user))
+		return FALSE
+
+	if(user.species.mob_size < 12)
+		var/obj/A = user.get_inactive_hand()
+		if(A)
+			to_chat(user, SPAN_WARNING("Your other hand is occupied!"))
+			return
+
+	user.visible_message("<b>[user]</b> tightens their grip on \the [src] and starts heaving...", SPAN_NOTICE("You tighten your grip on \the [src] and start heaving..."))
+	if(do_after(user, 1 SECONDS, src, DO_UNIQUE))
+		user.visible_message("<b>[user]</b> heaves \the [src] up!", SPAN_NOTICE("You heave \the [src] up!"))
+		// larger mobs, such as industrials, can hold two pieces of cargo
+		if(user.species.mob_size < 12)
+			wield(user)
+			slowdown = 1
+		else
+			slowdown = 0
+
+		user.update_equipment_speed_mods()
+
+		return TRUE
+	return FALSE
+
 /obj/item/package/delivery
 	name = "cargo package"
 	desc = "\
@@ -95,31 +120,6 @@ ABSTRACT_TYPE(/obj/item/package)
 		delivery_site = delivery_point.override_name
 	delivery_point_coordinates = "[delivery_point.x]-[delivery_point.y]"
 	pay_amount = pay_amount * delivery_point.payment_modifier
-
-/obj/item/package/delivery/do_additional_pickup_checks(var/mob/living/carbon/human/user)
-	if(!ishuman(user))
-		return FALSE
-
-	if(user.species.mob_size < 12)
-		var/obj/A = user.get_inactive_hand()
-		if(A)
-			to_chat(user, SPAN_WARNING("Your other hand is occupied!"))
-			return
-
-	user.visible_message("<b>[user]</b> tightens their grip on \the [src] and starts heaving...", SPAN_NOTICE("You tighten your grip on \the [src] and start heaving..."))
-	if(do_after(user, 1 SECONDS, src, DO_UNIQUE))
-		user.visible_message("<b>[user]</b> heaves \the [src] up!", SPAN_NOTICE("You heave \the [src] up!"))
-		// larger mobs, such as industrials, can hold two pieces of cargo
-		if(user.species.mob_size < 12)
-			wield(user)
-			slowdown = 1
-		else
-			slowdown = 0
-
-		user.update_equipment_speed_mods()
-
-		return TRUE
-	return FALSE
 
 /obj/item/package/delivery/offship
 	pays_horizon_account = FALSE

--- a/html/changelogs/fabiank3-bugfix-persistent-supplies-carry.yml
+++ b/html/changelogs/fabiank3-bugfix-persistent-supplies-carry.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed two handy carry and pickup of persistent supply packages."

--- a/html/changelogs/fabiank3-bugfix-persistent-supplies-carry.yml
+++ b/html/changelogs/fabiank3-bugfix-persistent-supplies-carry.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - bugfix: "Fixed two handy carry and pickup of persistent supply packages."
+  - bugfix: "Removed location check on persistent object register."

--- a/html/changelogs/fabiank3-bugfix-persistent-supplies-carry.yml
+++ b/html/changelogs/fabiank3-bugfix-persistent-supplies-carry.yml
@@ -3,5 +3,5 @@ author: FabianK3
 delete-after: True
 
 changes:
-  - bugfix: "Fixed two handy carry and pickup of persistent supply packages."
+  - bugfix: "Fixed two-hand carry and pickup of persistent supply packages."
   - bugfix: "Removed location check on persistent object register."


### PR DESCRIPTION
# Summary

This PR fixes the carry logic and persistence register of persistent supply packages.

## Changes

- Fixed proc path of additional pickup checks that was still pointing at only delivery packages.
- Fixed eager location check on persistence register. Objects finalize will do the same, but this will allow objects to be brought to the Horizon with persistence registered.