### PR TITLE
Minor tweaks and fixes for machinist workshop

### DIFF
--- a/html/changelogs/kano-workshop-improvements.yml
+++ b/html/changelogs/kano-workshop-improvements.yml
@@ -1,0 +1,9 @@
+author: kano
+delete-after: True
+changes:
+  - bugfix: "Fixed garage shutters and a single window in the fabrication section missing firelocks."
+  - qol: "Hull window shutters are now down by default. Fabrication and surgery rooms now have their own shutters."
+  - qol: "Re-arranges the piping and the vents in the area, so they're simple and no longer obscured."
+  - qol: "Re-positions some wall objects."
+  - qol: "Adds two portable cooling units and a power outlet to the workshop surgery room as per TGW's feedback."
+  - rscadd: "Slight changes to the tile-work."

--- a/html/changelogs/kano-workshop-improvements.yml
+++ b/html/changelogs/kano-workshop-improvements.yml
@@ -7,3 +7,4 @@ changes:
   - qol: "Re-positions some wall objects."
   - qol: "Adds two portable cooling units and a power outlet to the workshop surgery room as per TGW's feedback."
   - rscadd: "Slight changes to the tile-work."
+  - rscadd: "Adds a recharge station inside the workshop."

--- a/maps/sccv_horizon/areas/horizon_areas_operations.dm
+++ b/maps/sccv_horizon/areas/horizon_areas_operations.dm
@@ -122,6 +122,7 @@
 	icon_state = "machinist_workshop"
 	area_blurb = "Back in the workshop's surgical bay, the sharp-edged odor of sterilized equipment predominates."
 	horizon_deck = 2
+	lightswitch = FALSE
 
 /// OPERATIONS_AREAS - MINING_AREAS
 /area/horizon/operations/mining_main


### PR DESCRIPTION
## About PR

General improvements and bugfixes for the machinist workshop, namely:

- Fixes garage shutters and a single window in the fabrication section missing firelocks
- Hull window shutters are now down by default. Fabrication and surgery rooms now have their own shutters
- Re-arranges the piping and the vents in the area, so they're simple and no longer obscured
- Re-positions some wall objects
- Adds two portable cooling units and a power outlet to the workshop surgery room as per TGW's feedback
- Adds a recharger inside the workshop
- Slight changes to the tile-work

## Images

<img width="996" height="933" alt="1" src="https://github.com/user-attachments/assets/beac9b51-bb94-48ae-af59-97cb866e0673" />
<img width="480" height="448" alt="2" src="https://github.com/user-attachments/assets/7db2fb5a-fa3c-46b4-801c-0bf9eb48c38b" />


