### PR TITLE
Final Mob Destroy Audit

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -99,7 +99,7 @@
 				for(var/J in 1 to components_of_type.len)
 					var/datum/component/C = components_of_type[J]
 					if(C.type != our_type) //but not over other exact matches
-						components_of_type.Insert(J, I)
+						components_of_type.Insert(J, src)
 						inserted = TRUE
 						break
 				if(!inserted)

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -106,7 +106,7 @@
 		var/list/timers = _active_timers
 		_active_timers = null
 		for(var/datum/timedevent/timer as anything in timers)
-			if (timer.spent && !(timer.flags & TIMER_DELETE_ME))
+			if (!timer || (timer.spent && !(timer.flags & TIMER_DELETE_ME)))
 				continue
 			qdel(timer)
 
@@ -126,6 +126,8 @@
 			var/component_or_list = dc[component_key]
 			if(islist(component_or_list))
 				for(var/datum/component/component as anything in component_or_list)
+					if (!component)
+						continue
 					qdel(component, FALSE)
 			else
 				var/datum/component/C = component_or_list

--- a/code/datums/langchat/langchat.dm
+++ b/code/datums/langchat/langchat.dm
@@ -46,9 +46,13 @@
 /// Drops all active bubbles for this atom.
 /atom/proc/langchat_drop_images()
 	for(var/datum/langchat_bubble/entry as anything in langchat_images)
+		if (!entry || !entry.bubble)
+			continue
+
 		for(var/mob/listener as anything in entry.listeners)
-			if(listener.client)
-				listener.client.images -= entry.bubble
+			if (!listener || !listener.client)
+				continue
+			listener.client.images -= entry.bubble
 	langchat_images = null
 
 /atom/proc/get_maptext_x_offset(image/maptext_image)

--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -178,7 +178,12 @@
 	orbiters = null
 	do_unique_target_user = null
 	langchat_drop_images()
-	QDEL_LIST(contents)
+	if (length(contents))
+		for(var/content in contents)
+			if (QDELING(content))
+				continue
+			qdel(content)
+		contents.Cut()
 	return ..()
 
 /atom/proc/handle_ricochet(obj/projectile/ricocheting_projectile)

--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -178,12 +178,6 @@
 	orbiters = null
 	do_unique_target_user = null
 	langchat_drop_images()
-	if (length(contents))
-		for(var/atom/content in contents)
-			if (QDELETED(content))
-				continue
-			qdel(content)
-		contents.Cut()
 	return ..()
 
 /atom/proc/handle_ricochet(obj/projectile/ricocheting_projectile)

--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -179,8 +179,8 @@
 	do_unique_target_user = null
 	langchat_drop_images()
 	if (length(contents))
-		for(var/content in contents)
-			if (QDELING(content))
+		for(var/atom/content in contents)
+			if (QDELETED(content))
 				continue
 			qdel(content)
 		contents.Cut()

--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -155,6 +155,9 @@
 	if(length(overlays))
 		overlays.Cut()
 
+	if (length(underlays))
+		underlays.Cut()
+
 	QDEL_NULL(light)
 	QDEL_NULL(static_light)
 
@@ -175,6 +178,7 @@
 	orbiters = null
 	do_unique_target_user = null
 	langchat_drop_images()
+	QDEL_LIST(contents)
 	return ..()
 
 /atom/proc/handle_ricochet(obj/projectile/ricocheting_projectile)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -124,10 +124,9 @@
 		AddComponent(/datum/component/overlay_lighting, is_directional = TRUE)
 
 /atom/movable/Destroy(force)
-	if(orbiting)
-		orbiting.end_orbit(src)
-
+	orbiting?.end_orbit(src)
 	QDEL_NULL(emissive_overlay)
+	particles = null
 
 	if(move_packet)
 		if(!QDELETED(move_packet))
@@ -139,8 +138,6 @@
 
 	QDEL_LAZYLIST(contained_mobs)
 
-	for(var/movable_content in contents)
-		qdel(movable_content)
 
 	//Pretend this is moveToNullspace()
 	moveToNullspace()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -138,6 +138,8 @@
 
 	QDEL_LAZYLIST(contained_mobs)
 
+	for(var/movable_content in contents)
+		qdel(movable_content)
 
 	//Pretend this is moveToNullspace()
 	moveToNullspace()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -684,6 +684,8 @@
 	SSspatial_grid.remove_grid_membership(src, our_turf, SPATIAL_GRID_CONTENTS_TYPE_HEARING)
 
 	for(var/atom/movable/location as anything in get_nested_locs(src) + src)
+		if (!location)
+			continue
 		var/list/recursive_contents = location.important_recursive_contents // blue hedgehog velocity
 		recursive_contents[RECURSIVE_CONTENTS_HEARING_SENSITIVE] -= src
 		if(!length(recursive_contents[RECURSIVE_CONTENTS_HEARING_SENSITIVE]))

--- a/code/modules/mob/living/carbon/diona_base.dm
+++ b/code/modules/mob/living/carbon/diona_base.dm
@@ -636,7 +636,8 @@ Most of these values are calculated from information configured at authortime in
 	last_location = null
 	regen_limb = null
 	regen_extra = null
-	. = ..()
+	nym = null
+	return ..()
 
 /datum/dionastats/proc/do_blood_suck(var/mob/living/carbon/user, var/mob/living/carbon/human/H)
 	user.visible_message(SPAN_DANGER("[user] is trying to bite [H.name]."), SPAN_DANGER("You start biting \the [H], you both must stay still!"))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -101,7 +101,6 @@
 	//Srom (Shared Dreaming)
 	srom_pulled_by = null
 	srom_pulling = null
-	bg = null //Just to be sure.
 
 	GLOB.human_mob_list -= src
 	GLOB.intent_listener -= src

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -924,6 +924,7 @@ default behaviour is:
 		for (var/datum/action/action in actions)
 			action.Remove(src)
 			actions -= action
+		actions.Cut()
 
 	QDEL_NULL(stamina_bar)
 	QDEL_LIST(auras)
@@ -934,9 +935,7 @@ default behaviour is:
 	if(loc)
 		for(var/mob/M in contents)
 			M.dropInto(loc)
-	else
-		for(var/mob/M in contents)
-			qdel(M)
+			contents -= M
 
 	prepared_maneuver = null
 	available_maneuvers?.Cut()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -924,7 +924,6 @@ default behaviour is:
 		for (var/datum/action/action in actions)
 			action.Remove(src)
 			actions -= action
-		actions.Cut()
 
 	QDEL_NULL(stamina_bar)
 	QDEL_LIST(auras)
@@ -935,7 +934,9 @@ default behaviour is:
 	if(loc)
 		for(var/mob/M in contents)
 			M.dropInto(loc)
-			contents -= M
+	else
+		for(var/mob/M in contents)
+			qdel(M)
 
 	prepared_maneuver = null
 	available_maneuvers?.Cut()

--- a/html/changelogs/hellfirejag-final-atoms-audit.yml
+++ b/html/changelogs/hellfirejag-final-atoms-audit.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed numerous hard dels related to byond built-in refs not being cleared."


### PR DESCRIPTION
I've audited the entire destroy path between datum and human, this time paying attention to byond's built-in vars to make sure that the built-in refs are correctly being cleared. I've also gone and corrected some null-access mistakes, which are most prominently caused by as anything casts not being null checked, since as anything allows null entries in a list to be read.

By far the worst offender I've found was the lack of clearing of the atom.underlays var, which contains a list of refs. And when searching for uses of this var across the repo, I've discovered it's associated with an overwhelming majority of the remaining objects still in the hard del trackers. 