### PR TITLE
Adds various clothing shortcuts

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -85,6 +85,9 @@
 		if(LAZYACCESS(modifiers, CTRL_CLICK))
 			CtrlShiftClickOn(A)
 			return
+		if(LAZYACCESS(modifiers, ALT_CLICK))
+			AltShiftClickOn(A)
+			return
 		ShiftClickOn(A)
 		return
 	if(LAZYACCESS(modifiers, MIDDLE_CLICK))
@@ -315,19 +318,29 @@
 	Alt click
 	Unused except for AI
 */
-/mob/proc/AltClickOn(var/atom/A)
+/mob/proc/AltClickOn(atom/A)
 	A.AltClick(src)
 	return
 
-/atom/proc/AltClick(var/mob/user)
+/atom/proc/AltClick(mob/user)
 	var/turf/T = get_turf(src)
 	if(!T || !user.TurfAdjacent(T))
 		return FALSE
 	if(T && (isturf(loc) || isturf(src)) && user.TurfAdjacent(T))
 		user.set_listed_turf(T)
 
-/mob/proc/TurfAdjacent(var/turf/T)
+/mob/proc/TurfAdjacent(turf/T)
 	return T.AdjacentQuick(src)
+
+/**
+ * Alt Shift click
+ * Currently only used for removing accessories from clothing.
+ */
+/mob/proc/AltShiftClickOn(atom/A)
+	A.AltShiftClick(src)
+
+/atom/proc/AltShiftClick(mob/user)
+	return
 
 /mob/proc/RightClickOn(atom/A)
 	A.RightClick(src)

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -443,11 +443,27 @@
 			return 0
 	return 1
 
-/atom/movable/screen/inventory/Click()
+/atom/movable/screen/inventory/Click(location, control, params)
 	// At this point in client Click() code we have passed the 1/10 sec check and little else
 	// We don't even know if it's a middle click
 	if(!usr.canClick())
 		return TRUE
+
+	var/obj/item/worn_item = usr.get_equipped_item(slot_id)
+	if(istype(worn_item))
+		var/list/modifiers = params2list(params)
+		if(LAZYACCESS(modifiers, ALT_CLICK)) // --- Alt click combinations
+			if(LAZYACCESS(modifiers, SHIFT_CLICK)) // Alt-Shift click
+				worn_item.AltShiftClick(usr)
+				return TRUE
+
+			worn_item.AltClick(usr) // Alt click
+			return TRUE
+
+		if(LAZYACCESS(modifiers, SHIFT_CLICK)) // Shift click
+			worn_item.ShiftClick(usr)
+			return TRUE
+
 	if(use_check_and_message(usr, USE_ALLOW_NON_ADJACENT|USE_ALLOW_NON_ADV_TOOL_USR)) //You're always adjacent to your inventory in practice.
 		return TRUE
 	switch(name)
@@ -468,7 +484,7 @@
 				usr.update_inv_l_hand(0)
 				usr.update_inv_r_hand(0)
 
-	return 1
+	return TRUE
 
 /atom/movable/screen/movement_intent
 	name = "mov_intent"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -61,6 +61,11 @@
 			refit_for_species(refit_initialize)
 	update_icon()
 
+/obj/item/clothing/mechanics_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "You can <b>Alt-Click</b> to adjust \the [src]'s layer, if it's applicable to this item."
+	. += "You can <b>Alt-Shift-Click</b> to remove any attached accessories."
+
 /obj/item/clothing/Destroy()
 	STOP_PROCESSING(SSprocessing, src)
 
@@ -621,16 +626,29 @@
 	if(allow_hair_covering)
 		verbs += /obj/item/clothing/head/proc/toggle_block_hair
 
+/obj/item/clothing/head/mechanics_hints(mob/user, distance, is_adjacent)
+	. = list()
+	. += "You can <b>Alt-Click</b> to adjust hair coverage."
+
 /obj/item/clothing/head/proc/toggle_block_hair()
 	set name = "Toggle Hair Coverage"
 	set category = "Object.Equipped"
 	set src in usr
 
