### PR TITLE
Damage Menu - Seizure and Heart Attacks

### DIFF
--- a/code/modules/mob/living/carbon/human/damage_menu.dm
+++ b/code/modules/mob/living/carbon/human/damage_menu.dm
@@ -143,6 +143,13 @@
 		if("misc")
 			log_and_message_admins("used the Damage Menu to deploy [params["action"]] on [H]", usr, get_turf(H))
 			switch(params["action"])
+				// Minor actions()
+				if("seizure")
+					H.seizure()
+				if("heart attack")
+					if(!H.trigger_heart_attack())
+						to_chat(usr, SPAN_WARNING("Unable to trigger a heart attack on [H]."))
+				// Major actions
 				if("wind")
 					toggle_wind_paralysis(H, usr)
 				if("gigashatter")

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1353,6 +1353,26 @@
 	if(shock_stage >= 150)
 		Weaken(20)
 
+/mob/living/carbon/human/proc/trigger_heart_attack()
+	if(status_flags & GODMODE)
+		return FALSE
+	if(stat == DEAD || !should_have_organ(BP_HEART))
+		return FALSE
+
+	var/obj/item/organ/internal/heart/heart = internal_organs_by_name[BP_HEART]
+	if(!istype(heart) || BP_IS_ROBOTIC(heart) || (heart.status & ORGAN_DEAD))
+		return FALSE
+
+	shock_stage = max(shock_stage, 120)
+	heart.pulse = PULSE_NONE
+	heart.handle_pulse()
+	BITSET(hud_updateflag, HEALTH_HUD)
+
+	to_chat(src, SPAN_DANGER("Your heart has stopped!"))
+	visible_message("<b>[src]</b> suddenly collapses, clutching at [get_pronoun("his")] chest!")
+	Paralyse(15)
+	return TRUE
+
 
 /*
 	Called by life(), instead of having the individual hud items update icons each tick and check for status changes

--- a/html/changelogs/Bat-DmgMenu.yml
+++ b/html/changelogs/Bat-DmgMenu.yml
@@ -1,0 +1,5 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - rscadd: "Adds Seizure and Heart Attack buttons to the Damage Menu."
+  - rscadd: "Adds tooltips to several buttons in the Damage Menu."

--- a/tgui/packages/tgui/interfaces/DamageMenu.tsx
+++ b/tgui/packages/tgui/interfaces/DamageMenu.tsx
@@ -123,7 +123,15 @@ export const DamageMenu = (props) => {
             )}
           </Table>
         </Section>
-        <Section title="Miscellaneous">
+        <Section title="Miscellaneous - Minor">
+          <Button
+            content="Seizure"
+            color="yellow"
+            icon="wind"
+            onClick={() => act('misc', { action: 'seizure' })}
+          />
+        </Section>
+        <Section title="Miscellaneous - Major">
           <Button
             content="Toggle Wind"
             color="red"
@@ -131,27 +139,38 @@ export const DamageMenu = (props) => {
             onClick={() => act('misc', { action: 'wind' })}
           />
           <Button
+            content="Heart Attack"
+            color="red"
+            icon="heart-pulse"
+            tooltip="Stops the target's heart and pushes them into critical shock. Healthy, full-blood, quickly-treated targets may recover. Untreated or already-compromised targets are likely to die."
+            onClick={() => act('misc', { action: 'heart attack' })}
+          />
+          <Button
             content="Gigashatter"
             color="red"
             icon="bone"
+            tooltip="Applies Shatter (bone fracture) to all limbs simultaneously."
             onClick={() => act('misc', { action: 'gigashatter' })}
           />
           <Button
             content="Kill"
             color="red"
             icon="skull-crossbones"
+            tooltip="Kills the target mob. Instant death, no cause."
             onClick={() => act('misc', { action: 'kill' })}
           />
           <Button
             content="Gib"
             color="red"
             icon="splotch"
+            tooltip="Splat."
             onClick={() => act('misc', { action: 'gib' })}
           />
           <Button
             content="Dust"
             color="red"
             icon="exclamation-triangle"
+            tooltip="Turns the target mob into dust."
             onClick={() => act('misc', { action: 'dust' })}
           />
         </Section>


### PR DESCRIPTION
changes:
  - rscadd: "Adds Seizure and Heart Attack buttons to the Damage Menu."
  - rscadd: "Adds tooltips to several buttons in the Damage Menu."
<img width="668" height="772" alt="Screenshot 2026-07-12 115649" src="https://github.com/user-attachments/assets/7809096c-3f15-43b2-b741-21e54ff47e3d" />
