### PR TITLE
Fixes Longbow shells exploding when mechs pick them up

### DIFF
--- a/code/modules/overmap/ship_weaponry/_ship_ammunition.dm
+++ b/code/modules/overmap/ship_weaponry/_ship_ammunition.dm
@@ -66,8 +66,11 @@
 
 /obj/item/ship_ammunition/attackby(obj/item/attacking_item, mob/user)
 	if(attacking_item.force > 10 && (ammunition_flags & SHIP_AMMO_FLAG_VERY_FRAGILE))
-		log_and_message_admins("[user] has caused the cookoff of [src] by attacking it with [attacking_item]!", user)
-		cookoff(FALSE)
+		if(istype(attacking_item, /obj/item/mecha_equipment/clamp))
+			return ..()
+		else
+			log_and_message_admins("[user] has caused the cookoff of [src] by attacking it with [attacking_item]!", user)
+			cookoff(FALSE)
 
 	else if(attacking_item.tool_behaviour == TOOL_PEN)
 		var/obj/item/pen/P = attacking_item

--- a/html/changelogs/LongbowMechFix-Fenodyree.yml
+++ b/html/changelogs/LongbowMechFix-Fenodyree.yml
@@ -1,0 +1,7 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes Longbow shells exploding when mechs pick them up."
+


### PR DESCRIPTION
Fixes #22578
Longbow attackby now calls it's parent, which made them explode because mech clamps are more than force 10.
