### PR TITLE
Mindshield Rebalancing

### DIFF
--- a/code/datums/components/psionics/psi_suppression.dm
+++ b/code/datums/components/psionics/psi_suppression.dm
@@ -27,12 +27,12 @@
 	UnregisterSignal(parent, COMSIG_PSI_MIND_POWER)
 	return ..()
 
-/datum/component/psi_suppression/proc/modify_sensitivity(var/parent, var/effective_sensitivity)
+/datum/component/psi_suppression/proc/modify_sensitivity(parent, effective_sensitivity)
 	SIGNAL_HANDLER
 
 	*effective_sensitivity += sensitivity_modifier
 
-/datum/component/psi_suppression/proc/cancel_power(var/parent, var/caster, var/cancelled, var/cancel_return, var/wide_field)
+/datum/component/psi_suppression/proc/cancel_power(parent, caster, cancelled, cancel_return, wide_field)
 	SIGNAL_HANDLER
 
 	*cancelled = TRUE
@@ -40,3 +40,4 @@
 		return
 
 	to_chat(parent, SPAN_DANGER("You repulse an outside thought!"))
+	astype(parent, /mob/living)?.psi?.spend_power(15)

--- a/code/datums/components/psionics/psiblock_drugs.dm
+++ b/code/datums/components/psionics/psiblock_drugs.dm
@@ -59,8 +59,7 @@
 	SIGNAL_HANDLER
 	if (prob(telepathy_cancel_probability))
 		*cancelled = TRUE
-		max_blocks--
-		if (max_blocks <= 0)
+		if (--max_blocks <= 0)
 			qdel(src)
 
 /datum/component/timed_life/psiblock_drugs/proc/modify_ministry_empathy(minister, ministree, moodlet_value)

--- a/code/datums/components/psionics/psiblock_drugs.dm
+++ b/code/datums/components/psionics/psiblock_drugs.dm
@@ -14,6 +14,9 @@
 	/// The percent chance that this drug will cancel a psionic power when the user is targeted by one.
 	var/telepathy_cancel_probability = 95
 
+	/// The maximum amount of telepathic intrusions this drug can block before it immediately wears off.
+	var/max_blocks = 15
+
 /datum/component/timed_life/psiblock_drugs/Initialize(lifetime_seconds = 5 MINUTES)
 	. = ..()
 	if (!parent)
@@ -56,6 +59,9 @@
 	SIGNAL_HANDLER
 	if (prob(telepathy_cancel_probability))
 		*cancelled = TRUE
+		max_blocks--
+		if (max_blocks <= 0)
+			qdel(src)
 
 /datum/component/timed_life/psiblock_drugs/proc/modify_ministry_empathy(minister, ministree, moodlet_value)
 	SIGNAL_HANDLER

--- a/code/game/objects/items/weapons/implants/implants/mindshield.dm
+++ b/code/game/objects/items/weapons/implants/implants/mindshield.dm
@@ -10,6 +10,8 @@
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_ILLEGAL = 3)
 	default_action_type = null
 	known = TRUE
+	should_use_health = TRUE
+	maxhealth = 15
 	var/sensitivity_modifier = -1
 
 /obj/item/implant/mindshield/get_data()
@@ -49,11 +51,11 @@
 	UnregisterSignal(imp_in, COMSIG_PSI_MIND_POWER)
 	return ..()
 
-/obj/item/implant/mindshield/proc/modify_sensitivity(var/implantee, var/effective_sensitivity)
+/obj/item/implant/mindshield/proc/modify_sensitivity(implantee, effective_sensitivity)
 	SIGNAL_HANDLER
 	*effective_sensitivity += sensitivity_modifier
 
-/obj/item/implant/mindshield/proc/cancel_power(var/implantee, var/caster, var/cancelled, var/cancel_return, var/wide_field)
+/obj/item/implant/mindshield/proc/cancel_power(implantee, caster, cancelled, cancel_return, wide_field)
 	SIGNAL_HANDLER
 	*cancelled = TRUE
 	if(wide_field || implantee == caster)
@@ -61,6 +63,7 @@
 
 	*cancel_return = SPAN_DANGER("ACCESS DENIED: CONNECTION DROPPED.")
 	to_chat(implantee, SPAN_DANGER("Your [name] buzzes angrily."))
+	add_damage(1)
 
 /obj/item/implant/mindshield/emp_act(severity)
 	. = ..()

--- a/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
+++ b/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
@@ -50,6 +50,7 @@
 		return
 
 	to_chat(implantee, SPAN_DANGER("Your mind wriggles as it repulses an outside thought."))
+	take_damage(1)
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker/proc/modify_sensitivity(implantee, effective_sensitivity)
 	SIGNAL_HANDLER
@@ -125,6 +126,7 @@
 		return
 
 	to_chat(implantee, SPAN_DANGER("Your mind wriggles as it repulses an outside thought."))
+	take_damage(1)
 	if(isliving(caster))
 		var/mob/living/victim = caster
 		victim.adjustBrainLoss(20)

--- a/html/changelogs/hellfirejag-psiblocking-rebalance.yml
+++ b/html/changelogs/hellfirejag-psiblocking-rebalance.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "All Psi-Blocking sources (Mindshield, Mindblanker, Psiprotect pills, Psi Suppression) now have a finite number of uses before they wear out."


### PR DESCRIPTION
Now that psychic damage is its own unique new mechanic, I'm taking the gloves off here and making mindshielding no longer a completely perfect "Always safe" protection from it. This PR makes it so that there's a cost for each of the 4 different currently-existing sources of psi protection, making each of them a finite resource that can run out. They can be burned out by enough exposure to psychic damage.