### PR TITLE
Permit impact drills to work in IPC surgery and some minor tool fixes

### DIFF
--- a/code/game/objects/items/recharger_backpack.dm
+++ b/code/game/objects/items/recharger_backpack.dm
@@ -38,7 +38,7 @@
 		powersupply = attacking_item
 		update_icon()
 
-	else if(istype(attacking_item, /obj/item/screwdriver) && powersupply)
+	else if(attacking_item.tool_behaviour == TOOL_SCREWDRIVER && powersupply)
 		to_chat(user, SPAN_NOTICE("You remove \the [powersupply] from \the [src]'s power socket"))
 		powersupply.forceMove(get_turf(src))
 		user.put_in_hands(powersupply)

--- a/code/game/objects/items/tools/tools.dm
+++ b/code/game/objects/items/tools/tools.dm
@@ -861,9 +861,6 @@
 	update_tool(tool)
 	return TRUE
 
-/obj/item/powerdrill/issurgerycompatible()
-	return FALSE // too unwieldy for most surgeries
-
 /obj/item/steelwool
 	name = "steel wool"
 	desc = "Harvested from the finest NanoTrasen steel sheep."

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -953,7 +953,7 @@
 		else
 			to_chat(user, SPAN_WARNING("You need at least twelve rods to complete \the [src]."))
 			return
-	else if(istype(attacking_item, /obj/item/screwdriver))
+	else if(attacking_item.tool_behaviour == TOOL_SCREWDRIVER)
 		return
 	else
 		..()

--- a/code/game/objects/structures/barricades/liquid.dm
+++ b/code/game/objects/structures/barricades/liquid.dm
@@ -55,8 +55,8 @@
 		maxhealth += 50
 
 /obj/structure/barricade/liquid/attackby(obj/item/attacking_item, mob/user)
-	if(istype(attacking_item, /obj/item/crowbar) && user.a_intent != I_HURT)
-		var/obj/item/crowbar/ET = attacking_item
+	if(attacking_item.tool_behaviour == TOOL_CROWBAR && user.a_intent != I_HURT)
+		var/obj/item/ET = attacking_item
 		user.visible_message(SPAN_NOTICE("[user] starts disassembling [src]."), \
 		SPAN_NOTICE("You start disassembling [src]."))
 		if(ET.use_tool(src, user, 4 SECONDS))

--- a/code/modules/synthesized_instruments/real_instruments/Synthesizer/synthesizer.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Synthesizer/synthesizer.dm
@@ -13,7 +13,7 @@
 	sound_player = /datum/sound_player/synthesizer
 
 /obj/structure/synthesized_instrument/synthesizer/attackby(obj/item/attacking_item, mob/user, params)
-	if (istype(attacking_item, /obj/item/wrench))
+	if (attacking_item.tool_behaviour == TOOL_WRENCH)
 		if (!anchored && !isinspace())
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 			to_chat(usr, SPAN_NOTICE(" You begin to tighten \the [src] to the floor..."))

--- a/html/changelogs/ImpactingTheHatch.yml
+++ b/html/changelogs/ImpactingTheHatch.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Impact drills can now be used for robotics surgery the same way regular tools can."
+  - bugfix: "Fixed a couple of hardcoded tool interactions to use tool behavior instead."


### PR DESCRIPTION
This permits the impact drills to work for surgeries where a screwdriver would work. For the regular uses that would be opening the hatches on prosthetic limbs and prosthetic organ repairs. This was done as machinists, who primarily do those surgeries, usually print an impact drill for themself anyway so it was an annoyance to have a screwdriver just for that one thing in their entire workshop.

While at it, I also changed a few hardcoded tool checks elsewhere to not be as hardcoded.