### PR TITLE
Offship Piloting Fix

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -254,7 +254,8 @@
 		var/ndir = text2num(params["roll"])
 		if(ishuman(usr))
 			var/mob/living/carbon/human/H = usr
-			var/piloting_difference =  H.GetComponent(PILOT_SPACECRAFT_SKILL_COMPONENT)?.skill_level - connected.pilot_class
+			var/pilot_level = H.GetComponent(PILOT_SPACECRAFT_SKILL_COMPONENT)?.skill_level
+			var/piloting_difference =  pilot_level - connected.pilot_class
 
 			var/dir_to_move = turn(connected.dir, ndir == WEST ? 90 : -90)
 			var/turf/new_turf = get_step(connected, dir_to_move)
@@ -264,7 +265,7 @@
 			if(do_after(H, 1 SECOND) && connected.can_combat_roll())
 				visible_message(SPAN_DANGER("[H] tilts the yoke all the way to the [ndir == WEST ? "left" : "right"]!"))
 				connected.combat_roll(ndir)
-				if(piloting_difference <= 0 && prob(60)) //A lack of difference means skill level (1-4) is less than pilot_class (1-3)
+				if(pilot_level && piloting_difference <= 0 && prob(60)) //A lack of difference means skill level (1-4) is less than pilot_class (1-3)
 					ndir = pick(NORTH, SOUTH)
 					connected.forceMove(get_step(connected, ndir))
 					if(connected.pilot_class != PILOTING_CLASS_TWO && prob(70))
@@ -298,9 +299,10 @@
 	if(isliving(usr))// AI and robots are allowed to pilot now!
 		if (action == "move")
 			var/mob/living/H = usr
-			var/piloting_difference =  H.GetComponent(PILOT_SPACECRAFT_SKILL_COMPONENT)?.skill_level - connected.pilot_class
+			var/pilot_level = H.GetComponent(PILOT_SPACECRAFT_SKILL_COMPONENT)?.skill_level
+			var/piloting_difference =  pilot_level - connected.pilot_class
 
-			if(piloting_difference <= 0)
+			if(pilot_level && piloting_difference <= 0)
 				to_chat(H, SPAN_NOTICE("You begin burning up the vessel's speed..."))
 				if((connected.pilot_class != PILOTING_CLASS_TWO && do_after(H, 2 SECONDS)) || (connected.pilot_class == PILOTING_CLASS_TWO && do_after(H, 1 SECOND)))
 					connected.relaymove(H, connected.dir, accellimit)
@@ -324,9 +326,10 @@
 			var/ndir = text2num(params["turn"])
 			if(ishuman(usr))
 				var/mob/living/carbon/human/H = usr
-				var/piloting_difference =  H.GetComponent(PILOT_SPACECRAFT_SKILL_COMPONENT)?.skill_level - connected.pilot_class
+				var/pilot_level = H.GetComponent(PILOT_SPACECRAFT_SKILL_COMPONENT)?.skill_level
+				var/piloting_difference =  pilot_level - connected.pilot_class
 
-				if(connected.can_turn() && piloting_difference <= 0)
+				if(connected.can_turn() && pilot_level && piloting_difference <= 0)
 					to_chat(H, SPAN_NOTICE("You feel you can work a turn [ndir == WEST ? "left" : "right"] here..."))
 					if((connected.pilot_class != PILOTING_CLASS_TWO && do_after(H, 3 SECONDS))  || (connected.pilot_class == PILOTING_CLASS_TWO && do_after(H, 1 SECOND)))
 						connected.turn_ship(ndir)
@@ -370,10 +373,11 @@
 		if (action == "brake")
 			if(ishuman(usr))
 				var/mob/living/carbon/human/H = usr
-				var/piloting_difference =  H.GetComponent(PILOT_SPACECRAFT_SKILL_COMPONENT)?.skill_level - connected.pilot_class
+				var/pilot_level =  H.GetComponent(PILOT_SPACECRAFT_SKILL_COMPONENT)?.skill_level
+				var/piloting_difference = pilot_level - connected.pilot_class
 
 				to_chat(H, SPAN_NOTICE("You begin clamping down the vessel's speed..."))
