### PR TITLE
R&D console only updates on material shortage

### DIFF
--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -219,6 +219,8 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 
 	else
 		visible_message(SPAN_NOTICE("[icon2html(src, viewers(get_turf(src)))] \The [src] flashes: insufficient materials: [getLackingMaterials(D)]."))
+		if(linked_console)
+			linked_console.updateUsrDialog()
 
 	update_icon()
 

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -226,6 +226,8 @@
 
 	else
 		visible_message(SPAN_NOTICE("[icon2html(src, viewers(get_turf(src)))] \The [src] flashes: Insufficient materials: [getLackingMaterials(D)]."))
+		if(linked_console)
+			linked_console.updateUsrDialog()
 
 	update_icon()
 
@@ -298,9 +300,6 @@
 			if(new_item.matter && new_item.matter.len > 0)
 				for(var/i in new_item.matter)
 					new_item.matter[i] = new_item.matter[i] * mat_efficiency
-
-	if(linked_console)
-		linked_console.updateUsrDialog()
 
 	//We finished building, clear the timer
 	build_callback_timer = null

--- a/html/changelogs/Fenodyree-R&DConsoleScroll.yml
+++ b/html/changelogs/Fenodyree-R&DConsoleScroll.yml
@@ -1,0 +1,7 @@
+
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - qol: "Stops the R&D console scrolling back up to the top whenever a print finishes."


### PR DESCRIPTION
Every time you print an item in the protolathe or circuit printer, it scrolls back up to the top.
Printing multiple items is hell, especially as there is no bulk print option.

This makes the UI only update if there isn't enough material to finish a print.

This isn't the ideal solution, because the Material Amount doesn't update unless you click the R&D console again.
<img width="318" height="99" alt="image" src="https://github.com/user-attachments/assets/02e07ae6-b9ad-4538-af80-3a11b8778459" />
However the material amount doesn't even give a readout of what the materials are, so this value is useless anyway.

Also means buttons won't be greyed out as the material to print them runs out, but this is fine because if you press a button without enough material to print it, the UI will immediately update and grey it out. This does scroll you up to the top, but it's much better than having it happen EVERY time.

Best solution would be to update it to TGUI, but I just tried that and gave up almost immediately. So this is a stopgap.