### PR TITLE
Some Mob Define Cleanup

### DIFF
--- a/code/game/objects/effects/gibs.dm
+++ b/code/game/objects/effects/gibs.dm
@@ -1,25 +1,24 @@
-/proc/gibs(atom/location, var/list/viruses, var/datum/dna/MobDNA, gibber_type = /obj/effect/gibspawner/generic, var/fleshcolor, var/bloodcolor)
-	new gibber_type(location,viruses,MobDNA,fleshcolor,bloodcolor)
+/proc/gibs(atom/location, var/datum/dna/MobDNA, gibber_type = /obj/effect/gibspawner/generic, var/fleshcolor, var/bloodcolor)
+	new gibber_type(location,MobDNA,fleshcolor,bloodcolor)
 
 /obj/effect/gibspawner
 	icon = 'icons/effects/map_effects.dmi'
 	icon_state = "gibspawner"
 	var/sparks = 0 //whether sparks spread on Gib()
-	var/virusProb = 20 //the chance for viruses to spread on the gibs
 	var/list/gibtypes = list()
 	var/list/gibamounts = list()
 	var/list/gibdirections = list() //of lists
 	var/fleshcolor //Used for gibbed humans.
 	var/bloodcolor //Used for gibbed humans.
 
-/obj/effect/gibspawner/Initialize(mapload, list/viruses, datum/dna/MobDNA, fleshcolor, bloodcolor)
+/obj/effect/gibspawner/Initialize(mapload, datum/dna/MobDNA, fleshcolor, bloodcolor)
 	. = ..()
 
 	if(fleshcolor) src.fleshcolor = fleshcolor
 	if(bloodcolor) src.bloodcolor = bloodcolor
-	Gib(loc,viruses,MobDNA)
+	Gib(loc,MobDNA)
 
-/obj/effect/gibspawner/proc/Gib(atom/location, var/list/viruses = list(), var/datum/dna/MobDNA = null)
+/obj/effect/gibspawner/proc/Gib(atom/location, var/datum/dna/MobDNA = null)
 	if(gibtypes.len != gibamounts.len || gibamounts.len != gibdirections.len)
 		to_world(SPAN_WARNING("Gib list length mismatch!"))
 		return

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -782,7 +782,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	message_admins("[key_name_admin(usr)] has gibbed [key_name_admin(M)]", 1)
 
 	if(isobserver(M))
-		gibs(M.loc, M.viruses)
+		gibs(M.loc)
 		return
 
 	M.gib()

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -18,7 +18,7 @@
 	flick(anim, animation)
 
 	if(do_gibs)
-		gibs(loc, viruses, dna, get_gibs_type())
+		gibs(loc, dna, get_gibs_type())
 
 	QDEL_IN(animation, 15)
 	QDEL_IN(src, 15)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -14,7 +14,7 @@
 		I.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)), rand(1,3), round(30/I.w_class))
 
 	..(species.gibbed_anim)
-	gibs(loc, viruses, dna, null, species.flesh_color, get_blood_color())
+	gibs(loc, dna, null, species.flesh_color, get_blood_color())
 
 /mob/living/carbon/human/dust()
 	vr_disconnect()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -745,10 +745,6 @@ default behaviour is:
 		to_chat(src, SPAN_NOTICE("You can't move..."))
 		return
 	var/resisting = 0
-	for(var/obj/O in requests)
-		requests.Remove(O)
-		qdel(O)
-		resisting++
 	var/resist_power = get_resist_power() // How easily the mob can break out of a grab
 	for(var/obj/item/grab/G in grabbed_by)
 		resisting++

--- a/code/modules/mob/living/silicon/death.dm
+++ b/code/modules/mob/living/silicon/death.dm
@@ -1,6 +1,6 @@
 /mob/living/silicon/gib()
 	..("gibbed-r")
-	gibs(loc, viruses, null, /obj/effect/gibspawner/robot)
+	gibs(loc, null, /obj/effect/gibspawner/robot)
 
 /mob/living/silicon/dust()
 	..(/obj/effect/decal/remains/robot)

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -238,7 +238,7 @@
 		held_item = null
 
 	eject_brain()
-	gibs(loc, viruses, null, /obj/effect/gibspawner/robot) //TODO: use gib() or refactor spiderbots into synthetics.
+	gibs(loc, null, /obj/effect/gibspawner/robot) //TODO: use gib() or refactor spiderbots into synthetics.
 	qdel(src)
 	return
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -22,14 +22,10 @@
 	if (mind)
 		mind.handle_mob_deletion(src)
 
-	for(var/infection in viruses)
-		qdel(infection)
-
 	for(var/cc in client_colors)
 		qdel(cc)
 
 	client_colors = null
-	viruses.Cut()
 	item_verbs = null
 
 	//Added this to prevent nonliving mobs from ghostising

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -176,7 +176,6 @@
 	var/datum/hud/hud_used = null
 
 	var/list/grabbed_by = list(  )
-	var/list/requests = list(  )
 
 	var/list/mapobjs = list()
 
@@ -185,10 +184,6 @@
 	var/inertia_dir = 0
 
 	var/job = null//Living
-
-	var/const/blindness = 1//Carbon
-	var/const/deafness = 2//Carbon
-	var/const/muteness = 4//Carbon
 
 	var/can_pull_size = 10              // Maximum w_class the mob can pull.
 	var/can_pull_mobs = MOB_PULL_LARGER // Whether or not the mob can pull other mobs.
@@ -223,13 +218,6 @@
 
 //Wizard mode, but can be used in other modes thanks to the brand new "Give Spell" badmin button
 	var/list/spell/spell_list
-
-//List of active diseases
-
-	var/list/viruses = list() // replaces var/datum/disease/virus
-
-//Monkey/infected mode
-	var/list/resistances = list()
 
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 

--- a/html/changelogs/hellfirejag-mob-vars-cleanup.yml
+++ b/html/changelogs/hellfirejag-mob-vars-cleanup.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscdel: "Removed a couple of completely vestigial global-ish mob vars to save on memory and time."


### PR DESCRIPTION
Just removing a few ancient 2008-era vars that were on every mob globally, but were completely unused in the modern code. I thought about removing the Mutations too, but since the Hulk mutation is actually used by a tiny handful of things, I would probably have to do that in a separate PR by turning the Hulk code into an Element instead. 