### PR TITLE
Nicotine runtime

### DIFF
--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -1,4 +1,5 @@
-#define REM 0.2 // Means 'Reagent Effect Multiplier'. This is how many units of reagent are consumed per tick
+/// Base amount of reagents to metabolize "per second".
+#define REM 0.1
 
 #define CHEM_TOUCH 1
 #define CHEM_INGEST 2

--- a/code/modules/mob/living/carbon/alien/diona/life.dm
+++ b/code/modules/mob/living/carbon/alien/diona/life.dm
@@ -8,14 +8,15 @@
 	if(stat != DEAD)
 		diona_handle_light(DS)
 
-/mob/living/carbon/alien/diona/handle_chemicals_in_body()
+/mob/living/carbon/alien/diona/handle_chemicals_in_body(seconds_per_tick)
+	ENFORCE_CALCULUS(seconds_per_tick)
 	chem_effects.Cut()
 	analgesic = 0
 
-	if(touching) touching.metabolize()
-	if(bloodstr) bloodstr.metabolize()
-	if(breathing) breathing.metabolize()
-	if(ingested) ingested.metabolize()
+	if(touching) touching.metabolize(seconds_per_tick)
+	if(bloodstr) bloodstr.metabolize(seconds_per_tick)
+	if(breathing) breathing.metabolize(seconds_per_tick)
+	if(ingested) ingested.metabolize(seconds_per_tick)
 
 	for(var/_R in chem_doses)
 		if ((_R in bloodstr.reagent_volumes) || (_R in ingested.reagent_volumes) || (_R in breathing.reagent_volumes) || (_R in touching.reagent_volumes))

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -71,15 +71,16 @@
 		adjustFireLoss(5.0*discomfort)
 
 
-/mob/living/carbon/brain/handle_chemicals_in_body()
+/mob/living/carbon/brain/handle_chemicals_in_body(seconds_per_tick)
+	ENFORCE_CALCULUS(seconds_per_tick)
 	chem_effects.Cut()
 	analgesic = 0
 
-	if(touching) touching.metabolize()
+	if(touching) touching.metabolize(seconds_per_tick)
 	var/datum/reagents/metabolism/ingested = get_ingested_reagents()
-	if(istype(ingested)) ingested.metabolize()
-	if(bloodstr) bloodstr.metabolize()
-	if(breathing) breathing.metabolize()
+	if(istype(ingested)) ingested.metabolize(seconds_per_tick)
+	if(bloodstr) bloodstr.metabolize(seconds_per_tick)
+	if(breathing) breathing.metabolize(seconds_per_tick)
 
 	if(CE_PAINKILLER in chem_effects)
 		analgesic = chem_effects[CE_PAINKILLER]

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -25,7 +25,7 @@
 		handle_breathing()
 
 		//Chemicals in the body
-		handle_chemicals_in_body()
+		handle_chemicals_in_body(seconds_per_tick)
 
 		//Random events (vomiting etc)
 		handle_random_events()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -11,6 +11,7 @@
 		add_verb(src, /verb/toggle_indefinite_sleep)
 
 /mob/living/carbon/Life(seconds_per_tick, times_fired)
+	ENFORCE_CALCULUS(seconds_per_tick)
 	if(!..())
 		return
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -200,11 +200,12 @@
 			return reactor.bio_reagents
 	return touching
 
-/mob/living/carbon/human/proc/metabolize_ingested_reagents()
+/mob/living/carbon/human/proc/metabolize_ingested_reagents(seconds_per_tick)
+	ENFORCE_CALCULUS(seconds_per_tick)
 	if(should_have_organ(BP_STOMACH))
 		var/obj/item/organ/internal/stomach/stomach = internal_organs_by_name[BP_STOMACH]
 		if(stomach)
-			stomach.metabolize()
+			stomach.metabolize(seconds_per_tick)
 
 /mob/living/carbon/human/get_fullness()
 	if(!should_have_organ(BP_STOMACH))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -643,7 +643,8 @@
 
 	return min(1,thermal_protection)
 
-/mob/living/carbon/human/handle_chemicals_in_body()
+/mob/living/carbon/human/handle_chemicals_in_body(seconds_per_tick)
+	ENFORCE_CALCULUS(seconds_per_tick)
 	if(InStasis())
 		return
 
@@ -654,10 +655,10 @@
 	if(reagents)
 		analgesic = 0
 
-		if(touching) touching.metabolize()
-		if(bloodstr) bloodstr.metabolize()
-		if(ingested) metabolize_ingested_reagents()
-		if(breathing) breathing.metabolize()
+		if(touching) touching.metabolize(seconds_per_tick)
+		if(bloodstr) bloodstr.metabolize(seconds_per_tick)
+		if(ingested) metabolize_ingested_reagents(seconds_per_tick)
+		if(breathing) breathing.metabolize(seconds_per_tick)
 
 		if(CE_PAINKILLER in chem_effects)
 			analgesic = chem_effects[CE_PAINKILLER]

--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -70,18 +70,19 @@
 	temp_change = (temperature - current)
 	return temp_change
 
