### PR TITLE
Fixes that plants lose their harvest if the harvesting action is interrupted

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -787,12 +787,12 @@
 	// And check if any components on the plant wish to modify the harvest.
 	SEND_SIGNAL(src, COMSIG_PLANT_HARVESTED, user, &total_yield, &cancelled, &doafter)
 	if (cancelled)
-		return
+		return FALSE
 
 	user.visible_message(SPAN_WARNING("[user] starts harvesting \the [display_name]"))
 	if (doafter > 0 && !do_after(user, doafter))
 		to_chat(user, SPAN_DANGER("You were interrupted while trying to harvest \the [display_name]"))
-		return
+		return FALSE
 
 	if(!force_amount && GET_SEED_TRAIT(src, TRAIT_YIELD) == 0 && !harvest_sample)
 		to_chat(user, SPAN_DANGER("You fail to harvest anything useful."))
@@ -809,7 +809,7 @@
 			var/obj/item/seeds/seeds = new(get_turf(user))
 			seeds.seed_type = name
 			seeds.update_seed()
-			return
+			return TRUE
 
 		if(!isnull(force_amount))
 			total_yield = force_amount
@@ -828,6 +828,7 @@
 
 		for(var/i = 0;i<total_yield;i++)
 			spawn_seed(get_turf(user))
+	return TRUE
 
 /datum/seed/proc/spawn_seed(var/turf/spawning_loc)
 	var/obj/item/product = new product_type(spawning_loc, name)

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -376,7 +376,8 @@
 		return
 
 	if(user)
-		seed.harvest(user,yield_mod,stunted_status = stunted)
+		if(!seed.harvest(user,yield_mod,stunted_status = stunted))
+			return
 	else
 		seed.harvest(get_turf(src),yield_mod, stunted_status = stunted)
 	// Reset values.

--- a/html/changelogs/HydroFix.yml
+++ b/html/changelogs/HydroFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "The hydroponics tray no longer delete the harvests if the action is interrupted."


### PR DESCRIPTION
The early return caused the tray to lose the harvest status without giving anything. This fixes that.

Who thought it was a good idea to split the harvest status from the plant it is harvested from?