### PR TITLE
reade racing jacket loadout option fix

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/suit.dm
+++ b/code/modules/client/preference_setup/loadout/items/suit.dm
@@ -661,14 +661,14 @@ ABSTRACT_TYPE(/datum/gear/suit/miscellaneous)
 	path = /obj/item/clothing/suit/storage/toggle/wizrobe/gentlecoat
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
-/datum/gear/suit/leather/reade_racing_jacket
+/datum/gear/suit/reade_racing_jacket
 	display_name = "reade extreme racing jackets selection"
 	description = "A selection of racing jackets often seen on those at once involved in the underground racing scenes of Reade."
 	path = /obj/item/clothing/suit/storage/toggle/leather_jacket/reade_racing
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION | GEAR_HAS_ACCENT_COLOR_SELECTION
 	origin_restriction = list(/singleton/origin_item/origin/reade, /singleton/origin_item/origin/new_gibson, /singleton/origin_item/origin/skrell_biesel, /singleton/origin_item/origin/ipc_tau_ceti)
 
-/datum/gear/suit/leather/reade_racing_jacket/New()
+/datum/gear/suit/reade_racing_jacket/New()
 	..()
 	var/list/jackets = list()
 	jackets["racing jacket, no decal"] = /obj/item/clothing/suit/storage/toggle/leather_jacket/reade_racing

--- a/html/changelogs/kermit-reade-jackets-loadout-fix.yml
+++ b/html/changelogs/kermit-reade-jackets-loadout-fix.yml
@@ -1,0 +1,6 @@
+author: kermit
+
+delete-after: True
+
+changes:
+  - bugfix: "Removes duplicate leather jacket loadout selection from Reade racing jacket loadout selection."


### PR DESCRIPTION
- there was a duplicate leather jacket selection entangled with the reade jacket selection cause i made a silly pathing mistake  that i missed 