-/mob/living/carbon/slime/handle_chemicals_in_body()
+/mob/living/carbon/slime/handle_chemicals_in_body(seconds_per_tick)
+	ENFORCE_CALCULUS(seconds_per_tick)
 	chem_effects.Cut()
 	analgesic = FALSE
 
 	if(touching)
-		touching.metabolize()
+		touching.metabolize(seconds_per_tick)
 	if(ingested)
-		ingested.metabolize()
+		ingested.metabolize(seconds_per_tick)
 	if(bloodstr)
-		bloodstr.metabolize()
+		bloodstr.metabolize(seconds_per_tick)
 	if(breathing)
-		breathing.metabolize()
+		breathing.metabolize(seconds_per_tick)
 
 	if(CE_PAINKILLER in chem_effects)
 		analgesic = chem_effects[CE_PAINKILLER]

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -53,6 +53,7 @@
 	return
 
 /mob/living/proc/handle_chemicals_in_body(seconds_per_tick)
+	ENFORCE_CALCULUS(seconds_per_tick)
 	return
 
 /mob/living/proc/handle_mutations_and_radiation(seconds_per_tick)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -52,7 +52,7 @@
 /mob/living/proc/handle_breathing()
 	return
 
-/mob/living/proc/handle_chemicals_in_body()
+/mob/living/proc/handle_chemicals_in_body(seconds_per_tick)
 	return
 
 /mob/living/proc/handle_mutations_and_radiation(seconds_per_tick)

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -95,9 +95,10 @@
 
 // This call needs to be split out to make sure that all the ingested things are metabolised
 // before the process call is made on any of the other organs
-/obj/item/organ/internal/stomach/proc/metabolize()
+/obj/item/organ/internal/stomach/proc/metabolize(seconds_per_tick)
+	ENFORCE_CALCULUS(seconds_per_tick)
 	if(is_usable())
-		ingested.metabolize()
+		ingested.metabolize(seconds_per_tick)
 
 /obj/item/organ/internal/stomach/process()
 	..()

--- a/code/modules/reagents/Chemistry-Metabolism.dm
+++ b/code/modules/reagents/Chemistry-Metabolism.dm
@@ -13,7 +13,8 @@
 	parent = null
 	. = ..()
 
-/datum/reagents/metabolism/proc/metabolize()
+/datum/reagents/metabolism/proc/metabolize(seconds_per_tick)
+	ENFORCE_CALCULUS(seconds_per_tick)
 	if(!parent)
 		return
 	var/metabolism_type = 0 //non-human mobs
@@ -27,5 +28,5 @@
 	// then run this to actually do what the chems do
 	for(var/_current in reagent_volumes)
 		var/singleton/reagent/current = GET_SINGLETON(_current)
-		current.on_mob_life(parent, metabolism_type, metabolism_class, src)
+		current.on_mob_life(parent, metabolism_type, metabolism_class, src, seconds_per_tick)
 	update_total()

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -101,7 +101,8 @@
 	return OD && (REAGENT_VOLUME(holder, type) > OD) && (LAZYACCESS(M.chem_doses, type) > OD_min) && (!location || (location != CHEM_TOUCH)) //OD based on volume in blood, but waits for a small amount of the drug to metabolise before kicking in.
 
 /// Currently, on_mob_life is called on carbons. Any interaction with non-carbon mobs (lube) will need to be done in touch_mob.
-/singleton/reagent/proc/on_mob_life(var/mob/living/carbon/M, var/alien, var/location, var/datum/reagents/holder)
+/singleton/reagent/proc/on_mob_life(mob/living/carbon/M, alien, location, datum/reagents/holder, seconds_per_tick)
+	ENFORCE_CALCULUS(seconds_per_tick)
 	if(!istype(M))
 		return
 	if(!affects_dead && M.stat == DEAD)
@@ -116,7 +117,7 @@
 		removed = touch_met
 	if(breathe_met && (location == CHEM_BREATHE))
 		removed = breathe_met
-
+	removed *= seconds_per_tick
 	removed = M.get_metabolism(removed)
 
 	// ctual overdose threshold now = overdose + od_minimum_dose. ie. Synaptizine; 5u OD threshold + 1 unit min. metab'd dose = 6u actual OD threshold.

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1273,6 +1273,8 @@
 	messagedelay = MEDICATION_MESSAGE_DELAY * 0.75
 	goodmessage = list("You feel good.","You feel relaxed.","You feel alert and focused.")
 	value = 2
+	specific_heat = 2.1 // J/(mok*K)
+	fallback_specific_heat = 2.1 // J/(mok*K)
 
 /singleton/reagent/mental/nicotine/overdose(var/mob/living/carbon/M, var/alien, var/removed, var/scale, var/datum/reagents/holder)
 	..()

--- a/html/changelogs/hellfirejag-differentiate-chemistry.yml
+++ b/html/changelogs/hellfirejag-differentiate-chemistry.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - refactor: "Tick differentiated chem metabolism."


### PR DESCRIPTION
<img width="1136" height="668" alt="image" src="https://github.com/user-attachments/assets/f386f557-eeb8-49bd-b47a-b363eeeb8bdc" />

Nicotine spams this runtime error because it doesn't have a specific heat. 
While I was touching specific heat I decided to rip a bandaid off and differentiate metabolic rates by time. I was extremely annoyed that it wasn't already fully differentiated.