### PR TITLE
Surgery Attack Fix

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -140,3 +140,6 @@
 
 /// Signal raised against a character attempting to deliver a speech.
 #define COMSIG_GET_LEADERSHIP_MODIFIERS "get_leadership_modifiers"
+
+/// Signal raised against an item being used to attack a mob, and can optionally allow components to interrupt the attack by setting the handled pointer to TRUE
+#define COMSIG_MOB_ATTACKBY "mob_attackby"

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -85,19 +85,25 @@ This calls [atom/proc/tool_act], among others.
 		return FALSE
 
 	var/selected_zone = user.zone_sel ? user.zone_sel.selecting : BP_CHEST
-	var/operating = can_operate(src)
-	if(operating == SURGERY_SUCCESS)
-		if(do_surgery(src, user, attacking_item))
-			return TRUE
-		else
-			return attacking_item.attack(src, user, selected_zone) //This is necessary to make things like health analyzers work. -mattatlas
-	if(operating == SURGERY_FAIL)
-		if(do_surgery(src, user, attacking_item, TRUE))
-			return TRUE
-		else
-			return attacking_item.attack(src, user, selected_zone)
-	else
+	var/handled = FALSE
+	SEND_SIGNAL(attacking_item, COMSIG_MOB_ATTACKBY, user, src, selected_zone, &handled)
+	if (handled)
+		return TRUE
+
+	// Skip surgery checks entirely on harm intent.
+	if (user.a_intent == I_HURT)
 		return attacking_item.attack(src, user, selected_zone)
+
+	var/operating = can_operate(src)
+	switch (operating)
+		if(SURGERY_SUCCESS)
+			do_surgery(src, user, attacking_item)
+			return TRUE
+		if(SURGERY_FAIL)
+			do_surgery(src, user, attacking_item, TRUE)
+			return TRUE
+		if(SURGERY_IGNORE)
+			return user.a_intent == I_HELP ? TRUE : attacking_item.attack(src, user, selected_zone)
 
 /mob/living/carbon/human/attackby(obj/item/attacking_item, mob/user, params)
 	if(user == src && user.a_intent == I_GRAB && zone_sel?.selecting == BP_MOUTH && can_devour(attacking_item, silent = TRUE))

--- a/code/datums/components/medical/medicalAnalyzer.dm
+++ b/code/datums/components/medical/medicalAnalyzer.dm
@@ -52,6 +52,18 @@
 	if(!isobj(parent))
 		return
 	owner = parent
+	RegisterSignal(parent, COMSIG_MOB_ATTACKBY, PROC_REF(handle_attackby), override = TRUE)
+
+/datum/component/health_analyzer/Destroy()
+	owner = null
+	UnregisterSignal(parent, COMSIG_MOB_ATTACKBY)
+	return ..()
+
+/datum/component/health_analyzer/proc/handle_attackby(obj/item/attacking_item, mob/user, mob/living/target, target_zone, handled)
+	SIGNAL_HANDLER
+	*handled = TRUE
+	// StrongDMM can't tell that this proc will immediately return control to the caller. Oh well.
+	UNLINT(attack(target, user, target_zone))
 
 /datum/component/health_analyzer/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -85,6 +97,8 @@
 			return TRUE
 
 /datum/component/health_analyzer/proc/attack(mob/living/target_mob, mob/living/user, target_zone)
+	// This proc has to run async in order to immediately return control to the caller with the handled reply.
+	set waitfor = FALSE
 	sound_scan = TRUE
 
 	user.visible_message("\The [user] starts scanning [user == target_mob ? "themself" : "\the [target_mob]"] with \the [owner].")
@@ -94,14 +108,21 @@
 	var/time = max(5 - (0.5 * (device_level + (anatomy ? anatomy : 1))), 1)
 
 	if(do_after(user, time SECONDS, target_mob, DO_UNIQUE))
+		// These have to be rechecked since this proc is now in async.
+		if (!istype(user) || !istype(target_mob))
+			return
 		flick("[owner.icon_state]-scan", owner)
 
 		health_scan_mob(target_mob, user, FALSE, sound_scan = sound_scan)
 		ui_interact(user)
 
 		owner.add_fingerprint(user)
-	else
-		user.visible_message("\The [user] stops scanning \the [target_mob].")
+		return
+
+	// These have to be rechecked since this proc is now in async.
+	if (!istype(user) || !istype(target_mob))
+		return
+	user.visible_message("\The [user] stops scanning \the [target_mob].")
 
 /datum/component/health_analyzer/proc/attack_self(mob/user)
 	ui_interact(user)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -33,12 +33,6 @@ BREATH ANALYZER
 	. += "Health analyzers are faster at scanning people, the higher grade it is and the higher the anatomy skill of the user is."
 	. += "Clicking it in hand will pull up the last scan, if it has not been cleared."
 
-/obj/item/healthanalyzer/attack(mob/living/target_mob, mob/living/user, target_zone)
-	var/datum/component/health_analyzer/h_analyzer = src.GetComponent(/datum/component/health_analyzer)
-	if(!h_analyzer)
-		return
-	h_analyzer.attack(target_mob, user, target_zone)
-
 /obj/item/healthanalyzer/attack_self(mob/user)
 	var/datum/component/health_analyzer/h_analyzer = src.GetComponent(/datum/component/health_analyzer)
 	if(!h_analyzer)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -552,8 +552,8 @@ By design, d1 is the smallest direction and d2 is the highest
 
 		if(affecting.open != 0)
 			if(can_operate(H))
-				if(do_surgery(H,user,src))
-					return TRUE
+				do_surgery(H,user,src)
+				return user.a_intent != I_HURT
 		else
 			if(!BP_IS_ROBOTIC(affecting))
 				if(affecting.is_bandaged())

--- a/html/changelogs/hellfirejag-intent-fixes.yml
+++ b/html/changelogs/hellfirejag-intent-fixes.yml
@@ -1,0 +1,6 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed a bug where guessing the wrong tool during surgery results in attacking the patient."
+  - bugfix: "Attempting to use an item on someone while in HELP intent will now never ATTACK them."
+  - bugfix: "Being on HARM intent now skips all surgery steps in order to proceed directly to brutal murder."


### PR DESCRIPTION
This PR fixes a very annoying bug in that being on help intent does not prevent Attack actions. Apparently this was caused a long time ago by a PR to make it so that health analyzers still work when used on someone laying on a surgery table. There's probably going to be some niche casualties in this because the Attack proc is excessively overused by things that aren't related to physical combat at all, but that can be bypassed by just swapping over to any intent other than HELP. Essentially this PR fixes Intents so that it's physically impossible to HARM another person with an object if you're on HELP INTENT.

I put in a Signal check to allow Components of items to directly intercept the checks, such as the Health Analyzer component. Which means at least Health Analyzers and things operating on ECS methods are free to forcibly bypass the HELP/HARM check as desired.

Yes I have tested this PR.