### PR TITLE
High Gun Skill Fix

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -461,7 +461,7 @@ ABSTRACT_TYPE(/obj/item/gun)
 			break
 
 		var/acc = burst_accuracy[min(i, burst_accuracy.len)] - accuracy_decrease
-		var/disp = dispersion[min(i, dispersion.len)] + dispersion_increase
+		var/disp = max(0, dispersion[min(i, dispersion.len)] + dispersion_increase)
 		process_accuracy(projectile, user, target, acc, disp)
 
 		if(pointblank)

--- a/html/changelogs/hellfirejag-dispersion-fix.yml
+++ b/html/changelogs/hellfirejag-dispersion-fix.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed negative dispersion (from high gun skill) sometimes wrapping back around to inaccurate guns again."


### PR DESCRIPTION
This fixes a math error that caused sufficiently high firearms skill to wrap back around to less accurate guns. The fix is pretty simple, if the calculated dispersion (in degrees) is a negative number, it instead becomes 0. The dispersion math downstream of this effectively treats dispersion as a magnitude, meaning -15 degrees of dispersion was the same thing as 15 degrees, when the intended interaction was "Having -15 degrees of dispersion offsets the penalty from less accurate guns".