### PR TITLE
Tweaks the messages for the psi-protect and mind blankers

### DIFF
--- a/code/controllers/subsystems/hallucinations.dm
+++ b/code/controllers/subsystems/hallucinations.dm
@@ -350,7 +350,7 @@ SUBSYSTEM_DEF(hallucinations)
 	/// % chance to pick one of the general thematic ADPI messages. Enjoy, code peekers; this is all you get!
 	if(prob(15))
 		message = pick("The water is dripping dripping dripping all around you.","Water flowing over stone, but there is no stone.","The waterfall roars o'er the cliff's edge.","Water, water, water. You are drowning.","Water, water, water. You will be awake for it.","Drums, drums, drums, unrelenting.","The drumbeat draws e'er closer.","Tap, ta-tap, ta-tap, tap, ta-tap, ta-tap.","Tap, tap tap, ta-tap, tap-tap, ta-tap.","Ta-ta-tap, tap, ta-tap, tap, tap ta-tap.")
-	target.play_screen_text("[message]", /atom/movable/screen/text/screen_text/adpi_message, COLOR_PURPLE)
+	target.play_screen_text("[message]", /atom/movable/screen/text/screen_text/mental_message, COLOR_PURPLE)
 	to_chat(target, SPAN_CULT(FONT_LARGE("[message]")))
 
 	if(prob(33))

--- a/code/datums/components/psionics/psiblock_drugs.dm
+++ b/code/datums/components/psionics/psiblock_drugs.dm
@@ -14,6 +14,12 @@
 	/// The percent chance that this drug will cancel a psionic power when the user is targeted by one.
 	var/telepathy_cancel_probability = 95
 
+	/// The message randomly given while under the effect of the drug
+	var/ongoing_effect_message = list("Everything feels dulled and distant.", "You feel like you can't focus on anything.", "Your thoughts feel sluggish.", "Why should you care about others?")
+
+	/// Time until the next ongoing message
+	var/next_message = 0
+
 /datum/component/timed_life/psiblock_drugs/Initialize(lifetime_seconds = 5 MINUTES)
 	. = ..()
 	if (!parent)
@@ -29,6 +35,9 @@
 	RegisterSignal(parent, COMSIG_GET_MINISTRY_MODIFIERS, PROC_REF(modify_ministry_empathy), override = TRUE)
 	RegisterSignal(parent, COMSIG_RECEIVE_MINISTRY_MODIFIERS, PROC_REF(modify_ministry_receiving), override = TRUE)
 	RegisterSignal(parent, COMSIG_GET_LEADERSHIP_MODIFIERS, PROC_REF(modify_leadership_empathy), override = TRUE)
+
+	// A little slower than normal. Estimated frequency: 1 min
+	next_message = REALTIMEOFDAY + (DRUG_MESSAGE_COOLDOWN * 2)
 
 /datum/component/timed_life/psiblock_drugs/Destroy()
 	owner = null
@@ -84,6 +93,13 @@
 
 /datum/component/timed_life/psiblock_drugs/process(seconds_per_tick)
 	. = ..()
+	if(REALTIMEOFDAY >= next_message)
+		if(!length(ongoing_effect_message))
+			next_message = (REALTIMEOFDAY + 2 HOURS)
+			return
+		var/message = pick(ongoing_effect_message)
+		to_chat(owner, SPAN_NOTICE("[message]"))
+		next_message = (REALTIMEOFDAY + DRUG_MESSAGE_COOLDOWN * 2)
 
 // Variants of psiblocking drugs
 /datum/component/timed_life/psiblock_drugs/yomi_genetics
@@ -115,7 +131,7 @@
 	var/surgery_success_penalty = -10
 
 	/// The intensity of the seizures
-	var/seizure_intensity = 2
+	var/seizure_intensity = 1
 
 /datum/component/timed_life/psiblock_drugs/yomi_genetics/Initialize(lifetime_seconds = 5 MINUTES)
 	. = ..()
@@ -161,7 +177,7 @@
 	accuracy_penalty = 0.35
 	dispersion_penalty = 10
 	surgery_success_penalty = -20
-	seizure_intensity = 3
+	seizure_intensity = 2
 
 /datum/component/timed_life/psiblock_drugs/yomi_genetics/expensive
 	min_tremor_time = 2 MINUTES
@@ -172,4 +188,3 @@
 	accuracy_penalty = 0.15
 	dispersion_penalty = 2
 	surgery_success_penalty = -5
-	seizure_intensity = 1

--- a/code/datums/components/psionics/psiblock_drugs.dm
+++ b/code/datums/components/psionics/psiblock_drugs.dm
@@ -4,6 +4,10 @@
 
 #define RISK_HIGH list("You feel detached from your surroundings.", "Everyone seems less real.", "The world feels insulated.", "Everything seems so quiet.", "For a moment, it feels like there is a faint hum.", "The people around you seem indistinct.", "The quiet feels thicker than before.", "The world feels distant and muffled.", "Your thoughts seem to vanish before you can finish them.", "You cannot remember how long you have been standing here.", "You feel strangely absent for a moment.", "There was something important... What was it again?", "The world around you feels artificial.", "You feel disconnected from your actions.", "How did you get here again?", "Something feels like it is missing from you.")
 
+#define PSIBLOCK_EFFECT_HEADACHE "headache"
+#define PSIBLOCK_EFFECT_MOTOR "motor"
+#define PSIBLOCK_EFFECT_PALPITATIONS "palpitations"
+
 /datum/component/timed_life/psiblock_drugs
 	/// Typecasted parent of this component.
 	var/mob/living/carbon/human/owner
@@ -20,12 +24,6 @@
 	/// The percent chance that this drug will cancel a psionic power when the user is targeted by one.
 	var/telepathy_cancel_probability = 95
 
