### PR TITLE
Analyzer bugfixes

### DIFF
--- a/code/datums/components/medical/medicalAnalyzer.dm
+++ b/code/datums/components/medical/medicalAnalyzer.dm
@@ -88,7 +88,7 @@
 	var/obj/item/rig_module/containing_rig_module = owner.loc
 	if(!containing_rig_module)
 		return ..()
-	if(containing_rig_module?.holder?.wearer == user)
+	else if(containing_rig_module)
 		return UI_INTERACTIVE
 
 	return UI_CLOSE
@@ -113,6 +113,8 @@
 		user.visible_message("\The [user] stops scanning \the [target_mob].")
 
 /datum/component/health_analyzer/proc/attack_self(mob/user)
+	if(scan_title == "" || scan_title == null)
+		health_scan_mob(user, user, FALSE, sound_scan = sound_scan)
 	ui_interact(user)
 
 	owner.add_fingerprint(user)

--- a/html/changelogs/Bat-Analyzer.yml
+++ b/html/changelogs/Bat-Analyzer.yml
@@ -1,0 +1,5 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - bugfix: "Fixes non-hardsuit health analyzer runtime."
+  - bugfix: "Fixes hardsuit health analyzer not reliably self-scanning."


### PR DESCRIPTION
Fixes health analyzers NOT mounted on hardsuits (handheld, observer) not displaying TGUI on scan due to casting runtime. Fixes unrelated bug with self-scanning not playing nice.