### PR TITLE
More Misc Sentry Fixes

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -790,7 +790,7 @@
 		return
 
 	user.visible_message(SPAN_WARNING("[user] starts harvesting \the [display_name]"))
-	if (doafter > 0 && !do_after(user, doafter, src))
+	if (doafter > 0 && !do_after(user, doafter))
 		to_chat(user, SPAN_DANGER("You were interrupted while trying to harvest \the [display_name]"))
 		return
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -141,7 +141,7 @@
 		if(!footsound)
 			footsound = T.footstep_sound
 
-	if (client)
+	if (client && T)
 		var/turf/T1 = GET_TURF_ABOVE(T)
 		if(up_hint)
 			up_hint.icon_state = "uphint[(T1 ? !!isopenturf(T1) : 0)]"

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -85,7 +85,7 @@
 				LAZYADD(src.other_DNA, target_mob.dna.unique_enzymes)
 				src.other_DNA_type = "saliva"
 
-			while (do_after(user, 25, 5))
+			while (do_after(user, 25, src))
 				var/blood_taken = 0
 				blood_taken = min(5, REAGENT_VOLUME(reagents, /singleton/reagent/blood)/4)
 

--- a/code/modules/tgui_input/number.dm
+++ b/code/modules/tgui_input/number.dm
@@ -24,6 +24,8 @@
 			user = client.mob
 		else
 			return
+	if (!user.client)
+		return
 	// Client does NOT have tgui_input on: Returns regular input
 	if(!user.client.prefs.tgui_inputs)
 		var/input_number = input(user, message, title, default) as null|num
@@ -111,6 +113,9 @@
 	return GLOB.always_state
 
 /datum/tgui_input_number/ui_static_data(mob/user)
+	if (!user.client)
+		return list()
+
 	var/list/data = list()
 	data["init_value"] = default // Default is a reserved keyword
 	data["large_buttons"] = user.client.prefs.tgui_buttons_large

--- a/code/modules/tgui_input/text.dm
+++ b/code/modules/tgui_input/text.dm
@@ -24,6 +24,9 @@
 			user = client.mob
 		else
 			return
+	if (!user.client)
+		return
+
 	// Client does NOT have tgui_input on: Returns regular input
 	if(!user.client.prefs.tgui_inputs)
 		if(encode)
@@ -109,6 +112,9 @@
 	return GLOB.always_state
 
 /datum/tgui_input_text/ui_static_data(mob/user)
+	if (!user.client)
+		return list()
+
 	var/list/data = list()
 	data["large_buttons"] = user.client.prefs.tgui_buttons_large
 	data["swapped_buttons"] = user.client.prefs.tgui_inputs_swapped

--- a/html/changelogs/hellfirejag-misc-sentry-fixes.yml
+++ b/html/changelogs/hellfirejag-misc-sentry-fixes.yml
@@ -4,3 +4,4 @@ changes:
   - bugfix: "Fixed a runtime error caused by vampires trying to drink from a blood bag."
   - bugfix: "Fixed a niche runtime error that occurs occasionally during late spawns."
   - bugfix: "Fixed a runtime when harvesting plants."
+  - bugfix: "Fixed a runtime caused when a player disconnects while a tgui input window is open."

--- a/html/changelogs/hellfirejag-misc-sentry-fixes.yml
+++ b/html/changelogs/hellfirejag-misc-sentry-fixes.yml
@@ -1,0 +1,6 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed a runtime error caused by vampires trying to drink from a blood bag."
+  - bugfix: "Fixed a niche runtime error that occurs occasionally during late spawns."
+  - bugfix: "Fixed a runtime when harvesting plants."


### PR DESCRIPTION
Sorting runtime errors by most events in the past 2 weeks, here's a few fixes for the following:

https://aurorastation.sentry.io/issues/7472147004 - Runtime when someone attempts to move before their character is placed in the world.

https://aurorastation.sentry.io/issues/7443212526 - Runtime when harvesting plants

https://aurorastation.sentry.io/issues/7466716994 - Runtime when vampires try to drink a bloodbag

https://aurorastation.sentry.io/issues/7496800530 - Runtime when a player disconnects while a tgui window is open.