### PR TITLE
Diona Null Invoke Fix

### DIFF
--- a/code/modules/mob/living/carbon/diona_base.dm
+++ b/code/modules/mob/living/carbon/diona_base.dm
@@ -370,15 +370,14 @@ and some alternative things that are toxic to other life, such as radium and mut
 
 	updatehealth()
 
-/mob/living/carbon/human/proc/diona_regen_progress(var/datum/dionastats/DS)
+/mob/living/carbon/human/proc/diona_regen_progress(datum/dionastats/DS)
 	if(!DS)
 		return
 	if(DS.regen_limb_progress > LIMB_REGROW_REQUIREMENT)
-		DS.regen_limb.Invoke()
+		DS.regen_limb?.Invoke()
 		DS.regen_limb = null
-		if(DS.regen_extra)
-			DS.regen_extra.Invoke()
-			DS.regen_extra = null
+		DS.regen_extra?.Invoke()
+		DS.regen_extra = null
 	var/progress = nutrition * 0.45
 	adjustNutritionLoss(nutrition * 0.15)
 	progress += DS.stored_energy * 0.3

--- a/html/changelogs/hellfirejag-diona-regen-bugfix.yml
+++ b/html/changelogs/hellfirejag-diona-regen-bugfix.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed a runtime error caused by a diona entering a cryopod."


### PR DESCRIPTION
Fix for https://aurorastation.sentry.io/issues/7409286369

Which produced a runtime error (and associated hard del) when a Diona enters a cryopod.