### PR TITLE
Enable find and refresh on browser windows

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -514,7 +514,6 @@
 
 	to_chat(src, SPAN_INFO("You can now right click to use inspect on browsers."))
 	winset(src, null, list("browser-options" = "+devtools"))
-	winset(src, null, list("browser-options" = "+find"))
 
 /// A debug verb to check the sources of currently running timers
 /client/proc/check_timer_sources()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -391,6 +391,8 @@ GLOBAL_LIST_INIT(localhost_addresses, list(
 
 	winset(src, "map", "style=\"[MAP_STYLESHEET]\"")
 
+	winset(src, null, list("browser-options" = "+find,refresh"))
+
 	if(IsGuestKey(key) && GLOB.config.external_auth)
 		src.authed = FALSE
 		var/mob/abstract/unauthed/m = new()

--- a/html/changelogs/banditoz-enable-find-and-refresh-on-browser-windows.yml
+++ b/html/changelogs/banditoz-enable-find-and-refresh-on-browser-windows.yml
@@ -1,0 +1,4 @@
+author: Banditoz
+delete-after: True
+changes:
+  - rscadd: "Enable find (Ctrl+F) and refresh (F5) on browser windows."


### PR DESCRIPTION
Regression from BYOND versions <=515 because find/refresh was always enabled on browser windows even when it wasn't supposed to be.

Enable find (Ctrl+F) and refresh (F5) on browser windows.