### PR TITLE
Stickers now only have a 10% chance of staying persistent, and only save for 2 days.

### DIFF
--- a/code/game/objects/items/sticker.dm
+++ b/code/game/objects/items/sticker.dm
@@ -6,7 +6,7 @@
 	item_flags = ITEM_FLAG_NO_BLUDGEON
 	w_class = WEIGHT_CLASS_TINY
 	vis_flags = VIS_INHERIT_LAYER | VIS_INHERIT_DIR
-	persistant_objects_expiration_time_days = 7
+	persistant_objects_expiration_time_days = 2
 
 	var/datum/weakref/attached
 	var/list/rand_icons
@@ -69,7 +69,8 @@
 	user.drop_from_inventory(src, A)
 	attached = WEAKREF(A)
 	A.add_vis_contents(src)
-	SSpersistence.objectsRegisterTrack(src, ckey(user.key))
+	if(prob(10))
+		SSpersistence.objectsRegisterTrack(src, ckey(user.key))
 
 /obj/item/sticker/proc/remove_sticker(var/mob/user)
 	user.put_in_hands(src)

--- a/html/changelogs/mattatlas-stickers.yml
+++ b/html/changelogs/mattatlas-stickers.yml
@@ -55,4 +55,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Stickers now only have a 10% chance of staying persistent, and only stay around for 2 days."
+  - rscadd: "Stickers now only have a 10% chance of staying persistent, and only stay around for 2 days."

--- a/html/changelogs/mattatlas-stickers.yml
+++ b/html/changelogs/mattatlas-stickers.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Stickers now only have a 10% chance of staying persistent, and only stay around for 2 days."


### PR DESCRIPTION
Sticker spam makes the map really ugly and they're way too easy to come by, so people can keep spamming offices and stuff constantly. This makes them not be as much of an eyesore while still sticking around sometimes.