### PR TITLE
Revert "Refactor do-not-merge CI check to run on merge queue"

### DIFF
--- a/.github/workflows/enforce_merge_blockers.yaml
+++ b/.github/workflows/enforce_merge_blockers.yaml
@@ -1,9 +1,8 @@
 name: "'Do Not Merge' Blockers"
 
 on:
-  merge_group:
-    branches:
-      - master
+  pull_request:
+    types: [synchronize, opened, labeled, unlabeled]
 
 jobs:
   donotmerge-blocker:

--- a/html/changelogs/fabiank3-refactore-prevent-merge-ci-check.yml
+++ b/html/changelogs/fabiank3-refactore-prevent-merge-ci-check.yml
@@ -1,6 +1,0 @@
-author: FabianK3
-
-delete-after: True
-
-changes:
-  - refactor: "Update the do-not-merge GitHub CI check to fail on merge, not while the PR is open."


### PR DESCRIPTION
Reverts Aurorastation/Aurora.3#22444

GitHub actions are being funny, this apparently doesn't work like that.