### PR TITLE
Splits Psi-protect pills into their own loadout selection

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/drugs_meds.dm
+++ b/code/modules/client/preference_setup/loadout/items/drugs_meds.dm
@@ -179,9 +179,6 @@
 	psych_meds["Orastabin pills"] = /obj/item/storage/pill_bottle/orastabin
 	psych_meds["Parvosil pills"] = /obj/item/storage/pill_bottle/parvosil
 	psych_meds["Corophenidate pills"] = /obj/item/storage/pill_bottle/corophenidate
-	psych_meds["Psi-protect pills"] = /obj/item/storage/pill_bottle/psi_protect/yomi_genetics
-	psych_meds["Psi-protect pills (cheap)"] = /obj/item/storage/pill_bottle/psi_protect/yomi_genetics/cheap
-	psych_meds["Psi-protect pills (expensive)"] = /obj/item/storage/pill_bottle/psi_protect/yomi_genetics/expensive
 	gear_tweaks += new /datum/gear_tweak/path(psych_meds)
 
 /datum/gear/drugs_meds/otc
@@ -217,3 +214,16 @@
 	legal_rec["Wulumunusha extract bottle"] = /obj/item/reagent_containers/food/condiment/wulumunusha
 	legal_rec["Ambrosia extract bottle"] = /obj/item/reagent_containers/food/condiment/ambrosia
 	gear_tweaks += new /datum/gear_tweak/path(legal_rec)
+
+/datum/gear/drugs_meds/psi_pills
+	display_name = "psi-protect pill selection"
+	description = "Select from the different kinds of YomiGenetics Psi-protect pills, used to protect against Acute Debilitating Psionic Interference and to treat other psionic related conditions such as psionic echoes."
+	path = /obj/item/storage/pill_bottle/psi_protect/yomi_genetics
+
+/datum/gear/drugs_meds/psi_pills/New()
+	..()
+	var/list/psipills = list()
+	psipills["Psi-protect Broad-Use pills"] = /obj/item/storage/pill_bottle/psi_protect/yomi_genetics/cheap
+	psipills["Psi-protect Personalized pills"] = /obj/item/storage/pill_bottle/psi_protect/yomi_genetics
+	psipills["Psi-protect Personalized Gold pills"] = /obj/item/storage/pill_bottle/psi_protect/yomi_genetics/expensive
+	gear_tweaks += new /datum/gear_tweak/path(psipills)

--- a/html/changelogs/greenjoe - psipillsplit.yml
+++ b/html/changelogs/greenjoe - psipillsplit.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Greenjoe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Splits the Psi-protect pills into their own selection in the loadout."


### PR DESCRIPTION
Moves the psi-protect pills out of the psych medicine selection to their own selection. Allows characters to continue to bring their normal medicine prescription but also select the psi-protect pills.