### PR TITLE
Silicon Psionics Fix

### DIFF
--- a/code/modules/psionics/mob/mob_helpers.dm
+++ b/code/modules/psionics/mob/mob_helpers.dm
@@ -64,6 +64,9 @@
 /mob/living/has_zona_bovinae()
 	return TRUE
 
+/mob/living/silicon/has_zona_bovinae()
+	return FALSE
+
 /mob/living/carbon/has_zona_bovinae()
 	if(HAS_TRAIT(src, TRAIT_PSIONICALLY_DEAF))
 		return FALSE

--- a/html/changelogs/hellfirejag-silicon-psionics-fix.yml
+++ b/html/changelogs/hellfirejag-silicon-psionics-fix.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed silicons incorrectly being considered a valid target for psionics."


### PR DESCRIPTION
I was unaware that Silicons were somehow considered a valid target for psionics this whole time.