### PR TITLE
Warehouse spawn content changes

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -231,7 +231,7 @@
 //Cargo random stock vars
 //These are used in randomstock.dm
 //And also for generating random loot crates in crates.dm
-#define TOTAL_STOCK 	180//The total number of items we'll spawn in cargo stock
+#define TOTAL_STOCK 	120//The total number of items we'll spawn in cargo stock
 
 #define STOCK_UNCOMMON_PROB	25
 //The probability, as a percentage for each item, that we'll choose from the uncommon spawns list

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -1929,3 +1929,60 @@
 		/obj/item/organ/internal/augment/bioaug/mind_blanker
 	)
 	storage_slots = 4
+
+// Trash components. Bottom of the line
+/obj/item/storage/box/components
+	name = "low-grade component box"
+	illustration = "circuit"
+	color = COLOR_BLUE_GRAY
+	make_exact_fit = TRUE
+	can_hold_strict = TRUE
+	display_contents_with_number = TRUE
+	allow_quick_gather = TRUE
+	use_to_pickup = TRUE
+	can_hold = list(/obj/item/stock_parts)
+	starts_with = list(
+		/obj/item/stock_parts/console_screen = 3,
+		/obj/item/stock_parts/capacitor = 4,
+		/obj/item/stock_parts/scanning_module = 4,
+		/obj/item/stock_parts/manipulator = 4,
+		/obj/item/stock_parts/micro_laser = 4,
+		/obj/item/stock_parts/matter_bin = 4,
+	)
+
+// The decent stuff. Better than the small ones
+/obj/item/storage/box/components/advanced
+	name = "mid-grade component box"
+	starts_with = list(
+		/obj/item/stock_parts/console_screen = 3,
+		/obj/item/stock_parts/capacitor/adv = 4,
+		/obj/item/stock_parts/scanning_module/adv = 4,
+		/obj/item/stock_parts/manipulator/nano = 4,
+		/obj/item/stock_parts/micro_laser/high = 4,
+		/obj/item/stock_parts/matter_bin/adv = 4,
+	)
+
+// Top tier components
+/obj/item/storage/box/components/super_advanced
+	name = "high-grade component box"
+	starts_with = list(
+		/obj/item/stock_parts/console_screen = 3,
+		/obj/item/stock_parts/capacitor/super = 4,
+		/obj/item/stock_parts/scanning_module/phasic = 4,
+		/obj/item/stock_parts/manipulator/pico = 4,
+		/obj/item/stock_parts/micro_laser/ultra = 4,
+		/obj/item/stock_parts/matter_bin/super = 4,
+	)
+
+//Telecomms parts
+/obj/item/storage/box/components/telecomms
+	name = "telecomm component box"
+	starts_with = list(
+		/obj/item/stock_parts/subspace/ansible = 4,
+		/obj/item/stock_parts/subspace/filter = 4,
+		/obj/item/stock_parts/subspace/amplifier = 4,
+		/obj/item/stock_parts/subspace/treatment = 4,
+		/obj/item/stock_parts/subspace/analyzer = 4,
+		/obj/item/stock_parts/subspace/crystal = 4,
+		/obj/item/stock_parts/subspace/transmitter = 4
+	)

--- a/code/modules/cargo/random_stock/large.dm
+++ b/code/modules/cargo/random_stock/large.dm
@@ -148,3 +148,15 @@ STOCK_ITEM_LARGE(exosuit, 1.2) //A randomly generated exosuit in a very variable
 
 STOCK_ITEM_LARGE(unusualcrate, 0.3) //Like from the unknown object random event
 	new /obj/structure/closet/crate/loot(L)
+
+STOCK_ITEM_LARGE(fieldgen, 1)
+	new /obj/structure/machinery/field_generator(L)
+
+STOCK_ITEM_LARGE(shieldgenv1, 0.5)
+	new /obj/structure/machinery/shieldwallgen(L)
+
+STOCK_ITEM_LARGE(shieldgenv2, 0.5)
+	new /obj/structure/machinery/shieldgen(L)
+
+STOCK_ITEM_LARGE(heating, 1)
+	new /obj/structure/machinery/chem_heater(L)