-	/// The message randomly given while under the effect of the drug
-	var/ongoing_effect_message = list("Everything feels dulled and distant.", "You feel like you can't focus on anything.", "Your thoughts feel sluggish.", "Why should you care about others?", "You struggle to remember what you were just thinking.", "You cannot bring yourself to care.", "Other people's emotions seem tedious.", "You have trouble recalling why this mattered to you.", "Nothing seems urgent anymore.", "You feel detached from your surroundings.", "Your mind feels wrapped in a thick fog.", "Everyone seems less real.", "The world feels insulated.", "Why was it that this mattered to you again?", "Everything seems so quiet.", "For a moment, it feels like there is a faint hum.", "Your thoughts feel distant from you.", "It is difficult to hold onto a feeling.", "Why was it you were concerned again?", "You feel your attention drifting.", "The people around you seem indistinct.", "The quiet feels thicker than before.", "What was it you were feeling again?", "The world feels distant and muffled.")
-
-	/// Time until the next ongoing message
-	var/next_message = 0
-
 /datum/component/timed_life/psiblock_drugs/Initialize(lifetime_seconds = 5 MINUTES)
 	. = ..()
 	if (!parent)
@@ -41,9 +39,6 @@
 	RegisterSignal(parent, COMSIG_GET_MINISTRY_MODIFIERS, PROC_REF(modify_ministry_empathy), override = TRUE)
 	RegisterSignal(parent, COMSIG_RECEIVE_MINISTRY_MODIFIERS, PROC_REF(modify_ministry_receiving), override = TRUE)
 	RegisterSignal(parent, COMSIG_GET_LEADERSHIP_MODIFIERS, PROC_REF(modify_leadership_empathy), override = TRUE)
-
-	// A little slower than normal. Estimated frequency: 1 min
-	next_message = REALTIMEOFDAY + (DRUG_MESSAGE_COOLDOWN * 2)
 
 /datum/component/timed_life/psiblock_drugs/Destroy()
 	owner = null
@@ -96,17 +91,6 @@
 	to_chat(leader, SPAN_BAD("Why should you care about how others feel?"))
 	*moodlet_value = *moodlet_value * 0.5
 
-
-/datum/component/timed_life/psiblock_drugs/process(seconds_per_tick)
-	. = ..()
-	if(REALTIMEOFDAY >= next_message)
-		if(!length(ongoing_effect_message))
-			next_message = (REALTIMEOFDAY + 2 HOURS)
-			return
-		var/message = pick(ongoing_effect_message)
-		to_chat(owner, SPAN_NOTICE("[message]"))
-		next_message = (REALTIMEOFDAY + DRUG_MESSAGE_COOLDOWN * 2)
-
 // Variants of psiblocking drugs
 /datum/component/timed_life/psiblock_drugs/yomi_genetics
 	/// The next time (in real life seconds) that a hand tremor will occur.
@@ -139,10 +123,95 @@
 	/// The intensity of the seizures
 	var/seizure_intensity = 1
 
+	/// The time until the seizure after the warning
+	var/seizure_warning_delay = 1 MINUTE
+
+	/// The next time a routine Ranixidone side effect may occur.
+	var/next_side_effect_time = 0
+
+	/// Minimum time between routine side effects.
+	var/min_side_effect_time = 1 MINUTE
+
+	/// Maximum time between routine side effects.
+	var/max_side_effect_time = 3 MINUTES
+
+	/// Weighted likelihoods for routine side effects.
+	var/headache_weight = 35
+	var/motor_weight = 15
+	var/palpitations_weight = 10
+
+	/// The time until the next message
+	var/next_message = 0
+
+	/// The delay between messages, to avoid spamming the player
+	var/message_delay = 30 SECONDS
+
+	var/next_drug_message = 1 MINUTE
+
+	/// The message randomly given while under the effect of the drug. It should preferably be set in initialize
+	var/ongoing_effect_message = list(
+		"Everything feels dulled and distant.",
+		"You feel like you can't focus on anything.",
+		"Your thoughts feel sluggish.",
+		"Why should you care about others?",
+		"You struggle to remember what you were just thinking.",
+		"You cannot bring yourself to care.",
+		"Other people's emotions seem tedious.",
+		"You have trouble recalling why this mattered to you.",
+		"Nothing seems urgent anymore.",
+		"You feel detached from your surroundings.",
+		"Your mind feels wrapped in a thick fog.",
+		"Everyone seems less real.",
+		"The world feels insulated.",
+		"Why was it that this mattered to you again?",
+		"Everything seems so quiet.",
+		"For a moment, it feels like there is a faint hum.",
+		"Your thoughts feel distant from you.",
+		"It is difficult to hold onto a feeling.",
+		"Why was it you were concerned again?",
+		"You feel your attention drifting.",
+		"The people around you seem indistinct.",
+		"The quiet feels thicker than before.",
+		"What was it you were feeling again?",
+		"The world feels distant and muffled."
+	)
+
+	var/list/headache_messages = list(
+		"A dull ache builds behind your eyes.",
+		"Pain pulses through your temples.",
+		"Pressure gathers at the base of your skull.",
+		"A headache settles heavily behind your forehead."
+	)
+
+	var/list/motor_control_messages = list(
+		"Your footing suddenly feels uncertain.",
+		"Your balance shifts unexpectedly.",
+		"Your limbs move a moment later than expected.",
+		"Your steps feel awkward and uneven.",
+		"Your tongue briefly feels clumsy in your mouth."
+	)
+
+	var/list/palpitation_messages = list(
+		"Your heart skips a beat.",
+		"Your heartbeat suddenly flutters.",
+		"Your heart races for several uncomfortable moments."
+	)
+
+	var/list/seizure_warning_messages = list(
+		"A powerful metallic taste suddenly floods your mouth.",
+		"You briefly smell something burning.",
+		"An overpowering chemical taste fills your mouth.",
+		"The air suddenly smells sickeningly sweet."
+	)
+
 /datum/component/timed_life/psiblock_drugs/yomi_genetics/Initialize(lifetime_seconds = 5 MINUTES)
 	. = ..()
 	next_tremor_time = REALTIMEOFDAY + rand(min_tremor_time, max_tremor_time)
 	next_seizure_time = REALTIMEOFDAY + rand(min_seizure_time, max_seizure_time)
