### PR TITLE
Animates the disappearance of the lower half of the body when north-side leaning

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -46,6 +46,9 @@
 /// Sent when a mob rests.
 #define COMSIG_MOB_RESTED "mob_rested"
 
+/// Sent from /mob/proc/update_canmove() when the mob transitions into lying down.
+#define COMSIG_MOB_LYING_DOWN "mob_lying_down"
+
 /// From /obj/item/organ/external/take_damage. Updates the limb's colour matrix. Very laggy, so we do it on reaction to stuff.
 #define COMSIG_UPDATE_LIMB_IMAGE "update_limb_image"
 

--- a/code/datums/components/leanable.dm
+++ b/code/datums/components/leanable.dm
@@ -95,6 +95,7 @@
 			shift_pixel_x = 10
 	animate(src, pixel_x = shift_pixel_x, pixel_y = shift_pixel_y, time = 1)
 	if(direction == NORTH)
+		src.appearance_flags |= KEEP_TOGETHER
 		src.add_filter("cutout", 1, alpha_mask_filter(icon = icon('icons/effects/effects.dmi', "cutout")))
 	if(direction == SOUTH)
 		src.layer = ABOVE_DOOR_LAYER
@@ -105,7 +106,7 @@
 		SPAN_NOTICE("[src] leans against [lean_target]."),
 		SPAN_NOTICE("You lean against [lean_target]."),
 	)
-	RegisterSignals(src, list(COMSIG_MOVABLE_MOVED, COMSIG_MOB_RESISTED), PROC_REF(stop_leaning), src)
+	RegisterSignals(src, list(COMSIG_MOVABLE_MOVED, COMSIG_MOB_RESISTED, COMSIG_MOB_LYING_DOWN), PROC_REF(stop_leaning), src)
 
 /mob/living/proc/stop_leaning()
 	SIGNAL_HANDLER
@@ -116,11 +117,13 @@
 	UnregisterSignal(src, list(
 		COMSIG_MOVABLE_MOVED,
 		COMSIG_MOB_RESISTED,
+		COMSIG_MOB_LYING_DOWN,
 	))
 	SEND_SIGNAL(src, COMSIG_LIVING_STOPPED_LEANING)
 	to_chat(src, SPAN_NOTICE("You stop leaning on the wall."))
 	REMOVE_TRAIT(src, TRAIT_UNDENSE, TRAIT_SOURCE_WALL_LEANING)
 	REMOVE_TRAIT(src, TRAIT_LEANING, TRAIT_SOURCE_WALL_LEANING)
+	appearance_flags &= ~KEEP_TOGETHER
 	remove_filter("cutout")
 
 /datum/component/leanable/proc/stopped_leaning(datum/source)

--- a/code/datums/components/leanable.dm
+++ b/code/datums/components/leanable.dm
@@ -96,7 +96,8 @@
 	animate(src, pixel_x = shift_pixel_x, pixel_y = shift_pixel_y, time = 1)
 	if(direction == NORTH)
 		src.appearance_flags |= KEEP_TOGETHER
-		src.add_filter("cutout", 1, alpha_mask_filter(icon = icon('icons/effects/effects.dmi', "cutout")))
+		src.add_filter("cutout", 1, alpha_mask_filter(y = 0, icon = icon('icons/effects/effects.dmi', "white")))
+		animate(src.get_filter("cutout"), y = 10, time = 1, flags = ANIMATION_PARALLEL)
 	if(direction == SOUTH)
 		src.layer = ABOVE_DOOR_LAYER
 	set_density(FALSE)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -916,6 +916,8 @@
 
 	if( lying != lying_prev )
 		update_icon()
+		if(lying)
+			SEND_SIGNAL(src, COMSIG_MOB_LYING_DOWN)
 
 	return canmove
 

--- a/html/changelogs/llywelwyn-lean-layering.yml
+++ b/html/changelogs/llywelwyn-lean-layering.yml
@@ -1,0 +1,4 @@
+author: Llywelwyn
+delete-after: True
+changes:
+  - bugfix: "Leaning on the north side of a wall now correctly hides your lower body behind the wall instead of drawing you on top of it."

--- a/html/changelogs/llywelwyn-lean-layering.yml
+++ b/html/changelogs/llywelwyn-lean-layering.yml
@@ -2,3 +2,4 @@ author: Llywelwyn
 delete-after: True
 changes:
   - bugfix: "Leaning on the north side of a wall now correctly hides your lower body behind the wall instead of drawing you on top of it."
+  - code_imp: "Adds a COMSIG_MOB_LYING_DOWN signal, sent when a mob transitions into lying down."


### PR DESCRIPTION
fixes #22249 

- bugfix: "Leaning on the north side of a wall now correctly hides your lower body behind the wall instead of drawing you on top of it."
 - code_imp: "Adds a COMSIG_MOB_LYING_DOWN signal, sent when a mob transitions into lying down."

Cutout was previously only cutting out the base because KEEP_TOGETHER wasn't being applied. Adds the flag on lean, removes it on stop_lean. 

Animated the cutout while here. Applies a mask to the whole sprite, then animates it upwards in step with the lean itself, so the feet progressively disappear as they should.

https://github.com/user-attachments/assets/fec0a852-247a-4570-a6d1-60dda6fe6a3c

