### PR TITLE
Remove Projectile Quantum Tunneling

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -356,7 +356,7 @@ GLOBAL_LIST_INIT(organ_rel_size, list(
 	miss_chance = max(miss_chance + miss_chance_mod, 0)
 	if(prob(miss_chance))
 		if(prob(70))
-			return null
+			return BP_CHEST
 		return pick(GLOB.base_miss_chance)
 	return zone
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -443,16 +443,7 @@
 			return TRUE
 
 	var/distance = get_dist(T, starting) // Get the distance between the turf shot from and the mob we hit and use that for the calculations.
-	// Originally was only `def_zone = ran_zone(def_zone, max(100-(7*distance), 5)) //Lower accurancy/longer range tradeoff. 7 is a balanced number to use.`
-	//Because snowflake aurora BS, this is how we calculate what to hit if anything with a mob
-	if(ismob(A))
-		var/miss_modifier = max(15*(distance-1) - round(25*accuracy), 0)
-		def_zone = get_zone_with_miss_chance(def_zone, A, miss_modifier, (distance > 1 || original != A), point_blank)
-		if (!def_zone)
-			A.visible_message(SPAN_NOTICE("\The [src] misses [A] narrowly!"))
-			return FALSE
-	else
-		def_zone = ran_zone(def_zone, clamp(accurate_range - (accuracy_falloff * distance), 5, 100)) //Lower accurancy/longer range tradeoff. 7 is a balanced number to use.
+	def_zone = ran_zone(def_zone, clamp(accurate_range - (accuracy_falloff * distance), 5, 100)) //Lower accurancy/longer range tradeoff. 7 is a balanced number to use.
 
 	return process_hit(T, select_target(T, A, A), A) // SELECT TARGET FIRST!
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -442,8 +442,16 @@
 				store_hitscan_collision(point_cache)
 			return TRUE
 
-	var/distance = get_dist(T, starting) // Get the distance between the turf shot from and the mob we hit and use that for the calculations.
-	def_zone = ran_zone(def_zone, clamp(accurate_range - (accuracy_falloff * distance), 5, 100)) //Lower accurancy/longer range tradeoff. 7 is a balanced number to use.
+	// Get distance via the Pythagorean theorem because byond's get_dist() is dumb.
+	var/distance = (((T.x - starting.x) ** 2) + ((T.y - starting.y) ** 2)) ** (1/2)
+
+	// Originally was only `def_zone = ran_zone(def_zone, max(100-(7*distance), 5)) //Lower accurancy/longer range tradeoff. 7 is a balanced number to use.`
+	//Because snowflake aurora BS, this is how we calculate what to hit if anything with a mob
+	if(ismob(A))
+		var/miss_modifier = max(15*(distance-1) - round(25*accuracy), 0)
+		def_zone = get_zone_with_miss_chance(def_zone, A, miss_modifier, (distance > 1 || original != A), point_blank)
+	else
+		def_zone = ran_zone(def_zone, clamp(accurate_range - (accuracy_falloff * distance), 5, 100)) //Lower accurancy/longer range tradeoff. 7 is a balanced number to use.
 
 	return process_hit(T, select_target(T, A, A), A) // SELECT TARGET FIRST!
 

--- a/html/changelogs/hellfirejag-remove-projectile-quantum-tunneling.yml
+++ b/html/changelogs/hellfirejag-remove-projectile-quantum-tunneling.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscdel: "Removed projectiles being able to 'miss narrowly' things that they hit. If you want inaccurate guns, make their dispersion high..."


### PR DESCRIPTION
Projectile dispersion should NEVER have been combined with projectile quantum tunneling. After having finally had a good chance to witness a proper long-term ranged engagement, imagine my fury when finding out an overwhelming majority of all projectiles will never hit their target unless you're literally at point blank. Guns have dispersion, use it. It feels terrible to play a game where bullets and lasers can magically phase through something when combined with bullets and lasers having a dispersion arc. 

It also made guns completely unplayable when combined with low rank skills increasing gun dispersion. 

<img width="312" height="20" alt="image" src="https://github.com/user-attachments/assets/8a36350b-3e39-46ae-9015-e5b829340501" />