+	next_side_effect_time = REALTIMEOFDAY + rand(min_side_effect_time, max_side_effect_time)
+	next_message = REALTIMEOFDAY + message_delay
+	// A little slower than normal. Estimated frequency: 1 min
+	next_drug_message = REALTIMEOFDAY + (DRUG_MESSAGE_COOLDOWN * 2)
 
 	// Some skill check penalties related to hand tremors. Tremors give a small penalty to some skill checks.
 	RegisterSignal(parent, COMSIG_BEFORE_GUN_FIRE, PROC_REF(check_tremor_gun), override = TRUE)
@@ -166,20 +235,92 @@
 
 /datum/component/timed_life/psiblock_drugs/yomi_genetics/process(seconds_per_tick)
 	. = ..()
-	var/time_of_day = REALTIMEOFDAY
-	if (time_of_day >= next_tremor_time)
-		owner.visible_message(SPAN_NOTICE("[owner]'s hand shakes..."), SPAN_NOTICE("Your hand shakes..."))
-		next_tremor_time = time_of_day + rand(min_tremor_time, max_tremor_time)
+	if(REALTIMEOFDAY >= next_tremor_time && REALTIMEOFDAY >= next_message)
+		owner.visible_message(
+			SPAN_NOTICE("[owner]'s hand shakes..."),
+			SPAN_NOTICE("Your hand shakes...")
+		)
+		next_tremor_time = REALTIMEOFDAY + rand(min_tremor_time, max_tremor_time)
+		next_message = REALTIMEOFDAY + message_delay
 
-	if (time_of_day >= next_seizure_time)
-		owner.seizure(seizure_intensity)
-		next_seizure_time = time_of_day + rand(min_seizure_time, max_seizure_time)
+	if(REALTIMEOFDAY >= next_side_effect_time && REALTIMEOFDAY >= next_message)
+		trigger_random_side_effect()
+		next_side_effect_time = REALTIMEOFDAY + rand(min_side_effect_time, max_side_effect_time )
+		next_message = REALTIMEOFDAY + message_delay
+
+	if(REALTIMEOFDAY >= next_drug_message)
+		if(!length(ongoing_effect_message))
+			next_message = (REALTIMEOFDAY + 2 HOURS)
+			return
+		var/message = pick(ongoing_effect_message)
+		to_chat(owner, SPAN_NOTICE("[message]"))
+		next_drug_message = REALTIMEOFDAY + (DRUG_MESSAGE_COOLDOWN * 2)
+
+	if(REALTIMEOFDAY >= next_seizure_time)
+		begin_seizure_warning()
+		next_seizure_time = REALTIMEOFDAY + rand(min_seizure_time, max_seizure_time)
+
+/datum/component/timed_life/psiblock_drugs/yomi_genetics/proc/trigger_random_side_effect()
+	if(!owner)
+		return
+
+	var/list/effect_weights = list(
+		PSIBLOCK_EFFECT_HEADACHE = headache_weight,
+		PSIBLOCK_EFFECT_MOTOR = motor_weight,
+		PSIBLOCK_EFFECT_PALPITATIONS = palpitations_weight,
+	)
+
+	switch(pickweight(effect_weights))
+		if(PSIBLOCK_EFFECT_HEADACHE)
+			trigger_headache()
+
+		if(PSIBLOCK_EFFECT_MOTOR)
+			trigger_motor_episode()
+
+		if(PSIBLOCK_EFFECT_PALPITATIONS)
+			trigger_palpitations()
+
+/datum/component/timed_life/psiblock_drugs/yomi_genetics/proc/trigger_headache()
+	if(!owner)
+		return
+	var/obj/item/organ/external/affecting = owner.get_organ(BP_HEAD)
+	owner.custom_pain(pick(headache_messages), 2, TRUE, affecting, FALSE)
+
+/datum/component/timed_life/psiblock_drugs/yomi_genetics/proc/trigger_motor_episode()
+	if(!owner)
+		return
+
+	to_chat(owner, SPAN_WARNING(pick(motor_control_messages)))
+
+	owner.confused += rand(2, 4)
+
+/datum/component/timed_life/psiblock_drugs/yomi_genetics/proc/trigger_palpitations()
+	if(!owner)
+		return
+
+	to_chat(owner, SPAN_WARNING(pick(palpitation_messages)))
+	owner.add_chemical_effect(CE_PULSE, 2)
+
+/datum/component/timed_life/psiblock_drugs/yomi_genetics/proc/begin_seizure_warning()
+	if(!owner)
+		return
+
+	to_chat(owner, SPAN_WARNING(pick(seizure_warning_messages)))
+	// For some reason, the timer cuts one minute away, so we add an extra minute to make up for it
+	var/seizure_long_delay = seizure_warning_delay + 1 MINUTE
+	addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob/living/carbon/human, seizure), seizure_intensity), seizure_long_delay)
 
 /datum/component/timed_life/psiblock_drugs/yomi_genetics/cheap
 	min_tremor_time = 30 SECONDS
 	max_tremor_time = 2 MINUTES
+
 	min_seizure_time = 5 MINUTES
 	max_seizure_time = 30 MINUTES
+
+	headache_weight = 20
+	motor_weight = 25
+	palpitations_weight = 20
+
 	telepathy_cancel_probability = 75
 	psi_sensitivity_modifier = -0.75
 	accuracy_penalty = 0.35
@@ -194,7 +335,18 @@
 /datum/component/timed_life/psiblock_drugs/yomi_genetics/expensive
 	min_tremor_time = 2 MINUTES
 	max_tremor_time = 5 MINUTES
