### PR TITLE
Refactor do-not-merge CI check to run on merge queue

### DIFF
--- a/.github/workflows/enforce_merge_blockers.yaml
+++ b/.github/workflows/enforce_merge_blockers.yaml
@@ -1,8 +1,7 @@
 name: "'Do Not Merge' Blockers"
 
 on:
-  pull_request:
-    types: [synchronize, opened, labeled, unlabeled]
+  merge_group:
 
 jobs:
   donotmerge-blocker:

--- a/.github/workflows/enforce_merge_blockers.yaml
+++ b/.github/workflows/enforce_merge_blockers.yaml
@@ -2,6 +2,8 @@ name: "'Do Not Merge' Blockers"
 
 on:
   merge_group:
+    branches:
+      - master
 
 jobs:
   donotmerge-blocker:

--- a/html/changelogs/fabiank3-refactore-prevent-merge-ci-check.yml
+++ b/html/changelogs/fabiank3-refactore-prevent-merge-ci-check.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - refactor: "Update the do-not-merge GitHub CI check to fail on merge, not while the PR is open."


### PR DESCRIPTION
# Summary

This PR updates the CI check running on labels like 'changes required'.

## Changes

- Refactors DNM CI check to run on merge queue events only instead of open PRs to avoid confusion on the state of the PR code-wise.

This is an iteration of #22436