### PR TITLE
Makes rechargers buildable, deconstructable and upgradable

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -1238,6 +1238,7 @@
 #include "code\game\objects\items\weapons\circuitboards\machinery\portgen.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\power.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\recharge_station.dm"
+#include "code\game\objects\items\weapons\circuitboards\machinery\recharger.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\research.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\shieldgen.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\ship.dm"

--- a/code/game/objects/items/weapons/circuitboards/machinery/recharger.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/recharger.dm
@@ -2,11 +2,15 @@
 	name = T_BOARD("recharger")
 	build_path = /obj/structure/machinery/recharger
 	board_type = BOARD_MACHINE
-	origin_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 2)
-	req_components = list("/obj/item/stock_parts/capacitor" = 2)
+	origin_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 1)
+	req_components = list(
+		"/obj/item/stock_parts/capacitor" = 2
+		)
 
-/obj/item/circuitboard/recharger/wall
+/obj/item/circuitboard/recharger/wallcharger
 	name = T_BOARD("wall recharger")
-	build_path = /obj/structure/machinery/recharger/wall
-	origin_tech = list(TECH_DATA = 3, TECH_POWER = 3, TECH_ENGINEERING = 3)
-	req_components = list("/obj/item/stock_parts/capacitor" = 3)
+	build_path = /obj/structure/machinery/recharger/wallcharger
+	origin_tech = list(TECH_DATA = 4, TECH_POWER = 3, TECH_ENGINEERING = 3)
+	req_components = list(
+		"/obj/item/stock_parts/capacitor" = 3
+		)

--- a/code/game/objects/items/weapons/circuitboards/machinery/recharger.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/recharger.dm
@@ -1,0 +1,12 @@
+/obj/item/circuitboard/recharger
+	name = T_BOARD("recharger")
+	build_path = /obj/structure/machinery/recharger
+	board_type = BOARD_MACHINE
+	origin_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 2)
+	req_components = list("/obj/item/stock_parts/capacitor" = 2)
+
+/obj/item/circuitboard/recharger/wall
+	name = T_BOARD("wall recharger")
+	build_path = /obj/structure/machinery/recharger/wall
+	origin_tech = list(TECH_DATA = 3, TECH_POWER = 3, TECH_ENGINEERING = 3)
+	req_components = list("/obj/item/stock_parts/capacitor" = 3)

--- a/code/game/objects/structures/machinery/recharger.dm
+++ b/code/game/objects/structures/machinery/recharger.dm
@@ -86,18 +86,17 @@
 		attacking_item.play_tool_sound(get_turf(src), 75)
 		return TRUE
 
-	if(attacking_item.tool_behaviour == TOOL_SCREWDRIVER)
-		if(charging)
-			to_chat(user, SPAN_WARNING("You can't modify \the [src] while it has something charging inside."))
-		else
-			if(default_deconstruction_screwdriver(user, attacking_item))
-				update_icon()
-				return TRUE
-
-	if(default_part_replacement(user, attacking_item))
+	if(charging && (attacking_item.tool_behaviour == TOOL_SCREWDRIVER || attacking_item.tool_behaviour == TOOL_CROWBAR))
+		to_chat(user, SPAN_WARNING("You can't modify \the [src] while it has something charging inside."))
 		return TRUE
-	else if(default_deconstruction_crowbar(user, attacking_item))
-		return TRUE
+	else
+		if(default_deconstruction_screwdriver(user, attacking_item))
+			update_icon()
+			return TRUE
+		else if(default_deconstruction_crowbar(user, attacking_item))
+			return TRUE
+		else if(default_part_replacement(user, attacking_item))
+			return TRUE
 
 	if (istype(attacking_item, /obj/item/gripper))//Code for allowing cyborgs to use rechargers
 		var/obj/item/gripper/Gri = attacking_item
@@ -114,6 +113,7 @@
 
 	if (panel_open)
 		to_chat(user, SPAN_WARNING("You can't insert items into \the [src] while the panel is open."))
+		return TRUE
 	else
 		if(is_type_in_list(attacking_item, allowed_devices))
 			if (attacking_item.get_cell() == DEVICE_NO_CELL)
