### PR TITLE
Fixes that smoking while drinking causes hallucinations

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1272,6 +1272,7 @@
 	messagedelay = MEDICATION_MESSAGE_DELAY * 0.75
 	goodmessage = list("You feel good.","You feel relaxed.","You feel alert and focused.")
 	value = 2
+	alchohol_affected = FALSE
 
 /singleton/reagent/mental/nicotine/overdose(var/mob/living/carbon/M, var/alien, var/removed, var/scale, var/datum/reagents/holder)
 	..()

--- a/html/changelogs/BoozeHallucination.yml
+++ b/html/changelogs/BoozeHallucination.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Smoking while drinking no longer risks hallucinations."


### PR DESCRIPTION
As per the title. Nicotine, being a subtype of mental meds, previously caused hallucinations if a person was drunk while smoking.