### PR TITLE
Portable cooler tweaks + sprite fix

### DIFF
--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -1,12 +1,15 @@
 /obj/item/suit_cooling_unit
-	name = "portable suit cooling unit"
-	desc = "A portable heat sink and liquid cooled radiator that can be hooked up to a space suit's existing temperature controls to provide industrial levels of cooling."
+	name = "portable cooling unit"
+	desc = "A portable heat sink and liquid cooled radiator that can be hooked up to a space suit's \
+	existing temperature controls to provide industrial levels of cooling. Used by synthetics to \
+	enable spacewalks, and to stabilise the chassis in the event of internal cooler failure."
 	w_class = WEIGHT_CLASS_NORMAL
 	icon = 'icons/obj/item/suitcooler.dmi'
 	icon_state = "suitcooler0"
 	item_state = "coolingpack"
 	action_button_name = "Toggle Cooling Unit"
-	slot_flags = SLOT_BACK	//you can carry it on your back if you want, but it won't do anything unless attached to suit storage
+	slot_flags = SLOT_BACK
+	contained_sprite = TRUE
 
 	//copied from tank.dm
 	obj_flags = OBJ_FLAG_CONDUCTABLE
@@ -22,20 +25,20 @@
 
 	matter = list(MATERIAL_ALUMINIUM = 25000, MATERIAL_GLASS = 3500)
 
-	// Is it turned on?
+	/// Is it turned on?
 	var/on = 0
-	// Is the cover open?
+	/// Is the cover open?
 	var/cover_open = 0
 
 	var/obj/item/cell/cell
 
-	// In degrees kelvin per second - probably don't need to mess with heat capacity here
+	/// In degrees kelvin per second - probably don't need to mess with heat capacity here
 	var/max_cooling = 24
 
-	// Base charge consumption per second. Modified by how much cooling work the cooler is doing.
+	/// Base charge consumption per second. Modified by how much cooling work the cooler is doing.
 	var/charge_consumption = 15.4
 
-	// Target to cool an IPC to.
+	/// Target to cool an IPC to.
 	var/thermostat = T20C
 
 	//TODO: make it heat up the surroundings when not in space
@@ -253,5 +256,6 @@
 /obj/item/suit_cooling_unit/no_cell
 	celltype = null
 
-/obj/item/suit_cooling_unit/hyper_cell // Mostly for special spawns, events, etc., so they don't have to worry about cell charge.
+// Mostly for special spawns, events, etc., so they don't have to worry about cell charge.
+/obj/item/suit_cooling_unit/hyper_cell
 	celltype = /obj/item/cell/hyper

--- a/html/changelogs/hazelmouse-cooler.yml
+++ b/html/changelogs/hazelmouse-cooler.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Modified description and name of the portable cooling unit to make it more clear that it is important for IPC medical mechanics."
+  - bugfix: "Portable cooling units now appear on mobs correctly."


### PR DESCRIPTION
Modified the name and description of the portable cooling unit to reflect its importance for keeping synthetics alive after their coolers get shot up, and fixed its on-mobs not appearing on characters' backs. Now you can see when someone is wearing it!

<img width="208" height="137" alt="image" src="https://github.com/user-attachments/assets/d768d31b-d0aa-4fb8-8a67-4e1817355f6e" />
