### PR TITLE
Fixes PDA and cargo tug lights

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/dev_handheld.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_handheld.dm
@@ -14,6 +14,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	looping_sound = FALSE
 
+	light_system = MOVABLE_LIGHT
+
 /obj/item/modular_computer/handheld/mechanics_hints(mob/user, distance, is_adjacent)
 	. += ..()
 	. += "To deploy the charging cable on this device, either drag and drop it over a nearby APC, or click on the APC with the computer in hand."

--- a/code/modules/modular_computers/computers/subtypes/dev_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_pda.dm
@@ -11,6 +11,8 @@
 	var/icon_add // this is the "bar" part in "pda-bar"
 	enrolled = DEVICE_PRIVATE
 
+	light_system = MOVABLE_LIGHT
+
 /obj/item/modular_computer/handheld/pda/set_icon()
 	if(icon_add)
 		icon_state += "-[icon_add]"

--- a/code/modules/modular_computers/computers/subtypes/dev_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_pda.dm
@@ -11,8 +11,6 @@
 	var/icon_add // this is the "bar" part in "pda-bar"
 	enrolled = DEVICE_PRIVATE
 
-	light_system = MOVABLE_LIGHT
-
 /obj/item/modular_computer/handheld/pda/set_icon()
 	if(icon_add)
 		icon_state += "-[icon_add]"

--- a/code/modules/modular_computers/file_system/programs/system/configurator.dm
+++ b/code/modules/modular_computers/file_system/programs/system/configurator.dm
@@ -61,7 +61,7 @@
 	data["battery"] = computer.battery_module ? list("rating" = computer.battery_module.battery_rating, "percent" = computer.battery_module.battery.percent()) : null
 
 	if(computer.flashlight)
-		var/brightness = clamp(0, round(computer.flashlight.power, 0.1) * 10, 10)
+		var/brightness = clamp(0, round(computer.flashlight.light_power, 0.1) * 10, 10)
 		data["brightness"] = brightness
 
 	return data

--- a/code/modules/modular_computers/hardware/misc.dm
+++ b/code/modules/modular_computers/hardware/misc.dm
@@ -6,21 +6,26 @@
 	power_usage = 50
 	enabled = FALSE
 	critical = FALSE
-	var/range = 2
-	var/power = 1
-	var/flashlight_color = LIGHT_COLOR_HALOGEN
+
+	light_range = 1.2
+	light_power = 0.5
+	light_color = LIGHT_COLOR_HALOGEN
+	light_system = MOVABLE_LIGHT
+
+	light_on = FALSE
 
 /obj/item/computer_hardware/flashlight/enable()
 	. = ..()
 	if(parent_computer)
-		parent_computer.set_light(range, power, flashlight_color)
+		parent_computer.set_light_range_power_color(light_range, light_power, light_color)
+		parent_computer.set_light_on(enabled)
 
 /obj/item/computer_hardware/flashlight/disable()
 	. = ..()
 	if(parent_computer)
-		parent_computer.set_light(initial(parent_computer.light_range), initial(parent_computer.light_power), flashlight_color)
+		parent_computer.set_light_on(enabled)
 
 /obj/item/computer_hardware/flashlight/proc/tweak_brightness(var/new_power)
-	. = power = clamp(0, new_power, 1)
+	set_light_power(clamp(0, new_power, 1))
 	if(parent_computer && enabled)
-		parent_computer.set_light(range, power, flashlight_color)
+		parent_computer.set_light_power(light_power)

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -18,6 +18,9 @@
 	var/obj/item/key/key
 	var/key_type = /obj/item/key/cargo_train
 
+	light_range = 3
+	light_power = 1
+
 /obj/vehicle/train/cargo/engine/Destroy()
 	QDEL_NULL(key)
 	return ..()

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -40,6 +40,8 @@
 	var/organic = FALSE
 	var/corpse = null
 
+	light_system = DIRECTIONAL_LIGHT
+
 //-------------------------------------------
 // Standard procs
 //-------------------------------------------
@@ -188,13 +190,13 @@
 	if(powered && cell?.charge < charge_use && !organic)
 		return FALSE
 	on = TRUE
-	set_light(initial(light_range))
+	set_light_on(on)
 	update_icon()
 	return TRUE
 
 /obj/vehicle/proc/turn_off()
 	on = FALSE
-	set_light(0)
+	set_light_on(on)
 	update_icon()
 
 /obj/vehicle/emag_act(var/remaining_charges, mob/user as mob)

--- a/html/changelogs/PDAFix.yml
+++ b/html/changelogs/PDAFix.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes pda lights not working."
+  - bugfix: "Fixes the cargo tug lights."


### PR DESCRIPTION
PDA flashlights work again and their strength is now determined by the flashlight inside. There is still only one type of flashlight.
Cargo tug lights work again and are now directional.