### PR TITLE
Tgui null checks

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -632,7 +632,8 @@ SUBSYSTEM_DEF(jobs)
 	SSrecords.remove_record_by_field("name", H.real_name)
 	SSrecords.reset_manifest()
 
-	log_and_message_admins("([H.mind.role_alt_title]) entered cryostorage.", user = H)
+	if (H.mind)
+		log_and_message_admins("([H.mind.role_alt_title]) entered cryostorage.", user = H)
 
 	//This should guarantee that ghosts don't spawn.
 	H.ckey = null

--- a/code/modules/tgui/external.dm
+++ b/code/modules/tgui/external.dm
@@ -71,7 +71,7 @@
  */
 /datum/proc/update_static_data_for_all_viewers()
 	for (var/datum/tgui/window as anything in open_uis)
-		window.send_full_update()
+		window?.send_full_update()
 
 /**
  * public

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -73,6 +73,7 @@
 		src.window_size = list(ui_x, ui_y)
 
 /datum/tgui/Destroy()
+	SStgui.all_uis -= src
 	user = null
 	src_object = null
 	return ..()

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -145,7 +145,7 @@
 		// the error message properly.
 		window.release_lock()
 		window.close(can_be_suspended)
-		src_object.ui_close(user)
+		src_object?.ui_close(user)
 		SEND_SIGNAL(src, COMSIG_TGUI_CLOSE, user)
 		SStgui.on_close(src)
 	state = null

--- a/html/changelogs/hellfirejag-tgui-harddels.yml
+++ b/html/changelogs/hellfirejag-tgui-harddels.yml
@@ -1,0 +1,5 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed hard dels caused by tgui windows failing to close themselves if their owner was deleted causing a runtime error."
+  - bugfix: "Fixed a runtime error caused when a character with a nonstandard job goes through cryo"


### PR DESCRIPTION
TGUI windows would runtime error and thus fail to delete themselves if the person holding the tgui window was deleted. Pretty simple fix. If there's no owner to inform that they need to remove a window, don't send them the command. 