### PR TITLE
Renaming away sites no longer breaks telecomms

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -39,6 +39,7 @@
 
 var/list/AWAY_FREQS_UNASSIGNED = list(1491, 1493, 1495, 1497, 1499, 1501, 1503, 1505, 1507, 1509)
 var/list/AWAY_FREQS_ASSIGNED = list("Hailing" = HAIL_FREQ)
+var/list/AWAY_FREQS_DISPLAY_NAMES = list("Hailing" = "Hailing")
 
 var/list/radiochannels = list(
 	"Common"		= PUB_FREQ,

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -422,8 +422,7 @@
 			if(isrobot(usr))
 				var/mob/living/silicon/robot/R = usr
 				if(modifiers["shift"])
-					if(!R.radio.radio_desc)
-						R.radio.setupRadioDescription()
+					R.radio.setupRadioDescription()
 					to_chat(R, SPAN_NOTICE("You analyze your integrated radio:"))
 					to_chat(R, R.radio.radio_desc)
 					return

--- a/code/controllers/subsystems/radio.dm
+++ b/code/controllers/subsystems/radio.dm
@@ -223,43 +223,25 @@ SUBSYSTEM_DEF(radio)
 
 	return "radio"
 
-/proc/update_away_freq(old_channel, new_channel)
-	if(!old_channel || !new_channel || !(old_channel in AWAY_FREQS_ASSIGNED))
+/proc/update_away_freq_display(channel, display_name)
+	if(!channel || !display_name || !(channel in AWAY_FREQS_ASSIGNED))
 		return FALSE
 
-	var/freq = AWAY_FREQS_ASSIGNED[old_channel]
-	var/datum/radio_frequency/RF = SSradio.return_frequency(freq)
+	AWAY_FREQS_DISPLAY_NAMES[channel] = display_name
+	return TRUE
 
-	if(old_channel == new_channel)
-		return istype(RF) ? RF : assign_away_freq(new_channel)
+/proc/assign_away_freq(channel, display_name = null)
+	if (channel in AWAY_FREQS_ASSIGNED)
+		if(display_name)
+			update_away_freq_display(channel, display_name)
+		return AWAY_FREQS_ASSIGNED[channel]
 
-	LAZYREPLACEKEY(AWAY_FREQS_ASSIGNED, old_channel, new_channel)
-	LAZYREPLACEKEY(radiochannels, old_channel, new_channel)
-	LAZYREPLACEKEY(ALL_RADIO_CHANNELS, old_channel, new_channel)
-	reverseradiochannels["[freq]"] = new_channel
-
-	for(var/obj/item/radio/R in RF.devices[RADIO_CHAT])
-		var/obj/item/radio/headset/H = R
-		if(istype(H))
-			for(var/obj/item/encryptionkey/EK in list(H.keyslot1, H.keyslot2))
-				if(old_channel in EK.channels)
-					LAZYREPLACEKEY(EK.channels, old_channel, new_channel)
-
-			H.recalculateChannels(TRUE)
-
-		else if(old_channel in R.channels)
-			LAZYREPLACEKEY(R.channels, old_channel, new_channel)
-			LAZYREPLACEKEY(R.secure_radio_connections, old_channel, new_channel)
-
-/proc/assign_away_freq(channel)
 	if (!AWAY_FREQS_UNASSIGNED.len)
 		return FALSE
 
-	if (channel in AWAY_FREQS_ASSIGNED)
-		return AWAY_FREQS_ASSIGNED[channel]
-
 	var/freq = pick_n_take(AWAY_FREQS_UNASSIGNED)
 	AWAY_FREQS_ASSIGNED[channel] = freq
+	AWAY_FREQS_DISPLAY_NAMES[channel] = display_name || channel
 	radiochannels[channel] = freq
 	reverseradiochannels["[freq]"] = channel
 	ALL_RADIO_CHANNELS[channel] = TRUE

--- a/code/defines/procs/radio.dm
+++ b/code/defines/procs/radio.dm
@@ -8,6 +8,9 @@
 	if(SSradio)
 		SSradio.remove_object(source, frequency)
 
+/proc/get_radio_channel_display_name(var/channel)
+	return AWAY_FREQS_DISPLAY_NAMES[channel] || channel
+
 /proc/get_frequency_name(var/display_freq)
 	var/freq_text
 
@@ -21,7 +24,7 @@
 		else
 			for(var/channel in radiochannels)
 				if(radiochannels[channel] == display_freq)
-					freq_text = channel
+					freq_text = get_radio_channel_display_name(channel)
 					break
 
 	// --- If the frequency has not been assigned a name, just use the frequency as the name ---

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -31,15 +31,15 @@
 	var/sector_z = get_sector_z()
 	var/obj/effect/overmap/visitable/V = GLOB.map_sectors["[sector_z]"]
 	if(istype(V) && V.comms_support)
-		var/freq_name = V.name
+		var/frequency_name = V.get_comms_frequency_name()
+		assign_away_freq(frequency_name, V.get_comms_frequency_display_name())
 		if(V.freq_name)
-			freq_name = V.freq_name
 			name = "[V.freq_name] encryption key"
 		else if(V.comms_name)
 			name = "[V.comms_name] encryption key"
 
 		channels += list(
-			"[freq_name]" = TRUE,
+			"[frequency_name]" = TRUE,
 			CHANNEL_HAILING = TRUE
 		)
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -28,6 +28,8 @@
 /obj/item/radio/headset/feedback_hints(mob/user, distance, is_adjacent)
 	. = list()
 	. = ..()
+	if(channels.len)
+		setupRadioDescription()
 	if(!(is_adjacent && radio_desc))
 		return
 
@@ -943,7 +945,7 @@
 	var/obj/effect/overmap/visitable/V = GLOB.map_sectors["[sector_z]"]
 	if(istype(V))
 		if(V.comms_support)
-			default_frequency = assign_away_freq(V.name)
+			default_frequency = assign_away_freq(V.get_comms_frequency_name(), V.get_comms_frequency_display_name())
 			if(V.comms_name)
 				name = "[V.comms_name] radio headset"
 	else

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -71,9 +71,10 @@ pixel_x = 8;
 	if(istype(V) && V.comms_support)
 		if(V.comms_name)
 			name = "intercom ([V.comms_name])"
-		default_frequency = assign_away_freq(V.name)
+		var/frequency_name = V.get_comms_frequency_name()
+		default_frequency = assign_away_freq(frequency_name, V.get_comms_frequency_display_name())
 		channels += list(
-			V.name = TRUE,
+			"[frequency_name]" = TRUE,
 			CHANNEL_HAILING = TRUE
 		)
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -115,6 +115,8 @@ var/global/list/default_interrogation_channels = list(
 		else
 			. += SPAN_NOTICE("\The [src] can not be modified or attached!")
 
+	if(channels.len)
+		setupRadioDescription()
 	if(radio_desc)
 		. += radio_desc
 
@@ -328,7 +330,7 @@ var/global/list/default_interrogation_channels = list(
 			key = get_radio_key_from_channel("department")
 			found_first_department = TRUE
 
-		radio_text += "[key] - [channel]"
+		radio_text += "[key] - [get_radio_channel_display_name(channel)]"
 		if(i != channels.len)
 			radio_text += ", "
 
@@ -346,7 +348,7 @@ var/global/list/default_interrogation_channels = list(
 		var/chan_stat = channels[ch_name]
 		var/listening = chan_stat & FREQ_LISTENING
 
-		dat.Add(list(list("chan" = radiochannels[ch_name], "display_name" = ch_name, "secure_channel" = 1, "sec_channel_listen" = listening, "chan_span" = frequency_span_class(radiochannels[ch_name]))))
+		dat.Add(list(list("chan" = radiochannels[ch_name], "display_name" = get_radio_channel_display_name(ch_name), "secure_channel" = 1, "sec_channel_listen" = listening, "chan_span" = frequency_span_class(radiochannels[ch_name]))))
 
 	return dat
 
@@ -732,13 +734,11 @@ var/global/list/default_interrogation_channels = list(
 	var/turf/T = get_turf(src)
 	var/obj/effect/overmap/visitable/V = GLOB.map_sectors["[T.z]"]
 	if(istype(V) && V.comms_support)
-		var/freq_name = V.name
-		if(V.freq_name)
-			freq_name = V.freq_name
-		frequency = assign_away_freq(freq_name)
+		var/frequency_name = V.get_comms_frequency_name()
+		frequency = assign_away_freq(frequency_name, V.get_comms_frequency_display_name())
 		default_frequency = frequency
 		channels += list(
-			freq_name = TRUE,
+			"[frequency_name]" = TRUE,
 			CHANNEL_HAILING = TRUE
 		)
 		if(V.comms_name)

--- a/code/game/objects/structures/machinery/telecomms/machines/allinone.dm
+++ b/code/game/objects/structures/machinery/telecomms/machines/allinone.dm
@@ -65,7 +65,7 @@
 			name = "[lowertext(linked.comms_name)] [initial(name)]"
 		freq_listening = list(
 			HAIL_FREQ,
-			assign_away_freq(linked.name)
+			assign_away_freq(linked.get_comms_frequency_name(), linked.get_comms_frequency_display_name())
 		)
 
 /obj/structure/machinery/telecomms/allinone/ship/coalition_navy

--- a/code/game/objects/structures/machinery/telecomms/presets.dm
+++ b/code/game/objects/structures/machinery/telecomms/presets.dm
@@ -46,10 +46,12 @@
 
 	if(istype(linked) && linked.comms_support)
 		var/preset_name = linked.comms_name
+		var/frequency_name = linked.get_comms_frequency_name()
+		var/frequency_display_name = linked.get_comms_frequency_display_name()
 		var/name_lower = replacetext(lowertext(preset_name), " ", "_")
 		id = "[preset_name] Receiver"
 		network = "tcomm_[name_lower]"
-		freq_listening += list(assign_away_freq(preset_name), HAIL_FREQ)
+		freq_listening += list(assign_away_freq(frequency_name, frequency_display_name), HAIL_FREQ)
 		if (use_common || linked.use_common)
 			freq_listening += PUB_FREQ
 		autolinkers = list(
@@ -89,10 +91,12 @@
 
 	if(istype(linked) && linked.comms_support)
 		var/preset_name = linked.comms_name
+		var/frequency_name = linked.get_comms_frequency_name()
+		var/frequency_display_name = linked.get_comms_frequency_display_name()
 		var/name_lower = replacetext(lowertext(preset_name), " ", "_")
 		id = "[preset_name] Bus"
 		network = "tcomm_[name_lower]"
-		freq_listening += list(assign_away_freq(preset_name), HAIL_FREQ)
+		freq_listening += list(assign_away_freq(frequency_name, frequency_display_name), HAIL_FREQ)
 		if (use_common || linked.use_common)
 			freq_listening += PUB_FREQ
 		autolinkers = list(
@@ -195,11 +199,13 @@
 
 	if(istype(linked) && linked.comms_support)
 		var/preset_name = linked.comms_name
+		var/frequency_name = linked.get_comms_frequency_name()
+		var/frequency_display_name = linked.get_comms_frequency_display_name()
 		var/name_lower = replacetext(lowertext(preset_name), " ", "_")
 		id = "[preset_name] server"
 		network = "tcomm_[name_lower]"
 		freq_listening += list(
-			assign_away_freq(preset_name),
+			assign_away_freq(frequency_name, frequency_display_name),
 			HAIL_FREQ
 		)
 		if(use_common || linked.use_common)

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -60,6 +60,8 @@ GLOBAL_DATUM(map_overmap, /area/overmap)
 	var/comms_name = "shipboard"
 	/// Snowflake name to label frequency, if not set, frequency defaults to overmap name
 	var/freq_name = ""
+	/// Stable hidden key for the away comms frequency. Display names can change without retuning radios.
+	var/comms_frequency_name = ""
 	/// Whether away ship comms have access to the common channel / PUB_FREQ
 	var/use_common = FALSE
 	/// list of weakrefs to people viewing the overmap via this ship
@@ -218,13 +220,22 @@ GLOBAL_DATUM(map_overmap, /area/overmap)
 		return
 	if(obfuscated)
 		return
+	var/new_name = get_real_name()
 	if(comms_support)
-		update_away_freq(name, get_real_name())
+		update_away_freq_display(get_comms_frequency_name(new_name), get_comms_frequency_display_name(new_name))
 	SEND_SIGNAL(src, COMSIG_BASENAME_SETNAME, args)
-	name = get_real_name()
+	name = new_name
 
 /obj/effect/overmap/visitable/proc/get_real_name()
 	return class ? "[class] [designation]" : designation
+
+/obj/effect/overmap/visitable/proc/get_comms_frequency_name(var/overmap_name = null)
+	if(!comms_frequency_name)
+		comms_frequency_name = freq_name || overmap_name || name
+	return comms_frequency_name
+
+/obj/effect/overmap/visitable/proc/get_comms_frequency_display_name(var/overmap_name = null)
+	return freq_name || overmap_name || name
 
 /obj/effect/overmap/visitable/proc/set_new_designation(var/new_name)
 	designation = new_name

--- a/html/changelogs/Bat-RadioFix.yml
+++ b/html/changelogs/Bat-RadioFix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Batrachophrenoboocosmomachia
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Renaming away sites no longer breaks radios; only display names are updated instead, without modifying underlying frequencies."


### PR DESCRIPTION
See title.

Decouples frequency and display name from radio identity. When an away site is renamed, it adds a new mapping for that round to AWAY_FREQS_DISPLAY_NAMES, which any radios keyed to that frequency will automatically update