### PR TITLE
Fixes the chem codex and the images in the faction selection screen

### DIFF
--- a/code/controllers/subsystems/initialization/codex.dm
+++ b/code/controllers/subsystems/initialization/codex.dm
@@ -97,7 +97,7 @@ SUBSYSTEM_DEF(codex)
 		if(chemistry_codex_ignored_result_path && is_path_in_list(CR.result, chemistry_codex_ignored_result_path))
 			continue
 		var/singleton/reagent/R = GET_SINGLETON(CR.result)
-		var/chemistryReactionData = list(id = CR.id)
+		var/chemistryReactionData = list(id = "[chem_path]")
 		chemistryReactionData["result"] = list(
 			name = R.name,
 			description = R.description,

--- a/html/changelogs/TheUiFixening.yml
+++ b/html/changelogs/TheUiFixening.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed the chem codex searching."
+  - bugfix: "Fixed the oversized icons in the faction selection screen."

--- a/tgui/packages/tgui/interfaces/ChemCodex.tsx
+++ b/tgui/packages/tgui/interfaces/ChemCodex.tsx
@@ -8,6 +8,7 @@ export type CodexData = {
 };
 
 type Reaction = {
+  id: string;
   result: Result;
   reagents: Reagent[];
   catalysts: Reagent[];
@@ -59,7 +60,7 @@ export const ChemCodex = (props) => {
           .map((reaction) => (
             <Section
               title={`${reaction.result.name}(${reaction.result.amount}u)`}
-              key={reaction.result.name}
+              key={reaction.id}
             >
               <NoticeBox>{reaction.result.description}</NoticeBox>
               <Section title="Required Reagents">

--- a/tgui/packages/tgui/interfaces/FactionSelect.tsx
+++ b/tgui/packages/tgui/interfaces/FactionSelect.tsx
@@ -193,8 +193,8 @@ const FactionPanel = (props: { currentFaction: Faction }) => {
             <img
               src={resolveAsset(currentFaction.logo)}
               alt={currentFaction.name}
-              height="13em"
-              width="13em"
+              height="48px"
+              width="48px"
             />
           </Stack.Item>
           <Stack.Item bold fontSize={1.25}>

--- a/tgui/packages/tgui/interfaces/FactionSelect.tsx
+++ b/tgui/packages/tgui/interfaces/FactionSelect.tsx
@@ -73,8 +73,8 @@ const FactionList = (props) => {
                 <Flex.Item pt={1} pr={0.5}>
                   <img
                     src={resolveAsset(faction.logo)}
-                    width="192px"
-                    height="192px"
+                    width="48px"
+                    height="48px"
                   />
                 </Flex.Item>
               </Flex>


### PR DESCRIPTION
As per the title, not much more to it.

<img width="900" height="645" alt="image" src="https://github.com/user-attachments/assets/48f8bd38-fac0-4421-8eda-ec5f8c3789ce" />
