### PR TITLE
Fixes a second person scanning the patient cancelling the first scan

### DIFF
--- a/code/datums/components/medical/medicalAnalyzer.dm
+++ b/code/datums/components/medical/medicalAnalyzer.dm
@@ -102,7 +102,7 @@
 	// each device level and anatomy rank reduces the time by half a second. Get that skill up
 	var/time = max(5 - (0.5 * (device_level + (anatomy ? anatomy : 1))), 1)
 
-	if(do_after(user, time SECONDS, target_mob, DO_UNIQUE))
+	if(do_after(user, time SECONDS, target_mob)) //This can't be DO_UNIQUE because prevents two people from scanning the same patient.
 		flick("[owner.icon_state]-scan", owner)
 
 		health_scan_mob(target_mob, user, FALSE, sound_scan = sound_scan)

--- a/html/changelogs/Fenodyree-MedscannerFix.yml
+++ b/html/changelogs/Fenodyree-MedscannerFix.yml
@@ -1,0 +1,6 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes two people not being able to scan the same patient at the same time."


### PR DESCRIPTION
DO_UNIQUE prevented a second person scanning the same patient at the same time.

This does let you spam the medscanner and get multiple scans in progress at the same time, but that's much less of an issue than getting your scan canceled by a second well meaning doctor.
