### PR TITLE
Fixes a modlaser improvement exploit and an upgrade bug

### DIFF
--- a/code/__DEFINES/modular_guns.dm
+++ b/code/__DEFINES/modular_guns.dm
@@ -5,8 +5,6 @@
 #define MOD_SILENCE 1
 #define MOD_NUCLEAR_CHARGE 2
 
-///The maximum improvement that can be applied to a weapon component.
-#define IMPROVEMENT_CAP 100
 ///The maximum increase an individual variable can recieve over it's initial value.
 #define INCREASE_CAP 1.5
 ///The maximum decrease an individual variable can recieve under it's initial value.

--- a/code/modules/projectiles/guns/energy/modular.dm
+++ b/code/modules/projectiles/guns/energy/modular.dm
@@ -62,7 +62,7 @@
 	UnregisterSignal(src, COMSIG_PROJECTILE_ON_HIT)
 	return ..()
 
- ///This handles the improvement potential gain from firing the weapon. The actual improvement is handled in repair of the individual compoents, this just determines how much improvement potential is gained.
+///This handles the improvement potential gain from firing the weapon. The actual improvement is handled in repair of the individual compoents, this just determines how much improvement potential is gained.
 /obj/item/gun/energy/laser/prototype/proc/on_projectile_hit(fired_from, atom/movable/firer, atom/target, angle, def_zone, blocked)
 	SIGNAL_HANDLER
 	if(!target || target == firer)

--- a/code/modules/projectiles/guns/energy/modular.dm
+++ b/code/modules/projectiles/guns/energy/modular.dm
@@ -54,6 +54,49 @@
 			. += "Your combined professional expertise in firearms and research will show you all information about this weapon, you will also be able to repair it without decreasing its reliability, and have an excellent chance to improve it when repairing."
 			. += "It can be improved up to its improvement potential, which is increased by firing it. Firing it at players increases it most rapidly, following by firing it at simple mobs, then firing it at objects."
 
+/obj/item/gun/energy/laser/prototype/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_PROJECTILE_ON_HIT, PROC_REF(on_projectile_hit))
+
+/obj/item/gun/energy/laser/prototype/Destroy()
+	UnregisterSignal(src, COMSIG_PROJECTILE_ON_HIT)
+	return ..()
+
+ ///This handles the improvement potential gain from firing the weapon. The actual improvement is handled in repair of the individual compoents, this just determines how much improvement potential is gained.
+/obj/item/gun/energy/laser/prototype/proc/on_projectile_hit(fired_from, atom/movable/firer, atom/target, angle, def_zone, blocked)
+	SIGNAL_HANDLER
+	if(!target || target == firer)
+		return
+
+	if (istype(target, /obj/structure/machinery/portable_atmospherics/hydroponics))
+		if (istype(modulator, /obj/item/laser_components/modulator/floramut) || istype(modulator, /obj/item/laser_components/modulator/floramut2))
+			improvement_potential += (1  * IMPROVEMENT_MULTIPLIER) / (max(1, burst))
+			return
+
+	if(isliving(target))  //No improvement unless your target is a mob.
+		var/mob/living/target_mob = target
+		if(target_mob.stat != DEAD) //No improvement from shooting at dead things. Bring a doctor in to keep your target dummy alive. This also makes it harder to improve more powerful weapons, as you kill your target faster.
+			if(ishuman(target_mob))
+				var/mob/living/carbon/human/human_target = target
+				if (istype(modulator, /obj/item/laser_components/modulator/taser))
+					if (human_target.incapacitated()) //No benefit from tasing someone who's already incapacitated. Get the phramacist to make you oxycomorphine.
+						return
+				if(human_target.get_species() == SPECIES_MONKEY)
+					improvement_potential += (2  * IMPROVEMENT_MULTIPLIER) / (max(1, burst)) //Monkeys die easily, research only gets two boxes of monkey cubes without xenobiology.
+					return
+				if(human_target.client)
+					improvement_potential += (10  * IMPROVEMENT_MULTIPLIER) / (max(1, burst)) //10 seems like a lot, but this is a 20% improvement to 1 variable on 1 component. A 5 mod gun (8 total components), with an average of 3 improvable variables would need 120 shots on a player to max out.
+					return
+
+			if(isslime(target_mob))
+				if (istype(modulator, /obj/item/laser_components/modulator/freeze))
+					improvement_potential += (2 * IMPROVEMENT_MULTIPLIER) / (max(1, burst))
+					return
+
+			improvement_potential += (5 * IMPROVEMENT_MULTIPLIER) / (max(1, burst)) //Mechs, protohumans, and any other human mobs without a player.
+	else if(!isturf(target))
+		improvement_potential += (1 * IMPROVEMENT_MULTIPLIER) / (max(1, burst))
+
 /obj/item/gun/energy/laser/prototype/get_examine_text(mob/user, distance, is_adjacent, infix, suffix)
 	. = ..()
 	if(distance > 1)
