### PR TITLE
Fixes the machinery repath in Cryo Outpost map

### DIFF
--- a/html/changelogs/kano-dot-cryo-outpost-repath-fix.yml
+++ b/html/changelogs/kano-dot-cryo-outpost-repath-fix.yml
@@ -1,0 +1,6 @@
+author: Kano
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed the machinery repath in cryo outpost Odyssey map."

--- a/maps/away/scenarios/cryo_outpost/cryo_outpost.dmm
+++ b/maps/away/scenarios/cryo_outpost/cryo_outpost.dmm
@@ -8,7 +8,7 @@
 /area/cryo_outpost/inside/canteen)
 "aby" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -39,8 +39,8 @@
 /area/cryo_outpost/inside/habitation_east)
 "acr" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /obj/random/dirt_75,
@@ -111,7 +111,7 @@
 /area/cryo_outpost/inside/habitation_east)
 "ahj" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/watertank,
@@ -144,7 +144,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /obj/random/dirt_75,
@@ -159,13 +159,13 @@
 /area/cryo_outpost/inside/warehouse)
 "ajz" = (
 /obj/structure/table/steel,
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/structure/machinery/machinery/recharger{
+/obj/structure/machinery/recharger{
 	pixel_x = -6;
 	pixel_y = 10
 	},
@@ -185,8 +185,8 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/cryo_outpost/inside/warehouse)
 "all" = (
-/obj/structure/machinery/machinery/atmospherics/portables_connector,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/machinery/atmospherics/portables_connector,
+/obj/structure/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_s)
 "alv" = (
@@ -209,7 +209,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/camera/network/cryo_outpost{
+/obj/structure/machinery/camera/network/cryo_outpost{
 	dir = 8;
 	c_tag = "Labs, Offices"
 	},
@@ -225,12 +225,12 @@
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/outside/surface)
 "anW" = (
-/obj/structure/machinery/machinery/atmospherics/unary/cryo_cell,
+/obj/structure/machinery/atmospherics/unary/cryo_cell,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_s)
 "aob" = (
-/obj/structure/machinery/machinery/door/airlock/silver,
+/obj/structure/machinery/door/airlock/silver,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -367,13 +367,13 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_surgery)
 "awC" = (
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -391,7 +391,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -444,7 +444,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_hallway)
@@ -487,7 +487,7 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_rnd)
 "aBz" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engi_atmos)
