### PR TITLE
Probably fixes most of the random map test failures

### DIFF
--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -182,6 +182,7 @@
 	for(var/obj/structure/machinery/door/firedoor/F in world)
 		var/turf/T = get_turf(F)
 		checks++
+		TEST_ASSERT_NOTNULL(T, "A turf does not exist under the firedoor at [F.x],[F.y],[F.z]")
 		var/firelock_increment = 0
 		for(var/obj/structure/machinery/door/firedoor/FD in T)
 			firelock_increment += 1

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -159,6 +159,8 @@
 	var/checks = 0
 	var/failed_checks = 0
 	for(var/obj/structure/machinery/door/airlock/A in world)
+		if(QDELETED(A))
+			continue
 		var/turf/T = get_turf(A)
 		checks++
 		TEST_ASSERT_NOTNULL(T, "A turf does not exist under the door at [A.x],[A.y],[A.z]")
@@ -180,6 +182,8 @@
 	var/checks = 0
 	var/failed_checks = 0
 	for(var/obj/structure/machinery/door/firedoor/F in world)
+		if(QDELETED(F))
+			continue
 		var/turf/T = get_turf(F)
 		checks++
 		TEST_ASSERT_NOTNULL(T, "A turf does not exist under the firedoor at [F.x],[F.y],[F.z]")

--- a/html/changelogs/llywelwyn-maptest-deleted-doors.yml
+++ b/html/changelogs/llywelwyn-maptest-deleted-doors.yml
@@ -1,0 +1,4 @@
+author: Llywelwyn
+delete-after: True
+changes:
+  - code_imp: "Door tests skip qdeleted doors, so they should no longer intermittently fail when landing zone generation clears a ruin."


### PR DESCRIPTION
ran tests on a loop for like 2 hours while i was doin bits and had no failures. granted this one will immediately fail for some other indiscernible reason im sure

1. generate_landing() creates a clearing landmark which has a late_initialize() to qdel anything it overlaps with. usually it doesn't overlap with things, but if there's a failure to find an appropriate landing site, it will just pop it down anywhere. this means it happens significantly more on more compact sites, like the listening outpost which seems to fail frequently
2. test runs before gc tick so qdelled stuff has a null location and is still found `in world`
3. tests loop for `door in world` and find doors at a null location, which obviously has a null turf, so the test fails
4. in the firedoor test this causes a runtime too because of a missing assertion

there are probably more reasons map tests fail given they've been failing for years but this seems to fix a major cause of them

- code_imp: "Door tests skip qdeleted doors, so they should no longer intermittently fail when landing zone generation clears a ruin."