### PR TITLE
Fix missing disposal segment

### DIFF
--- a/html/changelogs/fabiank3-fix-missing-disposal-segment.yml
+++ b/html/changelogs/fabiank3-fix-missing-disposal-segment.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed missing disposal pipe segment."


### PR DESCRIPTION
# Summary

This PR fixes the missing disposal segment behind the atmospherics locker, introduced in the recent changes to the area.