@@ -508,7 +508,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/medical)
@@ -524,7 +524,7 @@
 /area/cryo_outpost/inside/hallway_central)
 "aCF" = (
 /obj/structure/bed/roller,
-/obj/structure/machinery/machinery/light/colored/decayed,
+/obj/structure/machinery/light/colored/decayed,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
@@ -551,10 +551,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -563,8 +563,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/habitation_west)
 "aEO" = (
@@ -581,7 +581,7 @@
 /obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/button/remote/airlock{
+/obj/structure/machinery/button/remote/airlock{
 	dir = 4;
 	id = "cryo_outpost_armory_door_bolts";
 	pixel_x = 24;
@@ -596,7 +596,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/machinery/machinery/light/small/broken{
+/obj/structure/machinery/light/small/broken{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -636,7 +636,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/habitation_east)
 "aIM" = (
@@ -684,7 +684,7 @@
 /area/cryo_outpost/inside/labs_maint_w)
 "aLs" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 8
 	},
 /turf/simulated/floor/lino,
@@ -746,7 +746,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/maint_entrance)
 "aNs" = (
-/obj/structure/machinery/machinery/light/colored/red{
+/obj/structure/machinery/light/colored/red{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -780,7 +780,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
@@ -850,8 +850,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/security{
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/security{
 	req_one_access = list(244)
 	},
 /obj/structure/cable{
@@ -873,7 +873,7 @@
 	icon_state = "4-8"
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -886,7 +886,7 @@
 /area/cryo_outpost/inside/engineering)
 "aWO" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -922,7 +922,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/structure/closet,
@@ -954,7 +954,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/random/dirt_75,
@@ -995,7 +995,7 @@
 /area/cryo_outpost/inside/warehouse)
 "bbD" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 4
 	},
 /obj/structure/closet/crate,
@@ -1031,7 +1031,7 @@
 /obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/button/remote/blast_door{
+/obj/structure/machinery/button/remote/blast_door{
 	id = "cryo_outpost_blastdoor_labs";
 	pixel_x = 20;
 	dir = 4;
@@ -1049,19 +1049,19 @@
 /area/cryo_outpost/inside/labs_surgery)
 "bdi" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/powered/pump/filled,
+/obj/structure/machinery/portable_atmospherics/powered/pump/filled,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engineering)
 "bdL" = (
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/full,
 /area/cryo_outpost/inside/labs_cryo_n)
 "bdV" = (
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/structure/machinery/machinery/door/blast/shutters{
+/obj/structure/machinery/door/blast/shutters{
 	dir = 2;
 	id = "cryo_outpost_shutter_entrance_aux_east_out"
 	},
@@ -1069,7 +1069,7 @@
 /area/cryo_outpost/inside/entrance_aux_east)
 "bej" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_door/red{
@@ -1084,7 +1084,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -1094,7 +1094,7 @@
 /area/cryo_outpost/inside/habitation_west)
 "beS" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/alarm/cold/north{
+/obj/structure/machinery/alarm/cold/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/freezer{
@@ -1103,7 +1103,7 @@
 	},
 /area/cryo_outpost/inside/labs_surgery)
 "beX" = (
-/obj/structure/machinery/machinery/photocopier,
+/obj/structure/machinery/photocopier,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_rnd)
 "bgU" = (
@@ -1144,7 +1144,7 @@
 "biz" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
@@ -1272,7 +1272,7 @@
 /obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 8
 	},
-/obj/structure/machinery/machinery/button/remote/airlock{
+/obj/structure/machinery/button/remote/airlock{
 	dir = 8;
 	id = "cryo_outpost_armory_door_bolts";
 	pixel_x = -24;
@@ -1319,10 +1319,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/glass_research{
+/obj/structure/machinery/door/airlock/glass_research{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1362,10 +1362,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/glass_medical{
+/obj/structure/machinery/door/airlock/glass_medical{
 	dir = 4;
 	req_one_access = list(244)
 	},
@@ -1375,7 +1375,7 @@
 /obj/vehicle/train/cargo/trolley{
 	light_power = 0
 	},
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/warehouse)
 "btu" = (
@@ -1446,7 +1446,7 @@
 /turf/simulated/floor/wood/ebony,
 /area/cryo_outpost/inside/habitation_west)
 "byg" = (
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_door/red{
@@ -1475,7 +1475,7 @@
 "bAp" = (
 /obj/item/reagent_containers/food/drinks/cans/dyn,
 /obj/structure/table/steel,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1537,8 +1537,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1578,7 +1578,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/cryo_outpost/inside/maint_warehouse)
 "bHk" = (
-/obj/structure/machinery/machinery/vending/boozeomat/merchant,
+/obj/structure/machinery/vending/boozeomat/merchant,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/canteen)
 "bHW" = (
@@ -1598,8 +1598,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/hallway_central)
 "bIe" = (
@@ -1607,7 +1607,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -1644,7 +1644,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/botany)
 "bLe" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/structure/table/standard,
@@ -1671,7 +1671,7 @@
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/item/storage/pill_bottle/inaprovaline{
@@ -1694,7 +1694,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/habitation_east)
 "bNj" = (
-/obj/structure/machinery/machinery/chemical_dispenser/full,
+/obj/structure/machinery/chemical_dispenser/full,
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
@@ -1735,7 +1735,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/maint_medbay)
 "bRf" = (
-/obj/structure/machinery/machinery/light/small/broken{
+/obj/structure/machinery/light/small/broken{
 	dir = 1
 	},
 /turf/simulated/floor/exoplanet/barren,
@@ -1744,8 +1744,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/engineering{
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/engineering{
 	req_one_access = list(244)
 	},
 /obj/structure/cable{
@@ -1786,7 +1786,7 @@
 	pixel_x = 3;
 	pixel_y = 5
 	},
-/obj/structure/machinery/machinery/light/small{
+/obj/structure/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer{
@@ -1818,7 +1818,7 @@
 /area/cryo_outpost/inside/maint_warehouse)
 "bWL" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
+/obj/structure/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
@@ -1832,7 +1832,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -1841,7 +1841,7 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/button/remote/blast_door{
+/obj/structure/machinery/button/remote/blast_door{
 	id = "cryo_outpost_shutter_entrance_aux_east_in";
 	pixel_x = 28;
 	pixel_y = 32;
@@ -1851,10 +1851,10 @@
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/inside/entrance_aux_east)
 "bXi" = (
-/obj/structure/machinery/machinery/smartfridge/drinks{
+/obj/structure/machinery/smartfridge/drinks{
 	opacity = 1
 	},
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1870,7 +1870,7 @@
 "bXs" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner_wide/green/diagonal,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -1878,7 +1878,7 @@
 "bXK" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1887,11 +1887,11 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/door/airlock/engineering{
+/obj/structure/machinery/door/airlock/engineering{
 	dir = 4;
 	req_one_access = list(244)
 	},
@@ -1915,7 +1915,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1940,7 +1940,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -1952,7 +1952,7 @@
 /turf/simulated/floor/wood/walnut,
 /area/cryo_outpost/inside/habitation_west)
 "cdi" = (
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 1
 	},
 /obj/random/dirt_75,
@@ -2015,7 +2015,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/labs_maint_w)
 "cgB" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/hidden{
+/obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
@@ -2037,11 +2037,11 @@
 /area/cryo_outpost/inside/entrance_aux_west)
 "chs" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/hydrogen,
+/obj/structure/machinery/portable_atmospherics/canister/empty/hydrogen,
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/surface)
 "chM" = (
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_door/red{
@@ -2067,7 +2067,7 @@
 	pixel_x = 3;
 	pixel_y = -1
 	},
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2102,7 +2102,7 @@
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -2111,7 +2111,7 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/medical)
 "ckv" = (
-/obj/structure/machinery/machinery/light/colored/decayed,
+/obj/structure/machinery/light/colored/decayed,
 /turf/simulated/floor/wood/walnut,
 /area/cryo_outpost/inside/habitation_west)
 "clR" = (
@@ -2185,7 +2185,7 @@
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_door/red{
@@ -2269,7 +2269,7 @@
 /turf/simulated/floor/lino,
 /area/cryo_outpost/inside/habitation_west)
 "cwm" = (
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -2318,7 +2318,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -2346,20 +2346,20 @@
 /area/cryo_outpost/inside/labs_cryo_n)
 "cBJ" = (
 /obj/effect/floor_decal/industrial/hatch_small/yellow,
-/obj/structure/machinery/machinery/atmospherics/portables_connector{
+/obj/structure/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/surface)
 "cCz" = (
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/security{
+/obj/structure/machinery/door/airlock/security{
 	dir = 4;
 	req_one_access = list(244)
 	},
@@ -2378,7 +2378,7 @@
 "cEh" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -2422,7 +2422,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 8
 	},
 /obj/random/dirt_75,
@@ -2450,14 +2450,14 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/habitation_west)
 "cKe" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small{
+/obj/structure/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -2507,7 +2507,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/random/dirt_75,
@@ -2615,7 +2615,7 @@
 /obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/button/remote/blast_door{
+/obj/structure/machinery/button/remote/blast_door{
 	id = "cryo_outpost_blastdoor_labs";
 	pixel_x = 20;
 	dir = 4;
@@ -2672,7 +2672,7 @@
 "cWA" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/broken{
+/obj/structure/machinery/light/small/broken{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -2712,7 +2712,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2720,7 +2720,7 @@
 "cZT" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -2890,11 +2890,11 @@
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/outside/surface)
 "diz" = (
-/obj/structure/machinery/machinery/floodlight/randomcharge{
+/obj/structure/machinery/floodlight/randomcharge{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -2957,7 +2957,7 @@
 	pixel_y = -16;
 	pixel_x = -2
 	},
-/obj/structure/machinery/machinery/door/blast/shutters/open{
+/obj/structure/machinery/door/blast/shutters/open{
 	id = "cryo_outpost_shutter_entrance_main_in"
 	},
 /turf/simulated/floor/plating/asteroid,
@@ -2980,7 +2980,7 @@
 /area/cryo_outpost/inside/labs_surgery)
 "dnC" = (
 /obj/effect/floor_decal/industrial/outline/research,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3002,10 +3002,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3028,7 +3028,7 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/medical)
 "drA" = (
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_door/red{
@@ -3056,7 +3056,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engineering)
 "dsg" = (
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 1
 	},
 /obj/random/dirt_75,
@@ -3069,7 +3069,7 @@
 /area/cryo_outpost/inside/habitation_west)
 "dsF" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/light/colored/decayed/dimmed{
+/obj/structure/machinery/light/colored/decayed/dimmed{
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid,
@@ -3092,7 +3092,7 @@
 	pixel_x = 6;
 	pixel_y = 6
 	},
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled,
@@ -3109,7 +3109,7 @@
 /obj/item/pen{
 	pixel_y = 4
 	},
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -3175,13 +3175,13 @@
 /area/cryo_outpost/inside/entrance_aux_west)
 "dzI" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/full,
 /area/cryo_outpost/inside/labs_cryo_s)
 "dzJ" = (
-/obj/structure/machinery/machinery/light/colored/dying,
+/obj/structure/machinery/light/colored/dying,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_s)
 "dzX" = (
@@ -3211,10 +3211,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/highsecurity{
+/obj/structure/machinery/door/airlock/highsecurity{
 	dir = 4;
 	req_one_access = list(244);
 	id_tag = "cryo_outpost_armory_door_bolts"
@@ -3223,7 +3223,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/security)
 "dDj" = (
-/obj/structure/machinery/machinery/power/portgen/basic/fusion,
+/obj/structure/machinery/power/portgen/basic/fusion,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -3256,7 +3256,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -3357,7 +3357,7 @@
 /area/cryo_outpost/inside/labs_cryo_pods)
 "dIH" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
 /area/cryo_outpost/inside/habitation_east)
@@ -3365,7 +3365,7 @@
 /obj/structure/table/standard,
 /obj/item/storage/box/gloves,
 /obj/effect/floor_decal/corner_wide/green/diagonal,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -3380,27 +3380,27 @@
 /area/cryo_outpost/outside/surface)
 "dLe" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/habitation_west)
 "dLH" = (
-/obj/structure/machinery/machinery/atmospherics/portables_connector{
+/obj/structure/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch_small/yellow,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engi_atmos)
 "dMA" = (
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/glass_engineering{
+/obj/structure/machinery/door/airlock/glass_engineering{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -3423,13 +3423,13 @@
 "dNk" = (
 /obj/structure/table/rack,
 /obj/random/loot,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/maint_warehouse)
 "dNM" = (
-/obj/structure/machinery/machinery/pipedispenser,
+/obj/structure/machinery/pipedispenser,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engi_atmos)
@@ -3514,7 +3514,7 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_pharmacy)
 "dTr" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/visible{
+/obj/structure/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
 /obj/random/dirt_75,
@@ -3531,7 +3531,7 @@
 /area/cryo_outpost/inside/engi_powergen)
 "dTK" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_surgery)
 "dTY" = (
@@ -3544,7 +3544,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -3553,10 +3553,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/research{
+/obj/structure/machinery/door/airlock/research{
 	dir = 4;
 	req_one_access = list(244)
 	},
@@ -3666,7 +3666,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3689,10 +3689,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3716,7 +3716,7 @@
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/outside/surface)
 "eha" = (
-/obj/structure/machinery/machinery/iff_beacon,
+/obj/structure/machinery/iff_beacon,
 /turf/simulated/floor/airless,
 /area/cryo_outpost/inside/sensors_iff)
 "ehm" = (
@@ -3748,7 +3748,7 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
@@ -3767,11 +3767,11 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/broken,
+/obj/structure/machinery/light/broken,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_surgery)
 "eiP" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/hidden{
+/obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
@@ -3786,13 +3786,13 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/maint_medbay)
 "ejT" = (
-/obj/structure/machinery/machinery/floodlight/randomcharge,
+/obj/structure/machinery/floodlight/randomcharge,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engi_atmos)
 "ekm" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/surface)
 "ela" = (
@@ -3868,7 +3868,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /turf/simulated/floor/plating,
@@ -3889,7 +3889,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/entrance_aux_west)
 "eqT" = (
-/obj/structure/machinery/machinery/shower{
+/obj/structure/machinery/shower{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -3924,7 +3924,7 @@
 /area/cryo_outpost/outside/surface)
 "erR" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -3941,7 +3941,7 @@
 /area/cryo_outpost/inside/warehouse)
 "esE" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/camera/network/cryo_outpost{
+/obj/structure/machinery/camera/network/cryo_outpost{
 	c_tag = "Outside, Landing Pads, Close"
 	},
 /turf/simulated/floor/plating/asteroid,
@@ -3954,7 +3954,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/canteen)
 "esH" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/hidden{
+/obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
@@ -3975,10 +3975,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -4000,12 +4000,12 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass_service,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass_service,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/canteen)
 "evj" = (
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 1
 	},
 /obj/random/loot{
@@ -4021,7 +4021,7 @@
 /turf/simulated/floor/wood/maple,
 /area/cryo_outpost/inside/habitation_west)
 "evQ" = (
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 8
 	},
 /obj/random/dirt_75,
@@ -4041,10 +4041,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/research{
+/obj/structure/machinery/door/airlock/research{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -4055,11 +4055,11 @@
 "exb" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/air,
+/obj/structure/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/entrance_aux_west)
 "exc" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline_door/red{
@@ -4179,10 +4179,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -4201,10 +4201,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/research{
+/obj/structure/machinery/door/airlock/research{
 	dir = 4;
 	req_one_access = list(244)
 	},
@@ -4223,8 +4223,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -4235,7 +4235,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -4254,7 +4254,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -4264,16 +4264,16 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/glass{
+/obj/structure/machinery/door/airlock/glass{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/habitation_west)
 "eHg" = (
-/obj/structure/machinery/machinery/power/apc/east{
+/obj/structure/machinery/power/apc/east{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -4325,7 +4325,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/cryo_outpost/inside/maint_warehouse)
 "eKh" = (
-/obj/structure/machinery/machinery/bodyscanner{
+/obj/structure/machinery/bodyscanner{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/white/diagonal,
@@ -4341,7 +4341,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/labs_hallway)
 "eLD" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow{
@@ -4359,7 +4359,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -4372,10 +4372,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -4398,7 +4398,7 @@
 	pixel_x = 6;
 	pixel_y = 8
 	},
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled,
@@ -4434,7 +4434,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/broken{
+/obj/structure/machinery/light/small/broken{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -4449,11 +4449,11 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 1
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4482,7 +4482,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engi_powergen)
 "eTc" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/visible{
+/obj/structure/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /obj/effect/map_effect/window_spawner/full/reinforced/grille,
@@ -4498,7 +4498,7 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/medical)
 "eTJ" = (
-/obj/structure/machinery/machinery/light/small/broken{
+/obj/structure/machinery/light/small/broken{
 	dir = 1
 	},
 /turf/simulated/floor/exoplanet/desert,
@@ -4543,9 +4543,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/eva)
 "eVc" = (
-/obj/structure/machinery/machinery/portable_atmospherics/hydroponics,
+/obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4554,7 +4554,7 @@
 /obj/structure/closet/toolcloset,
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/outfit/admin/generic/engineer,
@@ -4597,7 +4597,7 @@
 /turf/simulated/floor/exoplanet/desert,
 /area/cryo_outpost/outside/surface)
 "fbW" = (
-/obj/structure/machinery/machinery/papershredder,
+/obj/structure/machinery/papershredder,
 /obj/effect/floor_decal/corner/pink/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_offices)
@@ -4605,10 +4605,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -4620,7 +4620,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/structure/machinery/machinery/power/apc/west{
+/obj/structure/machinery/power/apc/west{
 	req_access = null
 	},
 /obj/random/dirt_75,
@@ -4645,7 +4645,7 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/medical)
 "feD" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -4654,7 +4654,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4704,7 +4704,7 @@
 /area/cryo_outpost/inside/labs_rnd)
 "fie" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/air,
+/obj/structure/machinery/portable_atmospherics/canister/empty/air,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -4741,7 +4741,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /obj/structure/table/steel,
 /obj/random/tool{
 	pixel_y = 5;
@@ -4757,7 +4757,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_offices)
 "flr" = (
-/obj/structure/machinery/machinery/alarm/west{
+/obj/structure/machinery/alarm/west{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4780,7 +4780,7 @@
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/outside/cave)
 "fmK" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/lino,
@@ -4809,7 +4809,7 @@
 /obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/button/remote/blast_door{
+/obj/structure/machinery/button/remote/blast_door{
 	id = "cryo_outpost_blastdoor_labs";
 	pixel_x = 20;
 	dir = 4;
@@ -4818,7 +4818,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_maint_e)
 "fnD" = (
-/obj/structure/machinery/machinery/camera/network/cryo_outpost{
+/obj/structure/machinery/camera/network/cryo_outpost{
 	c_tag = "Outside, Entrance, Aux, East"
 	},
 /turf/simulated/floor/exoplanet/barren,
@@ -4866,7 +4866,7 @@
 	dir = 5
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -4916,12 +4916,12 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/habitation_east)
 "fuA" = (
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -4962,7 +4962,7 @@
 /obj/item/handcuffs,
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/item/clothing/mask/gas/tactical,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/outfit/admin/generic/security,
@@ -4977,10 +4977,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/service{
+/obj/structure/machinery/door/airlock/service{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -5002,7 +5002,7 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/habitation_west)
 "fwT" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline_straight/yellow{
@@ -5040,7 +5040,7 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_surgery)
 "fxV" = (
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -5084,7 +5084,7 @@
 	pixel_y = 12
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -5100,7 +5100,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -5161,7 +5161,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/maint_engineering)
 "fDy" = (
-/obj/structure/machinery/machinery/light/colored/decayed,
+/obj/structure/machinery/light/colored/decayed,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/hallway_central)
 "fDW" = (
@@ -5212,8 +5212,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/entrance_aux_east)
@@ -5261,11 +5261,11 @@
 "fKB" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty,
+/obj/structure/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/inside/entrance_aux_east)
 "fKF" = (
-/obj/structure/machinery/machinery/computer/cloning,
+/obj/structure/machinery/computer/cloning,
 /obj/effect/floor_decal/corner/pink,
 /obj/effect/floor_decal/corner/white{
 	dir = 1
@@ -5346,7 +5346,7 @@
 /area/cryo_outpost/inside/maint_medbay)
 "fOf" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -5363,7 +5363,7 @@
 /area/cryo_outpost/inside/labs_surgery)
 "fOU" = (
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/structure/machinery/machinery/door/blast/regular{
+/obj/structure/machinery/door/blast/regular{
 	dir = 4;
 	id = "cryo_outpost_blastdoor_labs"
 	},
@@ -5417,7 +5417,7 @@
 /area/cryo_outpost/inside/entrance_aux_east)
 "fTY" = (
 /obj/effect/floor_decal/corner_wide/green/diagonal,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -5426,7 +5426,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -5479,7 +5479,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/random/dirt_75,
@@ -5490,13 +5490,13 @@
 	pixel_y = 13
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small{
+/obj/structure/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/hallway_central)
 "fWY" = (
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_s)
 "fXG" = (
@@ -5549,7 +5549,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
 	},
-/obj/structure/machinery/machinery/light/colored/decayed,
+/obj/structure/machinery/light/colored/decayed,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/habitation_west)
@@ -5567,7 +5567,7 @@
 /area/cryo_outpost/inside/labs_maint_w)
 "gac" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/structure/closet/crate/trashcart,
@@ -5593,7 +5593,7 @@
 /area/cryo_outpost/inside/labs_offices)
 "gdW" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/chlorine,
+/obj/structure/machinery/portable_atmospherics/canister/empty/chlorine,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/entrance_aux_west)
 "gey" = (
@@ -5662,13 +5662,13 @@
 	pixel_x = -6;
 	pixel_y = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_n)
 "ggO" = (
-/obj/structure/machinery/machinery/computer/ship/navigation/terminal,
+/obj/structure/machinery/computer/ship/navigation/terminal,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/comms)
 "ghg" = (
@@ -5706,7 +5706,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled,
@@ -5720,7 +5720,7 @@
 /area/cryo_outpost/outside/cave)
 "gkJ" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/broken{
+/obj/structure/machinery/light/small/broken{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -5729,7 +5729,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/maint_warehouse)
 "glc" = (
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/oxygen,
+/obj/structure/machinery/portable_atmospherics/canister/empty/oxygen,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/entrance_main)
 "glF" = (
@@ -5744,7 +5744,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -5791,7 +5791,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -5800,7 +5800,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/canteen)
 "gpH" = (
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_door/red{
@@ -5815,7 +5815,7 @@
 /obj/effect/floor_decal/corner/dark_green/full{
 	dir = 8
 	},
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled,
@@ -5826,7 +5826,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engineering)
 "grF" = (
@@ -5885,13 +5885,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/security)
 "gsF" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/engineering)
 "gsM" = (
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -5931,11 +5931,11 @@
 /area/cryo_outpost/outside/surface)
 "gwp" = (
 /obj/structure/table/wood/walnut,
-/obj/structure/machinery/machinery/chemical_dispenser/bar_alc/full{
+/obj/structure/machinery/chemical_dispenser/bar_alc/full{
 	pixel_y = -7;
 	dir = 4
 	},
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 8
 	},
 /turf/simulated/floor/wood/walnut,
@@ -5968,7 +5968,7 @@
 /area/cryo_outpost/inside/labs_maint_w)
 "gxn" = (
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/structure/machinery/machinery/door/blast/shutters{
+/obj/structure/machinery/door/blast/shutters{
 	dir = 2;
 	id = "cryo_outpost_shutter_entrance_aux_west_in"
 	},
@@ -5976,7 +5976,7 @@
 /area/cryo_outpost/inside/entrance_aux_west)
 "gxX" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/broken{
+/obj/structure/machinery/light/small/broken{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -6006,7 +6006,7 @@
 /obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 8
 	},
-/obj/structure/machinery/machinery/button/remote/blast_door{
+/obj/structure/machinery/button/remote/blast_door{
 	id = "cryo_outpost_blastdoor_labs";
 	pixel_x = -20;
 	dir = 8;
@@ -6018,10 +6018,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -6061,13 +6061,13 @@
 /area/cryo_outpost/outside/cave)
 "gGC" = (
 /obj/structure/grille,
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/chainlink_fence,
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/surface)
 "gHq" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/power/apc/east{
+/obj/structure/machinery/power/apc/east{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -6161,8 +6161,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -6209,10 +6209,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -6248,7 +6248,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/cryo_outpost/inside/habitation_east)
 "gTO" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/manifold/visible{
+/obj/structure/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
 /obj/random/dirt_75,
@@ -6280,7 +6280,7 @@
 /area/cryo_outpost/outside/cave)
 "gVx" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/habitation_east)
@@ -6305,7 +6305,7 @@
 /area/cryo_outpost/inside/engi_powergen)
 "gXJ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/air,
+/obj/structure/machinery/portable_atmospherics/canister/empty/air,
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/surface)
 "gXK" = (
@@ -6389,10 +6389,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -6421,7 +6421,7 @@
 /area/cryo_outpost/inside/engineering)
 "hgH" = (
 /obj/effect/floor_decal/industrial/warning/dust,
-/obj/structure/machinery/machinery/button/remote/blast_door{
+/obj/structure/machinery/button/remote/blast_door{
 	id = "cryo_outpost_shutter_entrance_aux_east_out";
 	pixel_x = 20;
 	dir = 4;
@@ -6459,7 +6459,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/light/colored/decayed/dimmed{
+/obj/structure/machinery/light/colored/decayed/dimmed{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -6473,7 +6473,7 @@
 /area/cryo_outpost/inside/maint_warehouse)
 "hlC" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -6505,13 +6505,13 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/labs_maint_w)
 "hpd" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/warehouse)
 "hpg" = (
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -6528,10 +6528,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -6570,8 +6570,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -6587,7 +6587,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /obj/structure/table/stone/marble,
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup{
 	pixel_x = -1;
@@ -6633,7 +6633,7 @@
 /area/cryo_outpost/inside/maint_habitation)
 "hwi" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -6658,8 +6658,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass_medical,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass_medical,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/medical)
@@ -6713,7 +6713,7 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_surgery)
 "hzs" = (
-/obj/structure/machinery/machinery/light/small{
+/obj/structure/machinery/light/small{
 	dir = 1
 	},
 /obj/random/dirt_75,
@@ -6721,7 +6721,7 @@
 /area/cryo_outpost/outside/surface)
 "hzN" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/vending/hydronutrients,
+/obj/structure/machinery/vending/hydronutrients,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/botany)
@@ -6737,7 +6737,7 @@
 /area/cryo_outpost/inside/engineering)
 "hAv" = (
 /obj/structure/trash_pile,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -6802,7 +6802,7 @@
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/cave)
 "hDz" = (
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline_straight/yellow{
@@ -6833,7 +6833,7 @@
 /area/cryo_outpost/inside/labs_maint_w)
 "hEK" = (
 /obj/effect/floor_decal/corner/pink,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -6852,17 +6852,17 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/engineering{
+/obj/structure/machinery/door/airlock/engineering{
 	dir = 4;
 	req_one_access = list(244)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/engineering)
 "hGI" = (
-/obj/structure/machinery/machinery/space_heater,
+/obj/structure/machinery/space_heater,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/habitation_west)
@@ -6874,7 +6874,7 @@
 /obj/item/clothing/glasses/sunglasses/aviator,
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/item/flashlight/maglight,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/outfit/admin/generic/security,
@@ -6891,7 +6891,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /obj/structure/table/stone/marble,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/canteen)
@@ -6998,7 +6998,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/entrance_aux_west)
 "hPg" = (
-/obj/structure/machinery/machinery/photocopier,
+/obj/structure/machinery/photocopier,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_offices)
 "hPm" = (
@@ -7013,7 +7013,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -7038,9 +7038,9 @@
 /area/cryo_outpost/inside/maint_habitation)
 "hQX" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/air,
+/obj/structure/machinery/portable_atmospherics/canister/air,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/full,
@@ -7069,7 +7069,7 @@
 /obj/effect/floor_decal/corner_wide/green/diagonal,
 /obj/structure/table/standard,
 /obj/item/clothing/accessory/stethoscope,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -7107,7 +7107,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -7135,7 +7135,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/engineering)
 "hXw" = (
-/obj/structure/machinery/machinery/cryopod{
+/obj/structure/machinery/cryopod{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -7195,7 +7195,7 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/door/blast/shutters{
+/obj/structure/machinery/door/blast/shutters{
 	id = "cryo_outpost_shutter_entrance_main_out"
 	},
 /turf/simulated/floor/plating/asteroid,
@@ -7256,7 +7256,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/structure/table/reinforced/steel,
@@ -7378,16 +7378,16 @@
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/inside/entrance_main)
 "iqq" = (
-/obj/structure/machinery/machinery/appliance/cooker/stove,
+/obj/structure/machinery/appliance/cooker/stove,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/canteen)
 "iqA" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/air,
+/obj/structure/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/surface)
 "iqY" = (
@@ -7480,7 +7480,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/warehouse)
 "ivy" = (
-/obj/structure/machinery/machinery/portable_atmospherics/hydroponics,
+/obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -7526,7 +7526,7 @@
 /area/cryo_outpost/inside/engineering)
 "iyy" = (
 /obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /obj/random/dirt_75,
@@ -7548,13 +7548,13 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/alarm/west{
+/obj/structure/machinery/alarm/west{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/labs_rnd)
 "iAa" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/manifold/hidden,
+/obj/structure/machinery/atmospherics/pipe/manifold/hidden,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_s)
@@ -7585,9 +7585,9 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/labs_cryo_n)
 "iBs" = (
-/obj/structure/machinery/machinery/portable_atmospherics/hydroponics,
+/obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -7596,7 +7596,7 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/door/blast/shutters/open{
+/obj/structure/machinery/door/blast/shutters/open{
 	id = "cryo_outpost_shutter_entrance_main_in"
 	},
 /turf/simulated/floor/plating/asteroid,
@@ -7629,7 +7629,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -7662,7 +7662,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/labs_offices)
 "iHW" = (
-/obj/structure/machinery/machinery/dna_scannernew,
+/obj/structure/machinery/dna_scannernew,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_rnd)
@@ -7710,7 +7710,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/white,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -7739,7 +7739,7 @@
 /obj/item/clothing/glasses/sunglasses/aviator,
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -7768,7 +7768,7 @@
 /turf/simulated/floor/exoplanet/desert,
 /area/cryo_outpost/outside/surface)
 "iPG" = (
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 8
 	},
 /obj/random/dirt_75,
@@ -7858,7 +7858,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/habitation_west)
 "iUL" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/hidden{
+/obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
@@ -7868,10 +7868,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -7887,7 +7887,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 10
 	},
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_offices)
 "iXB" = (
@@ -7909,7 +7909,7 @@
 /area/cryo_outpost/inside/hallway_west)
 "iYF" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
+/obj/structure/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/entrance_aux_east)
@@ -7944,7 +7944,7 @@
 "iZn" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/door/blast/shutters{
+/obj/structure/machinery/door/blast/shutters{
 	dir = 2;
 	id = "cryo_outpost_shutter_entrance_aux_east_in"
 	},
@@ -7971,7 +7971,7 @@
 /area/cryo_outpost/inside/maint_habitation)
 "jaq" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled,
@@ -7980,7 +7980,7 @@
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_door/red{
@@ -8024,7 +8024,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/entrance_main)
 "jdb" = (
-/obj/structure/machinery/machinery/portable_atmospherics/powered/scrubber,
+/obj/structure/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engi_atmos)
@@ -8033,13 +8033,13 @@
 	icon_state = "1-2"
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/maint_warehouse)
 "jde" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer{
@@ -8057,14 +8057,14 @@
 /turf/simulated/floor/exoplanet/plating,
 /area/cryo_outpost/outside/cave)
 "jdx" = (
-/obj/structure/machinery/machinery/portable_atmospherics/hydroponics,
+/obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/botany)
 "jdN" = (
 /obj/effect/floor_decal/industrial/warning/dust,
-/obj/structure/machinery/machinery/light/small{
+/obj/structure/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid,
@@ -8106,8 +8106,8 @@
 /area/cryo_outpost/inside/labs_surgery)
 "jhf" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /obj/random/dirt_75,
@@ -8126,7 +8126,7 @@
 /area/cryo_outpost/inside/botany)
 "jji" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/powered/scrubber,
+/obj/structure/machinery/portable_atmospherics/powered/scrubber,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engineering)
@@ -8149,7 +8149,7 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/item/stack/nanopaste{
@@ -8198,10 +8198,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -8225,7 +8225,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_offices)
 "jrZ" = (
-/obj/structure/machinery/machinery/shower{
+/obj/structure/machinery/shower{
 	pixel_y = 12
 	},
 /obj/structure/window/reinforced,
@@ -8237,8 +8237,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/entrance_aux_west)
 "jsA" = (
@@ -8350,7 +8350,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -8377,10 +8377,10 @@
 	master_tag = "cryo_outpost_co2";
 	name = "cryo_outpost_co2"
 	},
-/obj/structure/machinery/machinery/air_sensor{
+/obj/structure/machinery/air_sensor{
 	pixel_y = -16
 	},
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/visible{
+/obj/structure/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -8399,7 +8399,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/light/colored/dying{
+/obj/structure/machinery/light/colored/dying{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -8408,12 +8408,12 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/engineering)
 "jBl" = (
-/obj/structure/machinery/machinery/washing_machine,
+/obj/structure/machinery/washing_machine,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/habitation_west)
@@ -8439,7 +8439,7 @@
 /area/cryo_outpost/inside/medical)
 "jBX" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
+/obj/structure/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
 /area/cryo_outpost/inside/habitation_east)
@@ -8461,7 +8461,7 @@
 /obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/button/remote/blast_door{
+/obj/structure/machinery/button/remote/blast_door{
 	id = "cryo_outpost_shutter_entrance_aux_west_in";
 	pixel_x = 28;
 	pixel_y = -20;
@@ -8473,10 +8473,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/research{
+/obj/structure/machinery/door/airlock/research{
 	dir = 4;
 	req_one_access = list(244)
 	},
@@ -8494,7 +8494,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -8507,7 +8507,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/hallway_west)
 "jEV" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -8516,7 +8516,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
 	},
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/canteen)
 "jFz" = (
@@ -8528,7 +8528,7 @@
 /area/cryo_outpost/outside/cave)
 "jFA" = (
 /obj/effect/floor_decal/corner/pink/diagonal,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -8553,7 +8553,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/camera/network/cryo_outpost{
+/obj/structure/machinery/camera/network/cryo_outpost{
 	c_tag = "Canteen"
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -8565,8 +8565,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass_research,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass_research,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/hallway_central)
 "jIl" = (
@@ -8575,7 +8575,7 @@
 /area/cryo_outpost/inside/labs_surgery)
 "jIJ" = (
 /obj/effect/floor_decal/corner_wide/green/diagonal,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/white,
@@ -8648,7 +8648,7 @@
 /area/cryo_outpost/outside/cave)
 "jLw" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
+/obj/structure/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/surface)
 "jLy" = (
@@ -8695,7 +8695,7 @@
 	pixel_x = 3;
 	pixel_y = -1
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -8716,7 +8716,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/entrance_aux_east)
 "jOT" = (
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 1
 	},
 /turf/simulated/floor/wood/ebony,
@@ -8747,7 +8747,7 @@
 "jQT" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
+/obj/structure/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/surface)
 "jRs" = (
@@ -8813,7 +8813,7 @@
 /obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/button/remote/blast_door{
+/obj/structure/machinery/button/remote/blast_door{
 	id = "cryo_outpost_shutter_entrance_aux_east_in";
 	pixel_x = 28;
 	pixel_y = -20;
@@ -8889,13 +8889,13 @@
 "jYa" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/hydrogen,
+/obj/structure/machinery/portable_atmospherics/canister/hydrogen,
 /turf/simulated/floor/tiled/full,
 /area/cryo_outpost/inside/habitation_east)
 "jYb" = (
 /obj/structure/table/steel,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -8936,15 +8936,15 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_rnd)
 "kaa" = (
-/obj/structure/machinery/machinery/papershredder,
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/papershredder,
+/obj/structure/machinery/light/broken{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_offices)
 "kay" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
@@ -8953,7 +8953,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -8993,7 +8993,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -9005,10 +9005,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/research{
+/obj/structure/machinery/door/airlock/research{
 	dir = 4;
 	req_one_access = list(244)
 	},
@@ -9065,7 +9065,7 @@
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/outside/cave)
 "kfF" = (
-/obj/structure/machinery/machinery/camera/network/cryo_outpost{
+/obj/structure/machinery/camera/network/cryo_outpost{
 	c_tag = "Engineering"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -9133,7 +9133,7 @@
 /obj/structure/closet/crate/freezer,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/organ/internal/liver,
-/obj/structure/machinery/machinery/light/small{
+/obj/structure/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer{
@@ -9271,7 +9271,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -9282,7 +9282,7 @@
 	pixel_y = 6
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -9313,8 +9313,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/hallway_central)
@@ -9414,7 +9414,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_s)
 "kAr" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/manifold/hidden,
+/obj/structure/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_s)
 "kAw" = (
@@ -9440,7 +9440,7 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_rnd)
 "kBI" = (
-/obj/structure/machinery/machinery/space_heater,
+/obj/structure/machinery/space_heater,
 /turf/simulated/floor/wood/walnut,
 /area/cryo_outpost/inside/canteen)
 "kCd" = (
@@ -9472,8 +9472,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -9521,7 +9521,7 @@
 	pixel_y = 1;
 	pixel_x = 8
 	},
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/white,
@@ -9543,7 +9543,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/machinery/machinery/door/blast/regular{
+/obj/structure/machinery/door/blast/regular{
 	dir = 4;
 	id = "cryo_outpost_blastdoor_labs"
 	},
@@ -9581,7 +9581,7 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_rnd)
 "kId" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/hidden{
+/obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
@@ -9629,7 +9629,7 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_offices)
 "kLE" = (
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -9639,13 +9639,13 @@
 /area/cryo_outpost/inside/maint_habitation)
 "kLT" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/broken{
+/obj/structure/machinery/light/small/broken{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/cryo_outpost/inside/security)
 "kMf" = (
-/obj/structure/machinery/machinery/atmospherics/portables_connector{
+/obj/structure/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch_small/yellow,
@@ -9693,7 +9693,7 @@
 /area/cryo_outpost/inside/engineering)
 "kPt" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/sleeping_agent,
+/obj/structure/machinery/portable_atmospherics/canister/empty/sleeping_agent,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
@@ -9708,7 +9708,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/structure/table/standard,
@@ -9789,7 +9789,7 @@
 /area/cryo_outpost/inside/botany)
 "kUi" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -9874,7 +9874,7 @@
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/cave)
 "kXH" = (
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -9903,7 +9903,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/warehouse)
 "kYm" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/hidden{
+/obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
@@ -9924,7 +9924,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/maint_botany)
 "kYu" = (
-/obj/structure/machinery/machinery/door/airlock/silver,
+/obj/structure/machinery/door/airlock/silver,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
@@ -9947,12 +9947,12 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engi_powergen)
 "kZt" = (
-/obj/structure/machinery/machinery/hologram/holopad/long_range,
+/obj/structure/machinery/hologram/holopad/long_range,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/comms)
 "las" = (
 /obj/structure/table/reinforced/steel,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/random/dirt_75,
@@ -9989,7 +9989,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -9998,8 +9998,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/security{
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/security{
 	req_one_access = list(244)
 	},
 /turf/simulated/floor/tiled/dark,
@@ -10012,7 +10012,7 @@
 "lcV" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small{
+/obj/structure/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid,
@@ -10054,7 +10054,7 @@
 /area/cryo_outpost/inside/labs_rnd)
 "lfa" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/camera/network/cryo_outpost{
+/obj/structure/machinery/camera/network/cryo_outpost{
 	c_tag = "Outside, Landing Pads, Far"
 	},
 /turf/simulated/floor/exoplanet/barren,
@@ -10063,16 +10063,16 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/warehouse)
 "lgL" = (
-/obj/structure/machinery/machinery/atmospherics/unary/freezer,
+/obj/structure/machinery/atmospherics/unary/freezer,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_s)
 "lgR" = (
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -10091,7 +10091,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /obj/structure/table/stone/marble,
 /obj/item/trash/shakshouka{
 	pixel_y = 6;
@@ -10110,7 +10110,7 @@
 	dir = 10
 	},
 /obj/structure/bed/stool/chair,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /obj/random/dirt_75,
@@ -10124,7 +10124,7 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/colored/dying{
+/obj/structure/machinery/light/colored/dying{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -10144,7 +10144,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/warehouse)
 "ljg" = (
-/obj/structure/machinery/machinery/alarm/east{
+/obj/structure/machinery/alarm/east{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_door/red{
@@ -10187,8 +10187,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass{
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass{
 	req_one_access = list(244)
 	},
 /turf/simulated/floor/tiled/dark,
@@ -10228,10 +10228,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -10241,7 +10241,7 @@
 /area/cryo_outpost/inside/maint_habitation)
 "lnS" = (
 /obj/structure/table/steel,
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/warehouse)
 "lop" = (
@@ -10330,7 +10330,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/maint_medbay)
 "lti" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -10362,7 +10362,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_offices)
 "luL" = (
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/wood/maple,
 /area/cryo_outpost/inside/habitation_west)
 "lwN" = (
@@ -10414,7 +10414,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -10440,7 +10440,7 @@
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/outside/surface)
 "lAG" = (
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -10468,7 +10468,7 @@
 /area/cryo_outpost/inside/medical)
 "lBE" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -10489,7 +10489,7 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -10557,9 +10557,9 @@
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/outside/surface)
 "lJl" = (
-/obj/structure/machinery/machinery/washing_machine,
+/obj/structure/machinery/washing_machine,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -10599,7 +10599,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/structure/machinery/machinery/alarm/east{
+/obj/structure/machinery/alarm/east{
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
@@ -10652,14 +10652,14 @@
 "lND" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/maint_botany)
 "lPM" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/powered/pump/filled,
+/obj/structure/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engi_atmos)
 "lPS" = (
@@ -10684,7 +10684,7 @@
 /obj/item/pen{
 	pixel_y = 4
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -10696,7 +10696,7 @@
 "lRq" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
+/obj/structure/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
 /turf/simulated/floor/tiled/full,
 /area/cryo_outpost/inside/habitation_east)
 "lSq" = (
@@ -10784,7 +10784,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/machinery/machinery/power/portgen/basic,
+/obj/structure/machinery/power/portgen/basic,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engi_powergen)
@@ -10854,7 +10854,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -10870,7 +10870,7 @@
 /area/cryo_outpost/inside/engineering)
 "mcM" = (
 /obj/effect/floor_decal/industrial/warning/dust,
-/obj/structure/machinery/machinery/button/remote/blast_door{
+/obj/structure/machinery/button/remote/blast_door{
 	id = "cryo_outpost_shutter_entrance_aux_west_out";
 	pixel_x = 20;
 	dir = 4;
@@ -10879,7 +10879,7 @@
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/inside/entrance_aux_west)
 "mec" = (
-/obj/structure/machinery/machinery/cryopod{
+/obj/structure/machinery/cryopod{
 	dir = 2
 	},
 /obj/random/dirt_75,
@@ -10900,8 +10900,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -10916,7 +10916,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -10931,7 +10931,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/maint_warehouse)
 "mgO" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -11002,7 +11002,7 @@
 /obj/random/medical,
 /obj/effect/floor_decal/corner/dark_green/diagonal,
 /obj/effect/floor_decal/industrial/hatch/medical,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -11011,8 +11011,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/freezer,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/freezer,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/canteen)
 "mjN" = (
@@ -11033,8 +11033,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/habitation_west)
 "mkt" = (
@@ -11055,7 +11055,7 @@
 /obj/item/clothing/head/helmet/space/emergency{
 	pixel_x = -5
 	},
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 1
 	},
 /obj/random/dirt_75,
@@ -11130,11 +11130,11 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/habitation_west)
 "mpN" = (
-/obj/structure/machinery/machinery/light/colored/decayed/dimmed{
+/obj/structure/machinery/light/colored/decayed/dimmed{
 	dir = 8
 	},
 /turf/simulated/floor/lino,
@@ -11169,7 +11169,7 @@
 	},
 /area/cryo_outpost/inside/labs_surgery)
 "mwg" = (
-/obj/structure/machinery/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/machinery/portable_atmospherics/canister/oxygen,
 /obj/random/dirt_75,
 /obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 8
@@ -11183,7 +11183,7 @@
 "mwS" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -11193,7 +11193,7 @@
 	dir = 10
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/hallway_central)
 "myE" = (
@@ -11217,7 +11217,7 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/medical)
 "mCQ" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/visible/yellow{
+/obj/structure/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -11252,11 +11252,11 @@
 /area/cryo_outpost/outside/surface)
 "mGP" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/random/dirt_75,
@@ -11266,11 +11266,11 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_hallway)
 "mIc" = (
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/habitation_west)
 "mIz" = (
@@ -11295,14 +11295,14 @@
 /area/cryo_outpost/inside/botany)
 "mJv" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small{
+/obj/structure/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/inside/entrance_main)
 "mKq" = (
 /obj/structure/table/rack,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/random/loot,
@@ -11329,7 +11329,7 @@
 /area/cryo_outpost/inside/entrance_aux_east)
 "mMz" = (
 /obj/structure/table/standard,
-/obj/structure/machinery/machinery/chemical_dispenser/coffeemaster/full{
+/obj/structure/machinery/chemical_dispenser/coffeemaster/full{
 	dir = 0;
 	pixel_y = 12
 	},
@@ -11370,7 +11370,7 @@
 /area/cryo_outpost/inside/maint_warehouse)
 "mOn" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
-/obj/structure/machinery/machinery/light/colored/decayed/dimmed,
+/obj/structure/machinery/light/colored/decayed/dimmed,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engineering)
@@ -11420,7 +11420,7 @@
 /area/cryo_outpost/inside/entrance_main)
 "mQJ" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
@@ -11433,7 +11433,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_s)
 "mQU" = (
-/obj/structure/machinery/machinery/camera/network/cryo_outpost{
+/obj/structure/machinery/camera/network/cryo_outpost{
 	c_tag = "Outside, Entrance, Main"
 	},
 /obj/random/dirt_75,
@@ -11467,7 +11467,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/camera/network/cryo_outpost{
+/obj/structure/machinery/camera/network/cryo_outpost{
 	c_tag = "Entrance, Main"
 	},
 /turf/simulated/floor/tiled,
@@ -11508,14 +11508,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_maint_w)
 "mXn" = (
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty,
+/obj/structure/machinery/portable_atmospherics/canister/empty,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/effect/floor_decal/industrial/outline_straight/red,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engi_atmos)
 "mXr" = (
-/obj/structure/machinery/machinery/power/terminal{
+/obj/structure/machinery/power/terminal{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -11528,7 +11528,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engi_powergen)
 "mXw" = (
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -11548,7 +11548,7 @@
 /obj/item/clothing/head/helmet/space/emergency{
 	pixel_x = -5
 	},
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -11558,13 +11558,13 @@
 /area/cryo_outpost/inside/entrance_main)
 "naa" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
 /area/cryo_outpost/inside/habitation_east)
 "nad" = (
-/obj/structure/machinery/machinery/computer/security/terminal/cryo_outpost,
+/obj/structure/machinery/computer/security/terminal/cryo_outpost,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/comms)
 "naD" = (
@@ -11585,7 +11585,7 @@
 /turf/simulated/floor/exoplanet/desert,
 /area/cryo_outpost/outside/surface)
 "nbL" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/visible/yellow{
+/obj/structure/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -11622,15 +11622,15 @@
 	},
 /area/cryo_outpost/inside/canteen)
 "ndL" = (
-/obj/structure/machinery/machinery/suspension_gen,
+/obj/structure/machinery/suspension_gen,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/labs_maint_w)
 "neD" = (
 /obj/structure/table/reinforced/steel,
-/obj/structure/machinery/machinery/door/window/desk/eastright,
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/window/desk/eastright,
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -11648,7 +11648,7 @@
 /area/cryo_outpost/inside/entrance_main)
 "njh" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/air,
+/obj/structure/machinery/portable_atmospherics/canister/empty/air,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
 /area/cryo_outpost/inside/habitation_east)
@@ -11673,8 +11673,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
@@ -11710,7 +11710,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/structure/table/standard,
@@ -11720,7 +11720,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -11765,10 +11765,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -11803,7 +11803,7 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/button/remote/blast_door{
+/obj/structure/machinery/button/remote/blast_door{
 	id = "cryo_outpost_shutter_entrance_aux_west_in";
 	pixel_x = 28;
 	pixel_y = 32;
@@ -11829,7 +11829,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/camera/network/cryo_outpost{
+/obj/structure/machinery/camera/network/cryo_outpost{
 	c_tag = "Crew Quarters"
 	},
 /obj/random/dirt_75,
@@ -11864,7 +11864,7 @@
 /area/cryo_outpost/inside/canteen)
 "nsx" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/hydrogen,
+/obj/structure/machinery/portable_atmospherics/canister/empty/hydrogen,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/habitation_east)
@@ -11916,7 +11916,7 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/pink,
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -11936,7 +11936,7 @@
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/outside/surface)
 "nxi" = (
-/obj/structure/machinery/machinery/light/colored/decayed,
+/obj/structure/machinery/light/colored/decayed,
 /obj/random/dirt_75,
 /obj/effect/floor_decal/corner/beige/full{
 	dir = 4
@@ -11977,10 +11977,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/research{
+/obj/structure/machinery/door/airlock/research{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -12128,13 +12128,13 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/machinery/machinery/door/airlock/engineering{
+/obj/structure/machinery/door/airlock/engineering{
 	dir = 4;
 	req_one_access = list(244)
 	},
@@ -12144,7 +12144,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -12180,7 +12180,7 @@
 /area/cryo_outpost/inside/sensors_iff)
 "nMt" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/hydrogen,
+/obj/structure/machinery/portable_atmospherics/canister/hydrogen,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/habitation_east)
@@ -12239,7 +12239,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/canteen)
 "nRO" = (
-/obj/structure/machinery/machinery/cryopod{
+/obj/structure/machinery/cryopod{
 	dir = 2
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -12293,7 +12293,7 @@
 /area/cryo_outpost/outside/surface)
 "nWs" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small{
+/obj/structure/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/exoplanet/barren,
@@ -12346,13 +12346,13 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/maint_medbay)
 "oap" = (
-/obj/structure/machinery/machinery/portable_atmospherics/hydroponics,
+/obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/botany)
@@ -12367,8 +12367,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
@@ -12380,7 +12380,7 @@
 /area/cryo_outpost/inside/habitation_west)
 "obz" = (
 /obj/structure/table/reinforced/steel,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/random/pottedplant_small{
@@ -12416,8 +12416,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/medical,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/medical,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/medical)
 "odF" = (
@@ -12432,7 +12432,7 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/broken{
+/obj/structure/machinery/light/small/broken{
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid,
@@ -12463,7 +12463,7 @@
 /area/cryo_outpost/inside/habitation_west)
 "oft" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small{
+/obj/structure/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -12507,8 +12507,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
@@ -12519,10 +12519,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_s)
 "oiM" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/visible/yellow{
+/obj/structure/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/machinery/atmospherics/pipe/simple/visible,
 /obj/random/dirt_75,
 /obj/random/junk{
 	pixel_y = -18;
@@ -12531,13 +12531,13 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engi_atmos)
 "ojj" = (
-/obj/structure/machinery/machinery/atmospherics/unary/cryo_cell,
+/obj/structure/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_s)
 "ojt" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/door/blast/shutters/open{
+/obj/structure/machinery/door/blast/shutters/open{
 	id = "cryo_outpost_shutter_entrance_main_in"
 	},
 /turf/simulated/floor/plating/asteroid,
@@ -12574,10 +12574,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -12603,7 +12603,7 @@
 	pixel_x = 9;
 	pixel_y = 1
 	},
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -12670,7 +12670,7 @@
 "otf" = (
 /obj/effect/floor_decal/corner/orange/diagonal,
 /obj/structure/table/standard,
-/obj/structure/machinery/machinery/reagentgrinder{
+/obj/structure/machinery/reagentgrinder{
 	pixel_y = 11;
 	pixel_x = 3
 	},
@@ -12711,7 +12711,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/maint_botany)
 "ovP" = (
-/obj/structure/machinery/machinery/light/broken,
+/obj/structure/machinery/light/broken,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
@@ -12765,8 +12765,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass_research,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass_research,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_offices)
 "oyY" = (
@@ -12817,7 +12817,7 @@
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -12835,10 +12835,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/blue{
+/obj/structure/machinery/door/airlock/blue{
 	dir = 4;
 	req_one_access = list(244)
 	},
@@ -12856,7 +12856,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/warehouse)
 "oCO" = (
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /obj/structure/table/steel,
 /obj/item/towel/random{
 	pixel_x = 11;
@@ -12929,7 +12929,7 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
-/obj/structure/machinery/machinery/alarm/cold/north{
+/obj/structure/machinery/alarm/cold/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/freezer{
@@ -12945,7 +12945,7 @@
 /area/cryo_outpost/inside/habitation_west)
 "oFF" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -12986,7 +12986,7 @@
 /obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 8
 	},
-/obj/structure/machinery/machinery/button/remote/blast_door{
+/obj/structure/machinery/button/remote/blast_door{
 	id = "cryo_outpost_blastdoor_labs";
 	pixel_x = -20;
 	dir = 8;
@@ -13016,7 +13016,7 @@
 "oIy" = (
 /obj/structure/closet/crate/freezer,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/light/small{
+/obj/structure/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer{
@@ -13030,7 +13030,7 @@
 /area/cryo_outpost/inside/maint_entrance)
 "oIC" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
@@ -13078,10 +13078,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/glass{
+/obj/structure/machinery/door/airlock/glass{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -13193,10 +13193,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -13208,10 +13208,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/freezer{
+/obj/structure/machinery/door/airlock/freezer{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -13219,14 +13219,14 @@
 "oSF" = (
 /obj/structure/bed/stool/chair/office/dark,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/habitation_west)
 "oSI" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid,
@@ -13238,10 +13238,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/blue{
+/obj/structure/machinery/door/airlock/blue{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -13313,7 +13313,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 10
 	},
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/labs_hallway)
 "oXC" = (
@@ -13335,11 +13335,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/botany)
 "oYm" = (
-/obj/structure/machinery/machinery/atmospherics/portables_connector{
+/obj/structure/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch_small/yellow,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engi_atmos)
@@ -13368,7 +13368,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/habitation_east)
 "paq" = (
-/obj/structure/machinery/machinery/door/window/southright{
+/obj/structure/machinery/door/window/southright{
 	req_one_access = list(244)
 	},
 /obj/effect/floor_decal/corner/mauve{
@@ -13381,7 +13381,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -13437,7 +13437,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_maint_e)
 "pfB" = (
@@ -13516,7 +13516,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/random/dirt_75,
@@ -13625,17 +13625,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_offices)
 "ppV" = (
-/obj/structure/machinery/machinery/atmospherics/unary/cryo_cell,
+/obj/structure/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_n)
 "pqn" = (
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/glass{
+/obj/structure/machinery/door/airlock/glass{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -13645,8 +13645,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass_research,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass_research,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/hallway_central)
@@ -13654,7 +13654,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
@@ -13673,7 +13673,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -13689,7 +13689,7 @@
 /area/cryo_outpost/inside/habitation_west)
 "psE" = (
 /obj/structure/closet/crate/freezer,
-/obj/structure/machinery/machinery/alarm/cold/north{
+/obj/structure/machinery/alarm/cold/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/freezer{
@@ -13713,7 +13713,7 @@
 /turf/simulated/floor/exoplanet/desert,
 /area/cryo_outpost/outside/surface)
 "pvi" = (
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -13722,7 +13722,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_maint_e)
 "pvl" = (
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 1
 	},
 /obj/random/dirt_75,
@@ -13757,7 +13757,7 @@
 	},
 /area/cryo_outpost/inside/labs_surgery)
 "pxp" = (
-/obj/structure/machinery/machinery/alarm/east{
+/obj/structure/machinery/alarm/east{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/corner/mauve{
@@ -13766,7 +13766,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/labs_surgery)
 "pxE" = (
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -13791,7 +13791,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
 	},
-/obj/structure/machinery/machinery/light/broken,
+/obj/structure/machinery/light/broken,
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/cocktail{
 	pixel_x = -13;
 	pixel_y = 5
@@ -13906,7 +13906,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/entrance_aux_east)
 "pHy" = (
-/obj/structure/machinery/machinery/door/urban{
+/obj/structure/machinery/door/urban{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -13928,7 +13928,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/engi_atmos)
 "pHD" = (
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -13948,7 +13948,7 @@
 "pId" = (
 /obj/effect/floor_decal/corner_wide/green/diagonal,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/sleeper{
+/obj/structure/machinery/sleeper{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -13957,7 +13957,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/hallway_central)
 "pIv" = (
@@ -13999,7 +13999,7 @@
 "pMM" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
@@ -14008,7 +14008,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -14017,10 +14017,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/glass{
+/obj/structure/machinery/door/airlock/glass{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -14050,7 +14050,7 @@
 /area/cryo_outpost/outside/cave)
 "pPI" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
 /area/cryo_outpost/inside/habitation_east)
@@ -14080,7 +14080,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/alarm/east{
+/obj/structure/machinery/alarm/east{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled,
@@ -14119,10 +14119,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -14184,7 +14184,7 @@
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/cave)
 "pXw" = (
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/beige{
@@ -14277,8 +14277,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -14307,11 +14307,11 @@
 /area/cryo_outpost/inside/hallway_west)
 "qcr" = (
 /obj/structure/table/wood/walnut,
-/obj/structure/machinery/machinery/chemical_dispenser/bar_soft/full{
+/obj/structure/machinery/chemical_dispenser/bar_soft/full{
 	pixel_y = 7;
 	dir = 4
 	},
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 8
 	},
 /turf/simulated/floor/wood/walnut,
@@ -14329,10 +14329,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -14373,7 +14373,7 @@
 /obj/effect/floor_decal/corner/white{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/structure/table/glass,
@@ -14446,7 +14446,7 @@
 	pixel_x = -4;
 	pixel_y = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -14481,7 +14481,7 @@
 /turf/simulated/floor/exoplanet/desert,
 /area/cryo_outpost/outside/surface)
 "qlx" = (
-/obj/structure/machinery/machinery/power/apc/west{
+/obj/structure/machinery/power/apc/west{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -14501,7 +14501,7 @@
 /area/cryo_outpost/inside/warehouse)
 "qmw" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/phoron,
+/obj/structure/machinery/portable_atmospherics/canister/empty/phoron,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
 /area/cryo_outpost/inside/habitation_east)
@@ -14582,7 +14582,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/warehouse)
 "qsg" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue{
@@ -14594,7 +14594,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -14611,7 +14611,7 @@
 /area/cryo_outpost/inside/maint_engineering)
 "qtg" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -14641,7 +14641,7 @@
 	pixel_y = 4
 	},
 /obj/effect/floor_decal/corner_wide/green,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/white,
@@ -14664,13 +14664,13 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/habitation_east)
 "qvS" = (
-/obj/structure/machinery/machinery/alarm/east{
+/obj/structure/machinery/alarm/east{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_door/red,
@@ -14680,7 +14680,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/hallway_central)
 "qwc" = (
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 1
 	},
 /obj/random/dirt_75,
@@ -14725,7 +14725,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/labs_hallway)
 "qxg" = (
-/obj/structure/machinery/machinery/body_scanconsole{
+/obj/structure/machinery/body_scanconsole{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/white/diagonal,
@@ -14793,7 +14793,7 @@
 /turf/simulated/floor/tiled/full,
 /area/cryo_outpost/inside/habitation_west)
 "qAD" = (
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -14804,7 +14804,7 @@
 /area/cryo_outpost/inside/labs_cryo_n)
 "qBu" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
+/obj/structure/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/habitation_east)
@@ -14812,10 +14812,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/glass{
+/obj/structure/machinery/door/airlock/glass{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -14825,8 +14825,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/research,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/research,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_pharmacy)
 "qCL" = (
@@ -14882,10 +14882,10 @@
 /area/cryo_outpost/inside/hallway_central)
 "qFe" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 8
 	},
-/obj/structure/machinery/machinery/portable_atmospherics/canister/air/cold,
+/obj/structure/machinery/portable_atmospherics/canister/air/cold,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/entrance_aux_east)
 "qFp" = (
@@ -14904,10 +14904,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/engineering{
+/obj/structure/machinery/door/airlock/engineering{
 	dir = 4;
 	req_one_access = list(244)
 	},
@@ -14956,7 +14956,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/security)
 "qIk" = (
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /obj/random/dirt_75,
 /obj/effect/floor_decal/industrial/outline_straight/red,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -14992,17 +14992,17 @@
 /turf/simulated/wall,
 /area/cryo_outpost/inside/maint_warehouse)
 "qLd" = (
-/obj/structure/machinery/machinery/light/colored/decayed,
+/obj/structure/machinery/light/colored/decayed,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_n)
 "qLX" = (
-/obj/structure/machinery/machinery/pipedispenser/disposal,
+/obj/structure/machinery/pipedispenser/disposal,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engi_atmos)
 "qMx" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -15015,7 +15015,7 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/structure/closet,
@@ -15075,7 +15075,7 @@
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/outside/cave)
 "qTd" = (
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -15126,8 +15126,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -15195,13 +15195,13 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/machinery/machinery/door/airlock/research{
+/obj/structure/machinery/door/airlock/research{
 	dir = 4;
 	req_one_access = list(244)
 	},
@@ -15220,13 +15220,13 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/hallway_west)
 "qZu" = (
-/obj/structure/machinery/machinery/light/colored/decayed,
+/obj/structure/machinery/light/colored/decayed,
 /obj/structure/table/rack/cafe_table,
 /obj/item/toy/comic{
 	pixel_x = 4;
@@ -15235,7 +15235,7 @@
 /turf/simulated/floor/carpet/purple,
 /area/cryo_outpost/inside/habitation_west)
 "raa" = (
-/obj/structure/machinery/machinery/light/broken,
+/obj/structure/machinery/light/broken,
 /obj/structure/bed/stool/chair/sofa/yellow{
 	dir = 1
 	},
@@ -15259,7 +15259,7 @@
 /obj/item/handcuffs,
 /obj/item/clothing/glasses/sunglasses/aviator,
 /obj/effect/floor_decal/corner/blue/diagonal,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/item/melee/baton/stunrod,
@@ -15269,7 +15269,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/security)
 "rbS" = (
-/obj/structure/machinery/machinery/light/colored/dying{
+/obj/structure/machinery/light/colored/dying{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -15305,8 +15305,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -15340,15 +15340,15 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/maint_entrance)
 "rgl" = (
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/power/portgen/basic,
+/obj/structure/machinery/power/portgen/basic,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/labs_maint_e)
 "rgp" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
@@ -15469,7 +15469,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/security)
 "rml" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/mauve{
@@ -15551,7 +15551,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /obj/random/dirt_75,
@@ -15561,13 +15561,13 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/hallway_central)
 "rqg" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/powered/pump/filled,
+/obj/structure/machinery/portable_atmospherics/powered/pump/filled,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
@@ -15592,7 +15592,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/engi_atmos)
@@ -15639,7 +15639,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/security)
 "rvJ" = (
-/obj/structure/machinery/machinery/light/colored/decayed/dimmed{
+/obj/structure/machinery/light/colored/decayed/dimmed{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -15663,12 +15663,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_maint_w)
 "rwW" = (
-/obj/structure/machinery/machinery/portable_atmospherics/hydroponics/soil,
+/obj/structure/machinery/portable_atmospherics/hydroponics/soil,
 /obj/random/junk,
 /turf/simulated/floor/exoplanet/grass,
 /area/cryo_outpost/outside/surface)
 "rxr" = (
-/obj/structure/machinery/machinery/power/smes/buildable/third_party_shuttle,
+/obj/structure/machinery/power/smes/buildable/third_party_shuttle,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -15724,7 +15724,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -15857,7 +15857,7 @@
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/cave)
 "rIg" = (
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_door/red{
@@ -15897,7 +15897,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/habitation_west)
 "rJG" = (
-/obj/structure/machinery/machinery/shower{
+/obj/structure/machinery/shower{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -15928,8 +15928,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/warehouse)
 "rMa" = (
@@ -15946,14 +15946,14 @@
 /obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/button/remote/blast_door{
+/obj/structure/machinery/button/remote/blast_door{
 	id = "cryo_outpost_shutter_entrance_main_in";
 	pixel_y = 36;
 	dir = 1;
 	pixel_x = 6;
 	req_one_access = list(244)
 	},
-/obj/structure/machinery/machinery/button/remote/blast_door{
+/obj/structure/machinery/button/remote/blast_door{
 	id = "cryo_outpost_shutter_entrance_main_out";
 	pixel_y = 24;
 	dir = 1;
@@ -15966,7 +15966,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/entrance_main)
 "rOx" = (
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -15990,7 +15990,7 @@
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/outside/surface)
 "rQA" = (
-/obj/structure/machinery/machinery/shipsensors,
+/obj/structure/machinery/shipsensors,
 /turf/simulated/floor/airless,
 /area/cryo_outpost/inside/sensors_iff)
 "rRo" = (
@@ -16063,7 +16063,7 @@
 "rTq" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/door/blast/regular{
+/obj/structure/machinery/door/blast/regular{
 	dir = 4;
 	id = "cryo_outpost_blastdoor_labs"
 	},
@@ -16084,7 +16084,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/botany)
 "rTU" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/random/dirt_75,
@@ -16098,7 +16098,7 @@
 /area/cryo_outpost/inside/botany)
 "rVG" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/oxygen,
+/obj/structure/machinery/portable_atmospherics/canister/empty/oxygen,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
 /area/cryo_outpost/inside/habitation_east)
@@ -16117,7 +16117,7 @@
 /area/cryo_outpost/inside/hallway_west)
 "rWO" = (
 /obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/machinery/machinery/light/broken,
+/obj/structure/machinery/light/broken,
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/habitation_west)
 "rXJ" = (
@@ -16128,7 +16128,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/camera/network/cryo_outpost{
+/obj/structure/machinery/camera/network/cryo_outpost{
 	dir = 4;
 	c_tag = "Labs, RnD"
 	},
@@ -16152,7 +16152,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/power/apc/east{
+/obj/structure/machinery/power/apc/east{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -16181,7 +16181,7 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
 	},
-/obj/structure/machinery/machinery/chem_master,
+/obj/structure/machinery/chem_master,
 /turf/simulated/floor/carpet/rubber,
 /area/cryo_outpost/inside/labs_pharmacy)
 "scv" = (
@@ -16198,17 +16198,17 @@
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/cave)
 "scC" = (
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/entrance_main)
 "scV" = (
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/glass_research{
+/obj/structure/machinery/door/airlock/glass_research{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -16234,7 +16234,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -16255,7 +16255,7 @@
 /turf/simulated/wall/r_wall,
 /area/cryo_outpost/inside/hallway_central)
 "sfy" = (
-/obj/structure/machinery/machinery/power/smes/buildable/third_party_shuttle,
+/obj/structure/machinery/power/smes/buildable/third_party_shuttle,
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/labs_maint_e)
@@ -16266,7 +16266,7 @@
 /area/cryo_outpost/outside/surface)
 "sgh" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/emergency,
+/obj/structure/machinery/light/small/emergency,
 /obj/effect/decal/cleanable/generic{
 	pixel_x = 2;
 	pixel_y = 23
@@ -16298,7 +16298,7 @@
 /obj/item/storage/box/unique/sharps{
 	pixel_y = 4
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -16317,7 +16317,7 @@
 /area/cryo_outpost/inside/habitation_west)
 "sja" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/broken{
+/obj/structure/machinery/light/small/broken{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -16347,7 +16347,7 @@
 	pixel_x = 4
 	},
 /obj/effect/floor_decal/corner_wide/green,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -16444,7 +16444,7 @@
 	dir = 4
 	},
 /obj/structure/bed/stool/chair,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -16503,7 +16503,7 @@
 "spE" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -16540,7 +16540,7 @@
 	master_tag = "cryo_outpost_co2";
 	name = "cryo_outpost_co2"
 	},
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/visible/yellow{
+/obj/structure/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -16558,7 +16558,7 @@
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -16590,7 +16590,7 @@
 "sut" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -16607,7 +16607,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/maint_warehouse)
 "svg" = (
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_door/red{
@@ -16629,7 +16629,7 @@
 	pixel_x = -1;
 	pixel_y = 3
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -16653,14 +16653,14 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/door/airlock/research{
+/obj/structure/machinery/door/airlock/research{
 	dir = 4;
 	req_one_access = list(244)
 	},
@@ -16699,7 +16699,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engineering)
 "sxQ" = (
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -16756,7 +16756,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/labs_maint_e)
 "sAv" = (
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow{
@@ -16778,7 +16778,7 @@
 /area/cryo_outpost/inside/canteen)
 "sBT" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /obj/random/dirt_75,
@@ -16879,7 +16879,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small/broken{
+/obj/structure/machinery/light/small/broken{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -16921,7 +16921,7 @@
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/outside/surface)
 "sOI" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -16959,7 +16959,7 @@
 	},
 /area/cryo_outpost/inside/labs_surgery)
 "sRr" = (
-/obj/structure/machinery/machinery/papershredder,
+/obj/structure/machinery/papershredder,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_rnd)
 "sSo" = (
@@ -16971,7 +16971,7 @@
 /turf/simulated/wall,
 /area/cryo_outpost/inside/maint_medbay)
 "sTs" = (
-/obj/structure/machinery/machinery/light/colored/decayed/dimmed,
+/obj/structure/machinery/light/colored/decayed/dimmed,
 /obj/effect/floor_decal/corner/beige{
 	dir = 10
 	},
@@ -17028,7 +17028,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/engineering)
 "sXR" = (
-/obj/structure/machinery/machinery/atmospherics/unary/freezer,
+/obj/structure/machinery/atmospherics/unary/freezer,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_n)
 "sYn" = (
@@ -17084,7 +17084,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/maint_warehouse)
 "taR" = (
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 1
 	},
 /obj/random/dirt_75,
@@ -17094,7 +17094,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/warehouse)
 "tby" = (
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -17113,7 +17113,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/labs_cryo_s)
 "tdb" = (
-/obj/structure/machinery/machinery/cryopod,
+/obj/structure/machinery/cryopod,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/habitation_west)
@@ -17132,10 +17132,10 @@
 /area/cryo_outpost/inside/habitation_west)
 "tee" = (
 /obj/structure/table/steel,
-/obj/structure/machinery/machinery/cell_charger{
+/obj/structure/machinery/cell_charger{
 	pixel_y = 10
 	},
-/obj/structure/machinery/machinery/recharger{
+/obj/structure/machinery/recharger{
 	pixel_x = 14;
 	pixel_y = 10
 	},
@@ -17149,7 +17149,7 @@
 /area/cryo_outpost/inside/labs_surgery)
 "tfz" = (
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/structure/machinery/machinery/door/blast/shutters{
+/obj/structure/machinery/door/blast/shutters{
 	id = "cryo_outpost_shutter_entrance_main_out"
 	},
 /turf/simulated/floor/plating/asteroid,
@@ -17182,7 +17182,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/botany)
 "tiw" = (
@@ -17224,7 +17224,7 @@
 /area/cryo_outpost/inside/maint_engineering)
 "tkG" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/entrance_aux_west)
 "tkN" = (
@@ -17276,7 +17276,7 @@
 /obj/effect/floor_decal/corner/grey/full{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -17311,7 +17311,7 @@
 	master_tag = "cryo_outpost_co2";
 	name = "cryo_outpost_co2"
 	},
-/obj/structure/machinery/machinery/atmospherics/unary/outlet_injector{
+/obj/structure/machinery/atmospherics/unary/outlet_injector{
 	dir = 8
 	},
 /obj/random/dirt_75,
@@ -17322,7 +17322,7 @@
 	master_tag = "cryo_outpost_co2";
 	name = "cryo_outpost_co2"
 	},
-/obj/structure/machinery/machinery/computer/general_air_control/large_tank_control/terminal{
+/obj/structure/machinery/computer/general_air_control/large_tank_control/terminal{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -17331,7 +17331,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -17373,7 +17373,7 @@
 /area/cryo_outpost/inside/canteen)
 "tsE" = (
 /obj/effect/floor_decal/corner/pink/diagonal,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -17385,7 +17385,7 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -17402,8 +17402,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass_engineering{
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass_engineering{
 	req_one_access = list(244)
 	},
 /obj/structure/cable{
@@ -17447,7 +17447,7 @@
 /area/cryo_outpost/inside/labs_cryo_s)
 "tvI" = (
 /obj/effect/floor_decal/industrial/warning/dust,
-/obj/structure/machinery/machinery/button/remote/blast_door{
+/obj/structure/machinery/button/remote/blast_door{
 	id = "cryo_outpost_shutter_entrance_aux_west_out";
 	pixel_x = -20;
 	dir = 8
@@ -17464,7 +17464,7 @@
 /area/cryo_outpost/inside/engineering)
 "twr" = (
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/structure/machinery/machinery/door/blast/shutters{
+/obj/structure/machinery/door/blast/shutters{
 	dir = 2;
 	id = "cryo_outpost_shutter_entrance_aux_west_out"
 	},
@@ -17478,7 +17478,7 @@
 /area/cryo_outpost/inside/engineering)
 "twt" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/light/colored/dying{
+/obj/structure/machinery/light/colored/dying{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -17545,7 +17545,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/structure/closet/crate/loot,
-/obj/structure/machinery/machinery/light/colored/decayed/dimmed{
+/obj/structure/machinery/light/colored/decayed/dimmed{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -17554,10 +17554,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/glass{
+/obj/structure/machinery/door/airlock/glass{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -17612,9 +17612,9 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_offices)
 "tCc" = (
-/obj/structure/machinery/machinery/space_heater,
+/obj/structure/machinery/space_heater,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/colored/dying{
+/obj/structure/machinery/light/colored/dying{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -17627,7 +17627,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -17636,7 +17636,7 @@
 /area/cryo_outpost/inside/hallway_west)
 "tDH" = (
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/structure/machinery/machinery/door/blast/shutters{
+/obj/structure/machinery/door/blast/shutters{
 	dir = 2;
 	id = "cryo_outpost_shutter_entrance_aux_east_in"
 	},
@@ -17663,11 +17663,11 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/labs_maint_w)
 "tGq" = (
-/obj/structure/machinery/machinery/optable,
+/obj/structure/machinery/optable,
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/white,
@@ -17721,7 +17721,7 @@
 	pixel_x = 2;
 	pixel_y = 3
 	},
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 8
 	},
 /obj/random/dirt_75,
@@ -17730,8 +17730,8 @@
 /area/cryo_outpost/inside/engi_atmos)
 "tJU" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/machinery/machinery/appliance/cooker/grill,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/appliance/cooker/grill,
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/white,
@@ -17739,7 +17739,7 @@
 "tKe" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/floor_decal/industrial/outline/engineering,
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 1
 	},
 /obj/random/dirt_75,
@@ -17749,8 +17749,8 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engineering)
 "tLn" = (
-/obj/structure/machinery/machinery/iv_drip,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/iv_drip,
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -17772,7 +17772,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/labs_hallway)
 "tNY" = (
-/obj/structure/machinery/machinery/photocopier,
+/obj/structure/machinery/photocopier,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/security)
 "tOk" = (
@@ -17782,7 +17782,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/cryo_outpost/inside/warehouse)
 "tOn" = (
-/obj/structure/machinery/machinery/door/window/southleft{
+/obj/structure/machinery/door/window/southleft{
 	req_one_access = list(244)
 	},
 /obj/effect/floor_decal/corner/pink{
@@ -17806,7 +17806,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -17832,7 +17832,7 @@
 	pixel_x = 7;
 	pixel_y = 5
 	},
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -17879,10 +17879,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -17896,7 +17896,7 @@
 	pixel_y = 7;
 	pixel_x = -2
 	},
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -17905,7 +17905,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/alarm/west{
+/obj/structure/machinery/alarm/west{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled,
@@ -18027,12 +18027,12 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/habitation_west)
 "ucA" = (
-/obj/structure/machinery/machinery/light/broken,
+/obj/structure/machinery/light/broken,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_maint_e)
 "udd" = (
@@ -18055,7 +18055,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/security)
 "uea" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/hidden{
+/obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
@@ -18072,8 +18072,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/engi_atmos)
 "ufl" = (
@@ -18150,7 +18150,7 @@
 	pixel_x = 7;
 	pixel_y = 5
 	},
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -18173,7 +18173,7 @@
 	},
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/eva)
@@ -18181,7 +18181,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/random/dirt_75,
@@ -18207,17 +18207,17 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/glass{
+/obj/structure/machinery/door/airlock/glass{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/habitation_east)
 "unp" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/vending/hydroseeds,
+/obj/structure/machinery/vending/hydroseeds,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/botany)
 "unw" = (
@@ -18237,14 +18237,14 @@
 	},
 /area/cryo_outpost/inside/canteen)
 "unF" = (
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_n)
 "uoi" = (
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -18307,7 +18307,7 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -18337,7 +18337,7 @@
 /area/cryo_outpost/inside/maint_engineering)
 "usB" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/seed_extractor,
+/obj/structure/machinery/seed_extractor,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/botany)
 "usO" = (
@@ -18368,7 +18368,7 @@
 /turf/unsimulated/marker/red,
 /area/cryo_outpost/outside/cave)
 "uuh" = (
-/obj/structure/machinery/machinery/power/emitter{
+/obj/structure/machinery/power/emitter{
 	dir = 8
 	},
 /obj/random/dirt_75,
@@ -18379,8 +18379,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/research,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/research,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_surgery)
 "uvV" = (
@@ -18393,7 +18393,7 @@
 	pixel_x = 7;
 	pixel_y = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -18419,9 +18419,9 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/hallway_central)
 "uxC" = (
-/obj/structure/machinery/machinery/portable_atmospherics/hydroponics,
+/obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -18461,7 +18461,7 @@
 /obj/effect/floor_decal/industrial/hatch_tiny/yellow{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/surface)
 "uzL" = (
@@ -18484,7 +18484,7 @@
 	pixel_x = 7;
 	pixel_y = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -18521,22 +18521,22 @@
 	pixel_y = 13
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light/small{
+/obj/structure/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/habitation_west)
 "uEq" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/oxygen,
+/obj/structure/machinery/portable_atmospherics/canister/empty/oxygen,
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/surface)
 "uFa" = (
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -18662,7 +18662,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
@@ -18733,10 +18733,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -18746,7 +18746,7 @@
 /area/cryo_outpost/inside/warehouse)
 "uOV" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_door/red{
@@ -18778,7 +18778,7 @@
 	pixel_x = -9;
 	pixel_y = 5
 	},
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -18828,7 +18828,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/eva)
 "uSK" = (
-/obj/structure/machinery/machinery/computer/security/terminal/cryo_outpost{
+/obj/structure/machinery/computer/security/terminal/cryo_outpost{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue{
@@ -18837,12 +18837,12 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/security)
 "uSV" = (
-/obj/structure/machinery/machinery/portable_atmospherics/hydroponics/soil,
+/obj/structure/machinery/portable_atmospherics/hydroponics/soil,
 /turf/simulated/floor/exoplanet/grass,
 /area/cryo_outpost/outside/surface)
 "uVn" = (
 /obj/effect/floor_decal/corner_wide/green/diagonal,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -18878,7 +18878,7 @@
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/cave)
 "uWv" = (
-/obj/structure/machinery/machinery/light/broken,
+/obj/structure/machinery/light/broken,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_n)
 "uXo" = (
@@ -18912,7 +18912,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/warehouse)
 "uYx" = (
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/air,
+/obj/structure/machinery/portable_atmospherics/canister/empty/air,
 /obj/random/dirt_75,
 /obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 4
@@ -18969,7 +18969,7 @@
 	pixel_y = 7
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
@@ -19006,7 +19006,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/structure/table/standard,
@@ -19061,7 +19061,7 @@
 /obj/structure/bed/stool/chair/office/bridge/generic{
 	dir = 8
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -19080,14 +19080,14 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/white,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_rnd)
 "vfP" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/item/trash/cigbutt{
@@ -19097,13 +19097,13 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/maint_botany)
 "vgp" = (
-/obj/structure/machinery/machinery/computer/ship/sensors/terminal,
+/obj/structure/machinery/computer/ship/sensors/terminal,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/comms)
 "vhj" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/pink,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/item/reagent_scanner{
@@ -19117,7 +19117,7 @@
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/item/clothing/suit/armor/carrier/generic,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/random/civgun,
@@ -19168,7 +19168,7 @@
 /area/cryo_outpost/outside/surface)
 "vjI" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_door/red{
@@ -19180,9 +19180,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/engineering)
 "vlL" = (
-/obj/structure/machinery/machinery/optable,
+/obj/structure/machinery/optable,
 /mob/living/carbon/human/vatgrown,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/white,
@@ -19191,14 +19191,14 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/engineering)
 "vmJ" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
+/obj/structure/machinery/light,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/habitation_east)
@@ -19214,7 +19214,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /obj/structure/door_assembly/door_assembly_mhatch,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_maint_e)
@@ -19254,7 +19254,7 @@
 	dir = 9
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/camera/network/cryo_outpost{
+/obj/structure/machinery/camera/network/cryo_outpost{
 	dir = 4;
 	c_tag = "Hallway, Central, EVA"
 	},
@@ -19299,7 +19299,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /obj/structure/table/stone/marble,
 /obj/item/reagent_containers/glass/beaker/pitcher/coffee{
 	pixel_x = 5;
@@ -19413,7 +19413,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -19422,10 +19422,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -19445,7 +19445,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/camera/network/cryo_outpost{
+/obj/structure/machinery/camera/network/cryo_outpost{
 	dir = 4;
 	c_tag = "Hallway, Central, Security"
 	},
@@ -19514,7 +19514,7 @@
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/cave)
 "vGL" = (
-/obj/structure/machinery/machinery/clonepod,
+/obj/structure/machinery/clonepod,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_rnd)
@@ -19542,7 +19542,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -19595,7 +19595,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -19627,7 +19627,7 @@
 /area/cryo_outpost/inside/botany)
 "vNJ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/seed_storage/garden,
+/obj/structure/machinery/seed_storage/garden,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/botany)
 "vOr" = (
@@ -19647,7 +19647,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/camera/network/cryo_outpost{
+/obj/structure/machinery/camera/network/cryo_outpost{
 	dir = 8;
 	c_tag = "Labs, Hallway"
 	},
@@ -19686,7 +19686,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/labs_surgery)
 "vQQ" = (
-/obj/structure/machinery/machinery/telecomms/allinone/ship,
+/obj/structure/machinery/telecomms/allinone/ship,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/comms)
 "vRf" = (
@@ -19715,7 +19715,7 @@
 /turf/simulated/floor/wood/bamboo,
 /area/cryo_outpost/inside/labs_offices)
 "vRI" = (
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
@@ -19724,10 +19724,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch{
+/obj/structure/machinery/door/airlock/maintenance_hatch{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -19818,7 +19818,7 @@
 /area/cryo_outpost/inside/labs_maint_e)
 "was" = (
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -19868,7 +19868,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/hallway_central)
 "weV" = (
@@ -19912,7 +19912,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/alarm/east{
+/obj/structure/machinery/alarm/east{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled,
@@ -19933,7 +19933,7 @@
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/outside/surface)
 "wkK" = (
-/obj/structure/machinery/machinery/camera/network/cryo_outpost{
+/obj/structure/machinery/camera/network/cryo_outpost{
 	c_tag = "Outside, Entrance, Aux, West"
 	},
 /turf/simulated/floor/exoplanet/desert,
@@ -19966,7 +19966,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -19975,7 +19975,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engi_powergen)
 "wmr" = (
@@ -20001,8 +20001,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -20018,14 +20018,14 @@
 /area/cryo_outpost/inside/entrance_aux_west)
 "wpz" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/inside/entrance_aux_west)
 "wpE" = (
-/obj/structure/machinery/machinery/optable,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/optable,
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -20052,7 +20052,7 @@
 	pixel_x = 7;
 	pixel_y = 5
 	},
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -20063,7 +20063,7 @@
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/outside/surface)
 "wqu" = (
-/obj/structure/machinery/machinery/power/terminal{
+/obj/structure/machinery/power/terminal{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -20102,7 +20102,7 @@
 	dir = 10
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/hallway_west)
 "wuF" = (
@@ -20141,7 +20141,7 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_surgery)
 "wwF" = (
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -20168,7 +20168,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk/indoor/planks,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/wood/maple,
@@ -20199,7 +20199,7 @@
 "wzV" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/air,
+/obj/structure/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/full,
 /area/cryo_outpost/inside/habitation_east)
 "wAp" = (
@@ -20226,13 +20226,13 @@
 "wAM" = (
 /obj/effect/floor_decal/corner_wide/green/diagonal,
 /obj/structure/table/standard,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/medical)
 "wBu" = (
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -20263,7 +20263,7 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_rnd)
 "wFy" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/visible/yellow{
+/obj/structure/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
 /obj/effect/map_effect/window_spawner/full/reinforced/grille,
@@ -20273,7 +20273,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -20286,7 +20286,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -20295,7 +20295,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -20304,10 +20304,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/glass_engineering{
+/obj/structure/machinery/door/airlock/glass_engineering{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -20320,7 +20320,7 @@
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_rnd)
 "wIc" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/manifold/visible{
+/obj/structure/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
 /obj/random/dirt_75,
@@ -20346,7 +20346,7 @@
 "wIH" = (
 /obj/structure/closet,
 /obj/effect/floor_decal/corner_wide/green/diagonal,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/outfit/admin/generic/medical,
@@ -20385,15 +20385,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/maint_entrance)
 "wLK" = (
-/obj/structure/machinery/machinery/light/small,
+/obj/structure/machinery/light/small,
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/inside/entrance_main)
 "wLW" = (
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -20473,7 +20473,7 @@
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red{
@@ -20510,7 +20510,7 @@
 "wRv" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/storage/box/unique/freezer/organcooler,
-/obj/structure/machinery/machinery/light/small/broken{
+/obj/structure/machinery/light/small/broken{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer{
@@ -20532,7 +20532,7 @@
 "wSq" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/door/blast/shutters{
+/obj/structure/machinery/door/blast/shutters{
 	id = "cryo_outpost_shutter_entrance_main_out"
 	},
 /turf/simulated/floor/plating/asteroid,
@@ -20631,7 +20631,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
 	},
-/obj/structure/machinery/machinery/vending/coffee/free,
+/obj/structure/machinery/vending/coffee/free,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/canteen)
 "wXy" = (
@@ -20658,10 +20658,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/research{
+/obj/structure/machinery/door/airlock/research{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -20756,17 +20756,17 @@
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/cave)
 "xdZ" = (
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 4
 	},
 /turf/simulated/floor/lino,
 /area/cryo_outpost/inside/canteen)
 "xea" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/simple/visible{
+/obj/structure/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /obj/random/dirt_75,
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
@@ -20776,7 +20776,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -20786,7 +20786,7 @@
 	master_tag = "cryo_outpost_co2";
 	name = "cryo_outpost_co2"
 	},
-/obj/structure/machinery/machinery/atmospherics/unary/vent_pump/siphon/atmos{
+/obj/structure/machinery/atmospherics/unary/vent_pump/siphon/atmos{
 	dir = 8
 	},
 /obj/random/dirt_75,
@@ -20825,7 +20825,7 @@
 "xfT" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/pink/diagonal,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/item/clothing/suit/storage/toggle/labcoat/accent/alt{
@@ -20895,7 +20895,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/warehouse)
 "xjQ" = (
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/beige{
@@ -20910,7 +20910,7 @@
 "xmw" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/pink,
-/obj/structure/machinery/machinery/microscope{
+/obj/structure/machinery/microscope{
 	pixel_x = -5;
 	pixel_y = 6
 	},
@@ -20920,8 +20920,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass_research,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass_research,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_hallway)
 "xmR" = (
@@ -20932,7 +20932,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -20966,11 +20966,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_maint_w)
 "xoJ" = (
-/obj/structure/machinery/machinery/iv_drip,
+/obj/structure/machinery/iv_drip,
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 10
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -20996,7 +20996,7 @@
 /turf/simulated/floor/exoplanet/barren,
 /area/cryo_outpost/outside/landing)
 "xpC" = (
-/obj/structure/machinery/machinery/power/apc/north{
+/obj/structure/machinery/power/apc/north{
 	req_access = null
 	},
 /obj/structure/cable{
@@ -21077,15 +21077,15 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/labs_cryo_s)
 "xvB" = (
-/obj/structure/machinery/machinery/atmospherics/portables_connector,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/machinery/atmospherics/portables_connector,
+/obj/structure/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_n)
 "xvL" = (
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/structure/table/standard,
@@ -21106,13 +21106,13 @@
 /area/cryo_outpost/inside/canteen)
 "xwx" = (
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/engineering)
 "xxt" = (
-/obj/structure/machinery/machinery/door/airlock/silver,
+/obj/structure/machinery/door/airlock/silver,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
@@ -21126,7 +21126,7 @@
 /turf/simulated/floor/exoplanet/plating,
 /area/cryo_outpost/outside/cave)
 "xyh" = (
-/obj/structure/machinery/machinery/light/colored/decayed,
+/obj/structure/machinery/light/colored/decayed,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
@@ -21136,7 +21136,7 @@
 /area/cryo_outpost/inside/labs_offices)
 "xyP" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 8
 	},
 /obj/random/dirt_75,
@@ -21149,10 +21149,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/service{
+/obj/structure/machinery/door/airlock/service{
 	dir = 4
 	},
 /obj/random/dirt_75,
@@ -21179,8 +21179,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass_service,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass_service,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/canteen)
@@ -21204,7 +21204,7 @@
 "xCn" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/pink/diagonal,
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 1
 	},
 /obj/item/paper_bin{
@@ -21241,7 +21241,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/labs_maint_w)
 "xFl" = (
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_door/red{
@@ -21256,10 +21256,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock{
+/obj/structure/machinery/door/airlock{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -21296,7 +21296,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/outside/cave)
 "xHS" = (
-/obj/structure/machinery/machinery/appliance/cooker/oven,
+/obj/structure/machinery/appliance/cooker/oven,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/canteen)
@@ -21311,15 +21311,15 @@
 /obj/effect/floor_decal/corner/dark_green/full{
 	dir = 8
 	},
-/obj/structure/machinery/machinery/vending/cigarette/hacked,
+/obj/structure/machinery/vending/cigarette/hacked,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/canteen)
 "xJl" = (
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/maintenance_hatch,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -21377,7 +21377,7 @@
 /area/cryo_outpost/inside/maint_warehouse)
 "xMt" = (
 /obj/effect/floor_decal/industrial/warning/dust,
-/obj/structure/machinery/machinery/button/remote/blast_door{
+/obj/structure/machinery/button/remote/blast_door{
 	id = "cryo_outpost_shutter_entrance_aux_east_out";
 	pixel_x = -20;
 	dir = 8
@@ -21405,7 +21405,7 @@
 /area/cryo_outpost/inside/maint_medbay)
 "xPK" = (
 /obj/item/stack/material/cardboard/full,
-/obj/structure/machinery/machinery/light/small/emergency{
+/obj/structure/machinery/light/small/emergency{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -21443,7 +21443,7 @@
 /area/cryo_outpost/outside/surface)
 "xRs" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/machinery/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating/asteroid,
 /area/cryo_outpost/outside/surface)
 "xRu" = (
@@ -21471,8 +21471,8 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 1
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid,
-/obj/structure/machinery/machinery/door/airlock/glass_medical,
+/obj/structure/machinery/door/firedoor/noid,
+/obj/structure/machinery/door/airlock/glass_medical,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/medical)
 "xSm" = (
@@ -21505,7 +21505,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/engi_atmos)
 "xTn" = (
-/obj/structure/machinery/machinery/light/colored/decayed{
+/obj/structure/machinery/light/colored/decayed{
 	dir = 4
 	},
 /turf/simulated/floor/wood/walnut,
@@ -21524,7 +21524,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/labs_maint_e)
 "xUk" = (
-/obj/structure/machinery/machinery/light/broken{
+/obj/structure/machinery/light/broken{
 	dir = 8
 	},
 /turf/simulated/floor/wood/walnut,
@@ -21553,7 +21553,7 @@
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/labs_surgery)
 "xWJ" = (
-/obj/structure/machinery/machinery/photocopier,
+/obj/structure/machinery/photocopier,
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 9
 	},
@@ -21569,7 +21569,7 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engineering)
 "xXB" = (
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/full{
@@ -21581,10 +21581,10 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/airlock/glass_research{
+/obj/structure/machinery/door/airlock/glass_research{
 	dir = 4;
 	req_one_access = list(244)
 	},
@@ -21636,7 +21636,7 @@
 /turf/simulated/floor/carpet/darkblue,
 /area/cryo_outpost/inside/canteen)
 "yaO" = (
-/obj/structure/machinery/machinery/atmospherics/pipe/manifold/hidden,
+/obj/structure/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/labs_cryo_n)
 "ybu" = (
@@ -21644,7 +21644,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/cryo_outpost/inside/comms)
 "ydE" = (
-/obj/structure/machinery/machinery/light/small{
+/obj/structure/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/exoplanet/barren,
@@ -21656,7 +21656,7 @@
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 6
 	},
-/obj/structure/machinery/machinery/light{
+/obj/structure/machinery/light{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red,
@@ -21701,7 +21701,7 @@
 /obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/button/remote/blast_door{
+/obj/structure/machinery/button/remote/blast_door{
 	id = "cryo_outpost_blastdoor_labs";
 	pixel_x = 20;
 	dir = 4;
@@ -21725,12 +21725,12 @@
 /turf/simulated/floor/plating,
 /area/cryo_outpost/inside/engineering)
 "yjd" = (
-/obj/structure/machinery/machinery/photocopier,
+/obj/structure/machinery/photocopier,
 /obj/effect/floor_decal/corner/pink/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/cryo_outpost/inside/labs_offices)
 "yjq" = (
-/obj/structure/machinery/machinery/alarm/north{
+/obj/structure/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline_door/red{
@@ -21746,7 +21746,7 @@
 /turf/simulated/floor/exoplanet/desert,
 /area/cryo_outpost/outside/surface)
 "yka" = (
-/obj/structure/machinery/machinery/photocopier,
+/obj/structure/machinery/photocopier,
 /turf/simulated/floor/tiled/dark/full,
 /area/cryo_outpost/inside/warehouse)
 "ykH" = (
@@ -21765,7 +21765,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
-/obj/structure/machinery/machinery/light,
+/obj/structure/machinery/light,
 /turf/simulated/floor/tiled,
 /area/cryo_outpost/inside/hallway_west)
 "ylg" = (
@@ -21779,13 +21779,13 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/structure/machinery/machinery/door/firedoor/noid{
+/obj/structure/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/machinery/machinery/door/airlock/engineering{
+/obj/structure/machinery/door/airlock/engineering{
 	dir = 4;
 	req_one_access = list(244)
 	},


### PR DESCRIPTION
Fixes the missing machinery in the map, machinery repath was a huge pr and we were expecting something like this

<img width="640" height="570" alt="what-has-the-dog-done" src="https://github.com/user-attachments/assets/243afd83-74b9-4705-b98e-8897d52fc78f" />