-	min_seizure_time = 30 MINUTES // Will never induce a seizure.
+
+	min_seizure_time = 30 MINUTES
+
+	// Guaranteed one message, but two is not a certainty
+	min_side_effect_time = 3 MINUTES
+	max_side_effect_time = 8 MINUTES
+
+	// Overall way safer
+	headache_weight = 55
+	motor_weight = 7
+	palpitations_weight = 0
+
 	telepathy_cancel_probability = 100
 	psi_sensitivity_modifier = -1.25
 	accuracy_penalty = 0.15
@@ -204,6 +356,10 @@
 /datum/component/timed_life/psiblock_drugs/yomi_genetics/expensive/Initialize(lifetime_seconds)
 	. = ..()
 	ongoing_effect_message = RISK_LOW
+
+#undef PSIBLOCK_EFFECT_HEADACHE
+#undef PSIBLOCK_EFFECT_MOTOR
+#undef PSIBLOCK_EFFECT_PALPITATIONS
 
 #undef RISK_LOW
 

--- a/code/datums/components/psionics/psiblock_drugs.dm
+++ b/code/datums/components/psionics/psiblock_drugs.dm
@@ -87,6 +87,9 @@
 	to_chat(leader, SPAN_BAD("Why should you care about how others feel?"))
 	*moodlet_value = *moodlet_value * 0.5
 
+/datum/component/timed_life/psiblock_drugs/process(seconds_per_tick)
+	. = ..()
+
 // Variants of psiblocking drugs
 /datum/component/timed_life/psiblock_drugs/yomi_genetics
 	/// The next time (in real life seconds) that a hand tremor will occur.

--- a/code/datums/components/psionics/psiblock_drugs.dm
+++ b/code/datums/components/psionics/psiblock_drugs.dm
@@ -1,3 +1,9 @@
+#define RISK_LOW list("You feel like you can't focus on anything.", "Why should you care about others?", "You cannot bring yourself to care.", "Other people's emotions seem tedious.", "Nothing seems urgent anymore.", "You feel your attention drifting.", "It is difficult to hold onto a feeling.", "Why was it you were concerned again?", "You feel your attention wandering.", "Everyone seems too worried.", "Everything feels muffled.")
+
+#define RISK_MEDIUM list("Everything feels dulled and distant.", "Your thoughts feel sluggish.", "You struggle to remember what you were just thinking.", "You have trouble recalling why this mattered to you.", "Your mind feels wrapped in a thick fog.", "Why was it that this mattered to you again?", "Your thoughts feel distant from you.", "What was it you were feeling again?", "You lose track of what you meant to say.", "Everything feels numb.", "What was it you were doing again?")
+
+#define RISK_HIGH list("You feel detached from your surroundings.", "Everyone seems less real.", "The world feels insulated.", "Everything seems so quiet.", "For a moment, it feels like there is a faint hum.", "The people around you seem indistinct.", "The quiet feels thicker than before.", "The world feels distant and muffled.", "Your thoughts seem to vanish before you can finish them.", "You cannot remember how long you have been standing here.", "You feel strangely absent for a moment.", "There was something important... What was it again?", "The world around you feels artificial.", "You feel disconnected from your actions.", "How did you get here again?", "Something feels like it is missing from you.")
+
 /datum/component/timed_life/psiblock_drugs
 	/// Typecasted parent of this component.
 	var/mob/living/carbon/human/owner
@@ -15,7 +21,7 @@
 	var/telepathy_cancel_probability = 95
 
 	/// The message randomly given while under the effect of the drug
-	var/ongoing_effect_message = list("Everything feels dulled and distant.", "You feel like you can't focus on anything.", "Your thoughts feel sluggish.", "Why should you care about others?")
+	var/ongoing_effect_message = list("Everything feels dulled and distant.", "You feel like you can't focus on anything.", "Your thoughts feel sluggish.", "Why should you care about others?", "You struggle to remember what you were just thinking.", "You cannot bring yourself to care.", "Other people's emotions seem tedious.", "You have trouble recalling why this mattered to you.", "Nothing seems urgent anymore.", "You feel detached from your surroundings.", "Your mind feels wrapped in a thick fog.", "Everyone seems less real.", "The world feels insulated.", "Why was it that this mattered to you again?", "Everything seems so quiet.", "For a moment, it feels like there is a faint hum.", "Your thoughts feel distant from you.", "It is difficult to hold onto a feeling.", "Why was it you were concerned again?", "You feel your attention drifting.", "The people around you seem indistinct.", "The quiet feels thicker than before.", "What was it you were feeling again?", "The world feels distant and muffled.")
 
 	/// Time until the next ongoing message
 	var/next_message = 0
@@ -142,6 +148,8 @@
 	RegisterSignal(parent, COMSIG_BEFORE_GUN_FIRE, PROC_REF(check_tremor_gun), override = TRUE)
 	RegisterSignal(parent, COMSIG_GET_SURGERY_SUCCESS_MODIFIERS, PROC_REF(check_tremor_surgery), override = TRUE)
 
+	ongoing_effect_message = RISK_LOW + RISK_MEDIUM
+
 /datum/component/timed_life/psiblock_drugs/yomi_genetics/Destroy()
 	UnregisterSignal(parent, COMSIG_BEFORE_GUN_FIRE)
 	UnregisterSignal(parent, COMSIG_GET_SURGERY_SUCCESS_MODIFIERS)
@@ -179,6 +187,10 @@
 	surgery_success_penalty = -20
 	seizure_intensity = 2
 
+/datum/component/timed_life/psiblock_drugs/yomi_genetics/cheap/Initialize(lifetime_seconds)
+	. = ..()
+	ongoing_effect_message = RISK_LOW + RISK_MEDIUM + RISK_HIGH
+
 /datum/component/timed_life/psiblock_drugs/yomi_genetics/expensive
 	min_tremor_time = 2 MINUTES
 	max_tremor_time = 5 MINUTES