--- a/code/modules/cargo/random_stock/t1_common.dm
+++ b/code/modules/cargo/random_stock/t1_common.dm
@@ -200,14 +200,16 @@ STOCK_ITEM_COMMON(utensil, 2)
 
 STOCK_ITEM_COMMON(utilitygrenades, 1.5)
 	for(var/i in 1 to rand(1, 3))
-		if(prob(20))
-			new /obj/item/grenade/chem_grenade/metalfoam(L)
-		else if(prob(20))
-			new /obj/item/grenade/chem_grenade/antiweed
-		else if(prob(20))
-			new /obj/item/grenade/chem_grenade/monoammoniumphosphate
-		else
-			new /obj/item/grenade/chem_grenade/cleaner(L)
+		var/picked = rand(1, 4)
+		switch(picked)
+			if(1)
+				new /obj/item/grenade/chem_grenade/metalfoam(L)
+			if(2)
+				new /obj/item/grenade/chem_grenade/antiweed(L)
+			if(3)
+				new /obj/item/grenade/chem_grenade/monoammoniumphosphate(L)
+			if(4)
+				new /obj/item/grenade/chem_grenade/cleaner(L)
 
 STOCK_ITEM_COMMON(nanopaste, 2)
 	new /obj/item/stack/nanopaste(L)

--- a/code/modules/cargo/random_stock/t1_common.dm
+++ b/code/modules/cargo/random_stock/t1_common.dm
@@ -16,7 +16,7 @@ STOCK_ITEM_COMMON(meds, 5)
 STOCK_ITEM_COMMON(steel, 7)
 	new /obj/item/stack/material/steel(L, 50)
 
-STOCK_ITEM_COMMON(glass, 2.5)
+STOCK_ITEM_COMMON(glass, 3)
 	if(prob(35))
 		new /obj/item/stack/material/glass/reinforced(L, rand(10,50))
 	else
@@ -28,7 +28,7 @@ STOCK_ITEM_COMMON(wood, 2)
 STOCK_ITEM_COMMON(plastic, 1.5)
 	new /obj/item/stack/material/plastic(L, rand(10,50))
 
-STOCK_ITEM_COMMON(cardboard, 1)
+STOCK_ITEM_COMMON(cardboard, 3)
 	new /obj/item/stack/material/cardboard(L, rand(10,50))
 
 //A lightreplacer and a kit of lights
@@ -101,10 +101,6 @@ STOCK_ITEM_COMMON(crayons, 1.5)
 
 STOCK_ITEM_COMMON(figure, 1)
 	new /obj/random/action_figure(L)
-
-STOCK_ITEM_COMMON(bombsupply, 4.5)
-	for(var/i in 1 to rand(1, 3))
-		new /obj/random/bomb_supply(L)
 
 STOCK_ITEM_COMMON(tech, 5)
 	for(var/i in 1 to rand(1, 3))
@@ -197,15 +193,19 @@ STOCK_ITEM_COMMON(wheelchair, 1)
 STOCK_ITEM_COMMON(trap, 2)
 	new /obj/item/trap(L)
 	if(prob(30))
-		new /obj/item/trap(L)
+		new /obj/item/trap/animal(L)
 
 STOCK_ITEM_COMMON(utensil, 2)
 	new /obj/item/storage/box/kitchen(L)
 
 STOCK_ITEM_COMMON(utilitygrenades, 1.5)
 	for(var/i in 1 to rand(1, 3))
-		if(prob(50))
+		if(prob(20))
 			new /obj/item/grenade/chem_grenade/metalfoam(L)
+		else if(prob(20))
+			new /obj/item/grenade/chem_grenade/antiweed
+		else if(prob(20))
+			new /obj/item/grenade/chem_grenade/monoammoniumphosphate
 		else
 			new /obj/item/grenade/chem_grenade/cleaner(L)
 
@@ -235,8 +235,10 @@ STOCK_ITEM_COMMON(gloves, 3.3)
 
 STOCK_ITEM_COMMON(insulated, 1.5)
 	new /obj/item/clothing/gloves/yellow(L)
