### PR TITLE
Technomancer Jumpstarter

### DIFF
--- a/code/datums/uplink/highly visible and dangerous weapons.dm
+++ b/code/datums/uplink/highly visible and dangerous weapons.dm
@@ -293,6 +293,12 @@
 	path = /obj/item/psionic_jumpstarter/loner
 	antag_roles = list(MODE_TRAITOR)
 
+/datum/uplink_item/item/visible_weapons/technomancer_jumpstarter
+	name = "Technomancer Jumpstarter"
+	telecrystal_cost = 20
+	path = /obj/item/technomancer_jumpstarter
+	antag_roles = list(MODE_TRAITOR)
+
 /datum/uplink_item/item/visible_weapons/flamethrower
 	name = "Flamethrower"
 	desc = "A flamethrower, with a full canister of fuel installed. Handle with caution."

--- a/code/game/gamemodes/technomancer/technomancer.dm
+++ b/code/game/gamemodes/technomancer/technomancer.dm
@@ -14,3 +14,42 @@
 	fear and excitement. Ultimately, their purpose is unknown. However, it is up to you and your crew to decide if \
 	their powers can be used for good or if their arrival foreshadows the destruction of the entire [SSatlas.current_map.station_type], or worse."
 	. = ..()
+
+/obj/item/technomancer_jumpstarter
+	name = "technomancer jumpstarter"
+	desc = "Use this to become a technomancer. This item is definitely not canon."
+	icon = 'icons/obj/clothing/hats.dmi'
+	icon_state = "amp"
+	contained_sprite = FALSE
+
+/obj/item/technomancer_jumpstarter/attack_self(mob/user)
+	. = ..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+
+	var/datum/technomancer/technomancer = H.mind.antag_datums[MODE_TECHNOMANCER]
+	if(technomancer)
+		to_chat(H, SPAN_WARNING("You're already a technomancer!"))
+		return
+
+	if(GLOB.technomancers.add_antagonist(H.mind, FALSE, TRUE, FALSE, TRUE, TRUE))
+		var/obj/item/technomancer_core/core = new /obj/item/technomancer_core
+		if (core)
+			GLOB.technomancer_belongings.Add(core)
+			H.equip_or_collect(core, slot_in_backpack)
+		var/obj/item/technomancer_catalog/catalog = new /obj/item/technomancer_catalog
+		if (catalog)
+			catalog.bind_to_owner(H)
+			if(istype(H.back, /obj/item/storage))
+				var/obj/item/storage/S = H.back
+				S.handle_item_insertion(catalog, TRUE)
+			else
+				var/turf/T = get_turf(H)
+				if(istype(T))
+					catalog.forceMove(T)
+
+		to_chat(H, SPAN_NOTICE("You've become a technomancer! You will find your core and catalog inside your backpack."))
+		qdel(src)
+	else
+		to_chat(H, SPAN_WARNING("Something prevented you from becoming a technomancer."))

--- a/html/changelogs/hellfirejag-technomancer-jumpstarter.yml
+++ b/html/changelogs/hellfirejag-technomancer-jumpstarter.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "Added a new Technomancer Jumpstarter as a traitor uplink item."


### PR DESCRIPTION
Might as well complete the set of solo antag jumpstarters. This PR adds a Technomancer Jumpstarter, as a traitor exclusive item equivalent to the Vampire and Changeling jumpstarters. It lets them trade all of their TC to become a Technomancer instead of a traitor.

<img width="1902" height="988" alt="image" src="https://github.com/user-attachments/assets/7f392d58-a3e2-47aa-9a79-b737a17ea94c" />