@@ -188,3 +200,13 @@
 	accuracy_penalty = 0.15
 	dispersion_penalty = 2
 	surgery_success_penalty = -5
+
+/datum/component/timed_life/psiblock_drugs/yomi_genetics/expensive/Initialize(lifetime_seconds)
+	. = ..()
+	ongoing_effect_message = RISK_LOW
+
+#undef RISK_LOW
+
+#undef RISK_MEDIUM
+
+#undef RISK_HIGH

--- a/code/datums/components/psionics/psiblock_drugs.dm
+++ b/code/datums/components/psionics/psiblock_drugs.dm
@@ -4,10 +4,6 @@
 
 #define RISK_HIGH list("You feel detached from your surroundings.", "Everyone seems less real.", "The world feels insulated.", "Everything seems so quiet.", "For a moment, it feels like there is a faint hum.", "The people around you seem indistinct.", "The quiet feels thicker than before.", "The world feels distant and muffled.", "Your thoughts seem to vanish before you can finish them.", "You cannot remember how long you have been standing here.", "You feel strangely absent for a moment.", "There was something important... What was it again?", "The world around you feels artificial.", "You feel disconnected from your actions.", "How did you get here again?", "Something feels like it is missing from you.")
 
-#define PSIBLOCK_EFFECT_HEADACHE "headache"
-#define PSIBLOCK_EFFECT_MOTOR "motor"
-#define PSIBLOCK_EFFECT_PALPITATIONS "palpitations"
-
 /datum/component/timed_life/psiblock_drugs
 	/// Typecasted parent of this component.
 	var/mob/living/carbon/human/owner
@@ -124,21 +120,7 @@
 	var/seizure_intensity = 1
 
 	/// The time until the seizure after the warning
-	var/seizure_warning_delay = 1 MINUTE
-
-	/// The next time a routine Ranixidone side effect may occur.
-	var/next_side_effect_time = 0
-
-	/// Minimum time between routine side effects.
-	var/min_side_effect_time = 1 MINUTE
-
-	/// Maximum time between routine side effects.
-	var/max_side_effect_time = 3 MINUTES
-
-	/// Weighted likelihoods for routine side effects.
-	var/headache_weight = 35
-	var/motor_weight = 15
-	var/palpitations_weight = 10
+	var/seizure_warning_delay = 20 SECONDS
 
 	/// The time until the next message
 	var/next_message = 0
@@ -176,39 +158,19 @@
 		"The world feels distant and muffled."
 	)
 
-	var/list/headache_messages = list(
-		"A dull ache builds behind your eyes.",
-		"Pain pulses through your temples.",
-		"Pressure gathers at the base of your skull.",
-		"A headache settles heavily behind your forehead."
-	)
-
-	var/list/motor_control_messages = list(
-		"Your footing suddenly feels uncertain.",
-		"Your balance shifts unexpectedly.",
-		"Your limbs move a moment later than expected.",
-		"Your steps feel awkward and uneven.",
-		"Your tongue briefly feels clumsy in your mouth."
-	)
-
-	var/list/palpitation_messages = list(
-		"Your heart skips a beat.",
-		"Your heartbeat suddenly flutters.",
-		"Your heart races for several uncomfortable moments."
-	)
-
 	var/list/seizure_warning_messages = list(
 		"A powerful metallic taste suddenly floods your mouth.",
 		"You briefly smell something burning.",
 		"An overpowering chemical taste fills your mouth.",
-		"The air suddenly smells sickeningly sweet."
+		"The air suddenly smells sickeningly sweet.",
+		"A wave of nausea rises abruptly through your stomach."
 	)
 
 /datum/component/timed_life/psiblock_drugs/yomi_genetics/Initialize(lifetime_seconds = 5 MINUTES)
 	. = ..()
 	next_tremor_time = REALTIMEOFDAY + rand(min_tremor_time, max_tremor_time)
 	next_seizure_time = REALTIMEOFDAY + rand(min_seizure_time, max_seizure_time)
-	next_side_effect_time = REALTIMEOFDAY + rand(min_side_effect_time, max_side_effect_time)
+
 	next_message = REALTIMEOFDAY + message_delay
 	// A little slower than normal. Estimated frequency: 1 min
 	next_drug_message = REALTIMEOFDAY + (DRUG_MESSAGE_COOLDOWN * 2)
@@ -243,63 +205,18 @@
 		next_tremor_time = REALTIMEOFDAY + rand(min_tremor_time, max_tremor_time)
 		next_message = REALTIMEOFDAY + message_delay
 
-	if(REALTIMEOFDAY >= next_side_effect_time && REALTIMEOFDAY >= next_message)
-		trigger_random_side_effect()
-		next_side_effect_time = REALTIMEOFDAY + rand(min_side_effect_time, max_side_effect_time )
-		next_message = REALTIMEOFDAY + message_delay
-
-	if(REALTIMEOFDAY >= next_drug_message)
+	if(REALTIMEOFDAY >= next_drug_message && REALTIMEOFDAY >= next_message)
 		if(!length(ongoing_effect_message))
 			next_message = (REALTIMEOFDAY + 2 HOURS)
 			return
 		var/message = pick(ongoing_effect_message)
 		to_chat(owner, SPAN_NOTICE("[message]"))
 		next_drug_message = REALTIMEOFDAY + (DRUG_MESSAGE_COOLDOWN * 2)
+		next_message = REALTIMEOFDAY + message_delay
 
 	if(REALTIMEOFDAY >= next_seizure_time)
 		begin_seizure_warning()
 		next_seizure_time = REALTIMEOFDAY + rand(min_seizure_time, max_seizure_time)
