### PR TITLE
Enforce Calculus Linter Tags

### DIFF
--- a/code/__DEFINES/_unit_tests.dm
+++ b/code/__DEFINES/_unit_tests.dm
@@ -93,3 +93,15 @@
 #else
 #define TEST_OUTPUT_YELLOW(text) (text)
 #endif
+
+/**
+ * To be used in procs that involve calculus methods (either seconds_per_tick or delta_time).
+ * This enforces that said proc MUST have a valid seconds_per_tick given to it by all callers.
+ */
+#ifdef UNIT_TEST // REMOVE BEFORE FLIGHT
+#define ENFORCE_CALCULUS(seconds_per_tick) \
+	if (seconds_per_tick <= 0)\
+		CRASH("[caller.name] called [callee.name] without passing in seconds_per_tick (or gave a negative time). This proc MUST be given a positive and non-zero seconds_per_tick value.");
+#else
+#define ENFORCE_CALCULUS(seconds_per_tick)
+#endif

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -204,6 +204,8 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 		die()
 
 /obj/item/organ/proc/tick_surge_damage(seconds_per_tick)
+	ENFORCE_CALCULUS(seconds_per_tick)
+
 	if(!surge_damage)
 		clear_surge_effects()
 		return

--- a/html/changelogs/hellfirejag-remove-before-flight.yml
+++ b/html/changelogs/hellfirejag-remove-before-flight.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - code_imp: "Added an ENFORCE_CALCULUS(seconds_per_tick) macro to help spot bugs in procs that use calculus methods."


### PR DESCRIPTION
A not insignificant number of bugs caused when converting code to calculus methods is me missing that a proc is getting called from a different file entirely without passing in a seconds_per_tick value. Byond will just gleefully let my calculus methods for code run with a time delta of 0, which introduces all manner of exotic and fascinating bugs. 

So to better prevent this kind of issue from occuring, I'm adding a new linter tag called ENFORCE_CALCULUS(seconds_per_tick) which loudly forces unit test fails if a proc with the tag is called by a different proc without correctly passing in the needed time delta. I have previously run into this problem on occasion, such as in PR #22413 