-	if(prob(50))
-		new /obj/item/clothing/gloves/yellow(L)
+	if(prob(30))
+		new /obj/item/clothing/gloves/yellow/specialt(L)
+	if(prob(30))
+		new /obj/item/clothing/gloves/yellow/specialu(L)
 
 STOCK_ITEM_COMMON(scanners, 3.2)
 	//A random scanning device, most are useless
@@ -278,6 +280,12 @@ STOCK_ITEM_COMMON(forensic, 1)
 		new /obj/item/uv_light(L)
 	if(prob(25))
 		new /obj/item/storage/box/slides(L)
+	if(prob(10))
+		new /obj/item/forensics/sample_kit(L)
+	if(prob(10))
+		new /obj/item/forensics/sample_kit/powder(L)
+	if(prob(10))
+		new /obj/item/storage/box/fancy/csi_markers(L)
 
 STOCK_ITEM_COMMON(cleaning, 3.5)
 	if(prob(80))
@@ -438,7 +446,8 @@ STOCK_ITEM_COMMON(snacks, 4)
 		/obj/item/storage/box/snack = 10,
 		/obj/item/storage/box/large/produce = 8,
 		/obj/item/storage/field_ration = 3,
-		/obj/item/storage/field_ration/nka = 1
+		/obj/item/storage/field_ration/nka = 1,
+		/obj/item/storage/field_ration/dpra = 0.5
 	)
 
 	var/type = pickweight(snacks)
@@ -448,37 +457,6 @@ STOCK_ITEM_COMMON(posters, 3)
 	new /obj/item/contraband/poster(L)
 	if(prob(40))
 		new /obj/item/contraband/poster(L)
-
-STOCK_ITEM_COMMON(parts, 4)
-	var/list/parts = list(
-		/obj/item/stock_parts/console_screen = 3, //Low ranking parts, common
-		/obj/item/stock_parts/capacitor = 3,
-		/obj/item/stock_parts/scanning_module = 3,
-		/obj/item/stock_parts/manipulator = 3,
-		/obj/item/stock_parts/micro_laser = 3,
-		/obj/item/stock_parts/matter_bin = 3,
-		/obj/item/stock_parts/capacitor/adv = 1, //Improved parts, less common
-		/obj/item/stock_parts/scanning_module/adv = 1,
-		/obj/item/stock_parts/manipulator/nano = 1,
-		/obj/item/stock_parts/micro_laser/high = 1,
-		/obj/item/stock_parts/matter_bin/adv = 1,
-		/obj/item/stock_parts/capacitor/super = 0.3, //Top level parts, rare
-		/obj/item/stock_parts/scanning_module/phasic = 0.3,
-		/obj/item/stock_parts/manipulator/pico = 0.3,
-		/obj/item/stock_parts/micro_laser/ultra = 0.3,
-		/obj/item/stock_parts/matter_bin/super = 0.3,
-		/obj/item/stock_parts/subspace/ansible = 0.5, //Telecomms parts, useless novelties and red herrings.
-		/obj/item/stock_parts/subspace/filter = 0.5,
-		/obj/item/stock_parts/subspace/amplifier = 0.5,
-		/obj/item/stock_parts/subspace/treatment = 0.5,
-		/obj/item/stock_parts/subspace/analyzer = 0.5,
-		/obj/item/stock_parts/subspace/crystal = 0.5,
-		/obj/item/stock_parts/subspace/transmitter = 0.5
-	)
-
-	for(var/i in 1 to rand(1, 2))
-		var/part = pickweight(parts)
-		new part(L)
 
 STOCK_ITEM_COMMON(cane, 2)
 	if(prob(5))
@@ -496,13 +474,14 @@ STOCK_ITEM_COMMON(warning, 2.2)
 
 STOCK_ITEM_COMMON(gasmask, 2)
 	var/list/masks = list(
-		/obj/item/clothing/mask/gas = 10,
+		/obj/item/clothing/mask/gas = 5,
 		/obj/item/clothing/mask/gas/swat = 5,
 		/obj/item/clothing/mask/gas/mime = 0.5,
 		/obj/item/clothing/mask/gas/monkeymask = 0.5,
 		/obj/item/clothing/mask/gas/sexymime = 0.5,
 		/obj/item/clothing/mask/gas/cyborg = 1,
-		/obj/item/clothing/mask/gas/owl_mask = 1
+		/obj/item/clothing/mask/gas/owl_mask = 1,
+		/obj/item/clothing/mask/gas/half = 5
 	)
 
 	var/type = pickweight(masks)

