### PR TITLE
Stops processing Hivenet Echoes if lists aren't detected & No Extra Broadcast Echoes

### DIFF
--- a/code/datums/components/_hivenetechoes.dm
+++ b/code/datums/components/_hivenetechoes.dm
@@ -64,6 +64,9 @@
 	var/list/echo_response = file2list("config/hivenet_echoes/response_[topic].txt")
 	var/joined = pick(100;0, 60;1)
 
+	if(!length(echo_starter) || !length(echo_response))
+		STOP_PROCESSING(SSprocessing, src)
+		return
 	if(joined && topic == "gossip")
 		to_chat(owner, "<i><span class='game say'>Hivenet, <span class='name'>a [pick("Faint", "Distant", "Fading", "Fleeting", "Drifting", "Low", "Weak", "Far", "Pinging", "Whispering")] Echo</span> broadcasts, <span class='vaurca'>\"[pick(echo_starter)]" + " " + "[pick(echo_response)]\"</span></span></i>")
 	else

--- a/code/datums/components/_hivenetechoes.dm
+++ b/code/datums/components/_hivenetechoes.dm
@@ -2,6 +2,7 @@
 
 	/// The next real life time a broadcast echo will generate.
 	var/next_broadcastEcho = 0
+	var/topic
 	/// The next real life time a projection echo will generate.
 	var/next_projectionEcho = 0
 
@@ -32,8 +33,8 @@
 		return
 
 	// Setup the first time the echoes will begin playing.
-	next_broadcastEcho = REALTIMEOFDAY + rand(180, 300) SECONDS
-	next_projectionEcho = REALTIMEOFDAY + rand(240, 480) SECONDS
+	next_broadcastEcho = world.time + rand(180, 300) SECONDS
+	next_projectionEcho = world.time + rand(240, 480) SECONDS
 
 	// Finally start the clock.
 	START_PROCESSING(SSprocessing, src)
@@ -47,14 +48,14 @@
 	if(owner.stat != CONSCIOUS)
 		return
 
-	var/curtime = REALTIMEOFDAY
-	if(curtime >= next_broadcastEcho)
-		var/topic = "[pick(100;"gossip", 30;"happy", 15;"tense")]"
+	if(world.time >= next_broadcastEcho && !topic) // topic has to null itself, or an extra broadcast generates for w/e reason
+		topic = "[pick(100;"gossip", 30;"happy", 15;"tense")]"
 		GetBroadcastEcho(topic)
-		next_broadcastEcho = curtime + rand(180, 300) SECONDS
-	if(curtime >= next_projectionEcho)
+		topic = null
+		next_broadcastEcho = world.time + rand(180, 300) SECONDS
+	if(world.time >= next_projectionEcho)
 		GetProjectionEcho()
-		next_projectionEcho = curtime + rand(240, 480) SECONDS
+		next_projectionEcho = world.time + rand(240, 480) SECONDS
 
 /datum/component/HiveEchoes/proc/GetBroadcastEcho(topic)
 	if (!owner.internal_organs_by_name[BP_NEURAL_SOCKET] || within_jamming_range(owner))

--- a/html/changelogs/diggiez - EchoesListGuarding.yml
+++ b/html/changelogs/diggiez - EchoesListGuarding.yml
@@ -1,0 +1,12 @@
+author: diggiez
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Hivenet Echoes won't process if lists aren't detected."

--- a/html/changelogs/diggiez - EchoesListGuarding.yml
+++ b/html/changelogs/diggiez - EchoesListGuarding.yml
@@ -10,3 +10,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - qol: "Hivenet Echoes won't process if lists aren't detected."
+  - bugfix: "An extra broadcast echo no longer occasionally generates."


### PR DESCRIPTION
The lag from the event yesterday was because this triggered without getting valid lists because Matt didn't add them to the config yet. Probably won't happen again, but safety never hurts.

EDIT: This also fixes a bug where an extra broadcast echo would generate for whatever reason.