### PR TITLE
adds some psiprotect drugs to the pharmacy refill shelf

### DIFF
--- a/code/game/objects/items/weapons/storage/pill_bottle.dm
+++ b/code/game/objects/items/weapons/storage/pill_bottle.dm
@@ -240,3 +240,16 @@
 		+ "This one is thrice as expensive, for more affluent customers, and requiring more genetic and neurological profiling. " \
 		+ "Nonetheless, it remains cheaper than the more elegant ZHP-MSV3 'Mindblankers'."
 	starts_with = list(/obj/item/reagent_containers/pill/psi_protect/yomi_genetics/expensive = 6)
+
+/obj/item/paper/fluff/psiprotect_memo
+	name = "psiprotect memo"
+	desc = "A memo left behind by another pharmacist."
+	info = "\
+		<br>\
+		MEMO: PSI-PROTECT PILLS \
+		<br>\
+		<br>\
+		Our bulk PsiProtect Broad Use resupply has arrived for prescription refills and any emergency ADPI prescriptions.\
+		They were going at clearance prices so we have enough stored in the warehouse for the entire operation!<br><br>\
+		Personalised variants will continue to be mailed individually to patients (no wonder the price, on top of all the tests!).<br>\
+		- S"

--- a/html/changelogs/kermit-psiprotect-reserve.yml
+++ b/html/changelogs/kermit-psiprotect-reserve.yml
@@ -3,4 +3,4 @@ author: kermit
 delete-after: True
 
 changes:
-  - rscadd: "Adds 3x PsiProtect Broad Use and 1x Personalised pill bottles to the Pharmacy retail shelf for prescription refills (and investigation)."
+  - rscadd: "Adds 3x PsiProtect Broad Use pill bottles to the Pharmacy retail shelf for prescription refills (and investigation)."

--- a/html/changelogs/kermit-psiprotect-reserve.yml
+++ b/html/changelogs/kermit-psiprotect-reserve.yml
@@ -1,0 +1,6 @@
+author: kermit
+
+delete-after: True
+
+changes:
+  - rscadd: "Adds 3x PsiProtect Broad Use and 1x Personalised pill bottles to the Pharmacy retail shelf for prescription refills (and investigation)."


### PR DESCRIPTION
Adds 3x bottles of _PsiProtect Broad Use_ (Cheap variant) to the pharmacy retail shelf for prescription refills, emergency ADPI prescriptions (and investigation).