### PR TITLE
Timer Processing Cleanup

### DIFF
--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -20,6 +20,7 @@
 
 	timing = !timing
 	update_icon()
+	START_PROCESSING(SSprocessing, src)
 	return FALSE
 
 /obj/item/assembly/timer/toggle_secure()
@@ -33,6 +34,7 @@
 	return secured
 
 /obj/item/assembly/timer/proc/timer_end()
+	STOP_PROCESSING(SSprocessing, src)
 	if(!secured)
 		return FALSE
 	pulse(FALSE)
@@ -42,13 +44,15 @@
 	addtimer(CALLBACK(src, PROC_REF(process_cooldown)), 1 SECOND)
 
 /obj/item/assembly/timer/process()
-	if(timing)
-		if(time > 0)
-			time--
-		if(time <= 0)
-			timing = FALSE
-			timer_end()
-			time = 10
+	if(!timing)
+		return PROCESS_KILL
+
+	if(time > 0)
+		time--
+	if(time <= 0)
+		timing = FALSE
+		timer_end()
+		time = 10
 
 /obj/item/assembly/timer/update_icon()
 	ClearOverlays()

--- a/html/changelogs/hellfirejag-timer-process-cleanup.yml
+++ b/html/changelogs/hellfirejag-timer-process-cleanup.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed Timers processing forever even after their time runs out."


### PR DESCRIPTION
<img width="1144" height="599" alt="image" src="https://github.com/user-attachments/assets/675f645e-23c7-4c5b-905c-6ab259676fb3" />

Not a single one of these timers are doing anything, but they occupy processing time. This PR makes them not do that. When you activate a timer, they start processing. When the timer finishes, it stops processing. No need for it to linger in the processing queue indefinitely. There's like a hundred of these things on live. 