+	handle_toggle_block_hair(usr)
+
+/obj/item/clothing/head/AltClick(user)
+	handle_toggle_block_hair(user)
+
+/obj/item/clothing/head/proc/handle_toggle_block_hair(mob/user)
+	if(use_check_and_message(user))
+		return
+
 	if(allow_hair_covering)
 		flags_inv ^= BLOCKHEADHAIR
-		to_chat(usr, SPAN_NOTICE("[src] will now [flags_inv & BLOCKHEADHAIR ? "hide" : "show"] hair."))
-		if(ishuman(usr))
-			var/mob/living/carbon/human/H = usr
+		to_chat(user, SPAN_NOTICE("[src] will now [flags_inv & BLOCKHEADHAIR ? "hide" : "show"] hair."))
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
 			H.update_hair()
 
 /obj/item/clothing/head/get_image_key_mod()
@@ -964,11 +982,17 @@
 	set category = "Object.Equipped"
 	set src in usr
 
-	if(use_check_and_message(usr))
-		return 0
+	handle_toggle_layer(usr)
+
+/obj/item/clothing/shoes/AltClick(user)
+	handle_toggle_layer(user)
+
+/obj/item/clothing/shoes/proc/handle_toggle_layer(mob/user)
+	if(use_check_and_message(user))
+		return
 
 	if(shoes_under_pants == -1)
-		to_chat(usr, SPAN_NOTICE("[src] cannot be worn above your suit!"))
+		to_chat(user, SPAN_NOTICE("[src] cannot be worn above your suit!"))
 		return
 	shoes_under_pants = !shoes_under_pants
 	update_icon()

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -154,6 +154,9 @@
 
 	remove_accessory_handler(usr, FALSE)
 
+/obj/item/clothing/AltShiftClick(user)
+	remove_accessory_handler(usr, FALSE)
+
 /obj/item/clothing/proc/remove_accessory_handler(var/mob/living/user, var/force_radial = FALSE)
 	if(!isliving(user))
 		return

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -55,11 +55,20 @@ BLIND     // can't see anything
 	set name = "Change Glasses Layer"
 	set src in usr
 
+	handle_change_layer(usr)
+
+/obj/item/clothing/glasses/AltClick(user)
+	handle_change_layer(user)
+
+/obj/item/clothing/glasses/proc/handle_change_layer(mob/user)
+	if(use_check_and_message(user))
+		return
+
 	if(normal_layer == GLASSES_LAYER)
 		normal_layer = GLASSES_LAYER_ALT
 	else
 		normal_layer = GLASSES_LAYER
-	to_chat(usr, SPAN_NOTICE("\The [src] will now layer [normal_layer == 21 ? "under" : "over"] your hair."))
+	to_chat(user, SPAN_NOTICE("\The [src] will now layer [normal_layer == 21 ? "under" : "over"] your hair."))
 	update_clothing_icon()
 
 /obj/item/clothing/glasses/protects_eyestab(var/obj/stab_item, var/stabbed = FALSE)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -155,14 +155,20 @@
 	flags_inv = HIDEEARS
 	action_button_name = "Toggle Visor"
 
+/obj/item/clothing/head/helmet/riot/mechanics_hints(mob/user, distance, is_adjacent)
+	. = ..()
+	. += "You can <b>Alt-Shift-Click</b> to [icon_state == initial(icon_state) ? "raise" : "lower"] the visor."
+
+/obj/item/clothing/head/helmet/riot/AltShiftClick(user)
+	do_flip(user)
+
 /obj/item/clothing/head/helmet/riot/attack_self(mob/user as mob)
-	if (use_check_and_message(user))
+	do_flip(user)
+
+/obj/item/clothing/head/helmet/riot/proc/do_flip(mob/user)
+	if(use_check_and_message(user))
 		return
 
-	do_flip(user)
-	update_clothing_icon()
-
-/obj/item/clothing/head/helmet/riot/proc/do_flip(var/mob/user)
 	if(icon_state == initial(icon_state))
 		icon_state = "[icon_state]-up"
 		item_state = icon_state
@@ -174,6 +180,7 @@
 		to_chat(user, SPAN_NOTICE("You lower the visor on \the [src]."))
 		body_parts_covered = HEAD|FACE|EYES
 
