### PR TITLE
Mindblanker Tweaks

### DIFF
--- a/code/datums/components/psionics/psiblock_drugs.dm
+++ b/code/datums/components/psionics/psiblock_drugs.dm
@@ -63,7 +63,7 @@
 		return
 
 	to_chat(minister, SPAN_BAD("Why should you care how [ministree] feels?"))
-	*moodlet_value = 0
+	*moodlet_value = *moodlet_value * 0.5
 
 /datum/component/timed_life/psiblock_drugs/proc/modify_ministry_receiving(ministree, minister, moodlet_value)
 	SIGNAL_HANDLER
@@ -71,7 +71,7 @@
 		return
 
 	to_chat(ministree, SPAN_BAD("You feel nothing from [minister]'s words."))
-	*moodlet_value = 0
+	*moodlet_value = *moodlet_value * 0.5
 
 /datum/component/timed_life/psiblock_drugs/proc/modify_leadership_empathy(leader, moodlet_value)
 	SIGNAL_HANDLER
@@ -79,7 +79,7 @@
 		return
 
 	to_chat(leader, SPAN_BAD("Why should you care about how others feel?"))
-	*moodlet_value = 0
+	*moodlet_value = *moodlet_value * 0.5
 
 
 /datum/component/timed_life/psiblock_drugs/process(seconds_per_tick)

--- a/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
+++ b/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
@@ -64,7 +64,7 @@
 		return
 
 	to_chat(minister, SPAN_BAD("Why should you care how [ministree] feels?"))
-	*moodlet_value = 0
+	*moodlet_value = *moodlet_value * 0.5
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker/proc/modify_ministry_receiving(ministree, minister, moodlet_value)
 	SIGNAL_HANDLER
@@ -72,7 +72,7 @@
 		return
 
 	to_chat(ministree, SPAN_BAD("You feel nothing from [minister]'s words."))
-	*moodlet_value = 0
+	*moodlet_value = *moodlet_value * 0.5
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker/proc/modify_leadership_empathy(leader, moodlet_value)
 	SIGNAL_HANDLER
@@ -80,7 +80,7 @@
 		return
 
 	to_chat(leader, SPAN_BAD("Why should you care about how others feel?"))
-	*moodlet_value = 0
+	*moodlet_value = *moodlet_value * 0.5
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker_lethal
 	name = "lethal mind blanker"

--- a/html/changelogs/hellfirejag-mindblanker-tweaks.yml
+++ b/html/changelogs/hellfirejag-mindblanker-tweaks.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - balance: "Tweaked the empathy penalty from mindblankers and PsiProtect drugs to only cut the morale modifiers from Ministry and Leadership in half, rather than fully negate them."


### PR DESCRIPTION
This was kind of a harsh mechanic to surprise players with, and turns out it doesn't feel that great to tell them "Surprise your skill points don't matter here". So this PR tweaks the "Empathy Penalty" from Mindblanker and PsiProtect pills to 'only' cut the morale modifier from those skills in half, rather than fully negating it.