--- a/code/modules/cargo/random_stock/t1_common.dm
+++ b/code/modules/cargo/random_stock/t1_common.dm
@@ -460,6 +460,32 @@ STOCK_ITEM_COMMON(posters, 3)
 	if(prob(40))
 		new /obj/item/contraband/poster(L)
 
+STOCK_ITEM_COMMON(parts, 2)
+	var/list/parts = list(
+		/obj/item/storage/box/components = 10, //Low ranking parts, common
+		/obj/item/stock_parts/capacitor/adv = 1, //Improved parts, less common
+		/obj/item/stock_parts/scanning_module/adv = 1,
+		/obj/item/stock_parts/manipulator/nano = 1,
+		/obj/item/stock_parts/micro_laser/high = 1,
+		/obj/item/stock_parts/matter_bin/adv = 1,
+		/obj/item/stock_parts/capacitor/super = 0.3, //Top level parts, rare
+		/obj/item/stock_parts/scanning_module/phasic = 0.3,
+		/obj/item/stock_parts/manipulator/pico = 0.3,
+		/obj/item/stock_parts/micro_laser/ultra = 0.3,
+		/obj/item/stock_parts/matter_bin/super = 0.3,
+		/obj/item/stock_parts/subspace/ansible = 0.5, //Telecomms parts, useless novelties and red herrings.
+		/obj/item/stock_parts/subspace/filter = 0.5,
+		/obj/item/stock_parts/subspace/amplifier = 0.5,
+		/obj/item/stock_parts/subspace/treatment = 0.5,
+		/obj/item/stock_parts/subspace/analyzer = 0.5,
+		/obj/item/stock_parts/subspace/crystal = 0.5,
+		/obj/item/stock_parts/subspace/transmitter = 0.5
+	)
+
+	for(var/i in 1 to rand(1, 2))
+		var/part = pickweight(parts)
+		new part(L)
+
 STOCK_ITEM_COMMON(cane, 2)
 	if(prob(5))
 		new /obj/item/cane/concealed(L)

--- a/code/modules/cargo/random_stock/t2_uncommon.dm
+++ b/code/modules/cargo/random_stock/t2_uncommon.dm
@@ -20,18 +20,18 @@ STOCK_ITEM_UNCOMMON(phoronsheets, 0.25)
 STOCK_ITEM_UNCOMMON(phoronglass, 0.5)
 	new /obj/item/stack/material/glass/phoronglass(L, rand(10,20))
 
-STOCK_ITEM_UNCOMMON(sandstone, 2)
-	new /obj/item/stack/material/sandstone(L, 50)
-
-STOCK_ITEM_UNCOMMON(marble, 2)
-	new /obj/item/stack/material/marble(L, 50)
+STOCK_ITEM_UNCOMMON(stone, 2)
+	if(prob(50))
+		new /obj/item/stack/material/sandstone(L, 50)
+	else
+		new /obj/item/stack/material/marble(L, 50)
 
 STOCK_ITEM_UNCOMMON(iron, 2)
 	new /obj/item/stack/material/iron(L, 50)
 
 STOCK_ITEM_UNCOMMON(other_mat, 0.5)
 	var/obj/item/stack/material/M = pick(/obj/item/stack/material/osmium, /obj/item/stack/material/mhydrogen, /obj/item/stack/material/tritium, /obj/item/stack/material/bronze)
-	new M(L, rand(1, 10))
+	new M(L, rand(1, 20))
 
 STOCK_ITEM_UNCOMMON(flare, 2)
 	new /obj/item/flashlight/flare(L)