+	update_clothing_icon()
 
 /obj/item/clothing/head/helmet/ablative
 	name = "ablative helmet"

--- a/code/modules/clothing/pants/pants.dm
+++ b/code/modules/clothing/pants/pants.dm
@@ -40,16 +40,25 @@ ABSTRACT_TYPE(/obj/item/clothing/pants)
 		var/mob/M = src.loc
 		M.update_inv_pants()
 
+/obj/item/clothing/pants/AltClick(mob/user)
+	if(use_check_and_message(user))
+		return
+
+	handle_change_layer(user)
+
 /obj/item/clothing/pants/verb/change_layer()
 	set category = "Object.Equipped"
 	set name = "Change Pants Layer"
 	set src in usr
 
+	handle_change_layer(usr)
+
+/obj/item/clothing/pants/proc/handle_change_layer(mob/user)
 	var/list/options = list("Under Uniform" = UNDER_UNIFORM_LAYER_PA, "Over Uniform" = ABOVE_UNIFORM_LAYER_PA, "Over Suit" = ABOVE_SUIT_LAYER_PA)
-	var/new_layer = tgui_input_list(usr, "Position Pants", "Pants Layer", options)
+	var/new_layer = tgui_input_list(user, "Position Pants", "Pants Layer", options)
 	if(new_layer)
 		mob_wear_layer = options[new_layer]
-		to_chat(usr, SPAN_NOTICE("\The [src] will now layer [new_layer]."))
+		to_chat(user, SPAN_NOTICE("\The [src] will now layer [new_layer]."))
 		update_clothing_icon()
 
 /********** Pants Start **********/

--- a/code/modules/clothing/wrists/watches.dm
+++ b/code/modules/clothing/wrists/watches.dm
@@ -9,6 +9,35 @@
 	action_button_name = "Check time"
 	default_action_type = /datum/action/item_action/watch
 
+/obj/item/clothing/wrists/watch/mechanics_hints(mob/user, distance, is_adjacent)
+	. = ..()
+	. += "You can <b>Alt-Shift-Click</b> to swap \the [src] to your [src.flipped ? "right" : "left"] wrist."
+
+/obj/item/clothing/wrists/watch/proc/swap_wrists()
+	set category = "Object.Equipped"
+	set name = "Flip Wristwear"
+	set src in usr
+
+	handle_swap_wrists(usr)
+
+/obj/item/clothing/wrists/watch/AltShiftClick(user)
+	handle_swap_wrists(user)
+
+/obj/item/clothing/wrists/watch/proc/handle_swap_wrists(mob/user)
+	if(use_check_and_message(user))
+		return
+
+	flipped = !flipped
+	if(("[initial(icon_state)]_flip") in icon_states(icon))
+		icon_state = "[initial(item_state)][flipped ? "_flip" : ""]"
+	item_state = "[initial(item_state)][flipped ? "_flip" : ""]"
+	to_chat(user, "You change \the [src] to be on your [src.flipped ? "left" : "right"] wrist.")
+	if(equip_sound)
+		playsound(src, equip_sound, EQUIP_SOUND_VOLUME)
+	else
+		playsound(src, drop_sound, DROP_SOUND_VOLUME)
+	update_clothing_icon()
+
 /obj/item/clothing/wrists/watch/silver
 	desc = "It's a GaussIo ZeitMeister, a finely tuned wristwatch encased in silver."
 	desc_extended = "To unleash the telemarketer in you!"
@@ -51,7 +80,14 @@
 	slot_flags = SLOT_WRISTS | SLOT_BELT | SLOT_S_STORE
 	var/closed = FALSE
 
-/obj/item/clothing/wrists/watch/pocketwatch/AltClick(mob/user)
+/obj/item/clothing/wrists/watch/pocketwatch/mechanics_hints(mob/user, distance, is_adjacent)
+	. = ..()
+	. += "While \the [src] is in your inventory, you can <b>Ctrl-Click</b> to [closed ? "open" : "close"] its lid."
+
+/obj/item/clothing/wrists/watch/pocketwatch/CtrlClick(mob/user)
+	if(!(src in user)) // if it's not in our inventory then act normal
+		return ..()
+
 	if(!closed)
 		icon_state = "[initial(icon_state)]_closed"
 		item_state = "[initial(icon_state)]_closed"

