### PR TITLE
Electronic Earpiece Changes

### DIFF
--- a/code/controllers/subsystems/processing/electronics.dm
+++ b/code/controllers/subsystems/processing/electronics.dm
@@ -78,7 +78,7 @@ PROCESSING_SUBSYSTEM_DEF(electronics)
 		new /obj/item/clothing/glasses/circuitry,
 		new /obj/item/clothing/shoes/circuitry,
 		new /obj/item/clothing/head/circuitry,
-		new /obj/item/clothing/ears/circuitry,
+		new /obj/item/radio/headset/circuitry,
 		new /obj/item/clothing/suit/circuitry
 	)
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -978,6 +978,231 @@
 	use_common = TRUE
 	ks1type = /obj/item/encryptionkey/ship/common
 
+/*
+ * Electronic Radio Headset
+ * Real radio headset + internal integrated circuit assembly.
+ */
+
+/obj/item/radio/headset/circuitry
+	name = "electronic radio headset"
+	desc = "A radio headset modified to accept integrated circuitry. Takes encryption keys."
+	icon = 'icons/obj/assemblies/wearable_electronic_setups.dmi'
+	contained_sprite = TRUE
+	icon_state = "headset"
+	item_state = "headset"
+	slot_flags = SLOT_EARS
+
+	ks1type = /obj/item/encryptionkey/ship/common
+	ks2type = null
+
+	var/obj/item/electronic_assembly/clothing/small/circuit_assembly = null
+	var/obj/item/integrated_circuit/built_in/action_button/circuit_action = null
+
+
+/obj/item/radio/headset/circuitry/Initialize()
+	. = ..()
+	setup_headset_integrated_circuit()
+	refresh_headset_sprite()
+	refresh_radio_state()
+
+
+/obj/item/radio/headset/circuitry/Destroy()
+	QDEL_NULL(circuit_assembly)
+	circuit_action = null
+	return ..()
+
+
+/obj/item/radio/headset/circuitry/proc/setup_headset_integrated_circuit()
+	if(circuit_assembly)
+		return
+
+	circuit_assembly = new /obj/item/electronic_assembly/clothing/small(src)
+	circuit_assembly.clothing = src
+	circuit_assembly.name = name
+
+	circuit_action = new(circuit_assembly)
+	circuit_assembly.force_add_circuit(circuit_action)
+
+	default_action_type = /datum/action/item_action/integrated_circuit
+	action_button_name = "Activate [capitalize_first_letters(name)]"
+
+
+/obj/item/radio/headset/circuitry/proc/refresh_radio_state()
+	on = TRUE
+	set_frequency(PUB_FREQ)
+	set_listening(TRUE)
+	recalculateChannels(TRUE)
+
+	if(ismob(loc))
+		possibly_deactivate_in_loc()
+
+
+/obj/item/radio/headset/circuitry/proc/refresh_headset_sprite()
+	icon = 'icons/obj/assemblies/wearable_electronic_setups.dmi'
+	contained_sprite = TRUE
+	icon_state = circuit_assembly?.opened ? "headset-open" : "headset"
+	item_state = "headset"
+
+	ClearOverlays()
+
+	if(circuit_assembly?.detail_color)
+		var/image/detail_overlay = image('icons/obj/assemblies/wearable_electronic_setups.dmi', "[icon_state]-color")
+		detail_overlay.color = circuit_assembly.detail_color
+		AddOverlays(detail_overlay)
+
+	if(hascall(src, "update_clothing_icon"))
+		call(src, "update_clothing_icon")()
+
+
+/obj/item/radio/headset/circuitry/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
+	if(circuit_assembly)
+		examinate(user, circuit_assembly)
+
+	return ..()
+
+
+/obj/item/radio/headset/circuitry/attack_self(mob/user)
+	return ..()
+
+
+/obj/item/radio/headset/circuitry/attackby(obj/item/attacking_item, mob/user)
+	if(attacking_item.tool_behaviour == TOOL_CROWBAR && circuit_assembly)
+		circuit_assembly.attackby(attacking_item, user)
+		refresh_headset_sprite()
+		refresh_radio_state()
+		return
+
+	if(istype(attacking_item, /obj/item/encryptionkey))
+		. = ..()
+		refresh_radio_state()
+		return
+
+	if(circuit_assembly?.opened)
+		circuit_assembly.attackby(attacking_item, user)
+		refresh_headset_sprite()
+		return
+
+	return ..()
+
+
+/obj/item/radio/headset/circuitry/AltClick(mob/user)
+	if(!circuit_assembly)
+		return ..()
+
+	if(!circuit_assembly.opened)
+		to_chat(user, SPAN_WARNING("The circuit panel is closed."))
+		return
+
+	return circuit_assembly.attack_self(user)
+
+
+/obj/item/radio/headset/circuitry/verb/access_integrated_circuit()
+	set category = "Object.Equipped"
+	set name = "Access Integrated Circuit"
+	set src in usr
+
+	if(!circuit_assembly)
+		return
+
+	if(!circuit_assembly.opened)
+		to_chat(usr, SPAN_WARNING("The circuit panel is closed."))
+		return
+
+	circuit_assembly.attack_self(usr)
+
+
+/obj/item/radio/headset/circuitry/equipped(mob/user, slot)
+	. = ..()
+
+	if(slot == slot_l_ear || slot == slot_r_ear || slot == slot_l_ear_str || slot == slot_r_ear_str)
+		refresh_radio_state()
+		refresh_headset_sprite()
+
+
+/obj/item/radio/headset/circuitry/dropped(mob/user)
+	. = ..()
+	set_listening(FALSE, actual_setting = FALSE)
+
+
+/obj/item/radio/headset/circuitry/Moved(atom/old_loc, forced)
+	. = ..()
+	possibly_deactivate_in_loc()
+
+
+/obj/item/radio/headset/circuitry/build_additional_parts(mob/living/carbon/human/H, mob_icon, slot)
+	var/static/list/valid_slots
+
+	if(!valid_slots)
+		valid_slots = list(slot_l_ear_str, slot_r_ear_str)
+
+	if(circuit_assembly?.detail_color && (slot in valid_slots))
+		var/image/electronic_overlay = overlay_image(icon, "[item_state][slot_str_to_contained_flag(slot)]-color", circuit_assembly.detail_color, RESET_COLOR)
+		return electronic_overlay
+
+	return ..()
+
+
+/obj/item/radio/headset/circuitry/proc/get_wearer()
+	if(!ishuman(loc))
+		return null
+
+	var/mob/living/carbon/human/H = loc
+
+	if(H.l_ear == src)
+		return H
+
+	if(H.r_ear == src)
+		return H
+
+	return null
+
+
+/obj/item/radio/headset/circuitry/proc/private_output(message)
+	var/mob/living/carbon/human/H = get_wearer()
+
+	if(!H)
+		return
+
+	to_chat(H, SPAN_NOTICE("[message]"))
+
+
+/obj/item/radio/headset/circuitry/proc/private_tts_output(message)
+	var/mob/living/carbon/human/H = get_wearer()
+
+	if(!H)
+		return
+
+	to_chat(H, SPAN_NOTICE("\The [src] states, \"[message]\""))
+
+
+/obj/item/radio/headset/circuitry/proc/relay_radio_to_circuits(mob/living/speaker, message, channel, datum/language/speaking)
+	/*
+	 * Called by the radio receive/display path after this headset receives radio traffic.
+	 * This forwards accepted radio traffic into installed microphone circuits.
+	 */
+	if(!circuit_assembly)
+		return
+
+	if(!get_wearer())
+		return
+
+	for(var/obj/item/integrated_circuit/input/microphone/MIC in circuit_assembly.contents)
+		MIC.receive_radio_message(speaker, message, channel, speaking)
+
+
+/obj/item/radio/headset/circuitry/proc/relay_radio_text_to_circuits(speaker_name, message, channel, language_name)
+	/*
+	 * Text-only fallback if the radio receive proc does not expose mob/language datums.
+	 */
+	if(!circuit_assembly)
+		return
+
+	if(!get_wearer())
+		return
+
+	for(var/obj/item/integrated_circuit/input/microphone/MIC in circuit_assembly.contents)
+		MIC.receive_radio_text(speaker_name, message, channel, language_name)
+
 /obj/item/radio/headset/binary
 	origin_tech = list(TECH_ILLEGAL = 3)
 	ks2type = /obj/item/encryptionkey/binary

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -858,6 +858,10 @@
  * Misc
  */
 
