### PR TITLE
Fixes modular guns not self-recharging until first shot is fired

### DIFF
--- a/code/modules/projectiles/modular/laser_base.dm
+++ b/code/modules/projectiles/modular/laser_base.dm
@@ -413,6 +413,7 @@
 	A.forceMove(an)
 	an.item = A
 	A.updatetype()
+	A.try_recharge()
 	A.pin = null
 	gun_mods = null
 	focusing_lens = null

--- a/html/changelogs/llywelwyn-self-recharge-modular.yml
+++ b/html/changelogs/llywelwyn-self-recharge-modular.yml
@@ -1,0 +1,6 @@
+author: llywelwyn
+
+delete-after: True
+
+changes:
+  - bugfix: "Modular energy guns with a reactor now self-recharge from assembly, instead of only starting after the first shot is fired."


### PR DESCRIPTION
fixes #22025 

  - bugfix: "Modular energy guns with a reactor now self-recharge from assembly, instead of only starting after the first shot is fired."

try_recharge is currently only triggered on fire and loops until charge is full. this triggers it when a modular gun is completed to initiate the recharging