-
-/datum/component/timed_life/psiblock_drugs/yomi_genetics/proc/trigger_random_side_effect()
-	if(!owner)
-		return
-
-	var/list/effect_weights = list(
-		PSIBLOCK_EFFECT_HEADACHE = headache_weight,
-		PSIBLOCK_EFFECT_MOTOR = motor_weight,
-		PSIBLOCK_EFFECT_PALPITATIONS = palpitations_weight,
-	)
-
-	switch(pickweight(effect_weights))
-		if(PSIBLOCK_EFFECT_HEADACHE)
-			trigger_headache()
-
-		if(PSIBLOCK_EFFECT_MOTOR)
-			trigger_motor_episode()
-
-		if(PSIBLOCK_EFFECT_PALPITATIONS)
-			trigger_palpitations()
-
-/datum/component/timed_life/psiblock_drugs/yomi_genetics/proc/trigger_headache()
-	if(!owner)
-		return
-	var/obj/item/organ/external/affecting = owner.get_organ(BP_HEAD)
-	owner.custom_pain(pick(headache_messages), 2, TRUE, affecting, FALSE)
-
-/datum/component/timed_life/psiblock_drugs/yomi_genetics/proc/trigger_motor_episode()
-	if(!owner)
-		return
-
-	to_chat(owner, SPAN_WARNING(pick(motor_control_messages)))
-
-	owner.confused += rand(2, 4)
-
-/datum/component/timed_life/psiblock_drugs/yomi_genetics/proc/trigger_palpitations()
-	if(!owner)
-		return
-
-	to_chat(owner, SPAN_WARNING(pick(palpitation_messages)))
-	owner.add_chemical_effect(CE_PULSE, 2)
 
 /datum/component/timed_life/psiblock_drugs/yomi_genetics/proc/begin_seizure_warning()
 	if(!owner)
@@ -316,10 +233,6 @@
 
 	min_seizure_time = 5 MINUTES
 	max_seizure_time = 30 MINUTES
-
-	headache_weight = 20
-	motor_weight = 25
-	palpitations_weight = 20
 
 	telepathy_cancel_probability = 75
 	psi_sensitivity_modifier = -0.75
@@ -338,15 +251,6 @@
 
 	min_seizure_time = 30 MINUTES
 
-	// Guaranteed one message, but two is not a certainty
-	min_side_effect_time = 3 MINUTES
-	max_side_effect_time = 8 MINUTES
-
-	// Overall way safer
-	headache_weight = 55
-	motor_weight = 7
-	palpitations_weight = 0
-
 	telepathy_cancel_probability = 100
 	psi_sensitivity_modifier = -1.25
 	accuracy_penalty = 0.15
@@ -356,10 +260,6 @@
 /datum/component/timed_life/psiblock_drugs/yomi_genetics/expensive/Initialize(lifetime_seconds)
 	. = ..()
 	ongoing_effect_message = RISK_LOW
-
-#undef PSIBLOCK_EFFECT_HEADACHE
-#undef PSIBLOCK_EFFECT_MOTOR
-#undef PSIBLOCK_EFFECT_PALPITATIONS
 
 #undef RISK_LOW
 

--- a/code/datums/components/psionics/psiblock_drugs.dm
+++ b/code/datums/components/psionics/psiblock_drugs.dm
@@ -114,6 +114,9 @@
 	/// The penalty to surgery success chance due to hand tremors.
 	var/surgery_success_penalty = -10
 
+	/// The intensity of the seizures
+	var/seizure_intensity = 2
+
 /datum/component/timed_life/psiblock_drugs/yomi_genetics/Initialize(lifetime_seconds = 5 MINUTES)
 	. = ..()
 	next_tremor_time = REALTIMEOFDAY + rand(min_tremor_time, max_tremor_time)
@@ -145,7 +148,7 @@
 		next_tremor_time = time_of_day + rand(min_tremor_time, max_tremor_time)
 
 	if (time_of_day >= next_seizure_time)
-		owner.seizure()
+		owner.seizure(seizure_intensity)
 		next_seizure_time = time_of_day + rand(min_seizure_time, max_seizure_time)
 
 /datum/component/timed_life/psiblock_drugs/yomi_genetics/cheap
@@ -158,6 +161,7 @@
 	accuracy_penalty = 0.35
 	dispersion_penalty = 10
 	surgery_success_penalty = -20
+	seizure_intensity = 3
 
 /datum/component/timed_life/psiblock_drugs/yomi_genetics/expensive
 	min_tremor_time = 2 MINUTES
@@ -168,3 +172,4 @@
 	accuracy_penalty = 0.15
 	dispersion_penalty = 2
 	surgery_success_penalty = -5
+	seizure_intensity = 1

--- a/code/modules/maptext_alerts/screen_alerts.dm
+++ b/code/modules/maptext_alerts/screen_alerts.dm
@@ -76,7 +76,7 @@
 	style_open = "<span class='langchat' style=font-size:20pt;text-align:center valign='top'>"
 	style_close = "</span>"
 
-/atom/movable/screen/text/screen_text/adpi_message
+/atom/movable/screen/text/screen_text/mental_message
 	maptext_height = 64
 	maptext_width = 480
 	maptext_x = 0

--- a/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
+++ b/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
@@ -7,6 +7,12 @@
 	parent_organ = BP_HEAD
 	var/sensitivity_modifier = -1
 
+	/// The message randomly given while under the effect of the drug
+	var/ongoing_effect_message = list("Everything feels dulled and distant.", "You feel like you can't focus on anything.", "Your thoughts feel sluggish.", "Why should you care about others?")
+
+	/// Time until the next ongoing message
+	var/next_message = 0
+
 /obj/item/organ/internal/augment/bioaug/mind_blanker/Initialize()
 	. = ..()
 	if(!owner)