-				if(piloting_difference <= 0)
+				if(pilot_level && piloting_difference <= 0)
 					if((connected.pilot_class != PILOTING_CLASS_TWO && do_after(H, 2 SECONDS)) || (connected.pilot_class == PILOTING_CLASS_TWO && do_after(H, 1 SECOND)))
 						connected.decelerate()
 						if(prob(60)) // Can't ignore the 1s burn_delay, so manually do decelerate()'s effects instead

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -113,7 +113,7 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 		to_chat(user, SPAN_WARNING("There's just so many buttons... You have no idea where to even begin."))
 		return FALSE
 	// A lack of a difference means skill level (1-4) is less than pilot_class (1-3)
-	if(piloting_difference <= 0)
+	if(pilot_level && piloting_difference <= 0)
 		if(connected.pilot_class == PILOTING_CLASS_SHUTTLE)
 			user.visible_message("<b>[user]</b> starts indecisively messing with \the [src].", SPAN_WARNING("There's just so many buttons... You have no idea where to even begin, but..."))
 			if(do_after(user, 10 SECONDS) && Adjacent(user))
@@ -130,7 +130,7 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 		else
 			to_chat(user, SPAN_WARNING("This ship's class is notably more complex than you're used to, but you can still grasp the core controls."))
 	// Conversely, Non-Unfamiliar skill level (2-4) will always be higher than pilot class (1-3)
-	if(pilot_level < connected.pilot_class)
+	if(pilot_level && pilot_level < connected.pilot_class)
 		to_chat(user, SPAN_WARNING("There's just so many buttons... You have no idea where to even begin, this is far too complex for you."))
 		return
 	if(use_check_and_message(user))

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -108,7 +108,7 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 	// Snowflake case for checking player characters for a Pilot Spacecraft Skill.
 	// Only player characters will have the component. Which will both always be present on them, and will only enable its own return logic if it exists.
 	// NPCs, Ghostroles, and Offship Antags that don't generate skills are unaffected by this check by intentional design so that we don't have to account for them.
-	if (!connected.pilot_class && pilot_level <= SKILL_LEVEL_UNFAMILIAR)
+	if (!connected.pilot_class && pilot_level && pilot_level <= SKILL_LEVEL_UNFAMILIAR)
 	// No pilot_class means it's probably a station, so only Unfamiliar is checked for
 		to_chat(user, SPAN_WARNING("There's just so many buttons... You have no idea where to even begin."))
 		return FALSE

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -113,7 +113,7 @@
 		activate(user)
 		return TRUE
 
-	if(max_engineering_skill <= SKILL_LEVEL_TRAINED)
+	if(max_engineering_skill && max_engineering_skill <= SKILL_LEVEL_TRAINED)
 		to_chat(user, SPAN_WARNING("You try to find the switch on \the [src]... How do you even turn this thing on?"))
 		if(!do_after(user, 3 SECONDS + 1.5 SECONDS * (SKILL_LEVEL_TRAINED - max_engineering_skill)))
 			return

--- a/html/changelogs/diggiez - OffshipPilotingFix.yml
+++ b/html/changelogs/diggiez - OffshipPilotingFix.yml
@@ -1,0 +1,14 @@
+# Your name.
+author: diggiez
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Ghost roles aren't checked for Pilot: Spacecraft anymore."
+  - bugfix: "Ghost roles aren't checked for Mechanical Engineering for emitter use anymore."


### PR DESCRIPTION
Ghost roles or anything that doesn't use skills is no longer checked for them by Pilot: Spacecraft. (https://github.com/Aurorastation/Aurora.3/issues/22819)
Also fixes a similar oversight on using emitters.
(https://github.com/Aurorastation/Aurora.3/issues/22526)