### PR TITLE
Fixes an unguarded nullref in Fake Crew Arrival Announcement service

### DIFF
--- a/code/datums/uplink/announcements.dm
+++ b/code/datums/uplink/announcements.dm
@@ -54,7 +54,7 @@
 		record.sex = I.sex
 		record.employer = I.employer_faction
 		var/datum/faction/id_faction = SSjobs.name_factions[I.employer_faction]
-		var/faction_abbreviation = id_faction.title_suffix
+		var/faction_abbreviation = id_faction?.title_suffix
 		var/assignment = "[I.assignment][ faction_abbreviation ? " ([faction_abbreviation])" : ""]"
 		record.rank = assignment
 		record.real_rank = assignment

--- a/html/changelogs/llywelwyn-crewarrival.yml
+++ b/html/changelogs/llywelwyn-crewarrival.yml
@@ -1,0 +1,4 @@
+author: Llywelwyn
+delete-after: True
+changes:
+  - bugfix: "Fake Crew Arrival Announcement uplink service now works even with an invalid employer faction."


### PR DESCRIPTION
fixes #22334 

  - bugfix: "Fake Crew Arrival Announcement uplink service now works even with an invalid employer faction."