### PR TITLE
Kill Hardsuit Processing

### DIFF
--- a/code/controllers/subsystems/mob.dm
+++ b/code/controllers/subsystems/mob.dm
@@ -6,7 +6,6 @@ SUBSYSTEM_DEF(mobs)
 	wait = 2 SECONDS
 
 	var/list/currentrun = list()
-	var/list/processing = list()
 
 	var/list/all_rats = list()	// Contains all *living* rats.
 
@@ -72,29 +71,18 @@ SUBSYSTEM_DEF(mobs)
 /datum/controller/subsystem/mobs/fire(resumed = 0)
 	if (!resumed)
 		src.currentrun = GLOB.mob_list.Copy()
-		src.currentrun += processing.Copy()
 
 	//Mobs might have been removed between the previous and a resumed fire, yet we want to maintain the priority to process
 	//the mobs that we didn't in the previous run, hence we have to pay the price of a list subtraction
 	//with &= we say to remove any item in the first list that is not in the second one
 	//of course, if we haven't resumed, this comparison would be useless, hence we skip it
-	var/list/currentrun = resumed ? (src.currentrun &= (GLOB.mob_list + processing)) : src.currentrun
+	var/list/currentrun = resumed ? (src.currentrun &= GLOB.mob_list) : src.currentrun
 
 	var/seconds_per_tick = wait * 0.1
 
 	while(length(currentrun))
 		var/datum/thing = currentrun[length(currentrun)]
 		currentrun.len--
-		if(!ismob(thing))
-			if(!QDELETED(thing))
-				if(thing.process(seconds_per_tick, times_fired) == PROCESS_KILL)
-					stop_processing(thing)
-			else
-				processing -= thing
-			if(MC_TICK_CHECK)
-				return
-			continue
-
 		var/mob/M = thing
 
 		if(QDELETED(M))
@@ -151,7 +139,3 @@ SUBSYSTEM_DEF(mobs)
 				deltimer(mannequins_del_timers[ckey])
 			mannequins_del_timers[ckey] = null
 			mannequins_del_timers -= ckey
-
-// Helper so PROCESS_KILL works.
-/datum/controller/subsystem/mobs/proc/stop_processing(datum/D)
-	STOP_PROCESSING(src, D)

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -78,7 +78,7 @@
 		cell = new celltype(src)
 
 /obj/item/suit_cooling_unit/Destroy()
-	STOP_PROCESSING(SSmobs, src)
+	STOP_PROCESSING(SSprocessing, src)
 	QDEL_NULL(cell)
 	return ..()
 
@@ -151,7 +151,7 @@
 		return
 
 	on = TRUE
-	START_PROCESSING(SSmobs, src)
+	START_PROCESSING(SSprocessing, src)
 	update_icon()
 
 /obj/item/suit_cooling_unit/proc/turn_off()
@@ -159,7 +159,7 @@
 		var/mob/M = src.loc
 		to_chat(M, SPAN_WARNING("\The [src] clicks and whines as it powers down."))
 	on = FALSE
-	STOP_PROCESSING(SSmobs, src)
+	STOP_PROCESSING(SSprocessing, src)
 	update_icon()
 
 /obj/item/suit_cooling_unit/attack_self(mob/user)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -156,8 +156,6 @@
 
 	spark_system = bind_spark(src, 5)
 
-	START_PROCESSING(SSmobs, src)
-
 	last_remote_message = world.time
 
 	if(initial_modules && initial_modules.len)
@@ -224,7 +222,7 @@
 	piece.icon_supported_species_tags = icon_supported_species_tags
 
 /obj/item/rig/Destroy()
-	STOP_PROCESSING(SSmobs, src)
+	STOP_PROCESSING(SSprocessing, src)
 	QDEL_NULL(air_supply)
 	QDEL_NULL(boots)
 	QDEL_NULL(chest)
@@ -439,7 +437,7 @@
 			piece.item_flags |= ITEM_FLAG_AIRTIGHT
 	update_icon(1)
 
-/obj/item/rig/process()
+/obj/item/rig/process(seconds_per_tick)
 	// If we've lost any parts, grab them back.
 	var/mob/living/M
 	for(var/obj/item/piece in list(gloves,boots,helmet,chest))
@@ -452,7 +450,7 @@
 
 	var/previous_offline_status = offline
 	// Consume energy per tick while active. If you don't have a cell... Weird, but we'll deal with that shortly.
-	var/power_usage_this_tick = ((!offline && cell) ? cell_draw_rate : 0.0)
+	var/power_usage_this_tick = ((!offline && cell) ? (cell_draw_rate * seconds_per_tick) : 0.0)
 
 	if(!istype(wearer) || loc != wearer || wearer.back != src || canremove || !cell || cell.charge <= 0)
 		if(!cell || cell.charge <= 0)
@@ -487,10 +485,10 @@
 	set_vision(!offline)
 
 	if(cell && cell.charge > 0 && electrified > 0)
-		electrified--
+		electrified -= seconds_per_tick
 
 	if(crushing)
-		wearer.apply_damage(10) // Applies 10 brute damage to a random extremity each process
+		wearer.apply_damage(10 * seconds_per_tick) // Applies 10 brute damage per second to a random extremity
 		if(wearer.stat == DEAD)
 			crushing = FALSE
 			visible_message(SPAN_DANGER("A squelching sound comes from within the sealed hardsuit..")) // this denotes that the user inside has died.
@@ -1039,8 +1037,7 @@
 		SSstatpanels.set_action_tabs_RIG(user.client, user)
 
 	null_wearer(user)
-
-
+	STOP_PROCESSING(SSprocessing, src)
 //Todo
 /obj/item/rig/proc/malfunction()
 	return 0
@@ -1302,3 +1299,7 @@
 		air_supply.remove_air(air_supply.air_contents.total_moles)
 	else
 		air_supply = null
+
+/obj/item/rig/equipped()
+	. = ..()
+	START_PROCESSING(SSprocessing, src)

--- a/html/changelogs/hellfirejag-kill-hardsuit-processing.yml
+++ b/html/changelogs/hellfirejag-kill-hardsuit-processing.yml
@@ -1,0 +1,5 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed hardsuits globally wasting processing time when not equipped."
+  - refactor: "Tick differentiated hardsuits."


### PR DESCRIPTION
Life() was wasting a bunch of processing time on "Every hardsuit forever" regardless of if it was equipped or not. Additionally Life() was responsible for double-processing hardsuits, which is extremely improper. Since hardsuits are being moved to SSprocessing instead of SSmobs, which has a different tickrate, I went ahead and tick differentiated them to make sure that nothing will break.