### PR TITLE
Roleplaying injuries sustained in canon events is now mandatory.

### DIFF
--- a/code/datums/round_canonicity.dm
+++ b/code/datums/round_canonicity.dm
@@ -90,6 +90,7 @@
 		if(LIMITED_CHARACTER_DEATH)
 			. += "Character deaths are limited during this round. If all involved parties agree, character deaths can be retconned. If you would like to contest a death, or determine if a party counts as involved, please adminhelp."
 			. += "To count as involved, a player has to be an active participant of your death, meaning that they must have intentionally contributed to it. As an example, if you die to a carp on an expedition, you can retcon this death without asking others."
+			. += "All injuries sustained as part of this round are canon and should be roleplayed to the best of your ability. Do not ignore an injury you have obtained without explicit approval from administration."
 		if(FORCED_CHARACTER_DEATH)
 			. += "Character deaths are forced canon during this round. All character deaths must go through headmins and loremasters to be retconned, no exceptions!"
 		if(NO_CHARACTER_DEATH)

--- a/code/datums/round_canonicity.dm
+++ b/code/datums/round_canonicity.dm
@@ -90,9 +90,9 @@
 		if(LIMITED_CHARACTER_DEATH)
 			. += "Character deaths are limited during this round. If all involved parties agree, character deaths can be retconned. If you would like to contest a death, or determine if a party counts as involved, please adminhelp."
 			. += "To count as involved, a player has to be an active participant of your death, meaning that they must have intentionally contributed to it. As an example, if you die to a carp on an expedition, you can retcon this death without asking others."
-			. += "All injuries sustained as part of this round are canon and should be roleplayed to the best of your ability. Do not ignore an injury you have obtained without explicit approval from administration."
 		if(FORCED_CHARACTER_DEATH)
 			. += "Character deaths are forced canon during this round. All character deaths must go through headmins and loremasters to be retconned, no exceptions!"
+			. += "All injuries sustained as part of this round are immediately and fully canon, and should be roleplayed to the best of your ability. Do not ignore an injury you have obtained without explicit approval from administration."
 		if(NO_CHARACTER_DEATH)
 			. += "Character deaths are not canon during this round."
 

--- a/code/datums/round_canonicity.dm
+++ b/code/datums/round_canonicity.dm
@@ -92,7 +92,8 @@
 			. += "To count as involved, a player has to be an active participant of your death, meaning that they must have intentionally contributed to it. As an example, if you die to a carp on an expedition, you can retcon this death without asking others."
 		if(FORCED_CHARACTER_DEATH)
 			. += "Character deaths are forced canon during this round. All character deaths must go through headmins and loremasters to be retconned, no exceptions!"
-			. += "All injuries sustained as part of this round are immediately and fully canon, and should be roleplayed to the best of your ability. Do not ignore an injury you have obtained without explicit approval from administration."
+			. += "All injuries sustained as part of this round are immediately and fully canon, and should be roleplayed to the best of your ability, both in this round and the following. \
+				Do not ignore an injury you have obtained without explicit approval from administration. You are expected to roleplay its consequences believably, even extending to following rounds."
 		if(NO_CHARACTER_DEATH)
 			. += "Character deaths are not canon during this round."
 

--- a/html/changelogs/mattatlas-canontwaeks.yml
+++ b/html/changelogs/mattatlas-canontwaeks.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a line to event canonicity clarifying that you must roleplay injuries obtained during canon event rounds to the best of your ability, and that you cannot ignore or downplay them without explicit approval from administration."


### PR DESCRIPTION
> All injuries sustained as part of this round are immediately and fully canon, and should be roleplayed to the best of your ability, both in this round and the following. Do not ignore an injury you have obtained without explicit approval from administration. You are expected to roleplay its consequences believably, even extending to following rounds.

This means that if you were to get shot in the hand during an event, you cannot magically pop up next shift and pretend it's fully fine. You are expected to roleplay these things appropriately. Similarly, if your hand was removed during an event and is substituted with a prosthetic, you are also expected to keep this unless you adminhelp and an administrator tells you that you can void the event in question.

Surgeries taking 10 minutes and leaving no consequences is a gameplay contrivance, not a realistic representation of what surgery/medical recovery is like in the Auroraverse. Conditionmed will show this better.