@@ -82,7 +82,6 @@ STOCK_ITEM_UNCOMMON(mediumcell, 3)
 	for(var/i in 1 to rand(1,2))
 		var/type = pick( \
 			/obj/item/cell/super, \
-			/obj/item/cell/potato, \
 			/obj/item/cell/high \
 		)
 		new type(L)
@@ -224,7 +223,8 @@ STOCK_ITEM_UNCOMMON(headset, 2)
 		/obj/item/radio/headset/headset_sci = 0.8,
 		/obj/item/radio/headset/headset_medsci = 0.4,
 		/obj/item/radio/headset/headset_cargo = 1,
-		/obj/item/radio/headset/headset_service = 1
+		/obj/item/radio/headset/headset_service = 1,
+		/obj/item/radio/headset/headset_sec = 0.5
 	)
 
 	var/type = pickweight(sets)
@@ -240,17 +240,43 @@ STOCK_ITEM_UNCOMMON(laserpoint, 0.75)
 	new /obj/item/laser_pointer(L)
 
 STOCK_ITEM_UNCOMMON(manual, 2)
-	var/list/booklist = subtypesof(/obj/item/book/manual)
-	booklist -= /obj/item/book/manual/wiki //just this one. we want to keep the subtypes.
-	booklist -= /obj/item/book/manual/nuclear //yeah no
-	var/type = pick(booklist)
-	new type(L)
+	if(prob(20))
+		var/list/booklist = subtypesof(/obj/item/book/manual)
+		booklist -= /obj/item/book/manual/wiki //just this one. we want to keep the subtypes.
+		booklist -= /obj/item/book/manual/nuclear //yeah no
+		var/type = pick(booklist)
+		new type(L)
+	else
+		if (!establish_db_connection(GLOB.dbcon))
+			return
+
+		var/query_str = "SELECT author, title, content FROM ss13_library ORDER BY RAND() LIMIT :amount:"
+		var/list/query_data = list("amount" = 3)
+
+		var/DBQuery/query_books = GLOB.dbcon.NewQuery(query_str)
+		query_books.Execute(query_data)
+
+		while (query_books.NextRow())
+			CHECK_TICK
+			var/author = query_books.item[1]
+			var/title = query_books.item[2]
+			var/content = query_books.item[3]
+			var/obj/item/book/B = new(L)
+			B.name = "Book: [title]"
+			B.title = title
+			B.author = author
+			B.dat = content
+			var/randbook = "book[rand(1,16)]"
+			B.icon_state = randbook
+			B.item_state = randbook
 
 STOCK_ITEM_UNCOMMON(spystuff, 0.75)
 	if(prob(40))
 		new /obj/item/radiojammer(L)
 	else
 		new /obj/item/clothing/glasses/night(L)
+	if(prob(10))
+		new /obj/item/storage/box/syndie_kit/spy/hidden(L)
 
 STOCK_ITEM_UNCOMMON(seeds, 1)
 	for(var/i in 1 to rand(1, 3))
@@ -382,8 +408,11 @@ STOCK_ITEM_UNCOMMON(alt_glasses, 1)
 STOCK_ITEM_UNCOMMON(gumballs, 3)
 	new /obj/item/glass_jar/gumball(L)
 
-STOCK_ITEM_UNCOMMON(googly, 0.75)
-	new /obj/item/storage/stickersheet/googly_eye(L)
+STOCK_ITEM_UNCOMMON(stickers, 1)
+	var/list/all_stickers = subtypesof(/obj/item/storage/stickersheet)
+
+	var/type = pick(all_stickers)
+	new type(L)
 
 STOCK_ITEM_UNCOMMON(wizarddressup, 1)
 	new /obj/random/wizard_dressup(L)

--- a/code/modules/cargo/random_stock/t3_rare.dm
+++ b/code/modules/cargo/random_stock/t3_rare.dm
@@ -88,7 +88,11 @@ STOCK_ITEM_RARE(exogear, 1.5)
 		/obj/item/mecha_equipment/mounted_system/rfd = 0.08,
 		/obj/item/mecha_equipment/mounted_system/plasmacutter = 0.5,
 		/obj/item/mecha_equipment/catapult = 0.8,
