### PR TITLE
Fixes bold/italics rendering in emotes and saved chatlog MIME type

### DIFF
--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -159,9 +159,9 @@
 	if (message)
 		log_emote("[name]/[key] : [message]")
 
-	message = process_chat_markup(message, list("~", "_"))
-	var/langchat_message = message
+	var/langchat_message = process_chat_markup(message, list("~", "_"))
 	message = format_emote(src, message)
+	message = process_chat_markup(message, list("~", "_"))
 	var/list/emote_viewers = list()
 	if(m_type == VISIBLE_MESSAGE)
 		visible_message(message, show_observers = do_show_observers)

--- a/html/changelogs/llywelwyn-chatlog.yml
+++ b/html/changelogs/llywelwyn-chatlog.yml
@@ -1,0 +1,5 @@
+author: Llywelwyn
+delete-after: True
+changes:
+  - bugfix: "Saved chat logs are now written with the correct text/html file type."
+  - bugfix: "Emote markup like *bold* and /italics/ once again renders in chat instead of showing literal tags."

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -616,7 +616,7 @@ class ChatRenderer {
       + '</body>\n'
       + '</html>\n';
     // Create and send a nice blob
-    const blob = new Blob([pageHtml], { type: 'text/plain' });
+    const blob = new Blob([pageHtml], { type: 'text/html' });
     const timestamp = new Date()
       .toISOString()
       .substring(0, 19)


### PR DESCRIPTION
format_emote has to come first, otherwise it will re-encode the markup into literals. however, the langchat_message does not want to have format_emote called on it. ergo, we have to either process the markup twice, once for each path, or we have to accept that one of the two will not support bold/italics. the perf from doing it twice is completely inconsequential

<img width="299" height="150" alt="image" src="https://github.com/user-attachments/assets/4a34a0ae-6895-4275-be53-586820fd5b7d" />


 - bugfix: "Saved chat logs are now written with the correct text/html file type."
 - bugfix: "Emote markup like *bold* and /italics/ once again renders in chat instead of showing literal tags."