### PR TITLE
Duffelbag tweaks

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -31,8 +31,14 @@
 	 * Suffix used for overlays with an attached sleeping bag, because satchels are at people's sides while other bags are on people's backs.
 	 */
 	var/attached_icon = "backpack"
-	var/worn_access = TRUE // If the object may be accessed while equipped in a storage slot.
-	var/equip_access = TRUE // If the object may be accessed while equipped anywhere on a character, including hands.
+	/**
+	 * If the object may be accessed while equipped in a storage slot.
+	 */
+	var/worn_access = TRUE
+	/**
+	 * If the object may be accessed while equipped anywhere on a character, including hands.
+	 */
+	var/equip_access = TRUE
 
 /obj/item/storage/backpack/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -689,7 +689,8 @@
 	desc = "A snazzy black and red duffel bag, perfect for smuggling C4 and Parapens. It seems to be made of a lighter material."
 	icon_state = "duffel-syndie"
 	item_state = "duffel-syndie"
-	slowdown = 0
+	worn_access = TRUE
+	equip_access = TRUE
 	empty_delay = 0.8 SECOND
 
 /obj/item/storage/backpack/duffel/cmo

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -31,6 +31,8 @@
 	 * Suffix used for overlays with an attached sleeping bag, because satchels are at people's sides while other bags are on people's backs.
 	 */
 	var/attached_icon = "backpack"
+	var/worn_access = TRUE // If the object may be accessed while equipped in a storage slot.
+	var/equip_access = TRUE // If the object may be accessed while equipped anywhere on a character, including hands.
 
 /obj/item/storage/backpack/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
@@ -104,6 +106,8 @@
 		H.drop_from_inventory(attached_bag)
 		attached_bag.loc = null
 		return
+	if (!worn_check())
+		return
 	return ..()
 
 /obj/item/storage/backpack/update_icon()
@@ -131,6 +135,33 @@
 		return
 	return ..()
 
+/obj/item/storage/backpack/open(mob/user)
+	if (!worn_check())
+		return
+	..()
+
+/obj/item/storage/backpack/proc/worn_check(no_message = FALSE)
+	if(ismob(loc))
+		var/mob/M = loc
+		if(!istype(M))
+			return TRUE //not equipped
+		if(!worn_access && (slot_flags & SLOT_BACK) && M.get_equipped_item(slot_back) == src)
+			if(!no_message)
+				to_chat(M, SPAN_WARNING("Your arms are not long enough to open \the [src] while it is on your back!"))
+				if(use_sound)
+					playsound(loc, use_sound, 50, 1, -5)
+				if(animated)
+					animate_parent()
+			return FALSE
+		if(!equip_access && (ismob(loc)))
+			if(!no_message)
+				to_chat(M, SPAN_WARNING("\The [src] is too cumbersome to handle, you're going to have to set it down somewhere!"))
+				if(use_sound)
+					playsound(loc, use_sound, 50, 1, -5)
+				if(animated)
+					animate_parent()
+			return FALSE
+	return TRUE
 
 /*
  * Backpack Types
@@ -592,7 +623,8 @@
 	icon = 'icons/obj/storage/duffelbag.dmi'
 	icon_state = "duffel"
 	item_state = "duffel"
-	slowdown = 0.3
+	worn_access = FALSE
+	equip_access = FALSE
 	max_storage_space = DEFAULT_DUFFELBAG_STORAGE
 	straps = TRUE
 

--- a/html/changelogs/wezzy-duffeltweaks.yml
+++ b/html/changelogs/wezzy-duffeltweaks.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Wowzewow (Wezzy)
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Duffelbags no longer give slowdown. Instead, you have to take them off first before opening them."


### PR DESCRIPTION
- Duffelbags no longer give slowdown. Instead, you'll have to set them down first before using them.

Slowdown is a pretty abhorrent malus, so much so that they've mostly went extinct on the server.

Experimenting with this feature inspired from Eris. Might extend it to backpacks (also very unused due to lack of drip) and look for it as an alternative to trading something other than slowdown for slots.