### PR TITLE
Buffs Technomancer slightly

### DIFF
--- a/code/datums/outfits/outfit_antag.dm
+++ b/code/datums/outfits/outfit_antag.dm
@@ -699,10 +699,10 @@
 	name = "Technomancer"
 	allow_backbag_choice = FALSE
 
-	head = /obj/item/clothing/head/chameleon/technomancer
-	l_ear = /obj/item/radio/headset/bluespace
+	head = /obj/item/clothing/head/helmet/chameleon
+	l_ear = /obj/item/radio/headset/syndicate/alt
 	uniform = /obj/item/clothing/under/chameleon/technomancer
-	suit = /obj/item/clothing/suit/chameleon/technomancer
+	suit = /obj/item/clothing/suit/armor/chameleon
 	belt = /obj/item/flashlight
 	back = /obj/item/technomancer_core
 	shoes = /obj/item/clothing/shoes/chameleon/technomancer
@@ -710,7 +710,7 @@
 	r_pocket = /obj/item/disposable_teleporter/free
 	l_pocket = /obj/item/technomancer_catalog
 
-	id = /obj/item/card/id/bluespace
+	id = /obj/item/card/id/syndicate
 	id_iff = IFF_BLUESPACE
 
 	var/id_assignment = "Technomagus"
@@ -736,9 +736,9 @@
 /obj/outfit/admin/techomancer/apprentice
 	name = "Technomancer Apprentice"
 
-	head = /obj/item/clothing/head/chameleon/technomancer
+	head = /obj/item/clothing/head/helmet/chameleon
 	uniform = /obj/item/clothing/under/chameleon/technomancer
-	suit = /obj/item/clothing/suit/chameleon/technomancer
+	suit = /obj/item/clothing/suit/armor/chameleon
 	shoes = /obj/item/clothing/shoes/chameleon/technomancer
 
 	l_pocket = /obj/item/technomancer_catalog/apprentice

--- a/html/changelogs/fyni-techno.yml
+++ b/html/changelogs/fyni-techno.yml
@@ -1,0 +1,4 @@
+author: fyni
+delete-after: True
+changes:
+ - rscadd: "Buffs technomancer slightly by changing their starting loadout. They will now have chameleon armour, a proper agent ID and an antag headset."


### PR DESCRIPTION
- Changes the Technomancer's starting gear. They now set of chameleon armour, a normal agent ID and a raider headset.
- Techno is too vulnerable to the newly rolled out Security pistols, and even two sec officers can take one down in less than a second.
- They can still be taken down by LTLs, but are slightly less vulnerable to it.
- The bluespace ID and headset, while lovely sprites, are clunky as they do not fit in with all gimmicks. Notably, the bluespace ID could not be edited in a meaningful way to aid with gimmicks.
- Notably, the agent ID can swipe access and has access to the Electronic Warfare Suite, making this a minor buff too.
- The agent ID can already be set to have the same appearance as the bluespace ID, should you wish to be a classic technomagus.
- The headset does intercept comms, making this a buff also.

Should this prove too much, things can easily be edited. Notably, the techno loses access to the rarely used bluespace comms channel, an exclusive comms channel. Given this is a solo mode, this is not a major loss but if required a workaround could be made.