@@ -17,6 +23,9 @@
 	RegisterSignal(owner, COMSIG_GET_MINISTRY_MODIFIERS, PROC_REF(modify_ministry_empathy), override = TRUE)
 	RegisterSignal(owner, COMSIG_RECEIVE_MINISTRY_MODIFIERS, PROC_REF(modify_ministry_receiving), override = TRUE)
 	RegisterSignal(owner, COMSIG_GET_LEADERSHIP_MODIFIERS, PROC_REF(modify_leadership_empathy), override = TRUE)
+
+	/// This lasts all round, so lets make it less frequent. Estimated frequency: every 1.5 min
+	next_message = REALTIMEOFDAY + (DRUG_MESSAGE_COOLDOWN * 3)
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker/replaced()
 	. = ..()
@@ -39,6 +48,16 @@
 	UnregisterSignal(owner, COMSIG_RECEIVE_MINISTRY_MODIFIERS)
 	UnregisterSignal(owner, COMSIG_GET_LEADERSHIP_MODIFIERS)
 	return ..()
+
+/obj/item/organ/internal/augment/bioaug/mind_blanker/process(seconds_per_tick)
+	. = ..()
+	if(REALTIMEOFDAY >= next_message)
+		if(!length(ongoing_effect_message))
+			next_message = (REALTIMEOFDAY + 2 HOURS)
+			return
+		var/message = pick(ongoing_effect_message)
+		to_chat(owner, SPAN_NOTICE("[message]"))
+		next_message = (REALTIMEOFDAY + DRUG_MESSAGE_COOLDOWN * 3)
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker/proc/cancel_power(implantee, caster, cancelled, cancel_return, wide_field)
 	SIGNAL_HANDLER
@@ -91,6 +110,12 @@
 	parent_organ = BP_HEAD
 	var/sensitivity_modifier = -1
 
+	/// The message randomly given while under the effect of the drug
+	var/ongoing_effect_message = list("Everything feels dulled and distant.", "You feel like you can't focus on anything.", "Your thoughts feel sluggish.", "Why should you care about others?")
+
+	/// Time until the next ongoing message
+	var/next_message = 0
+
 /obj/item/organ/internal/augment/bioaug/mind_blanker_lethal/Initialize()
 	. = ..()
 	if(!owner)
@@ -98,6 +123,19 @@
 
 	RegisterSignal(owner, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power_lethal), override = TRUE)
 	RegisterSignal(owner, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity), override = TRUE)
+
+	/// This lasts all round, so lets make it less frequent. Estimated frequency: every 1.5 min
+	next_message = REALTIMEOFDAY + (DRUG_MESSAGE_COOLDOWN * 3)
+
+/obj/item/organ/internal/augment/bioaug/mind_blanker_lethal/process(seconds_per_tick)
+	. = ..()
+	if(REALTIMEOFDAY >= next_message)
+		if(!length(ongoing_effect_message))
+			next_message = (REALTIMEOFDAY + 2 HOURS)
+			return
+		var/message = pick(ongoing_effect_message)
+		to_chat(owner, SPAN_NOTICE("[message]"))
+		next_message = (REALTIMEOFDAY + DRUG_MESSAGE_COOLDOWN * 3)
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker_lethal/replaced()
 	. = ..()

--- a/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
+++ b/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
@@ -8,7 +8,7 @@
 	var/sensitivity_modifier = -1
 
 	/// The message randomly given while under the effect of the drug
-	var/ongoing_effect_message = list("Everything feels dulled and distant.", "You feel like you can't focus on anything.", "Your thoughts feel sluggish.", "Why should you care about others?")
+	var/ongoing_effect_message = list("Everything feels dulled and distant.", "You feel like you can't focus on anything.", "Your thoughts feel sluggish.", "Why should you care about others?", "You struggle to remember what you were just thinking.", "You cannot bring yourself to care.", "Other people's emotions seem tedious.", "You have trouble recalling why this mattered to you.", "Nothing seems urgent anymore.", "You feel detached from your surroundings.", "Your mind feels wrapped in a thick fog.", "Everyone seem less real.", "The world feels insulated.", "Why was it this mattered to you again?", "Everything seems so quiet.", "For a moment, it feels like there is a faint hum.")
 
 	/// Time until the next ongoing message
 	var/next_message = 0
@@ -57,6 +57,7 @@
 			return
 		var/message = pick(ongoing_effect_message)
 		to_chat(owner, SPAN_NOTICE("[message]"))
+		owner.play_screen_text("[message]", /atom/movable/screen/text/screen_text/mental_message, COLOR_TEAL)
 		next_message = (REALTIMEOFDAY + DRUG_MESSAGE_COOLDOWN * 3)
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker/proc/cancel_power(implantee, caster, cancelled, cancel_return, wide_field)
@@ -111,7 +112,7 @@
 	var/sensitivity_modifier = -1
 
 	/// The message randomly given while under the effect of the drug
-	var/ongoing_effect_message = list("Everything feels dulled and distant.", "You feel like you can't focus on anything.", "Your thoughts feel sluggish.", "Why should you care about others?")
+	var/ongoing_effect_message = list("Everything feels dulled and distant.", "You feel like you can't focus on anything.", "Your thoughts feel sluggish.", "Why should you care about others?", "You struggle to remember what you were just thinking.", "You cannot bring yourself to care.", "Other people's emotions seem tedious.", "You have trouble recalling why this mattered to you.", "Nothing seems urgent anymore.", "You feel detached from your surroundings.", "Your mind feels wrapped in a thick fog.", "Everyone seem less real.", "The world feels insulated.", "Why was it this mattered to you again?", "Everything seems so quiet.", "For a moment, it feels like there is a faint hum.")
 
 	/// Time until the next ongoing message
 	var/next_message = 0
@@ -135,6 +136,7 @@
 			return
 		var/message = pick(ongoing_effect_message)
 		to_chat(owner, SPAN_NOTICE("[message]"))
