### PR TITLE
Fixes No Breathe Trait

### DIFF
--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -8,7 +8,7 @@
 /mob/living/carbon/proc/breathe(var/volume_needed = BREATH_VOLUME)
 	if(species && (species.flags & NO_BREATHE))
 		return
-	if(HAS_TRAIT(src, TRAIT_PRESSURE_IMMUNITY))
+	if(HAS_TRAIT(src, TRAIT_NO_BREATHE))
 		return
 
 	volume_needed *= (species?.breath_vol_mul || 1)

--- a/html/changelogs/diggiez - NoBreatheFix.yml
+++ b/html/changelogs/diggiez - NoBreatheFix.yml
@@ -1,0 +1,12 @@
+author: diggiez
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "The No Breathe Trait works, and Runtime's shuttle area requires power."

--- a/maps/runtime/runtime_overmap.dm
+++ b/maps/runtime/runtime_overmap.dm
@@ -30,6 +30,7 @@
 /area/shuttle/runtime
 	name = "While True"
 	base_turf = /turf/simulated/floor/shuttle/black
+	requires_power = TRUE
 
 /datum/shuttle/autodock/overmap/runtime
 	name = "WhileTrue"


### PR DESCRIPTION
No Breathe wasn't properly checked anywhere because Pressure Immunity was doing its job by accident.
Also makes Runtime's shuttle area require power, for convenience.