--- a/code/modules/clothing/wrists/wrists.dm
+++ b/code/modules/clothing/wrists/wrists.dm
@@ -24,14 +24,27 @@
 	. = ..()
 	update_flip_verb()
 
+/obj/item/clothing/wrists/mechanics_hints(mob/user, distance, is_adjacent)
+	. = list()
+	. += "You can <b>Alt-Click</b> to adjust \the [src]'s layer."
+
 /obj/item/clothing/wrists/proc/update_flip_verb()
 	if((gender != PLURAL) && (flipped != -1)) // Check for plurality and whether it has a flipped icon.
-		verbs += /obj/item/clothing/wrists/watch/proc/swapwrists
+		verbs += /obj/item/clothing/wrists/watch/proc/swap_wrists
 
 /obj/item/clothing/wrists/verb/change_layer()
 	set category = "Object.Equipped"
 	set name = "Change Wristwear Layer"
 	set src in usr
+
+	handle_change_layer(usr)
+
+/obj/item/clothing/wrists/AltClick(user)
+	handle_change_layer(user)
+
+/obj/item/clothing/wrists/proc/handle_change_layer(mob/user)
+	if(use_check_and_message(user))
+		return
 
 	var/list/options = list("Under Uniform" = UNDER_UNIFORM_LAYER_WR, "Over Uniform" = ABOVE_UNIFORM_LAYER_WR, "Over Suit" = ABOVE_SUIT_LAYER_WR)
 	var/new_layer = tgui_input_list(usr, "Position Wristwear", "Wristwear Style", options)
@@ -39,25 +52,6 @@
 		mob_wear_layer = options[new_layer]
 		to_chat(usr, SPAN_NOTICE("\The [src] will now layer [new_layer]."))
 		update_clothing_icon()
-
-/obj/item/clothing/wrists/watch/proc/swapwrists()
-	set category = "Object.Equipped"
-	set name = "Flip Wristwear"
-	set src in usr
-
-	if(use_check_and_message(usr))
-		return 0
-
-	flipped = !flipped
-	if(("[initial(icon_state)]_flip") in icon_states(icon))
-		icon_state = "[initial(item_state)][flipped ? "_flip" : ""]"
-	item_state = "[initial(item_state)][flipped ? "_flip" : ""]"
-	to_chat(usr, "You change \the [src] to be on your [src.flipped ? "left" : "right"] wrist.")
-	if(equip_sound)
-		playsound(src, equip_sound, EQUIP_SOUND_VOLUME)
-	else
-		playsound(src, drop_sound, DROP_SOUND_VOLUME)
-	update_clothing_icon()
 
 /obj/item/clothing/wrists/bracelet
 	name = "bracelet"

--- a/html/changelogs/kano-dot-clothing-shortcuts.yml
+++ b/html/changelogs/kano-dot-clothing-shortcuts.yml
@@ -1,0 +1,8 @@
+author: Kano
+
+delete-after: True
+
+changes:
+  - qol: "Added various clothing shortcuts. You can now Alt-Click to adjust layers, Alt-Shit-Click to remove accessories, etc. on most clothings."
+  - rscadd: "Tweaked inventory HUD icon frames to process shortcut clicks (Alt-Click and Shift-Alt-Click for now). This means you no longer have to click specifically on item icons to use shortcuts."
+  - code_imp: "Moved a block of code to where it belongs, minor code improvements."


### PR DESCRIPTION
Changes:

  - Added various clothing shortcuts. You can now Alt-Click to adjust layers, Alt-Shift-Click to remove accessories, etc. on most clothings.
  - Tweaked inventory HUD icon frames to process shortcut clicks (Alt-Click and Shift-Alt-Click for now). This means you no longer have to click specifically on item icons to use shortcuts.
  - Moved a block of code to where it belongs, minor code improvements.

There might cases where the new shortcuts collide with already present snowflake shortcut interactions on certain items, i tweaked the ones i stumbled into but there might be more
