### PR TITLE
Fix persistent papers text insertion

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -66,6 +66,8 @@
 	var/can_change_icon_state = TRUE
 	var/set_unsafe_on_init = FALSE
 
+	persistant_objects_expiration_time_days = 90
+
 /obj/item/paper/Destroy()
 	info = null
 	info_links = null
@@ -103,11 +105,11 @@
 		else
 			addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_icon)), 1, TIMER_STOPPABLE | TIMER_DELETE_ME)
 
-/obj/item/paper/proc/set_content(title, text)
+/obj/item/paper/proc/set_content(title, text, adddefaultfont = TRUE)
 	if(title)
 		name = title
 	if (text && length(text))
-		info = parsepencode(text)
+		info = parsepencode(text, skipdefaultfont = !adddefaultfont)
 	else
 		info = ""
 
@@ -357,7 +359,7 @@
 
 	return signfont
 
-/obj/item/paper/proc/parsepencode(t, obj/item/pen/P, mob/user, iscrayon, isfountain, istypewriter)
+/obj/item/paper/proc/parsepencode(t, obj/item/pen/P, mob/user, iscrayon, isfountain, istypewriter, skipdefaultfont = FALSE)
 	if(user)
 		t = parse_languages(user, t, TRUE)
 	if(P)
@@ -413,14 +415,15 @@
 		t = replacetext(t, "\[cell\]", "")
 		t = replacetext(t, "\[barcode\]", "")
 
-	if(iscrayon)
-		t = "<font face=\"[crayonfont]\" color=[P ? P.colour : "black"]><b>[t]</b></font>"
-	else if(isfountain)
-		t = "<font face=\"[fountainfont]\" color=[P ? P.colour : "black"]><i>[t]</i></font>"
-	else if(istypewriter)
-		t = "<font face=\"[typewriterfont]\" color=[P ? P.colour : "black"]><i>[t]</i></font>"
-	else
-		t = "<font face=\"[deffont]\" color=[P ? P.colour : "black"]>[t]</font>"
+	if(!skipdefaultfont)
+		if(iscrayon)
+			t = "<font face=\"[crayonfont]\" color=[P ? P.colour : "black"]><b>[t]</b></font>"
+		else if(isfountain)
+			t = "<font face=\"[fountainfont]\" color=[P ? P.colour : "black"]><i>[t]</i></font>"
+		else if(istypewriter)
+			t = "<font face=\"[typewriterfont]\" color=[P ? P.colour : "black"]><i>[t]</i></font>"
+		else
+			t = "<font face=\"[deffont]\" color=[P ? P.colour : "black"]>[t]</font>"
 
 	t = pencode2html(t)
 
@@ -842,7 +845,7 @@
 	return content
 
 /obj/item/paper/persistent_objects_apply_content(content, x, y, z)
-	set_content(content["title"], content["text"])
+	set_content(content["title"], content["text"], adddefaultfont = FALSE)
 	src.x = x
 	src.y = y
 	src.z = z

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -66,7 +66,7 @@
 	var/can_change_icon_state = TRUE
 	var/set_unsafe_on_init = FALSE
 
-	persistant_objects_expiration_time_days = 90
+	persistant_objects_expiration_time_days = 180
 
 /obj/item/paper/Destroy()
 	info = null

--- a/html/changelogs/fabiank3-fix-persistent-papers-text-insertions.yml
+++ b/html/changelogs/fabiank3-fix-persistent-papers-text-insertions.yml
@@ -3,4 +3,4 @@ author: FabianK3
 delete-after: True
 
 changes:
-  - bugfix: "Fixed repeting default font tag getting added to persistent papers, breaking their life cycle and resulting in massive text sizes."
+  - bugfix: "Fixed repeating default font tag getting added to persistent papers, breaking their life cycle and resulting in massive text sizes."

--- a/html/changelogs/fabiank3-fix-persistent-papers-text-insertions.yml
+++ b/html/changelogs/fabiank3-fix-persistent-papers-text-insertions.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - bugfix: "Fixed repeating default font tag getting added to persistent papers, breaking their life cycle and resulting in massive text sizes."
+  - balance: "Raised expiration time of persistent papers from 30 to 90 days."

--- a/html/changelogs/fabiank3-fix-persistent-papers-text-insertions.yml
+++ b/html/changelogs/fabiank3-fix-persistent-papers-text-insertions.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
   - bugfix: "Fixed repeating default font tag getting added to persistent papers, breaking their life cycle and resulting in massive text sizes."
-  - balance: "Raised expiration time of persistent papers from 30 to 90 days."
+  - balance: "Raised expiration time of persistent papers from 30 to 180 days."

--- a/html/changelogs/fabiank3-fix-persistent-papers-text-insertions.yml
+++ b/html/changelogs/fabiank3-fix-persistent-papers-text-insertions.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed repeting default font tag getting added to persistent papers, breaking their life cycle and resulting in massive text sizes."


### PR DESCRIPTION
# Summary

This PR fixes continuously added default font tags getting added to papers when initialized by the persistency subsystem resulting in massive text sizes and broken life cycles.

## Changes

- Added default parameters allowing to skip the default font tag when parsing pencode.
- Set default font tag skipping to true for paper contents when set by persistency.
- Raised persistent paper life time to 180 days, from originally 30 days. 