### PR TITLE
Tweak Skrell Strength

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
+++ b/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
@@ -112,6 +112,7 @@
 	has_psionics = PSI_RANK_SENSITIVE
 	character_creation_psi_points = 2
 	mass_modifier = REFERENCE_MASS_SKRELL / REFERENCE_MASS_HUMAN
+	mob_strength = 1.8 // Offset for very low mass.
 
 /datum/species/skrell/handle_trail(var/mob/living/carbon/human/H, var/turf/T)
 	var/list/trail_info = ..()

--- a/code/modules/mob/living/carbon/human/species/station/skrell/skrell_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/skrell/skrell_subspecies.dm
@@ -25,3 +25,4 @@
 	max_pulse = 140 // Species default 130
 
 	mass_modifier = REFERENCE_MASS_SKRELL_AXIORI / REFERENCE_MASS_HUMAN
+	mob_strength = 1.5 // Offset for very low mass.

--- a/html/changelogs/hellfirejag-tweak-skrell-strength.yml
+++ b/html/changelogs/hellfirejag-tweak-skrell-strength.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - balance: "Tweaked baseline strength modifiers for Skrell to allow them to fireman carry a human without requiring the Conditioning skill."


### PR DESCRIPTION
The conditioning skill was a little too harsh on Skrell, who suffered heavily from being the lightest and smallest species, which made them have extremely unfavorable interactions with mass and fireman carrying. This PR gives them a higher than normal mob strength modifier to offset their low mass, so that they can at least fireman carry a human without requiring the conditioning skill. This makes both standard and Axiori skrell start at a similar level as a human's limits for carrying before the Conditioning skill is considered.