### PR TITLE
Fix exception on persistent_objects_get_content parent proc

### DIFF
--- a/code/game/objects/items/sticker.dm
+++ b/code/game/objects/items/sticker.dm
@@ -81,7 +81,7 @@
 	SSpersistence.objectsDeregisterTrack(src)
 
 /obj/item/sticker/persistent_objects_get_content()
-	var/list/content = ..()
+	var/list/content = list()
 	content["pixel_x"] = pixel_x
 	content["pixel_y"] = pixel_y
 	return content

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -425,7 +425,7 @@
  * RETURN: Associated list with custom information (e.g.: ["test" = "abc", "counter" = 123])
  */
 /obj/proc/persistent_objects_get_content()
-	return
+	return list()
 
 /**
  * Called by the persistence subsystem to apply persistent data on the created object.

--- a/html/changelogs/fabiank3-fix-persistent-default-get-content.yml
+++ b/html/changelogs/fabiank3-fix-persistent-default-get-content.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed bad index exception when saving persistent objects using the parent persistent_objects_get_content proc."


### PR DESCRIPTION
# Summary

This PR fixes an exception during saving persistent contents caused by the base proc persistent_objects_get_content returning nothing instead of a default list.

## Changes

- Fixed parent proc to return an empty list instead of null.
- Refactored stickers to use own list instead of parent proc.