-		/obj/item/mecha_equipment/sleeper = 0.9
+		/obj/item/mecha_equipment/sleeper = 0.9,
+		/obj/item/mecha_equipment/autolathe = 0.5,
+		/obj/item/mecha_equipment/crisis_drone = 0.4,
+		/obj/item/mecha_equipment/mounted_system/medanalyzer = 1,
+		/obj/item/mecha_equipment/quick_enter = 1
 	)
 
 	for(var/i in 1 to rand(1,2))

--- a/code/modules/cargo/random_stock/t3_rare.dm
+++ b/code/modules/cargo/random_stock/t3_rare.dm
@@ -81,22 +81,23 @@ STOCK_ITEM_RARE(ims, 1.5)
 	new /obj/item/surgery/scalpel/manager(L)
 
 STOCK_ITEM_RARE(exogear, 1.5)
-	var/list/equips = list(
-		/obj/item/mecha_equipment/clamp = 1,
-		/obj/item/mecha_equipment/drill = 1,
-		/obj/item/mecha_equipment/mounted_system/extinguisher = 1,
-		/obj/item/mecha_equipment/mounted_system/rfd = 0.08,
-		/obj/item/mecha_equipment/mounted_system/plasmacutter = 0.5,
-		/obj/item/mecha_equipment/catapult = 0.8,
-		/obj/item/mecha_equipment/sleeper = 0.9,
-		/obj/item/mecha_equipment/autolathe = 0.5,
-		/obj/item/mecha_equipment/crisis_drone = 0.4,
-		/obj/item/mecha_equipment/mounted_system/medanalyzer = 1,
-		/obj/item/mecha_equipment/quick_enter = 1
+	var/list/allmecha = typesof(/obj/item/mecha_equipment)
+
+	var/list/exclusion = list(
+		/obj/item/mecha_equipment/mounted_system/soul_javelin,
+		/obj/item/mecha_equipment/doomblade,
+		/obj/item/mecha_equipment/mounted_system/combat,
+		/obj/item/gun/launcher/mech,
+		/obj/item/mecha_equipment,
+		/obj/item/mecha_equipment/crisis_drone/alien,
+		/obj/item/mecha_equipment/mounted_system/mining,
+		/obj/item/mecha_equipment/phazon
 	)
 
+	allmecha -= exclusion
+
 	for(var/i in 1 to rand(1,2))
-		var/type = pickweight(equips)
+		var/type = pickweight(allmecha)
 		new type(L)
 
 STOCK_ITEM_RARE(teleporter, 1)

--- a/code/modules/cargo/randomstock.dm
+++ b/code/modules/cargo/randomstock.dm
@@ -100,12 +100,18 @@ GLOBAL_LIST_EMPTY(random_stock_large)
 		/mob/living/simple_animal/bee/standalone = 1,
 		/mob/living/simple_animal/hostile/retaliate/diyaab = 1,
 		/mob/living/simple_animal/hostile/viscerator = 1,
-		/mob/living/simple_animal/hostile/scarybat = 1)
+		/mob/living/simple_animal/hostile/scarybat = 1,
+		// TODO: Reduce this to 1/3rd the current value once the lemurian sea arc concludes
+		/mob/living/simple_animal/hostile/psiren = 1,
+		/mob/living/simple_animal/hostile/psiren/omen = 1,
+		/mob/living/simple_animal/hostile/psiren/ranged = 1
+		)
 
 	var/list/infest_mobs_severe = list(
 		/mob/living/simple_animal/hostile/giant_spider/hunter = 1,
 		/mob/living/simple_animal/hostile/retaliate/shantak = 0.7,
 		/mob/living/simple_animal/hostile/carp = 1.5,
+		/mob/living/simple_animal/hostile/bear = 0.8
 	)
 
 /datum/cargospawner/New()
@@ -202,7 +208,7 @@ GLOBAL_LIST_EMPTY(random_stock_large)
 // Moderate mobs are checked per crate
 #define INFEST_PROB_MODERATE	3
 
-#define INFEST_PROB_SEVERE	3//Severe is once per round, not per crate
+#define INFEST_PROB_SEVERE	6//Severe is once per round, not per crate
 
 /datum/cargospawner/proc/handle_infestation()
 	for (var/obj/structure/closet/crate/C as anything in containers)

