### PR TITLE
updates vscode's build task to use build.sh instead of build

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
     "tasks": [
       {
         "type": "process",
-        "command": "tools/build/build",
+        "command": "tools/build/build.sh",
         "windows": {
             "command": ".\\tools\\build\\build.bat"
         },


### PR DESCRIPTION
the build file for linux got renamed (probably with the TGUI update), this PR just updates the VScode build task to use build.sh instead of the defunct build.