@@ -128,10 +128,10 @@
 				to_chat(user, SPAN_WARNING("\The [name] blinks red as you try to insert the item!"))
 				return TRUE
 
-		user.drop_from_inventory(attacking_item,src)
-		charging = attacking_item
-		update_icon()
-		return TRUE
+			user.drop_from_inventory(attacking_item,src)
+			charging = attacking_item
+			update_icon()
+			return TRUE
 
 /obj/structure/machinery/recharger/attack_hand(mob/user as mob)
 	if(istype(user,/mob/living/silicon))
@@ -210,6 +210,9 @@
 			B.bcell.charge = 0
 
 /obj/structure/machinery/recharger/update_icon()	//we have an update_icon() in addition to the stuff in process to make it feel a tiny bit snappier.
+	ClearOverlays()
+	if (panel_open)
+		AddOverlays(image(icon, "npanel_open", pixel_x = -2, pixel_y = 11))
 	if(charging)
 		icon_state = icon_state_charging + "0"
 	else
@@ -239,3 +242,12 @@
 /obj/structure/machinery/recharger/wallcharger/mechanics_hints(mob/user, distance, is_adjacent)
 	. = list()
 	. += "This device can recharge energy weapons, stun batons, and flashlights."
+
+/obj/structure/machinery/recharger/wallcharger/update_icon()	//we have an update_icon() in addition to the stuff in process to make it feel a tiny bit snappier.
+	ClearOverlays()
+	if (panel_open)
+		AddOverlays(image(icon, "npanel_open", pixel_x = -1, pixel_y = 12))
+	if(charging)
+		icon_state = icon_state_charging + "0"
+	else
+		icon_state = icon_state_idle

--- a/code/game/objects/structures/machinery/recharger.dm
+++ b/code/game/objects/structures/machinery/recharger.dm
@@ -45,7 +45,7 @@
 /obj/structure/machinery/recharger/assembly_hints(mob/user, distance, is_adjacent)
 	. += ..()
 	. += "It [anchored ? "is" : "could be"] anchored to the floor with some <b>bolts</b>."
-	. += "Its maintenance panel is [panel_open ? "open and it can be modified with a part exchanger, or deconstructed with a crowbar." : "closed"]"
+	. += "Its maintenance panel is [panel_open ? "open and it can be modified with a part exchanger[portable ? " or deconstructed with a crowbar" : "."]" : "closed. It could be opened with a screwdriver."]"
 
 /obj/structure/machinery/recharger/feedback_hints(mob/user, distance, is_adjacent)
 	. += ..()
@@ -86,17 +86,18 @@
 		attacking_item.play_tool_sound(get_turf(src), 75)
 		return TRUE
 
-	if(charging && (attacking_item.tool_behaviour == TOOL_SCREWDRIVER || attacking_item.tool_behaviour == TOOL_CROWBAR))
-		to_chat(user, SPAN_WARNING("You can't modify \the [src] while it has something charging inside."))
-		return TRUE
-	else
-		if(default_deconstruction_screwdriver(user, attacking_item))
-			update_icon()
+	if(portable) //We don't want wall chargers to be buildable, they can't be put back on walls if they are deconstructed.
+		if(charging && (attacking_item.tool_behaviour == TOOL_SCREWDRIVER || attacking_item.tool_behaviour == TOOL_CROWBAR))
+			to_chat(user, SPAN_WARNING("You can't modify \the [src] while it has something charging inside."))
 			return TRUE
-		else if(default_deconstruction_crowbar(user, attacking_item))
-			return TRUE
-		else if(default_part_replacement(user, attacking_item))
-			return TRUE
+		else
+			if(default_deconstruction_screwdriver(user, attacking_item))
+				update_icon()
+				return TRUE
+			else if(default_deconstruction_crowbar(user, attacking_item))
+				return TRUE
+			else if(default_part_replacement(user, attacking_item))
+				return TRUE
 
 	if (istype(attacking_item, /obj/item/gripper))//Code for allowing cyborgs to use rechargers
 		var/obj/item/gripper/Gri = attacking_item
@@ -251,3 +252,15 @@
 		icon_state = icon_state_charging + "0"
 	else
 		icon_state = icon_state_idle
