### PR TITLE
Adds a slot pity system.

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -198,7 +198,9 @@ SUBSYSTEM_DEF(jobs)
 	//Get the players who are ready
 	for(var/mob/abstract/new_player/player in GLOB.player_list)
 		if(player.ready && player.mind && !player.mind.assigned_role)
-			unassigned += player
+			var/datum/job/high_job = astype(player.client.prefs.return_chosen_high_job(), /datum/job)
+			if(high_job.name in player.client.prefs.job_pity)
+				unassigned[player] = player.client.prefs.job_pity[high_job.name]
 
 	Debug("DO, Len: [unassigned.len]")
 	if(unassigned.len == 0)
@@ -268,6 +270,7 @@ SUBSYSTEM_DEF(jobs)
 
 	// For those who wanted to be assistant if their preferences were filled, here you go.
 	for(var/mob/abstract/new_player/player in unassigned)
+		player.client.prefs.job_pity |= astype(player.client.prefs.return_chosen_high_job(), /datum/job).name
 		if(player.client.prefs.alternate_option == BE_ASSISTANT)
 			Debug("AC2 Assistant located, Player: [player]")
 			AssignRole(player, "Assistant")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -176,6 +176,8 @@ GLOBAL_LIST_EMPTY_TYPED(preferences_datums, /datum/preferences)
 
 	// OOC Metadata:
 	var/metadata = ""
+	/// A list of pity; affects your chances to get a slot when you fail/succeed a roll.
+	var/list/job_pity
 
 	// SPAAAACE
 	var/toggles_secondary = SEE_ITEM_OUTLINES | PROGRESS_BARS | FLOATING_MESSAGES | HOTKEY_DEFAULT


### PR DESCRIPTION
As you fail to roll your slot and roll more, you will progressively gain either positive or negative pity. Pity affects your chances to roll a slot, with a 20% malus and bonus every time you roll a slot or fail to roll a slot.

This system won't be in effect for event rounds (both canon and non-canon), only for normal voted gamemodes.

To-do:

- [ ] Probably shift job prefs to a yes/no system rather than low/medium/high since that's basically defunct functionality
- [ ] Pity system itself (pickweight?)