@@ -163,38 +206,8 @@
 	else
 		to_chat(user, "There is nothing to repair on the gun!")
 
-/obj/item/gun/energy/laser/prototype/handle_post_fire(mob/user, atom/target) //This handles the improvement potential gain from firing the weapon. The actual improvement is handled in repair of the individual compoents, this just determines how much improvement potential is gained.
-	if(target)
-		improvement_potential += (0.1 * IMPROVEMENT_MULTIPLIER) / (max(1, burst))  //100 shots to improve by 1%, you can only improve if your gun takes damage, so it will need many repair cycles for this to be significant.
-
-		if (istype(target, /obj/structure/machinery/portable_atmospherics/hydroponics))
-			if (istype(modulator, /obj/item/laser_components/modulator/floramut) || istype(modulator, /obj/item/laser_components/modulator/floramut2))
-				improvement_potential += (1  * IMPROVEMENT_MULTIPLIER) / (max(1, burst))
-				return ..()
-
-		if(target != user) //No improvement from shooting yourself.
-			if(isliving(target))  //No improvement unless your target is a mob.
-				var/mob/living/target_mob = target
-				if(target_mob.stat != DEAD) //No improvement from shooting at dead things. Bring a doctor in to keep your target dummy alive. This also makes it harder to improve more powerful weapons, as you kill your target faster.
-					if(ishuman(target_mob))
-						var/mob/living/carbon/human/human_target = target
-						if (istype(modulator, /obj/item/laser_components/modulator/taser))
-							if (human_target.incapacitated()) //No benefit from tasing someone who's already incapacitated. Get the phramacist to make you oxycomorphine.
-								return ..()
-						if(human_target.get_species() == SPECIES_MONKEY)
-							improvement_potential += (2  * IMPROVEMENT_MULTIPLIER) / (max(1, burst)) //Monkeys die easily, research only gets two boxes of monkey cubes without xenobiology.
-							return ..()
-						if(human_target.client)
-							improvement_potential += (10  * IMPROVEMENT_MULTIPLIER) / (max(1, burst)) //10 seems like a lot, but this is a 20% improvement to 1 variable on 1 component. A 5 mod gun (8 total components), with an average of 3 improvable variables would need 120 shots on a player to max out.
-							return ..()
-
-					if(isslime(target_mob))
-						if (istype(modulator, /obj/item/laser_components/modulator/freeze))
-							improvement_potential += (2 * IMPROVEMENT_MULTIPLIER) / (max(1, burst))
-							return ..()
-
-					improvement_potential += (5 * IMPROVEMENT_MULTIPLIER) / (max(1, burst)) //Mechs, protohumans, and any other human mobs without a player.
-	..()
+/obj/item/gun/energy/laser/prototype/handle_post_fire(mob/user, atom/target)
+	return ..()
 
 /obj/item/gun/energy/laser/prototype/update_icon()
 	..()
@@ -388,7 +401,7 @@
 	while(improvement_potential > 0 && damaged_components.len)
 		var/list/upgradable_components = list()
 		for(var/obj/item/laser_components/component in damaged_components) //Only give it improvement potential if it's damaged.
-			if((component.total_improved + component.improvement_potential) < IMPROVEMENT_CAP) //Only give it improvement potential if it doesn't have enough to hit cap.
+			if((component.total_improved + component.improvement_potential) < component.improvement_cap) //Only give it improvement potential if it doesn't have enough to hit cap.
 				if(component.increasable_stats.len || component.decreaseable_stats.len) //Don't give it to components with nothing to improve.
 					upgradable_components += component
 			else

--- a/code/modules/projectiles/modular/laser_base.dm
+++ b/code/modules/projectiles/modular/laser_base.dm
@@ -25,6 +25,8 @@
 	var/improvement_potential = 0
 	///The total amount the component has been improved by repairs. This is used to put an upper limit on how much a component can be improved.
 	var/total_improved = 0