+
+/obj/structure/machinery/recharger/wallcharger/attackby(obj/item/attacking_item, mob/user)
+	if(charging && (attacking_item.tool_behaviour == TOOL_SCREWDRIVER || attacking_item.tool_behaviour == TOOL_CROWBAR))
+		to_chat(user, SPAN_WARNING("You can't modify \the [src] while it has something charging inside."))
+		return TRUE
+	else
+		if(default_deconstruction_screwdriver(user, attacking_item))
+			update_icon()
+			return TRUE
+		else if(default_part_replacement(user, attacking_item))
+			return TRUE
+	. = ..()

--- a/code/game/objects/structures/machinery/recharger.dm
+++ b/code/game/objects/structures/machinery/recharger.dm
@@ -45,6 +45,7 @@
 /obj/structure/machinery/recharger/assembly_hints(mob/user, distance, is_adjacent)
 	. += ..()
 	. += "It [anchored ? "is" : "could be"] anchored to the floor with some <b>bolts</b>."
+	. += "Its maintenance panel is [panel_open ? "open and it can be modified with a part exchanger, or deconstructed with a crowbar." : "closed"]"
 
 /obj/structure/machinery/recharger/feedback_hints(mob/user, distance, is_adjacent)
 	. += ..()
@@ -85,6 +86,19 @@
 		attacking_item.play_tool_sound(get_turf(src), 75)
 		return TRUE
 
+	if(attacking_item.tool_behaviour == TOOL_SCREWDRIVER)
+		if(charging)
+			to_chat(user, SPAN_WARNING("You can't modify \the [src] while it has something charging inside."))
+		else
+			if(default_deconstruction_screwdriver(user, attacking_item))
+				update_icon()
+				return TRUE
+
+	if(default_part_replacement(user, attacking_item))
+		return TRUE
+	else if(default_deconstruction_crowbar(user, attacking_item))
+		return TRUE
+
 	if (istype(attacking_item, /obj/item/gripper))//Code for allowing cyborgs to use rechargers
 		var/obj/item/gripper/Gri = attacking_item
 		if (charging)//If there's something in the charger
@@ -95,26 +109,24 @@
 				to_chat(user, SPAN_DANGER("Your gripper cannot hold \the [charging]."))
 		return TRUE
 
-	if(default_part_replacement(user, attacking_item))
-		return TRUE
-	else if(default_deconstruction_screwdriver(user, attacking_item))
-		return TRUE
-
 	if(!attacking_item.dropsafety())
 		return TRUE
 
-	if(is_type_in_list(attacking_item, allowed_devices))
-		if (attacking_item.get_cell() == DEVICE_NO_CELL)
-			if (attacking_item.charge_failure_message)
-				to_chat(user, SPAN_WARNING("\The [attacking_item][attacking_item.charge_failure_message]"))
-			return TRUE
-		if(charging)
-			to_chat(user, SPAN_WARNING("\A [charging] is already charging here."))
-			return TRUE
-		// Checks to make sure he's not in space doing it, and that the area got proper power.
-		if(!powered())
-			to_chat(user, SPAN_WARNING("\The [name] blinks red as you try to insert the item!"))
-			return TRUE
+	if (panel_open)
+		to_chat(user, SPAN_WARNING("You can't insert items into \the [src] while the panel is open."))
+	else
+		if(is_type_in_list(attacking_item, allowed_devices))
+			if (attacking_item.get_cell() == DEVICE_NO_CELL)
+				if (attacking_item.charge_failure_message)
+					to_chat(user, SPAN_WARNING("\The [attacking_item][attacking_item.charge_failure_message]"))
+				return TRUE
+			if(charging)
+				to_chat(user, SPAN_WARNING("\A [charging] is already charging here."))
+				return TRUE
+			// Checks to make sure he's not in space doing it, and that the area got proper power.
+			if(!powered())
+				to_chat(user, SPAN_WARNING("\The [name] blinks red as you try to insert the item!"))
+				return TRUE
 
 		user.drop_from_inventory(attacking_item,src)
 		charging = attacking_item

