### PR TITLE
More Atom Cleanup

### DIFF
--- a/code/controllers/subsystems/icon_updates.dm
+++ b/code/controllers/subsystems/icon_updates.dm
@@ -74,7 +74,7 @@ SUBSYSTEM_DEF(icon_update)
 	if(QDELETED(item_cache))
 		return
 
-	if(!item_cache.icon_update_queued && (!item_cache.icon_update_delay || (item_cache.last_icon_update + item_cache.icon_update_delay < world.time)))
+	if(!item_cache.icon_update_queued && item_cache.last_icon_update < world.time)
 		item_cache.icon_update_queued = TRUE
 
 		// Determine if we got any parameter, and if we do set it in the associative list, otherwise just set it to TRUE

--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -18,13 +18,6 @@
 	///Intearaction flags
 	var/interaction_flags_atom = NONE
 
-	var/flags_ricochet = NONE
-
-	///When a projectile tries to ricochet off this atom, the projectile ricochet chance is multiplied by this
-	var/receive_ricochet_chance_mod = 1
-	///When a projectile ricochets off this atom, it deals the normal damage * this modifier to this atom
-	var/receive_ricochet_damage_coeff = 0.33
-
 	var/update_icon_on_init	= FALSE // Default to 'no'.
 
 	var/level = 2
@@ -53,8 +46,6 @@
 	var/datum/reagents/reagents = null
 	var/list/reagents_to_add
 	var/list/reagent_data
-
-	var/gfi_layer_rotation = GFI_ROTATION_DEFAULT
 
 	//light stuff
 
@@ -129,9 +120,6 @@
 
 	/// If the atom is currently queued to have it's icon updated in `SSicon_update`
 	var/tmp/icon_update_queued = FALSE
-
-	/// Delay to apply before updating the icon in `SSicon_update`
-	var/icon_update_delay = null
 
 	/// How this atom should react to having its astar blocking checked
 	var/can_astar_pass = CANASTARPASS_DENSITY

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -35,7 +35,6 @@
 	var/can_dismantle = TRUE
 	var/can_pad = TRUE
 
-	gfi_layer_rotation = GFI_ROTATION_DEFDIR
 	var/makes_rolling_sound = FALSE
 	var/held_item = null // Set to null if you don't want people to pick this up.
 	slowdown = 2.5

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -29,7 +29,6 @@ Pipelines + Other Objects -> Pipe network
 	var/obj/structure/machinery/atmospherics/node1
 	var/obj/structure/machinery/atmospherics/node2
 	var/atmos_initialised = FALSE
-	gfi_layer_rotation = GFI_ROTATION_OVERDIR
 
 /obj/structure/machinery/atmospherics/Initialize(mapload)
 	. = ..()

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -190,7 +190,6 @@
 	alert_pressure = ATMOS_DEFAULT_ALERT_PRESSURE
 
 	level = 1
-	gfi_layer_rotation = GFI_ROTATION_DEFDIR
 
 /obj/structure/machinery/atmospherics/pipe/simple/Initialize(mapload)
 	if(mapload)
@@ -487,7 +486,6 @@
 
 	level = 1
 
-	gfi_layer_rotation = GFI_ROTATION_OVERDIR
 
 /obj/structure/machinery/atmospherics/pipe/manifold/Initialize(mapload)
 	if(mapload)
@@ -1426,7 +1424,6 @@
 	desc = "An adapter for regular, supply, scrubbers, fuel, and auxiliary pipes."
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL|CONNECT_TYPE_AUX
 	icon_state = "map_universal"
-	gfi_layer_rotation = GFI_ROTATION_OVERDIR
 
 /obj/structure/machinery/atmospherics/pipe/simple/visible/universal/mechanics_hints(mob/user, distance, is_adjacent)
 	. = list()
@@ -1465,7 +1462,6 @@
 	desc = "An adapter for regular, supply, scrubbers, fuel, and auxiliary pipes."
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL|CONNECT_TYPE_AUX
 	icon_state = "map_universal"
-	gfi_layer_rotation = GFI_ROTATION_OVERDIR
 
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/universal/mechanics_hints(mob/user, distance, is_adjacent)
 	. = list()

--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -56,14 +56,6 @@
 	qdel(verb_holder)
 	return ..()
 
-/obj/item/rig_module/ai_container/process()
-	if(integrated_ai)
-		var/obj/item/rig/rig = get_rig()
-		if(rig && rig.ai_override_enabled)
-			integrated_ai.get_rig_stats = 1
-		else
-			integrated_ai.get_rig_stats = 0
-
 /obj/item/rig_module/ai_container/proc/update_verb_holder()
 	if(!verb_holder)
 		verb_holder = new(src)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -171,3 +171,11 @@
 	var/obj/item/rig/wearing_rig
 	/// Pref holder for the speech bubble style.
 	var/speech_bubble_type
+
+	var/med_record = ""
+	var/sec_record = ""
+	var/list/incidents = list()
+	var/gen_record = ""
+	var/ccia_record = ""
+	var/list/ccia_actions = list()
+	var/exploit_record = ""

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -129,3 +129,5 @@
 	var/datum/weakref/last_weather
 
 	var/tmp/last_push_notif
+
+	var/seer = 0 //for cult//Carbon, probably Human

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -91,16 +91,8 @@
 	var/brokejaw = null
 	var/real_name = null
 	var/flavor_text = ""