+	///The total amount of improvement a component can support. This should not be more than the sum of the increase and decrease caps on all stats, or the component will never stop consuming improvement potential.
+	var/improvement_cap = 100
 	///Added to the accuracy of the weapon.
 	var/accuracy = 0
 	///The item required to repair the component.
@@ -43,12 +45,12 @@
 
 /obj/item/laser_components/proc/handle_improvement(var/skill_level, var/mob/user)
 
-	if (total_improved >= IMPROVEMENT_CAP)
+	if (total_improved >= improvement_cap)
 		to_chat(user, SPAN_NOTICE("You don't see any way to improve \the [src] any further."))
 		improvement_potential = 0
 		return
 
-	while (improvement_potential > 0 && total_improved < IMPROVEMENT_CAP)
+	while (improvement_potential > 0 && total_improved < improvement_cap)
 
 		var/improvement = min(abs(improvement_potential / 100), 0.2) //Caps improvement from a single repair to 20%. This spreads the effect out across multiple stats
 		var/stat_direction = 1
@@ -125,7 +127,7 @@
 		else
 			break //The stat to improve isn't on this component, something went wrong with the lists of stats or the component itself.
 
-		if (total_improved > IMPROVEMENT_CAP)
+		if (total_improved > improvement_cap)
 			improvement_potential = 0
 			to_chat(user, SPAN_NOTICE("You have improved \the [src] as much as you can."))
 
@@ -177,6 +179,10 @@
 					. += SPAN_WARNING("You can see \the [src]'s [replacetext(stat, "_", " ")] has been degraded, increasing it by approximately [round((initial(src.vars[stat]) - src.vars[stat]) / initial(src.vars[stat]) * 100)] percent.")
 			if(improvement_potential > 0)
 				. += SPAN_GOOD("You see a few places where damage has revealed design flaws. Correcting them could improve \the [src] by up to [improvement_potential] percent.")
+
+/obj/item/laser_components/mechanics_hints(mob/user, distance, is_adjacent)
+	. = ..()
+	. += "This component can be repaired with \a [repair_item.name]. If you have research and firearms skills you have a chance to improve it when repairing it."
 
 /obj/item/laser_components/attackby(obj/item/attacking_item, mob/user)
 	if(!istype(attacking_item, repair_item))
@@ -353,7 +359,7 @@
 
 /obj/item/laser_assembly
 	name = "laser assembly (small)"
-	desc = "A case for shoving things into. Hopefully they work."
+	desc = "A small pistol-sized assembly."
 	icon = 'icons/obj/guns/modular_laser.dmi'
 	var/base_icon_state = "small"
 	contained_sprite = TRUE
@@ -372,6 +378,17 @@
 /obj/item/laser_assembly/Initialize()
 	. = ..()
 	update_icon()
+
+/obj/item/laser_assembly/examine_tags(mob/user)
+	. = ..()
+	if(stage == 1)
+		.["thick"] = "Stops or slows minor piercing effects, such as from injectors."
+
+/obj/item/laser_assembly/mechanics_hints(mob/user)
+	. = ..()
+	. += "Components can be added to this assembly by attacking it with the component in hand. If you lack the appropriate skills you need to use a weapons analyzer."
+	. += "Components must be added in the correct order, starting with the capacitor, then the focusing lens, and finally the modulator. Modifiers can be added at any time but are limited by the assembly size."
+	. += "This assembly can hold [modifier_cap] modifiers."
 
 /obj/item/laser_assembly/attackby(obj/item/attacking_item, mob/user)
 	var/obj/item/laser_components/A = attacking_item

--- a/code/modules/projectiles/modular/laser_components.dm
+++ b/code/modules/projectiles/modular/laser_components.dm
@@ -2,6 +2,7 @@
 
 /obj/item/laser_assembly/medium
 	name = "laser assembly (medium)"
+	desc = "A medium carbine-sized assembly."
 	base_icon_state = "medium"
 	w_class = WEIGHT_CLASS_SMALL
 	size = CHASSIS_MEDIUM
@@ -9,6 +10,7 @@
 
 /obj/item/laser_assembly/large
 	name = "laser assembly (large)"
+	desc = "A large rifle-sized assembly."
 	base_icon_state = "large"
 	w_class = WEIGHT_CLASS_NORMAL
 	size = CHASSIS_LARGE
@@ -16,6 +18,7 @@
 
 /obj/item/laser_assembly/admin
 	name = "laser assembly (obscene)"