--- a/code/game/objects/structures/machinery/recharger.dm
+++ b/code/game/objects/structures/machinery/recharger.dm
@@ -220,7 +220,7 @@
 	appearance_flags = TILE_BOUND // prevents people from viewing us through a wall
 	portable = FALSE
 	component_types = list(
-		/obj/item/circuitboard/recharger/wall,
+		/obj/item/circuitboard/recharger/wallcharger,
 		/obj/item/stock_parts/capacitor = 3
 	)
 

--- a/code/game/objects/structures/machinery/recharger.dm
+++ b/code/game/objects/structures/machinery/recharger.dm
@@ -7,10 +7,16 @@
 	icon_state = "recharger_off"
 	anchored = 1
 	idle_power_usage = 6
-	active_power_usage = 45 KILO WATTS
+	active_power_usage = 50 KILO WATTS
 	pass_flags = PASSTABLE
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
-	var/charging_efficiency = 1.3
+	var/charging_efficiency = 1
+	var/charging_efficiency_per_capacitor = 0.1
+	var/charging_speed_per_capacitor = 25 KILO WATTS
+	component_types = list(
+		/obj/item/circuitboard/recharger,
+		/obj/item/stock_parts/capacitor = 2
+	)
 	//Entropy. The charge put into the cell is multiplied by this
 	var/obj/item/charging
 
@@ -58,6 +64,17 @@
 		LAZYREMOVE(chargebars, bar)
 		qdel(bar)
 
+/obj/structure/machinery/recharger/RefreshParts()
+	..()
+
+	var/cap_rating = 0
+	for(var/obj/item/stock_parts/P in component_parts)
+		if(iscapacitor(P))
+			cap_rating += P.rating
+
+	charging_efficiency += cap_rating * charging_efficiency_per_capacitor
+	active_power_usage = cap_rating * charging_speed_per_capacitor
+
 /obj/structure/machinery/recharger/attackby(obj/item/attacking_item, mob/user)
 	if(portable && attacking_item.tool_behaviour == TOOL_WRENCH)
 		if(charging)
@@ -76,6 +93,11 @@
 				update_icon()
 			else
 				to_chat(user, SPAN_DANGER("Your gripper cannot hold \the [charging]."))
+		return TRUE
+
+	if(default_part_replacement(user, attacking_item))
+		return TRUE
+	else if(default_deconstruction_screwdriver(user, attacking_item))
 		return TRUE
 
 	if(!attacking_item.dropsafety())
@@ -197,6 +219,10 @@
 	icon_state_idle = "wrecharger_off"
 	appearance_flags = TILE_BOUND // prevents people from viewing us through a wall
 	portable = FALSE
+	component_types = list(
+		/obj/item/circuitboard/recharger/wall,
+		/obj/item/stock_parts/capacitor = 3
+	)
 
 /obj/structure/machinery/recharger/wallcharger/mechanics_hints(mob/user, distance, is_adjacent)
 	. = list()

--- a/code/modules/research/designs/circuit/machine_circuits.dm
+++ b/code/modules/research/designs/circuit/machine_circuits.dm
@@ -71,6 +71,16 @@
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 2)
 	build_path = /obj/item/circuitboard/recharge_station
 
+/datum/design/circuit/machine/recharger
+	name = "Recharger"
+	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 1)
+	build_path = /obj/item/circuitboard/recharger
+
+/datum/design/circuit/machine/recharger/wallcharger
+	name = "Wall Recharger"
+	req_tech = list(TECH_DATA = 2, TECH_POWER = 3, TECH_ENGINEERING = 1)
+	build_path = /obj/item/circuitboard/recharger/wallcharger
+
 /datum/design/circuit/machine/holopadboard
 	name = "Holopad"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 2)

--- a/html/changelogs/Fenodyree-BuildableRechargers.yml
+++ b/html/changelogs/Fenodyree-BuildableRechargers.yml
@@ -1,0 +1,6 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - rscadd: "Makes rechargers buildable and upgradable. Circuits to build them can be printed in a circuit printer."


### PR DESCRIPTION
Adds circuit boards and parts for rechargers and wall rechargers.
Rechargers can be built, deconstructed and upgraded. Wall rechargers can only be upgraded.
The required parts can be printed in R&D.

<img width="1086" height="613" alt="image" src="https://github.com/user-attachments/assets/9deb7917-4c59-4149-b1db-85e53b0447d3" />
