### PR TITLE
Fixes education age restriction and max skill level in educated skills

### DIFF
--- a/code/datums/skills/_skills.dm
+++ b/code/datums/skills/_skills.dm
@@ -62,7 +62,7 @@
 
 	// Otherwise, we need to check the education...
 	if(type in education.skills)
-		return education.skills[type]
+		return maximum_level
 
 
 	return uneducated_skill_cap

--- a/code/datums/skills/combat/combat.dm
+++ b/code/datums/skills/combat/combat.dm
@@ -16,7 +16,7 @@
 	name = "Unarmed Combat"
 	description = "Unarmed combat represents your training in hand-to-hand combat, or without a weapon. It also influences your ability to resist actions like disarms or martial arts. " \
 		+ "Higher ranks in Unarmed Combat provide bonuses when attacking with your fists, as well as bonuses to defending against others unarmed attacks and disarms."
-	maximum_level = SKILL_LEVEL_PROFESSIONAL
+	maximum_level = SKILL_LEVEL_TRAINED
 	skill_level_descriptions = alist(
 		SKILL_LEVEL_UNFAMILIAR = "You have rarely, if ever, fought someone in your life.<br>" \
 			+ " - You are more likely to miss when attempting to punch anywhere not the torso.<br>" \
@@ -43,7 +43,7 @@
 /singleton/skill/armed_combat
 	name = "Armed Combat"
 	description = "Armed Combat influences your effectiveness when fighting with any melee weapon. Having low ranks in this skill slightly decreases damage dealt with melee weapons, while higher ranks can slightly increase it."
-	maximum_level = SKILL_LEVEL_PROFESSIONAL
+	maximum_level = SKILL_LEVEL_TRAINED
 	category = /singleton/skill_category/combat
 	subcategory = SKILL_SUBCATEGORY_MELEE
 	component_type = ARMED_COMBAT_SKILL_COMPONENT
@@ -51,7 +51,7 @@
 /singleton/skill/firearms
 	name = "Firearms"
 	description = "Firearms represents your training in using all forms of ranged weapons. Having a high rank in in this skill provides bonuses to accuracy when shooting."
-	maximum_level = SKILL_LEVEL_PROFESSIONAL
+	maximum_level = SKILL_LEVEL_TRAINED
 	category = /singleton/skill_category/combat
 	subcategory = SKILL_SUBCATEGORY_RANGED
 	required = TRUE

--- a/code/modules/background/education/engineering.dm
+++ b/code/modules/background/education/engineering.dm
@@ -5,6 +5,10 @@
 	jobs = list("Engineer")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 25,
+		SPECIES_TAJARA = 25,
+		SPECIES_TAJARA_MSAI = 25,
+		SPECIES_TAJARA_ZHAN = 25,
+		SPECIES_UNATHI = 25,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -22,6 +26,10 @@
 	jobs = list("Engineer")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 25,
+		SPECIES_TAJARA = 25,
+		SPECIES_TAJARA_MSAI = 25,
+		SPECIES_TAJARA_ZHAN = 25,
+		SPECIES_UNATHI = 25,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -39,6 +47,10 @@
 	jobs = list("Atmospherics Technician")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 25,
+		SPECIES_TAJARA = 25,
+		SPECIES_TAJARA_MSAI = 25,
+		SPECIES_TAJARA_ZHAN = 25,
+		SPECIES_UNATHI = 25,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -57,6 +69,10 @@
 	jobs = list("Engineer")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 25,
+		SPECIES_TAJARA = 25,
+		SPECIES_TAJARA_MSAI = 25,
+		SPECIES_TAJARA_ZHAN = 25,
+		SPECIES_UNATHI = 25,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -75,6 +91,10 @@
 	jobs = list("Engineer")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 25,
+		SPECIES_TAJARA = 25,
+		SPECIES_TAJARA_MSAI = 25,
+		SPECIES_TAJARA_ZHAN = 25,
+		SPECIES_UNATHI = 25,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)

--- a/code/modules/background/education/medical.dm
+++ b/code/modules/background/education/medical.dm
@@ -40,11 +40,11 @@
 					accredited hospital or clinic."
 	jobs = list("Pharmacist")
 	minimum_character_age = list(
-		SPECIES_HUMAN = 30,
-		SPECIES_TAJARA = 30,
-		SPECIES_TAJARA_MSAI = 30,
-		SPECIES_TAJARA_ZHAN = 30,
-		SPECIES_UNATHI = 30,
+		SPECIES_HUMAN = 25,
+		SPECIES_TAJARA = 25,
+		SPECIES_TAJARA_MSAI = 25,
+		SPECIES_TAJARA_ZHAN = 25,
+		SPECIES_UNATHI = 25,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)

--- a/code/modules/background/education/medical.dm
+++ b/code/modules/background/education/medical.dm
@@ -21,6 +21,10 @@
 	jobs = list("Physician")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 30,
