### PR TITLE
Antagonists can now see what antags there are and how many + rev tweaks.

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -70,7 +70,7 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 		U.attach_accessory(null, medal)
 
 	if(MODE_REVOLUTIONARY in SSticker.mode.antag_tags)
-		to_chat(H, FONT_LARGE(SPAN_DANGER("You are a Captain in a Revolution round!")))
+		to_chat(H, FONT_HUGE(SPAN_DANGER("You are a Captain in a Revolution round!")))
 		to_chat(H, FONT_LARGE(SPAN_BOLD("Remember that you are supposed to comply with all orders from SCC Command. Although you may not spawn as a Loyalist, you are the person on the ship that is most beholden to Central Command orders.")))
 		to_chat(H, FONT_LARGE(SPAN_BOLD("This is both due to your status in the hierarchy of the SCC, and also to allow the gamemode as a whole to work. Only very extreme factors may justify you not joining the Loyalists. [SPAN_DANGER("If this is the case, confirm it with admins via adminhelp first!")]")))
 

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -69,6 +69,11 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 		var/obj/item/clothing/accessory/medal/gold/captain/medal = new()
 		U.attach_accessory(null, medal)
 
+	if(MODE_REVOLUTIONARY in SSticker.mode.antag_tags)
+		to_chat(H, FONT_LARGE(SPAN_DANGER("You are a Captain in a Revolution round!")))
+		to_chat(H, FONT_LARGE(SPAN_BOLD("Remember that you are supposed to comply with all orders from SCC Command. Although you may not spawn as a Loyalist, you are the person on the ship that is most beholden to Central Command orders.")))
+		to_chat(H, FONT_LARGE(SPAN_BOLD("This is both due to your status in the hierarchy of the SCC, and also to allow the gamemode as a whole to work. Only very extreme factors may justify you not joining the Loyalists. [SPAN_DANGER("If this is the case, confirm it with admins via adminhelp first!")]")))
+
 	return TRUE
 
 /datum/job/captain/get_access()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -270,7 +270,7 @@
 			. += "Chemical Storage: [changeling.chem_charges]"
 			. += "Genetic Damage Time: [changeling.geneticdamage]"
 
-		if(special_role) //we are an antag
+		if(mind.special_role) //we are an antag
 			. += "<font color='red'>Current Antagonists:</font>"
 			for(var/antag_type in GLOB.all_antag_types)
 				var/datum/antagonist/validhunted = GLOB.all_antag_types[antag_type]

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -270,6 +270,13 @@
 			. += "Chemical Storage: [changeling.chem_charges]"
 			. += "Genetic Damage Time: [changeling.geneticdamage]"
 
+		if(special_role) //we are an antag
+			. += "<font color='red'>Current Antagonists:</font>"
+			for(var/antag_type in GLOB.all_antag_types)
+				var/datum/antagonist/validhunted = GLOB.all_antag_types[antag_type]
+				if(length(validhunted.current_antagonists))
+					. += "- [validhunted.role_text]: [length(validhunted.current_antagonists)]"
+
 	if(. && istype(back,/obj/item/rig))
 		var/obj/item/rig/R = back
 		if(R && !R.canremove && R.installed_modules.len)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -271,7 +271,7 @@
 			. += "Genetic Damage Time: [changeling.geneticdamage]"
 
 		if(mind.special_role) //we are an antag
-			. += "<font color='red'>Current Antagonists:</font>"
+			. += "Current Antagonists:"
 			for(var/antag_type in GLOB.all_antag_types)
 				var/datum/antagonist/validhunted = GLOB.all_antag_types[antag_type]
 				if(length(validhunted.current_antagonists))

--- a/html/changelogs/mattatlas-revtweaks.yml
+++ b/html/changelogs/mattatlas-revtweaks.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Antagonists can now see what other types of antagonists there are and how many in the Status tab."
+  - rscadd: "If the gamemode contains revolutionaries, the Captain will now receive specific instructions on how to play the gamemode when they spawn in order to avoid confusion."


### PR DESCRIPTION
Antagonists can now see what other types of antagonists there are and how many in the Status tab.

Additionally, the Captain now receive this blurb when spawning in a gamemode that contains revs:

> You are a Captain in a Revolution round!
> Remember that you are supposed to comply with all orders from SCC Command. Although you may not spawn as a Loyalist, you are the person on the ship that is most beholden to Central Command orders.
> This is both due to your status in the hierarchy of the SCC, and also to allow the gamemode as a whole to work. Only very extreme factors may justify you not joining the Loyalists. If this is the case, confirm it with admins via adminhelp first!