+/*
+ * Electronic Radio Headset
+ */
+
 /obj/item/radio/headset/headset_medsci
 	name = "medical research radio headset"
 	desc = "A headset that is a result of the mating between medical and science."

--- a/code/modules/integrated_electronics/core/assemblies/clothing.dm
+++ b/code/modules/integrated_electronics/core/assemblies/clothing.dm
@@ -10,7 +10,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	max_components = IC_COMPONENTS_BASE
 	max_complexity = IC_COMPLEXITY_BASE
-	var/obj/item/clothing/clothing = null
+	var/obj/item/clothing = null
 
 /obj/item/electronic_assembly/clothing/ui_host()
 	return clothing
@@ -22,12 +22,18 @@
 	return clothing
 
 /obj/item/electronic_assembly/clothing/update_icon()
-	clothing.icon_state = "[initial(clothing.icon_state)][opened ? "-open" : ""]"
+	if(!clothing)
+		return
+
+	clothing.icon_state = opened ? "[initial(clothing.icon_state)]-open" : initial(clothing.icon_state)
 	clothing.ClearOverlays()
-	var/image/detail_overlay = image('icons/obj/assemblies/wearable_electronic_setups.dmi', "[initial(clothing.icon_state)][opened ? "-open" : ""]-color")
+
+	var/image/detail_overlay = image('icons/obj/assemblies/wearable_electronic_setups.dmi', "[clothing.icon_state]-color")
 	detail_overlay.color = detail_color
 	clothing.AddOverlays(detail_overlay)
