### PR TITLE
Nerfs painkillers

### DIFF
--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -47,7 +47,6 @@
 #define IS_UNDEAD  128
 
 // Apply status effects
-#define CE_ADRENALINE	"adrenal"		// Like speedboost but different
 #define CE_ALCOHOL      "alcohol"		// Liver filtering
 #define CE_ANTIEMETIC   "antiemetic"	// suppresses vomiting
 #define CE_ITCH         "itch"          // causes itching
@@ -64,6 +63,14 @@
 #define CE_SLOWDOWN     "goslow"
 #define CE_STABLE       "stable"		// Epinephrine
 #define CE_PACIFIED     "pacified"
+
+/**
+ * Reduces pain taken by organs, is subtracted from organ pain and from traumatic_shock.alist
+ * This value stacks with itself. Multiple painkillers stack additively.
+ * Sets the analgesic value for /mob/living/carbon/, if this value is over 200 (CE_PAINKILLER 200), the mob will suffer no effects from pain or traumatic shock.
+ * The pain recieved from any source is reduced by (CE_PAINKILLER / 3) in /obj/item/organ/external/proc/add_pain(var/amount)
+ * Traumatic shock (the effect that causes a mob to collapse from pain) is reduced by this value in /mob/living/carbon/human/get_shock()
+ */
 #define CE_PAINKILLER   "painkiller"
 #define CE_PULSE        "xcardic"		// increases or decreases heartrate
 #define CE_UNDEXTROUS   "undextrous"    // arms no work right

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -570,7 +570,7 @@
 		return FALSE
 	if ((mutations & HULK))
 		return FALSE
-	if (analgesic > 100)
+	if (analgesic > 200)
 		return FALSE
 	if(pain_immune)
 		return FALSE

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -68,13 +68,14 @@
 			return species.total_health
 	return 0
 
+///This fetches the cumulative total pain from all organs.
 /mob/living/carbon/human/getHalLoss()
 	var/amount = 0
 	for(var/obj/item/organ/external/E in organs)
 		amount += E.get_pain()
 	return amount
 
-//These procs fetch a cumulative total damage from all organs
+///These procs fetch a cumulative total damage from all organs
 /mob/living/carbon/human/getBruteLoss()
 	var/amount = 0
 	for(var/obj/item/organ/external/O in organs)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -706,12 +706,6 @@
 		stamina_recovery = species.stamina_recovery
 		sprint_cost_factor = species.sprint_cost_factor
 
-		if(CE_ADRENALINE in chem_effects)
-			sprint_speed_factor += 0.1*chem_effects[CE_ADRENALINE]
-			max_stamina *= 1 + chem_effects[CE_ADRENALINE]
-			sprint_cost_factor -= 0.35 * chem_effects[CE_ADRENALINE]
-			stamina_recovery += max ((stamina_recovery * 0.7 * chem_effects[CE_ADRENALINE]), 5)
-
 		var/obj/item/clothing/suit = wear_suit
 		var/protected = FALSE
 		if(suit && (suit.body_parts_covered & HANDS) && (suit.heat_protection & HANDS))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -347,7 +347,7 @@
 	M.notify_message(SPAN_GOOD(pick(joy_messages)), rand(20 SECONDS, 40 SECONDS), key = "morta_affect_blood")
 
 	if(check_min_dose(M))
-		M.add_chemical_effect(CE_PAINKILLER, 50)
+		M.add_chemical_effect(CE_PAINKILLER, 60)
 		if(!M.chem_effects[CE_CLEARSIGHT])
 			M.eye_blurry = max(M.eye_blurry, 5)
 		if(!M.chem_effects[CE_STRAIGHTWALK])
@@ -527,7 +527,7 @@
 		to_chat(M, SPAN_GOOD(pick("You feel soothed and at ease.", "You feel content and at peace.", "You feel a pleasant emptiness.", "You feel like sharing the wonderful memories and feelings you're experiencing.", "All your anxieties fade away.", "You feel like you're floating off the ground.", "You don't want this feeling to end.")))
 
 	if(check_min_dose(M))
