### PR TITLE
Fixes the cooking codex searching and some duplicate entry shenanigans

### DIFF
--- a/code/controllers/subsystems/initialization/codex.dm
+++ b/code/controllers/subsystems/initialization/codex.dm
@@ -34,6 +34,9 @@ SUBSYSTEM_DEF(codex)
 		var/singleton/recipe/recipe = GET_SINGLETON(reaction_path)
 		var/list/cookingRecipeData = list()
 
+		// ID for TGUI to use
+		cookingRecipeData["id"] = "[reaction_path]"
+
 		// result
 		var/obj/item/recipe_result = recipe.result
 		cookingRecipeData["result"] = initial(recipe_result.name)
@@ -74,6 +77,8 @@ SUBSYSTEM_DEF(codex)
 			cookingRecipeData["ingredients"] += "[reagent.name] coating"
 
 		// kitchen appliance
+		cookingRecipeData["appliances"] = ""
+
 		if(recipe.appliance)
 			cookingRecipeData["appliances"] = recipe.get_appliance_names()
 

--- a/html/changelogs/TGUISearchFixing.yml
+++ b/html/changelogs/TGUISearchFixing.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed the bugged search function in the cooking codex."
+  - bugfix: "Fixed potential duplicate and entries not being removed in the cooking codex and cargo programs."

--- a/tgui/packages/tgui/interfaces/CargoControl.tsx
+++ b/tgui/packages/tgui/interfaces/CargoControl.tsx
@@ -268,7 +268,7 @@ export const CargoControl = (props) => {
                   <Table.Cell>Price</Table.Cell>
                 </Table.Row>
                 {data.order_details.items.map((item) => (
-                  <Table.Row key={item.name}>
+                  <Table.Row key={item.item_id}>
                     <Table.Cell>{item.name}</Table.Cell>
                     <Table.Cell>{item.supplier_name}</Table.Cell>
                     <Table.Cell>{item.price.toFixed(2)}电</Table.Cell>

--- a/tgui/packages/tgui/interfaces/CargoDelivery.tsx
+++ b/tgui/packages/tgui/interfaces/CargoDelivery.tsx
@@ -222,7 +222,7 @@ export const Overview = (props) => {
             <Table.Cell>Price</Table.Cell>
           </Table.Row>
           {data.order_details.items.map((item) => (
-            <Table.Row key={item.name}>
+            <Table.Row key={item.id}>
               <Table.Cell>{item.name}</Table.Cell>
               <Table.Cell>{item.supplier_name}</Table.Cell>
               <Table.Cell>{item.price}电</Table.Cell>

--- a/tgui/packages/tgui/interfaces/CargoOrder.tsx
+++ b/tgui/packages/tgui/interfaces/CargoOrder.tsx
@@ -207,7 +207,7 @@ export const MainPage = (props) => {
             .map((item) => (
               <Section
                 title={item.name}
-                key={item.name}
+                key={item.id}
                 buttons={
                   <Button
                     content={`${item.price_adjusted.toFixed(2)}电`}
@@ -270,7 +270,7 @@ export const ShowDetails = (props) => {
           <Table.Cell>{data.crate_fee.toFixed(2)}电</Table.Cell>
         </Table.Row>
         {data.order_items.map((item) => (
-          <Table.Row key={item.name}>
+          <Table.Row key={item.id}>
             <Table.Cell>{item.name}</Table.Cell>
             <Table.Cell>{item.price.toFixed(2)}电</Table.Cell>
           </Table.Row>

--- a/tgui/packages/tgui/interfaces/CookingCodex.tsx
+++ b/tgui/packages/tgui/interfaces/CookingCodex.tsx
@@ -8,6 +8,7 @@ export type CodexData = {
 };
 
 type Recipe = {
+  id: string;
   result: string;
   result_image: any; // base64 icon
   ingredients: string;
@@ -45,21 +46,17 @@ export const CookingCodex = (props) => {
             </Table.Row>
             {data.recipes
               .filter((recipe) => {
+                const query = searchTerm.toLocaleLowerCase();
+
                 return (
-                  recipe.result
-                    .toLocaleLowerCase()
-                    .includes(searchTerm.toLocaleLowerCase()) ||
-                  recipe.ingredients
-                    .toLocaleLowerCase()
-                    .includes(searchTerm.toLocaleLowerCase()) ||
-                  recipe.appliances
-                    .toLocaleLowerCase()
-                    .includes(searchTerm.toLocaleLowerCase())
+                  recipe.result?.toLocaleLowerCase().includes(query) ||
+                  recipe.ingredients?.toLocaleLowerCase().includes(query) ||
+                  recipe.appliances?.toLocaleLowerCase().includes(query)
                 );
               })
               .sort((a, b) => a.result.localeCompare(b.result))
               .map((recipe) => (
-                <Table.Row header className="candystripe" key={recipe.result}>
+                <Table.Row header className="candystripe" key={recipe.id}>
                   <Table.Cell textAlign="right" verticalAlign="middle" pl="5px">
                     {recipe.result.toLocaleLowerCase()}
                   </Table.Cell>


### PR DESCRIPTION
Cargo orders would have trouble clearing the list of orders shown without reloading the ui, due to a lack of unique ID if there was several of the same item. The same applied to the cooking codex. This is fixed now.
This also fixes the cooking codex search.