### PR TITLE
Item Size Adjustments

### DIFF
--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -2,7 +2,6 @@
 	name = "airlock electronics"
 	icon = 'icons/obj/module.dmi'
 	icon_state = "door_electronics"
-	w_class = WEIGHT_CLASS_TINY
 
 	matter = list(DEFAULT_WALL_MATERIAL = 50, MATERIAL_GLASS = 50)
 

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -93,7 +93,6 @@
 	icon = 'icons/obj/item/scanner.dmi'
 	icon_state = "dosimeter_off"
 	item_state = "dosimeter"
-	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = SLOT_WRISTS
 	action_button_name = "Toggle dosimeter counter"
 	matter = list(DEFAULT_WALL_MATERIAL = 100, MATERIAL_GLASS = 50)

--- a/code/game/objects/items/tools/tools.dm
+++ b/code/game/objects/items/tools/tools.dm
@@ -132,7 +132,7 @@
 	force = 14
 	throw_speed = 2
 	throw_range = 9
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_TINY
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	matter = list(DEFAULT_WALL_MATERIAL = 80)
 	attack_verb = list("pinched", "nipped")

--- a/code/game/objects/items/tools/tools.dm
+++ b/code/game/objects/items/tools/tools.dm
@@ -132,7 +132,7 @@
 	force = 14
 	throw_speed = 2
 	throw_range = 9
-	w_class = WEIGHT_CLASS_TINY
+	w_class = WEIGHT_CLASS_SMALL
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	matter = list(DEFAULT_WALL_MATERIAL = 80)
 	attack_verb = list("pinched", "nipped")
@@ -207,6 +207,7 @@
 	name = "bomb defusal wirecutters"
 	desc = "A tool used to delicately sever the wires used in bomb fuses."
 	icon_state = "mini_wirecutters"
+	w_class = WEIGHT_CLASS_TINY
 	toolspeed = 0.6
 	bomb_defusal_chance = 90 // 90% chance, because the thrill of dying must be kept at all times, duh
 

--- a/code/modules/clothing/ears/earphones.dm
+++ b/code/modules/clothing/ears/earphones.dm
@@ -399,7 +399,7 @@ Earphone Variants
 	desc = "A music cartridge."
 	icon = 'icons/obj/item/music_cartridges.dmi'
 	icon_state = "generic"
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_TINY
 	var/list/datum/track/tracks
 	/// Whether or not this cartridge can be removed from the datum/jukebox it belongs to.
 	var/hardcoded = FALSE

--- a/html/changelogs/Bat-ItemSizes.yml
+++ b/html/changelogs/Bat-ItemSizes.yml
@@ -2,5 +2,5 @@ author: Batrachophrenoboocosmomachia
 delete-after: True
 changes:
   - balance: "Decreases size of Dosimeter from Normal to Small."
-  - balance: "Decreases size of Wirecutters and Music Cartridge from Small to Tiny."
+  - balance: "Decreases size of Bomb Defusal Wirecutters and Music Cartridge from Small to Tiny."
   - balance: "Increases size of Airlock Electronics from Tiny to Small (matches other circuitboards)."

--- a/html/changelogs/Bat-ItemSizes.yml
+++ b/html/changelogs/Bat-ItemSizes.yml
@@ -1,0 +1,6 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - balance: "Decreases size of Dosimeter from Normal to Small."
+  - balance: "Decreases size of Wirecutters and Music Cartridge from Small to Tiny."
+  - balance: "Increases size of Airlock Electronics from Tiny to Small (matches other circuitboards)."


### PR DESCRIPTION
Small handful of obj/item size adjustments for common sense, QoL, and standardization.

changes:
  - balance: "Decreases size of Dosimeter from Normal to Small."
  - balance: "Decreases size of Bomb Defusal Wirecutters and Music Cartridge from Small to Tiny."
  - balance: "Increases size of Airlock Electronics from Tiny to Small (matches other circuitboards)."