### PR TITLE
Removes Hephaestus as an option for New Kingdom of Adhomai Tajara

### DIFF
--- a/code/game/jobs/faction/hephaestus.dm
+++ b/code/game/jobs/faction/hephaestus.dm
@@ -30,7 +30,8 @@
 	)
 
 	blacklisted_citizenship_types = list(
-		/datum/citizenship/free_council
+		/datum/citizenship/free_council,
+		/datum/citizenship/nka
 	)
 
 	job_species_blacklist = list(

--- a/html/changelogs/CatsinHD - NKA_Hephaestus.yml
+++ b/html/changelogs/CatsinHD - NKA_Hephaestus.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: CatsinHD
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Removes Hephaestus as an option for the New Kingdom of Adhomai citizenship."


### PR DESCRIPTION
Title.

As originally planned by the Tajara lore team, Hephaestus was to be removed as an option for New Kingdom of Adhomai Tajara roughly a month from the original PR date of this PR #22201. It has been just over a month, therefore Heph will be removed.

Original intent is for the transition from Heph to Zavod, both in-lore and OOC so players have time to play out characters changing contracts. 