### PR TITLE
Air Stat Panel Tweaks

### DIFF
--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -124,8 +124,14 @@ SUBSYSTEM_DEF(air)
 	can_fire = TRUE
 
 /datum/controller/subsystem/air/stat_entry(msg)
-	msg = "TtU:[tiles_to_update.len] ZtU:[zones_to_update.len] AFZ:[active_fire_zones.len] AH:[active_hotspots.len] AE:[active_edges.len]"
-	return msg
+	msg = {"\n\
+		Update Queues: \
+		Tiles [tiles_to_update.len] \
+		Zones [zones_to_update.len] \
+		Active Fire Zones [active_fire_zones.len] \
+		Active Hotspots [active_hotspots.len] \
+		Active Edges [active_edges.len]"}
+	return ..()
 
 /datum/controller/subsystem/air/Initialize(timeofday, simulate = TRUE)
 

--- a/html/changelogs/hellfirejag-atmos-debug-info.yml
+++ b/html/changelogs/hellfirejag-atmos-debug-info.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "Tweaked the Air stat panel to give significantly more useful information for debugging when and why air is causing lag."


### PR DESCRIPTION
This PR tweaks the Air stat panel to give more actually useful information about when and why its lagging.
Old:

<img width="456" height="39" alt="image" src="https://github.com/user-attachments/assets/125f89e9-e336-4df7-aad0-608a15655619" />

New: 

<img width="835" height="100" alt="image" src="https://github.com/user-attachments/assets/170901bd-255a-407f-98e5-38da1124ea74" />
