### PR TITLE
Remove rare gas isotopes from exoplanet atmospheres

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -441,9 +441,12 @@
 	else //let the fuckery commence
 		var/list/newgases = gas_data.gases.Copy()
 		newgases -= GAS_PHORON
+		newgases -= GAS_DEUTERIUM
+		newgases -= GAS_TRITIUM
+		newgases -= GAS_HELIUMFUEL
+		newgases -= GAS_WATERVAPOR
 		if(prob(50)) //alium gas should be slightly less common than mundane shit
 			newgases -= GAS_ALIEN
-		newgases -= GAS_WATERVAPOR
 
 		var/total_moles = MOLES_CELLSTANDARD * rand(80,120)/100
 		var/badflag = 0

--- a/html/changelogs/Bat-AtmosIsotopes.yml
+++ b/html/changelogs/Bat-AtmosIsotopes.yml
@@ -1,0 +1,4 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - balance: "Rare gas isotopes are no longer present in the atmospheres of randomly-generated exoplanets."


### PR DESCRIPTION
See title. Deuterium, Tritium, and Helium-3 no longer eligible to spawn in the atmospheres of randomly-generated exoplanets.