--- a/code/modules/cargo/randomstock.dm
+++ b/code/modules/cargo/randomstock.dm
@@ -104,14 +104,28 @@ GLOBAL_LIST_EMPTY(random_stock_large)
 		// TODO: Reduce this to 1/3rd the current value once the lemurian sea arc concludes
 		/mob/living/simple_animal/hostile/psiren = 1,
 		/mob/living/simple_animal/hostile/psiren/omen = 1,
-		/mob/living/simple_animal/hostile/psiren/ranged = 1
+		/mob/living/simple_animal/hostile/psiren/ranged = 1,
+		/mob/living/simple_animal/hostile/rogue_drone = 0.5
 		)
 
 	var/list/infest_mobs_severe = list(
-		/mob/living/simple_animal/hostile/giant_spider/hunter = 1,
+		// Grems get a low value because they have so many options and we don't want the majority to be pure grem.
+		/mob/living/simple_animal/hostile/giant_spider/hunter = 0.2,
+		/mob/living/simple_animal/hostile/giant_spider/emp = 0.2,
+		/mob/living/simple_animal/hostile/giant_spider/bombardier = 0.2,
+		/mob/living/simple_animal/hostile/giant_spider/nurse = 0.2,
+		/mob/living/simple_animal/hostile/giant_spider/emp = 0.2,
 		/mob/living/simple_animal/hostile/retaliate/shantak = 0.7,
 		/mob/living/simple_animal/hostile/carp = 1.5,
-		/mob/living/simple_animal/hostile/bear = 0.8
+		/mob/living/simple_animal/hostile/bear = 0.8,
+		/mob/living/simple_animal/hostile/harron = 0.8,
+		/mob/living/simple_animal/hostile/wind_devil = 0.5,
+		/mob/living/simple_animal/hostile/carp/shark = 0.3,
+		/mob/living/simple_animal/hostile/carp/shark/reaver = 0.3,
+		/mob/living/simple_animal/hostile/carp/bloater = 0.5,
+		/mob/living/simple_animal/hostile/retaliate/royalcrab = 0.5,
+		/mob/living/simple_animal/hostile/retaliate/hegeranzi = 0.5,
+		/mob/living/simple_animal/hostile/hivebot = 0.8
 	)
 
 /datum/cargospawner/New()
@@ -208,7 +222,7 @@ GLOBAL_LIST_EMPTY(random_stock_large)
 // Moderate mobs are checked per crate
 #define INFEST_PROB_MODERATE	3
 
-#define INFEST_PROB_SEVERE	6//Severe is once per round, not per crate
+#define INFEST_PROB_SEVERE	9//Severe is once per round, not per crate
 
 /datum/cargospawner/proc/handle_infestation()
 	for (var/obj/structure/closet/crate/C as anything in containers)

--- a/html/changelogs/WarehouseChanges.yml
+++ b/html/changelogs/WarehouseChanges.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Changed up some of the possible warehouse spawns, including mob spawns."
+  - rscadd: "tripled the chance of large hostile xenofauna in the warehouse from 3% to 9% per round."

--- a/html/changelogs/WarehouseChanges.yml
+++ b/html/changelogs/WarehouseChanges.yml
@@ -5,3 +5,4 @@ delete-after: True
 changes:
   - rscadd: "Changed up some of the possible warehouse spawns, including mob spawns."
   - rscadd: "tripled the chance of large hostile xenofauna in the warehouse from 3% to 9% per round."
+  - balance: "Reduced the warehouse spawn total from 180 to 120."


### PR DESCRIPTION
This changes up some of the possible warehouse spawn content. More book options, couple of shield gens, slightly higher chance of some mats and some other changes.

The big notable one is the chance of a big mob in the warehouse was changed from 3% per round to 9% and the list for small and large mobs was expanded. Particularly psirens were added, with a need to reduce the spawn rate after the arc.

The warehouse spawn total was also reduced from 180 to 120, partly as a test and to make the warehouse slightly less overloaded.