### PR TITLE
Adds a chance for cigarettes to ignite people when lit around oxygen IVs

### DIFF
--- a/code/game/objects/structures/machinery/iv_drip.dm
+++ b/code/game/objects/structures/machinery/iv_drip.dm
@@ -267,7 +267,46 @@
 					tank.distribute_pressure = safe_pressure_min // Constantly adjusts the pressure to keep up with the damage
 					breather.losebreath = 0
 					to_chat(breather, SPAN_NOTICE("You feel fresh air being pushed into your lungs."))
+				if(prob(5))
+					try_oxygen_fire()
 			update_icon()
+
+///Make a reason for no smoking signs in medbay. This finds anyone smoking (or any other open flame) within 1 tile and tries to set them and the patient on fire.
+/obj/structure/machinery/iv_drip/proc/try_oxygen_fire()
+	if(!tank)
+		return
+	if(tank.distribute_pressure <= 21) //Only if positive pressure is pushing more oxygen than normal.
+		return
+
+	var/list/moblist = mobs_in_view(1, src)
+	var/mob/living/smoker = null
+	var/obj/item/clothing/mask/smokable/lit_cig = null
+	var/obj/item/flame/lit_flame = null
+	for(var/mob/M in moblist)
+		if(!M)
+			return
+		for(var/obj/item/held_item in list(M.r_hand, M.l_hand, M.wear_mask))
+			if(!held_item)
+				continue
+			if(istype(held_item, /obj/item/flame))
+				lit_flame = held_item
+				if(lit_flame.lit)
+					smoker = M
+			if(istype(held_item, /obj/item/clothing/mask/smokable))
+				lit_cig = held_item
+				if(lit_cig.lit)
+					smoker = M
+
+	if(breather && smoker)
+		if(lit_flame)
+			breather.IgniteMob(1)
+			src.visible_message(SPAN_WARNING("Sparks from [smoker]'s [lit_flame.name] flare up in the oxygen leaking from \the [breather]'s mask!"))
+		else if(lit_cig)
+			breather.IgniteMob(1)
+			src.visible_message(SPAN_WARNING("Sparks from [smoker]'s [lit_cig.name] flare up in the oxygen leaking from \the [breather]'s mask!"))
+
+	if(smoker && smoker != attached) //Make sure we don't ignite them twice, if they've got a lit cigarette in their hand when they're hooked up to oxygen.
+		smoker.IgniteMob(1)
 
 /obj/structure/machinery/iv_drip/proc/attached_process()
 	if(attached)

--- a/code/game/objects/structures/machinery/iv_drip.dm
+++ b/code/game/objects/structures/machinery/iv_drip.dm
@@ -275,6 +275,9 @@
 /obj/structure/machinery/iv_drip/proc/try_oxygen_fire()
 	if(!tank)
 		return
+	if(tank.air_contents)
+		if(tank.air_contents.gas[GAS_OXYGEN] != tank.air_contents.total_moles) //If the gas is not pure oxygen, return.
+			return
 	if(tank.distribute_pressure <= 21) //Only if positive pressure is pushing more oxygen than normal.
 		return
 

--- a/html/changelogs/Fenodyree-OxygenFireMedbay.yml
+++ b/html/changelogs/Fenodyree-OxygenFireMedbay.yml
@@ -1,0 +1,6 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - rscadd: "Adds a small chance for lit cigarettes within one tile to ignite oxygen leaking from an IV drip's poisitive pressure mask. This ignites both the patient and the smoker. Respect the no smoking signs."


### PR DESCRIPTION
When an IV is giving oxygen using positive pressure (Eg. on someone with damaged lungs).
There is now a chance for a lit cigarette or lighter to ignite both the smoker and the patient.

5% chance per tick to give one fire stack, only if the mask is giving more than 21kPa of pressure.

This gives doctors a reason to murder smokers in medbay. :)

https://github.com/user-attachments/assets/049ad52f-6b76-421c-adce-3fb5e6e2612e

https://github.com/user-attachments/assets/3073da2c-2818-422d-9e80-0bbcfc2b6864