+		owner.play_screen_text("[message]", /atom/movable/screen/text/screen_text/mental_message, COLOR_TEAL)
 		next_message = (REALTIMEOFDAY + DRUG_MESSAGE_COOLDOWN * 3)
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker_lethal/replaced()

--- a/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
+++ b/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
@@ -24,8 +24,8 @@
 	RegisterSignal(owner, COMSIG_RECEIVE_MINISTRY_MODIFIERS, PROC_REF(modify_ministry_receiving), override = TRUE)
 	RegisterSignal(owner, COMSIG_GET_LEADERSHIP_MODIFIERS, PROC_REF(modify_leadership_empathy), override = TRUE)
 
-	/// This lasts all round, so lets make it less frequent. Estimated frequency: every 1.5 min
-	next_message = REALTIMEOFDAY + (DRUG_MESSAGE_COOLDOWN * 3)
+	/// This lasts all round, so lets make it less frequent. Estimated frequency: every 2 min
+	next_message = REALTIMEOFDAY + (DRUG_MESSAGE_COOLDOWN * 4)
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker/replaced()
 	. = ..()
@@ -58,7 +58,7 @@
 		var/message = pick(ongoing_effect_message)
 		to_chat(owner, SPAN_NOTICE("[message]"))
 		owner.play_screen_text("[message]", /atom/movable/screen/text/screen_text/mental_message, COLOR_TEAL)
-		next_message = (REALTIMEOFDAY + DRUG_MESSAGE_COOLDOWN * 3)
+		next_message = (REALTIMEOFDAY + DRUG_MESSAGE_COOLDOWN * 4)
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker/proc/cancel_power(implantee, caster, cancelled, cancel_return, wide_field)
 	SIGNAL_HANDLER
@@ -125,8 +125,8 @@
 	RegisterSignal(owner, COMSIG_PSI_MIND_POWER, PROC_REF(cancel_power_lethal), override = TRUE)
 	RegisterSignal(owner, COMSIG_PSI_CHECK_SENSITIVITY, PROC_REF(modify_sensitivity), override = TRUE)
 
-	/// This lasts all round, so lets make it less frequent. Estimated frequency: every 1.5 min
-	next_message = REALTIMEOFDAY + (DRUG_MESSAGE_COOLDOWN * 3)
+	/// This lasts all round, so lets make it less frequent. Estimated frequency: every 2 min
+	next_message = REALTIMEOFDAY + (DRUG_MESSAGE_COOLDOWN * 4)
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker_lethal/process(seconds_per_tick)
 	. = ..()

--- a/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
+++ b/code/modules/organs/subtypes/augment/augments/mind_blanker.dm
@@ -57,7 +57,8 @@
 			return
 		var/message = pick(ongoing_effect_message)
 		to_chat(owner, SPAN_NOTICE("[message]"))
-		owner.play_screen_text("[message]", /atom/movable/screen/text/screen_text/mental_message, COLOR_TEAL)
+		if(prob(20))
+			owner.play_screen_text("[message]", /atom/movable/screen/text/screen_text/mental_message, COLOR_TEAL)
 		next_message = (REALTIMEOFDAY + DRUG_MESSAGE_COOLDOWN * 4)
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker/proc/cancel_power(implantee, caster, cancelled, cancel_return, wide_field)
@@ -136,7 +137,8 @@
 			return
 		var/message = pick(ongoing_effect_message)
 		to_chat(owner, SPAN_NOTICE("[message]"))
-		owner.play_screen_text("[message]", /atom/movable/screen/text/screen_text/mental_message, COLOR_TEAL)
+		if(prob(20))
+			owner.play_screen_text("[message]", /atom/movable/screen/text/screen_text/mental_message, COLOR_TEAL)
 		next_message = (REALTIMEOFDAY + DRUG_MESSAGE_COOLDOWN * 3)
 
 /obj/item/organ/internal/augment/bioaug/mind_blanker_lethal/replaced()

--- a/html/changelogs/PsiProtect.yml
+++ b/html/changelogs/PsiProtect.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added regular messages when under the effect of a mindblanker or psi-protect drugs."
+  - balance: "Tweaked the seizure effects of the cheap psi-protect drugs."

--- a/html/changelogs/PsiProtect.yml
+++ b/html/changelogs/PsiProtect.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: TheGreyWolf
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/PsiProtect.yml
+++ b/html/changelogs/PsiProtect.yml
@@ -1,59 +1,7 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes:
-#   bugfix
-#     - (fixes bugs)
-#   wip
-#     - (work in progress)
-#   qol
-#     - (quality of life)
-#   soundadd
-#     - (adds a sound)
-#   sounddel
-#     - (removes a sound)
-#   rscadd
-#     - (adds a feature)
-#   rscdel
-#     - (removes a feature)
-#   imageadd
-#     - (adds an image or sprite)
-#   imagedel
-#     - (removes an image or sprite)
-#   spellcheck
-#     - (fixes spelling or grammar)
-#   experiment
-#     - (experimental change)
-#   balance
-#     - (balance changes)
-#   code_imp
-#     - (misc internal code change)
-#   refactor
-#     - (refactors code)
-#   config
-#     - (makes a change to the config files)
-#   admin
-#     - (makes changes to administrator tools)
-#   server
-#     - (miscellaneous changes to server)
-#################################
-
-# Your name.
 author: TheGreyWolf
 
-# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
 
-# Any changes you've made.  See valid prefix list above.
-# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
-# SCREW THIS UP AND IT WON'T WORK.
-# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
-# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscadd: "Added regular messages when under the effect of a mindblanker or psi-protect drugs."
   - balance: "Tweaked the seizure effects of the cheap psi-protect drugs."


### PR DESCRIPTION
Mind blankers and psi-protect pills now display messages roughly every 2 minutes and 1 min respectively.
Mind blankers have a random chance for the message to also display on the screen, as they're more invasive, being implants, but also safer.
A warning timer was also added for seizures from psi-protect, so people have a short moment to react in.