+	desc = "An obscene laser assembly."
 	base_icon_state = "large"
 	w_class = WEIGHT_CLASS_BULKY
 	size = CHASSIS_LARGE
@@ -316,18 +319,21 @@
 	name = "reinforced barrel"
 	desc = "Reinforcement along the barrel extends the longevity of the prototype."
 	reliability = 25
+	improvement_cap = 50
 	icon_state = "reinforced_barrel"
 
 /obj/item/laser_components/modifier/barrel/nano
 	name = "nano-reinforced barrel"
 	desc = "Reinforcement along the barrel extends the longevity of the prototype even more than predecessor barrel. Uses nano-technology to increase reinforcement while retaining same weight."
 	reliability = 35
+	improvement_cap = 50
 	icon_state = "nano_barrel"
 
 /obj/item/laser_components/modifier/vents
 	name = "exhaust venting"
 	desc = "More efficient exhaust venting reduces the impact of firing the prototype."
 	reliability = 0
+	improvement_cap = 50
 	base_malus = -0.5
 	malus = -0.5
 	malus_multiplier = 0.5
@@ -338,6 +344,7 @@
 /obj/item/laser_components/modifier/grip
 	name = "enhanced grip"
 	desc = "A modification that improves the fire delay of the prototype."
+	improvement_cap = 50
 	fire_delay = 0.8
 	gun_overlay = "grip"
 	icon_state = "grip"
@@ -347,6 +354,7 @@
 /obj/item/laser_components/modifier/grip/improved
 	name = "enhanced grip MK2"
 	desc = "A modification that improves the fire delay of the prototype. Slight improvement over a predecessor."
+	improvement_cap = 50
 	fire_delay = 0.7
 	gun_overlay = "grip"
 	icon_state = "enhanced_grip"
@@ -371,6 +379,7 @@
 /obj/item/laser_components/modifier/bayonet
 	name = "bayonet"
 	desc = "A modification that adds a big knife to your gun. Science."
+	improvement_cap = 50
 	gun_force = 10
 	gun_overlay = "bayonet"
 	icon_state = "bayonet_item"
@@ -380,6 +389,7 @@
 /obj/item/laser_components/modifier/ebayonet
 	name = "energy bayonet"
 	desc = "A modification that adds a hardlight knife to your gun. Science!"
+	improvement_cap = 50
 	gun_force = 25
 	gun_overlay = "ebayonet"
 	icon_state = "ebayonet_item"
@@ -421,6 +431,8 @@
 /obj/item/laser_components/modulator/ion
 	name = "ion cannon"
 	desc = "Modulates the prototype to fire disparate ion projectiles."
+	shots = 0.5 //Ions are very powerful and not affected by damage.
+	damage = 0
 	projectile = /obj/projectile/ion
 	icon_state = "ion"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 3)

--- a/html/changelogs/Fenodyree-EvenMoreModlaserFixes.yml
+++ b/html/changelogs/Fenodyree-EvenMoreModlaserFixes.yml
@@ -5,3 +5,4 @@ delete-after: True
 changes:
   - bugfix: "Moved improvement cap from a define to the base component. Fixes components that had too few upgradable variables never counting as fully upgraded."
   - bugfix: "Fixes weapons improving even if they miss their targets. Now they only improve if they hit something. Prevents infinite upgrades by deliberately shooting walls."
+  - bugfix: "Fixes ions doing damage, in addition to EMPing their target. Also reduces the shot capacity of modular Ion guns to better match existing ones."

--- a/html/changelogs/Fenodyree-EvenMoreModlaserFixes.yml
+++ b/html/changelogs/Fenodyree-EvenMoreModlaserFixes.yml
@@ -1,0 +1,7 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - bugfix: "Moved improvement cap from a define to the base component. Fixes components that had too few upgradable variables never counting as fully upgraded."
+  - bugfix: "Fixes weapons improving even if they miss their targets. Now they only improve if they hit something. Prevents infinite upgrades by deliberately shooting walls."


### PR DESCRIPTION
Added an on_hit signal, instead of using the target in post_fire.
This fixes cheesing upgrades by standing behind a wall and shooting at a target you will never hit.

Moved improvement cap from a define, onto the base object.
This fixes some components continuing to eat improvement potential, even when they are fully upgraded.

Fixes Ions dealing damage in addition to EMPing their target. Also reduced the max number of shots when an Ion emitter is fitted.