### PR TITLE
Makes cult constructs immune to pain

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs/constructs/cult_construct.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs/cult_construct.dm
@@ -88,6 +88,11 @@
 /mob/living/simple_animal/construct/get_bullet_impact_effect_type(var/def_zone)
 	return BULLET_IMPACT_METAL
 
+
+
+/mob/living/simple_animal/construct/adjustHalLoss(var/amount) // Constructs are purely PVP simple mobs, they shouldn't take pain as damage.
+	return
+
 /mob/living/simple_animal/construct/attack_generic(mob/user, damage, attack_message, environment_smash, armor_penetration, attack_flags, damage_type)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(istype(user, /mob/living/simple_animal/construct))

--- a/code/modules/mob/living/simple_animal/constructs/constructs/cult_construct.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs/cult_construct.dm
@@ -88,8 +88,6 @@
 /mob/living/simple_animal/construct/get_bullet_impact_effect_type(var/def_zone)
 	return BULLET_IMPACT_METAL
 
-
-
 /mob/living/simple_animal/construct/adjustHalLoss(var/amount) // Constructs are purely PVP simple mobs, they shouldn't take pain as damage.
 	return
 

--- a/html/changelogs/FenodyreeConstructBuff.yml
+++ b/html/changelogs/FenodyreeConstructBuff.yml
@@ -1,4 +1,4 @@
-author: ChangeMe
+author: Fenodyree
 
 delete-after: True
 

--- a/html/changelogs/FenodyreeConstructBuff.yml
+++ b/html/changelogs/FenodyreeConstructBuff.yml
@@ -1,0 +1,7 @@
+author: ChangeMe
+
+delete-after: True
+
+changes:
+  - balance: "Makes constructs immune to pain damage. It used to deal damage at 1/2 value."
+


### PR DESCRIPTION
changes:
  - balance: "Makes constructs immune to pain damage. It used to deal damage at 1/2 value."

I watched a cult juggernaut get two shot by stinger grenades, these are PVP mobs, they shouldn't take pain as damage.