### PR TITLE
Shifts the teleporter to D2

### DIFF
--- a/html/changelogs/hazelmouse-bread.yml
+++ b/html/changelogs/hazelmouse-bread.yml
@@ -1,0 +1,5 @@
+author: hazelmouse
+
+delete-after: True
+changes:
+  - rscadd: "Shifted the teleporter to the central ring, to be more accessible. Replaced former position with maintenance."

--- a/maps/sccv_horizon/areas/horizon_areas_command.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_command.dm
@@ -136,7 +136,7 @@
 //Teleporter
 /area/horizon/command/teleporter
 	name = "Teleporter"
-	area_lighting = LIGHT_HIGHSEC_COLORS
+	area_lighting = LIGHT_CLINICAL_COLORS
 	icon_state = "teleporter"
 	horizon_deck = 1
 	area_blurb = "The air in here always feels charged with the subdued crackle of electricity, tasting faintly of ozone."


### PR DESCRIPTION
As title. It now fills that little empty area that is currently maintenance. Intended to be hyper-visible, given how important it is for everyone to know where the teleporter is given its present importance for expeditions and odysseys.

Its airlock can be bolted open, if it's desirable to keep the teleporter open in the absence of active staffing.

Ideally we wouldn't be so reliant on teleporting people around, but for now it deserves some visibility.

<img width="288" height="256" alt="image" src="https://github.com/user-attachments/assets/591765cc-d1d7-4464-bec9-f48503740360" />