+		SPECIES_TAJARA = 30,
+		SPECIES_TAJARA_MSAI = 30,
+		SPECIES_TAJARA_ZHAN = 30,
+		SPECIES_UNATHI = 30,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -37,6 +41,10 @@
 	jobs = list("Pharmacist")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 30,
+		SPECIES_TAJARA = 30,
+		SPECIES_TAJARA_MSAI = 30,
+		SPECIES_TAJARA_ZHAN = 30,
+		SPECIES_UNATHI = 30,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -55,6 +63,10 @@
 	jobs = list("Psychologist")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 30,
+		SPECIES_TAJARA = 30,
+		SPECIES_TAJARA_MSAI = 30,
+		SPECIES_TAJARA_ZHAN = 30,
+		SPECIES_UNATHI = 30,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -75,6 +87,10 @@
 	jobs = list("Psychiatrist")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 30,
+		SPECIES_TAJARA = 30,
+		SPECIES_TAJARA_MSAI = 30,
+		SPECIES_TAJARA_ZHAN = 30,
+		SPECIES_UNATHI = 30,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -91,6 +107,10 @@
 	jobs = list("Paramedic")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 18,
+		SPECIES_TAJARA = 18,
+		SPECIES_TAJARA_MSAI = 18,
+		SPECIES_TAJARA_ZHAN = 18,
+		SPECIES_UNATHI = 18,
 		SPECIES_SKRELL = 55,
 		SPECIES_SKRELL_AXIORI = 55
 	)

--- a/code/modules/background/education/misc.dm
+++ b/code/modules/background/education/misc.dm
@@ -4,6 +4,10 @@
 		You can count very well, and you have a statistician's eye - especially for credits."
 	minimum_character_age = list(
 		SPECIES_HUMAN = 21,
+		SPECIES_TAJARA = 21,
+		SPECIES_TAJARA_MSAI = 21,
+		SPECIES_TAJARA_ZHAN = 21,
+		SPECIES_UNATHI = 21,
 		SPECIES_SKRELL = 55,
 		SPECIES_SKRELL_AXIORI = 55
 	)
@@ -14,6 +18,10 @@
 		psychology. Otherwise, your life has provided ample opportunity for these pursuits such that you have comparable expertise. You are likely very well-read on foreign cultures and on the human mind."
 	minimum_character_age = list(
 		SPECIES_HUMAN = 21,
+		SPECIES_TAJARA = 21,
+		SPECIES_TAJARA_MSAI = 21,
+		SPECIES_TAJARA_ZHAN = 21,
+		SPECIES_UNATHI = 21,
 		SPECIES_SKRELL = 55,
 		SPECIES_SKRELL_AXIORI = 55
 	)

--- a/code/modules/background/education/science.dm
+++ b/code/modules/background/education/science.dm
@@ -5,6 +5,10 @@
 	jobs = list("Scientist")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 30,
+		SPECIES_TAJARA = 30,
+		SPECIES_TAJARA_MSAI = 30,
+		SPECIES_TAJARA_ZHAN = 30,
+		SPECIES_UNATHI = 30,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -20,6 +24,10 @@
 	jobs = list("Roboticist")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 25,
+		SPECIES_TAJARA = 25,
+		SPECIES_TAJARA_MSAI = 25,
+		SPECIES_TAJARA_ZHAN = 25,
+		SPECIES_UNATHI = 25,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -37,6 +45,10 @@
 	jobs = list("Roboticist")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 25,
+		SPECIES_TAJARA = 25,
+		SPECIES_TAJARA_MSAI = 25,
+		SPECIES_TAJARA_ZHAN = 25,
+		SPECIES_UNATHI = 25,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -54,6 +66,10 @@
 	jobs = list("Xenobotanist")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 30,
+		SPECIES_TAJARA = 30,
+		SPECIES_TAJARA_MSAI = 30,
+		SPECIES_TAJARA_ZHAN = 30,
+		SPECIES_UNATHI = 30,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -70,6 +86,10 @@
 	jobs = list("Xenobiologist")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 30,
+		SPECIES_TAJARA = 30,
+		SPECIES_TAJARA_MSAI = 30,
+		SPECIES_TAJARA_ZHAN = 30,
+		SPECIES_UNATHI = 30,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)

--- a/code/modules/background/education/security.dm
+++ b/code/modules/background/education/security.dm
@@ -5,6 +5,10 @@
 	jobs = list("Investigator")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 25,
