### PR TITLE
Bugbite only needs neckgrab + Lower Black K'ois message spam

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -387,8 +387,8 @@
 		to_chat(src, SPAN_WARNING("You are not grabbing anyone."))
 		return
 
-	if(!ignore_grab && G.state < GRAB_KILL)
-		to_chat(src, SPAN_WARNING("You must have a strangling grip to bite someone!"))
+	if(!ignore_grab && G.state < GRAB_NECK)
+		to_chat(src, SPAN_WARNING("You must have a neck grip to bite someone!"))
 		return
 
 	if(ishuman(G.affecting))

--- a/code/modules/organs/subtypes/parasite/black_kois.dm
+++ b/code/modules/organs/subtypes/parasite/black_kois.dm
@@ -24,7 +24,7 @@
 	if(prob(10) && (owner.can_feel_pain()))
 		if(stage < 3)
 			to_chat(owner, SPAN_WARNING("You feel a stinging pain in your head!"))
-		else
+		else if(prob(10))
 			to_chat(owner, "A part of you tries to fight back, but the taste of the black k'ois puts you at ease.")
 		owner.visible_message("<b>[owner]</b> winces slightly.")
 		owner.adjustHalLoss(5)
@@ -43,14 +43,14 @@
 		if(prob(5))
 			if(stage < 4)
 				to_chat(owner, SPAN_WARNING("You feel something squirming inside of you!"))
-			else
+			else if(prob(5))
 				to_chat(owner, SPAN_GOOD("You feel it, within you. Its presence soothes, a constant companion. There is no need to resist. We are with you. We will not abandon you."))
 			owner.reagents.add_reagent(/singleton/reagent/kois/black, 4)
 
 		else if(prob(5))
 			if(stage < 4)
 				to_chat(owner, SPAN_GOOD("In your struggle, a part of you wishes for the spread to continue."))
-			else
+			else if(prob(5))
 				to_chat(owner, SPAN_GOOD("You cannot ever believe that you struggled against this feeling. You are home. You are happy."))
 
 		else if(prob(10))
@@ -92,7 +92,7 @@
 			if(owner.can_feel_pain())
 				to_chat(owner, SPAN_WARNING("You feel an unbearable pain in your mind!"))
 				owner.emote("scream")
-			else if(full_zombie)
+			else if(full_zombie && prob(10))
 				to_chat(owner, SPAN_GOOD("Your mind hums with a billion voices that are not your own. You will never be alone again. Unbidden, a smile comes to your face."))
 			owner.adjustBrainLoss(1, 55)
 

--- a/html/changelogs/diggiez - Bugbite.yml
+++ b/html/changelogs/diggiez - Bugbite.yml
@@ -1,0 +1,14 @@
+# Your name.
+author: diggiez
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "The Bite ability, currently only available to Ta, only requires a neckgrab."
+  - qol: "Black K'ois zombies get less message spam."


### PR DESCRIPTION
The Bite ability used to be available to Za years ago and was way over-nerfed then.

Needing a killgrab to do 25 brute is so pointless, you're literally already strangling them unconscious. Of course, I asked lore before changing this.

While testing grabs, I noticed the Black K'ois zombie got really bad message spam from process(), so I lowered the rates by tying the messages to another 5-10% roll.
**BEFORE**
<img width="770" height="364" alt="image" src="https://github.com/user-attachments/assets/47a84a27-0795-44ed-ab86-bc5aae0d51fe" />
**AFTER**
<img width="761" height="374" alt="image" src="https://github.com/user-attachments/assets/18805c0f-abe1-4d81-a396-0edf6c26fc2c" />
