### PR TITLE
Fixes all hostile simple mobs that don't override /fire shooting the wrong projectile

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -429,7 +429,7 @@ ABSTRACT_TYPE(/mob/living/simple_animal/hostile)
 
 	// var/def_zone = get_exposed_defense_zone(target)
 
-	fire_projectile(/obj/projectile, target, projectilesound, firer = user)
+	fire_projectile(projectiletype, target, projectilesound, firer = user)
 
 /mob/living/simple_animal/hostile/proc/DestroySurroundings(var/bypass_prob = FALSE)
 	if(ON_ATTACK_COOLDOWN(src))

--- a/html/changelogs/FixesSimpleMobProjectiles.yml
+++ b/html/changelogs/FixesSimpleMobProjectiles.yml
@@ -1,0 +1,7 @@
+
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes all hostile simple mobs shooting the base projectile, instead of their specified projectile."


### PR DESCRIPTION
Hivebots, & rogue drones tested, they now shoot their lasers and needles correctly again.
The hivebot beacon is particularly mean.