+		SPECIES_TAJARA = 25,
+		SPECIES_TAJARA_MSAI = 25,
+		SPECIES_TAJARA_ZHAN = 25,
+		SPECIES_UNATHI = 25,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -21,6 +25,10 @@
 		or or simply surviving for long in a grim environment where self-discipline matters as much as skill."
 	minimum_character_age = list(
 		SPECIES_HUMAN = 18,
+		SPECIES_TAJARA = 18,
+		SPECIES_TAJARA_MSAI = 18,
+		SPECIES_TAJARA_ZHAN = 18,
+		SPECIES_UNATHI = 18,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -37,6 +45,10 @@
 		+ "A character with this training is NOT legally considered a medical doctor. You're on the hook for manslaughter if you attempt and fail to save them yourself instead of taking them to a real doctor."
 	minimum_character_age = list(
 		SPECIES_HUMAN = 18,
+		SPECIES_TAJARA = 18,
+		SPECIES_TAJARA_MSAI = 18,
+		SPECIES_TAJARA_ZHAN = 18,
+		SPECIES_UNATHI = 18,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -55,6 +67,10 @@
 		Your combat skills are not as stringent as actual military service, though this is made up for with more generalized training suitable for a first-responder."
 	minimum_character_age = list(
 		SPECIES_HUMAN = 18,
+		SPECIES_TAJARA = 18,
+		SPECIES_TAJARA_MSAI = 18,
+		SPECIES_TAJARA_ZHAN = 18,
+		SPECIES_UNATHI = 18,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)

--- a/code/modules/background/education/service.dm
+++ b/code/modules/background/education/service.dm
@@ -5,6 +5,10 @@
 	jobs = list("Bartender")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 18,
+		SPECIES_TAJARA = 18,
+		SPECIES_TAJARA_MSAI = 18,
+		SPECIES_TAJARA_ZHAN = 18,
+		SPECIES_UNATHI = 18,
 		SPECIES_SKRELL = 50,
 		SPECIES_SKRELL_AXIORI = 50
 	)
@@ -18,6 +22,10 @@
 	jobs = list("Chef")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 18,
+		SPECIES_TAJARA = 18,
+		SPECIES_TAJARA_MSAI = 18,
+		SPECIES_TAJARA_ZHAN = 18,
+		SPECIES_UNATHI = 18,
 		SPECIES_SKRELL = 50,
 		SPECIES_SKRELL_AXIORI = 50
 	)
@@ -32,6 +40,10 @@
 	jobs = list("Chef")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 18,
+		SPECIES_TAJARA = 18,
+		SPECIES_TAJARA_MSAI = 18,
+		SPECIES_TAJARA_ZHAN = 18,
+		SPECIES_UNATHI = 18,
 		SPECIES_SKRELL = 50,
 		SPECIES_SKRELL_AXIORI = 50
 	)
@@ -46,6 +58,10 @@
 	jobs = list("Gardener")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 18,
+		SPECIES_TAJARA = 18,
+		SPECIES_TAJARA_MSAI = 18,
+		SPECIES_TAJARA_ZHAN = 18,
+		SPECIES_UNATHI = 18,
 		SPECIES_SKRELL = 50,
 		SPECIES_SKRELL_AXIORI = 50
 	)
@@ -60,6 +76,10 @@
 	jobs = list("Gardener")
 	minimum_character_age = list(
 		SPECIES_HUMAN = 18,
+		SPECIES_TAJARA = 18,
+		SPECIES_TAJARA_MSAI = 18,
+		SPECIES_TAJARA_ZHAN = 18,
+		SPECIES_UNATHI = 18,
 		SPECIES_SKRELL = 50,
 		SPECIES_SKRELL_AXIORI = 50
 	)

--- a/html/changelogs/SkillFixes.yml
+++ b/html/changelogs/SkillFixes.yml
@@ -5,4 +5,5 @@ delete-after: True
 changes:
   - bugfix: "Fixed that skills with education didn't let one pick higher levels of it than the education gave."
   - bugfix: "Fixed age restrictions for educations not applying to tajara or unathi."
+  - bugfix: "The doctor of pharmacy education is now correctly allowed for 25 years old, bringing it in line with both the description and the pharmacist job."
   - rscdel: "Reduced the max unarmed combat, armed combat and firearms skill to trained. No player facing changes as it was not possible to get professional before."

--- a/html/changelogs/SkillFixes.yml
+++ b/html/changelogs/SkillFixes.yml
@@ -1,0 +1,8 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed that skills with education didn't let one pick higher levels of it than the education gave."
+  - bugfix: "Fixed age restrictions for educations not applying to tajara or unathi."
+  - rscdel: "Reduced the max unarmed combat, armed combat and firearms skill to trained. No player facing changes as it was not possible to get professional before."


### PR DESCRIPTION
The education age restriction now applies to tajara and unathi as well.
The max skill level was supposed to be unlocked in educated skills, but was being accidentally locked to only the skill level the education gave. This meant someone uneducated could sometimes get even higher skill than an educated person, by spending skill points.
The three combat skill ranks were reduced to trained level as their max. It was not possible for players to get higher before, and 3 was already the baseline. If a professional is ever implemented for antags or similar, it can be set back again then.
Doctor of Pharmacy was reduced to only need 25 years old, due to both the description and that the pharmacist job has that age requirement too.

fixes https://github.com/Aurorastation/Aurora.3/issues/22376
fixes https://github.com/Aurorastation/Aurora.3/issues/22286
fixes https://github.com/Aurorastation/Aurora.3/issues/22232 kinda. It was already fixed, but more fixing on restrictions also reported on it.
fixes https://github.com/Aurorastation/Aurora.3/issues/22610