-		M.add_chemical_effect(CE_PAINKILLER, 200)
+		M.add_chemical_effect(CE_PAINKILLER, 210)
 		M.add_chemical_effect(CE_SLOWDOWN, 2)
 		if(!M.chem_effects[CE_CLEARSIGHT])
 			M.eye_blurry = max(M.eye_blurry, 5)
@@ -587,9 +587,8 @@
 	if(.)
 		M.add_chemical_effect(CE_CLEARSIGHT)
 		M.add_chemical_effect(CE_STRAIGHTWALK)
-		M.add_chemical_effect(CE_PAINKILLER, 30)
+		M.add_chemical_effect(CE_PAINKILLER, 10)
 		M.add_chemical_effect(CE_HALLUCINATE, -1)
-		M.add_up_to_chemical_effect(CE_ADRENALINE, 1)
 		M.add_chemical_effect(CE_BLOODTHIN, 25)
 
 /singleton/reagent/synaptizine/overdose(var/mob/living/carbon/M, var/alien, var/datum/reagents/holder)
@@ -1972,7 +1971,6 @@
 		M.add_chemical_effect(CE_STRAIGHTWALK)
 		M.add_chemical_effect(CE_PAINKILLER, 30)
 		M.add_chemical_effect(CE_HALLUCINATE, -1)
-		M.add_up_to_chemical_effect(CE_ADRENALINE, 1)
 
 /singleton/reagent/kilosemine/overdose(mob/living/carbon/M, alien, removed, scale, datum/reagents/holder)
 	if(!ishuman(M))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -347,7 +347,7 @@
 	M.notify_message(SPAN_GOOD(pick(joy_messages)), rand(20 SECONDS, 40 SECONDS), key = "morta_affect_blood")
 
 	if(check_min_dose(M))
-		M.add_chemical_effect(CE_PAINKILLER, 60)
+		M.add_chemical_effect(CE_PAINKILLER, 70)
 		if(!M.chem_effects[CE_CLEARSIGHT])
 			M.eye_blurry = max(M.eye_blurry, 5)
 		if(!M.chem_effects[CE_STRAIGHTWALK])

--- a/html/changelogs/Fenodyree-PainkillerRebalance.yml
+++ b/html/changelogs/Fenodyree-PainkillerRebalance.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: Fenodyree
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/Fenodyree-PainkillerRebalance.yml
+++ b/html/changelogs/Fenodyree-PainkillerRebalance.yml
@@ -1,0 +1,62 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Removes CE_ADRENALINE. This was a synaptizine only flag that gave you a momvement speed and stamina buff."
+  - balance: "Increases the threshold for NO_PAIN to 200, from 100. This means you need more and stronger painkillers to be immune to pain effects."
+  - balance: "Nerfs Synaptizine from 30 to 10 painkill."
+  - balance: "Buffs Oxycomorphine from 200 to 210 painkill. This makes sure it always puts you into NO_PAIN."
+  - balance: "Buffs Mortaphenyl from 50 to 70 painkill. This means antag stimpacks have the same total painkill."


### PR DESCRIPTION
Sets the NO_PAIN threshold to 200, instead of 100. Meaning painkiller values above 100 are necessary to ignore all pain effects.
This is necessary because:
- CE_PAINKILLER stacks additively.
- Mobs get given adrenaline every time they are hit.
- Adrenaline gives between 15 and 5 CE_PAINKILLER.
- Inaprovaline (10), Perconol (35), Mortaphenyl (50), Synaptizine (30), Adrenaline (15-5).
- There was no reason to use more powerful painkillers with worse side effects, when easy to obtain, longer lasting painkillers do the same job.

Removes CE_ADRENALINE, which was poorly named, only used for Synaptizine and didn't use the desired movespeed 
modification pathways.

Reduces Synaptizine's painkilling value from 30 to 10.
Synaptizine cancels stuns, cancels all other painkiller side effects and 10u of it lasts an hour.
It is still the best combat drug in the game even with these nerfs.

Slight buff to oxycomorphine, to make sure that it doesn't tick down and can consistently keep analgesic above 200.

Slight buff to mortaphenyl. This means the painkilling effect of antag stims will remain the same, but for a shorter duration. Also makes it more useful to doctors.
