### PR TITLE
IPC Suit Cooler Size + Power Tweaks

### DIFF
--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -17,14 +17,25 @@
 
 	origin_tech = list(TECH_MAGNET = 2, TECH_MATERIAL = 2)
 
-	var/celltype = /obj/item/cell/high
+	// Type of cell the IPC cooling unit starts with.
+	var/celltype = /obj/item/cell/apc
 
 	matter = list(MATERIAL_ALUMINIUM = 25000, MATERIAL_GLASS = 3500)
-	var/on = 0				//is it turned on?
-	var/cover_open = 0		//is the cover open?
+
+	// Is it turned on?
+	var/on = 0
+	// Is the cover open?
+	var/cover_open = 0
+
 	var/obj/item/cell/cell
-	var/max_cooling = 24				//in degrees kelvin per second - probably don't need to mess with heat capacity here
-	var/charge_consumption = 8.3		//charge per second at max_cooling
+
+	// In degrees kelvin per second - probably don't need to mess with heat capacity here
+	var/max_cooling = 24
+
+	// Base charge consumption per second. Modified by how much cooling work the cooler is doing.
+	var/charge_consumption = 15.4
+
+	// Target to cool an IPC to.
 	var/thermostat = T20C
 
 	//TODO: make it heat up the surroundings when not in space
@@ -241,3 +252,6 @@
 
 /obj/item/suit_cooling_unit/no_cell
 	celltype = null
+
+/obj/item/suit_cooling_unit/hyper_cell // Mostly for special spawns, events, etc., so they don't have to worry about cell charge.
+	celltype = /obj/item/cell/hyper

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -1,7 +1,7 @@
 /obj/item/suit_cooling_unit
 	name = "portable suit cooling unit"
 	desc = "A portable heat sink and liquid cooled radiator that can be hooked up to a space suit's existing temperature controls to provide industrial levels of cooling."
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	icon = 'icons/obj/item/suitcooler.dmi'
 	icon_state = "suitcooler0"
 	item_state = "coolingpack"

--- a/html/changelogs/kermit-ipc-cooler-size.yml
+++ b/html/changelogs/kermit-ipc-cooler-size.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - qol: "Downsizes the IPC Suit Cooler from Bulky to Normal so they can fit in bags (on par with large oxygen tanks)."
+  - balance: "Downgrades the IPC Suit Cooler's cell to a heavy-duty cell (-50% charge capacity) and increases charge consumption modifer by 85% (result is: approx. 10 minutes cooling a cooler-less IPC; in ordinary EVA conditions, it still lasts ages, don't worry)."

--- a/html/changelogs/kermit-ipc-cooler-size.yml
+++ b/html/changelogs/kermit-ipc-cooler-size.yml
@@ -1,0 +1,6 @@
+author: kermit
+
+delete-after: True
+
+changes:
+  - qol: "Downsizes the IPC Suit Cooler from Bulky to Normal so they can fit in bags (on par with large oxygen tanks)."


### PR DESCRIPTION
This allows IPC suit coolers to fit inside of bags and be more easily used as a first response tool for IPCs who have had their coolers shot out, whether it be an IPC keeping one in their bag for self-stabilisation or a machinist lugging one around when responding to a call. 

The battery that spawns in suit coolers was reduced to a heavy-duty power cell (from 30,000 power storage to 15,000), and the maximum discharge rate was increased by 85%. 
- When cooling a cooler-less IPC, it lasts roooghly 10 minutes, which is still plenty long enough for 90% of incidents and only becomes problematic on expeditions.
- Under more ordinary EVA conditions, it still lasts ages.

Upgrading power cells is incredibly worthwhile, x2ing (high) or x4ing (super) or x6ing (hyper) these durations.