### PR TITLE
Ship Projectiles Hard Del

### DIFF
--- a/code/modules/overmap/ship_weaponry/projectiles/_overmap_projectiles.dm
+++ b/code/modules/overmap/ship_weaponry/projectiles/_overmap_projectiles.dm
@@ -26,7 +26,7 @@
 	x = sx
 	y = sy
 	z = SSatlas.current_map.overmap_z
-	addtimer(CALLBACK(src, PROC_REF(move_to)), 1)
+	addtimer(CALLBACK(src, PROC_REF(move_to)), 1, TIMER_STOPPABLE|TIMER_DELETE_ME)
 
 /obj/effect/overmap/projectile/Bump(var/atom/A)
 	if(istype(A, /turf/unsimulated/map/edge))

--- a/code/modules/overmap/ship_weaponry/projectiles/_overmap_projectiles.dm
+++ b/code/modules/overmap/ship_weaponry/projectiles/_overmap_projectiles.dm
@@ -66,6 +66,7 @@
 	ammunition = null
 	target = null
 	entry_target = null
+	walk(src, 0)
 	return ..()
 
 /obj/effect/overmap/projectile/proc/prepare_for_entry()

--- a/html/changelogs/hellfirejag-overmap-projectiles-harddel.yml
+++ b/html/changelogs/hellfirejag-overmap-projectiles-harddel.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed a hard delete caused by ship overmap projectiles."


### PR DESCRIPTION
Fix for a hard del caused by overmap projectiles failing to clear their walk cycle and timers consistently. This hard delete is relatively rare, except in any kind of event involving ship combat....