### PR TITLE
Horizon starlight bandaids

### DIFF
--- a/html/changelogs/hazelmouse-bandaid.yml
+++ b/html/changelogs/hazelmouse-bandaid.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Resolved unusual-looking lighting around diagonal hull walls and the supermatter radiators of the Horizon."


### PR DESCRIPTION
Applies a bandaid to fix up the two most egregious lighting bugs on the Horizon. Ideally we wouldn't need to use area lighting to get these cases functional, space turfs should be enough, but this gets them looking not-awful tentatively until the behaviour of space turfs and of open turfs can be looked at more thoroughly.

**Old & new SM radiator lighting.**
<details>
<img width="966" height="894" alt="image" src="https://github.com/user-attachments/assets/5bf633d0-06ae-42e6-9f2c-b2fa797daa30" />
<img width="978" height="975" alt="image" src="https://github.com/user-attachments/assets/7e450b41-eba0-4a04-a2e0-084aa8ecf713" />

**NOTE:** this fix comes at the price of slightly odd lighting below. It seems like open turfs currently get confused if they belong to a starlit area while being above a non-lit area, hence the weird patchiness. The ideal solution here is either to simply not map things like this, or to fix up open turfs so they accurately reflect their area's lighting even while above non-lit turfs.

<img width="974" height="972" alt="image" src="https://github.com/user-attachments/assets/8e6eaded-2fe1-452b-b357-d10cf284c1ae" />
</details>

**Old & new diagonal wall lighting.**
<details>
<img width="996" height="805" alt="image" src="https://github.com/user-attachments/assets/a2c101bb-7d92-4a68-880b-5d9237137291" />
<img width="835" height="539" alt="image" src="https://github.com/user-attachments/assets/b25022ad-3fc4-4a81-86b8-900e78f01735" />
</details>