-	clothing.update_clothing_icon()
+
+	if(hascall(clothing, "update_clothing_icon"))
+		call(clothing, "update_clothing_icon")()
 
 // This is 'small' relative to the size of regular clothing assemblies.
 /obj/item/electronic_assembly/clothing/small
@@ -220,7 +226,8 @@
 		return electronic_overlay
 	return ..()
 
-// Ear
+// Ears
+
 /obj/item/clothing/ears/circuitry
 	name = "electronic earwear"
 	desc = "It's a wearable case for electronics. This one appears to be a technical-looking headset."
@@ -235,11 +242,14 @@
 
 /obj/item/clothing/ears/circuitry/build_additional_parts(mob/living/carbon/human/H, mob_icon, slot)
 	var/static/list/valid_slots
+
 	if(!valid_slots)
 		valid_slots = list(slot_l_ear_str, slot_r_ear_str)
-	if(IC.detail_color && (slot in valid_slots))
+
+	if(IC?.detail_color && (slot in valid_slots))
 		var/image/electronic_overlay = overlay_image(icon, "[item_state][slot_str_to_contained_flag(slot)]-color", IC.detail_color, RESET_COLOR)
 		return electronic_overlay
+
 	return ..()
 
 // Exo-slot

--- a/html/changelogs/mineymonkey changelog electronic earpiece.yml
+++ b/html/changelogs/mineymonkey changelog electronic earpiece.yml
@@ -1,0 +1,7 @@
+author: mineymonkey
+
+delete-after: True
+
+changes:
+  - qol: "Changed the electronic headset to behave as both a radio headset and an integrated circuit assembly."
+  - qol: "Changed integrated circuit microphone and text-to-speech behavior for /obj/item/radio/headset/circuitry so radio speech can be received by circuits and text-to-speech output is only heard by the wearer."

--- a/html/changelogs/mineymonkey changelog.yml
+++ b/html/changelogs/mineymonkey changelog.yml
@@ -1,0 +1,7 @@
+author: mineymonkey
+
+delete-after: True
+
+changes:
+  - qol: "Changed electronic headset to work and behave like both a radio headset and integrated circuits."
+  - qol: "Changed both integrated circuit microphone and text-to-speech to allow for specific instance useage with /obj/item/radio/headset/circuitry so it preserves normal function, but now will take speech from the radio into consideration and not announce it to anyone within range, now it needs to be worn to hear."

--- a/html/changelogs/mineymonkey changelog.yml
+++ b/html/changelogs/mineymonkey changelog.yml
@@ -1,7 +1,0 @@
-author: mineymonkey
-
-delete-after: True
-
-changes:
-  - qol: "Changed electronic headset to work and behave like both a radio headset and integrated circuits."
-  - qol: "Changed both integrated circuit microphone and text-to-speech to allow for specific instance useage with /obj/item/radio/headset/circuitry so it preserves normal function, but now will take speech from the radio into consideration and not announce it to anyone within range, now it needs to be worn to hear."


### PR DESCRIPTION
Changes electronic earpiece into a radio object while keeping integrated circuit compatability. I did not touch the complexity nor the size allowance, but this allows the headsets to now take encryption keys and behave like any other headset.

Also changed the behavior for the TTS and Microphone, specifically when slotted in /obj/item/radio/headset/circuitry so it shouldn't have any changes to base functionality. Though the changes added allow it to receive through the radio and output directly into the ear of the wearer, instead of blurting out for all to hear if they see you.