-	var/med_record = ""
-	var/sec_record = ""
-	var/list/incidents = list()
 	var/list/additional_vision_handlers = list()
-	var/gen_record = ""
-	var/ccia_record = ""
-	var/list/ccia_actions = list()
-	var/exploit_record = ""
 	var/blinded = null
-	var/bhunger = 0						//Carbon
 	var/ajourn = 0
 	var/druggy = 0						//Carbon
 	var/confused = 0					//Carbon
@@ -156,7 +148,6 @@
 	var/stunned = 0
 	var/weakened = 0
 	var/losebreath = 0 //Carbon
-	var/shakecamera = 0
 	var/a_intent = I_HELP//Living
 	var/m_intent = M_WALK //Living
 	var/lastKnownIP = null
@@ -170,8 +161,6 @@
 	/// contains [/atom/movable/screen/alert only] // On /mob so clientless mobs will throw alerts properly
 	var/list/alerts = list()
 	var/list/screens = list()
-
-	var/seer = 0 //for cult//Carbon, probably Human
 
 	var/datum/hud/hud_used = null
 
@@ -258,7 +247,6 @@
 
 	var/frozen = FALSE //related to wizard statues, if set to true, life won't process
 
-	gfi_layer_rotation = GFI_ROTATION_DEFDIR
 	var/disconnect_time = null//Time of client loss, set by Logout(), for timekeeping
 
 	var/mob_thinks = TRUE
@@ -312,9 +300,6 @@
 	//handles up-down floaty effect in space and zero-gravity
 	var/is_floating = FALSE
 
-	// Used by the Nano UI Manager (/datum/SSnanoui) to track UIs opened by this mob
-	var/list/open_nanouis = list()
-
 	var/last_pain_message = ""
 	var/next_pain_time = 0
 
@@ -351,7 +336,5 @@
 	var/list/usable_emotes = list()
 
 	var/client/my_client // Need to keep track of this ourselves, since by the time Logout() is called the client has already been nulled
-
-	var/get_rig_stats = 0
 
 	var/thinking_enabled = FALSE

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -111,7 +111,6 @@ ABSTRACT_TYPE(/obj/structure/machinery/power/apc)
 	anchored = TRUE
 	use_power = POWER_USE_OFF
 	req_access = list(ACCESS_ENGINE_EQUIP)
-	gfi_layer_rotation = GFI_ROTATION_DEFDIR
 	clicksound = SFX_SWITCH
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 	var/area/area

--- a/code/modules/power/lights/fixtures.dm
+++ b/code/modules/power/lights/fixtures.dm
@@ -19,7 +19,6 @@
 	/// Lights are calculated via area so they don't need to be in the machine list.
 	power_channel = AREA_USAGE_LIGHT
 	always_area_sensitive = TRUE
-	gfi_layer_rotation = GFI_ROTATION_DEFDIR
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 	/// Luminosity when on, also used in power calculation.
 	var/brightness_range = 7

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -441,7 +441,7 @@
 		return FALSE
 	var/turf/T = get_turf(A)
 	var/datum/point/point_cache = trajectory.copy_to()
-	if(ricochets < ricochets_max && check_ricochet_flag(A) && check_ricochet(A))
+	if(ricochets < ricochets_max && check_ricochet(A))
 		ricochets++
 		if(A.handle_ricochet(src))
 			on_ricochet(A)
@@ -725,24 +725,11 @@
 	return PROJECTILE_PIERCE_NONE
 
 /obj/projectile/proc/check_ricochet(atom/A)
-	var/chance = ricochet_chance * A.receive_ricochet_chance_mod
+	var/chance = ricochet_chance
 	if(firer && HAS_TRAIT(firer, TRAIT_NICE_SHOT))
 		chance += NICE_SHOT_RICOCHET_BONUS
 	if(ricochets < min_ricochets || prob(chance))
 		return TRUE
-	return FALSE
-
-/obj/projectile/proc/check_ricochet_flag(atom/A)
-	// if((armor_flag in list(ENERGY, LASER)) && (A.flags_ricochet & RICOCHET_SHINY))
-	// 	return TRUE
-
-	// if((armor_flag in list(BOMB, BULLET)) && (A.flags_ricochet & RICOCHET_HARD))
-	// 	return TRUE
-
-	//Keep it easy for now
-	if(A.flags_ricochet & RICOCHET_SHINY|RICOCHET_HARD)
-		return TRUE
-
 	return FALSE
 
 /obj/projectile/proc/return_predicted_turf_after_moves(moves, forced_angle) //I say predicted because there's no telling that the projectile won't change direction/location in flight.

--- a/html/changelogs/hellrejag-mob-var-cleanup.yml
+++ b/html/changelogs/hellrejag-mob-var-cleanup.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - refactor: "Removed several unused vars from atoms and mobs to save on memory and time."


### PR DESCRIPTION
Unused vars take up memory and worsen proc overhead. By far the worst offenders to this are vars on /atom and /mob since they more or less globally stack lots and lots and lots and lots of proc overhead. So I'm cleaning up unused vars on these to save resources. I also noted several vars that are excellent candidates for making components or elements. When I'm not drowning in school work anymore, their time is numbered. 

Mfw every space carp forever has a CCIA record, no wonder mobs are laggy.