### PR TITLE
Ship Sensors Runtime Fix

### DIFF
--- a/code/modules/overmap/contacts/contact_sensors.dm
+++ b/code/modules/overmap/contacts/contact_sensors.dm
@@ -35,8 +35,9 @@
 	if(sensors?.use_power)
 		sensor_range = round(sensors.range,1)
 	var/datum/overmap_contact/self_record = contact_datums[linked]
-	self_record.update_marker_icon()
-	self_record.show()
+	if (self_record)
+		self_record.update_marker_icon()
+		self_record.show()
 
 	// Update our 'sensor range' (ie. overmap lighting)
 	if(!sensors || !sensors.use_power || (stat & (NOPOWER|BROKEN)))
@@ -51,7 +52,7 @@
 
 		objects_in_view.Cut()
 	else
-		self_record.ping_radar(sensor_range)
+		self_record?.ping_radar(sensor_range)
 
 		// What can we see?
 		var/list/objects_in_current_view = list()

--- a/html/changelogs/hellfirejag-ship-sensors-runtime.yml
+++ b/html/changelogs/hellfirejag-ship-sensors-runtime.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed a very expensive (lags the server during ship combat) runtime error related to ship sensors."


### PR DESCRIPTION
Fix for https://aurorastation.sentry.io/issues/7405225650

Which is a significant cause for server lag during "ship combat events". I can no joke see the exact times ship combats occcured just by looking at the timing chart for when this runtime gets reported.