### PR TITLE
Fixed the elevator time display and increased the elevator timer

### DIFF
--- a/code/controllers/subsystems/cargo.dm
+++ b/code/controllers/subsystems/cargo.dm
@@ -439,7 +439,7 @@ SUBSYSTEM_DEF(cargo)
 				new_shipment()
 
 			// Set the elevator movement time.
-			current_shipment.shuttle_time = get_pending_shipment_time()
+			current_shipment.shuttle_time = get_pending_shipment_time() + min_movetime
 			current_shipment.shuttle_fee = shipment_cost
 
 			if(current_shipment.shuttle_time < min_movetime)
@@ -453,7 +453,7 @@ SUBSYSTEM_DEF(cargo)
 			movetime = current_shipment.shuttle_time
 			//Launch it
 			shuttle.launch(src)
-			. = "The cargo elevator has been called and will arrive in approximately [shuttle.eta_seconds()] seconds."
+			. = "The cargo elevator has been called and will arrive in approximately [shuttle.launch_estimate(TRUE)] seconds."
 			current_shipment.shuttle_called_by = requester_name
 
 // Cancels the elevator. Can return a status message.

--- a/code/modules/shuttles/shuttle_supply.dm
+++ b/code/modules/shuttles/shuttle_supply.dm
@@ -121,7 +121,7 @@
 			play_elevator_animation(TRUE) // returning to CC, play the animation after elevator physically leaves
 
 		//wait ETA here.
-		arrive_time = world.time + SScargo.movetime
+		arrive_time = launch_estimate()
 		while (world.time <= arrive_time)
 			sleep(5)
 
@@ -154,10 +154,22 @@
 /datum/shuttle/autodock/ferry/supply/proc/idle()
 	return (moving_status == SHUTTLE_IDLE)
 
-//returns the ETA in seconds
+/// returns the ETA in seconds
 /datum/shuttle/autodock/ferry/supply/proc/eta_seconds()
 	var/ticksleft = arrive_time - world.time
-	return round(ticksleft/10,1)
+	if(ticksleft > 0)
+		return "[round(ticksleft/10,1)] seconds"
+	else
+		return "soon."
+
+/// Gets the cargo moving time
+/datum/shuttle/autodock/ferry/supply/proc/launch_estimate(var/in_seconds = FALSE)
+	var/time = world.time + SScargo.movetime
+	if(in_seconds)
+		time = time - world.time
+		return round(time/10,1)
+	else
+		return time
 
 /**************************
 	Elevator Animations

--- a/html/changelogs/CargoTweaks.yml
+++ b/html/changelogs/CargoTweaks.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Increased the time of the cargo elevator to be 30 seconds + 10 per different supplier, instead of going with the higher of the two numbers."
+  - bugfix: "Fixed that the cargo control program displayed a negative number when calling the elevator."

--- a/tgui/packages/tgui/interfaces/CargoControl.tsx
+++ b/tgui/packages/tgui/interfaces/CargoControl.tsx
@@ -39,7 +39,7 @@ export type CargoData = {
   have_printer: BooleanLike;
   shuttle_available: BooleanLike;
   shuttle_has_arrive_time: BooleanLike;
-  shuttle_eta_seconds: number;
+  shuttle_eta_seconds: string;
   shuttle_can_launch: BooleanLike;
   shuttle_can_cancel: BooleanLike;
   shuttle_can_force: BooleanLike;
@@ -308,7 +308,7 @@ export const MainWindow = (props, context) => {
         <Section title="Elevator Information">
           <LabeledList>
             <LabeledList.Item label="ETA">
-              {data.shuttle_eta_seconds} seconds
+              {data.shuttle_eta_seconds}
             </LabeledList.Item>
           </LabeledList>
         </Section>


### PR DESCRIPTION
fixes https://github.com/Aurorastation/Aurora.3/issues/22409

The reason for the increased elevator timer was due to how rarely it came up that the supplier time would be longer than the base 30 second timer, so instead the two timers were combined to trial how a longer timer would feel.