### PR TITLE
Fix python numpy dependency version 

### DIFF
--- a/html/changelogs/fabiank3-fix-numpy-version.yml
+++ b/html/changelogs/fabiank3-fix-numpy-version.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fix changelog generation by fixing python numpy version to support current cpython version."

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -3,4 +3,4 @@ bidict==0.23.1
 Pillow==12.0.0
 PyYAML==6.0.3
 beautifulsoup4==4.14.2
-numpy==1.26.0
+numpy==1.26.4


### PR DESCRIPTION
# Summary

This PR raises the python numpy dependency from [1.26.0](https://pypi.org/project/numpy/1.26.0/) to [1.26.4](https://pypi.org/project/numpy/1.26.4/) (comp) to give support to higher python versions  
(from Python [<3.13, >=3.9] to Python [>=3.9]).

This should fix the CI changelog job failing its setup.

## PoC

CI python setup returns python v3.14:

<img width="321" height="98" alt="image" src="https://github.com/user-attachments/assets/3d0ddc16-7e4d-4c22-9661-578b404bdc7f" />

numpy, dependency for the changelog gen pinned v1.26.0, which doesn't support python >3.13.  
numpy v1.26.4 raises support to >=3.9.
