### PR TITLE
Buffs mech heavy gauss

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -485,11 +485,11 @@
 	explosion(get_turf(target), -1, 0, 2)
 	if(ismob(target))
 		var/mob/living/L = target  //This damage is dealt directly, instead of using ex_act, so that floors aren't destroyed and the target isnt stunned.
-			apply_damage(42, DAMAGE_BRUTE, def_zone, "Explosive blast", DAMAGE_FLAG_EXPLODE)
-			apply_damage(42, DAMAGE_BURN, def_zone, "Explosive blast", DAMAGE_FLAG_EXPLODE)
+			apply_damage(40, DAMAGE_BRUTE, def_zone, "Explosive blast", DAMAGE_FLAG_EXPLODE)
+			apply_damage(40, DAMAGE_BURN, def_zone, "Explosive blast", DAMAGE_FLAG_EXPLODE)
 
-			apply_damage(18, DAMAGE_BRUTE, null, "Explosive blast", DAMAGE_FLAG_EXPLODE | DAMAGE_FLAG_DISPERSED)
-			apply_damage(18, DAMAGE_BURN, null, "Explosive blast", DAMAGE_FLAG_EXPLODE | DAMAGE_FLAG_DISPERSED)
+			apply_damage(15, DAMAGE_BRUTE, null, "Explosive blast", DAMAGE_FLAG_EXPLODE | DAMAGE_FLAG_DISPERSED)
+			apply_damage(15, DAMAGE_BURN, null, "Explosive blast", DAMAGE_FLAG_EXPLODE | DAMAGE_FLAG_DISPERSED)
 	if(ismovable(target))
 		var/atom/movable/T = target
 		var/throwdir = get_dir(firer,target)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -484,11 +484,11 @@
 	. = ..()
 	explosion(get_turf(target), -1, 0, 2)
 	if(ismob(target))
-		var/mob/living/L = target  //This damage is dealt directly, instead of using ex_act, so that floors aren't destroyed and the target isnt stunned.
-		apply_damage(40, DAMAGE_BRUTE, def_zone, "Explosive blast", DAMAGE_FLAG_EXPLODE)
-		apply_damage(40, DAMAGE_BURN, def_zone, "Explosive blast", DAMAGE_FLAG_EXPLODE)
-		apply_damage(15, DAMAGE_BRUTE, null, "Explosive blast", DAMAGE_FLAG_EXPLODE | DAMAGE_FLAG_DISPERSED)
-		apply_damage(15, DAMAGE_BURN, null, "Explosive blast", DAMAGE_FLAG_EXPLODE | DAMAGE_FLAG_DISPERSED)
+		var/mob/living/exploding_mob = target  //This damage is dealt directly, instead of using ex_act, so that floors aren't destroyed and the target isnt stunned.
+		exploding_mob.apply_damage(40, DAMAGE_BRUTE, def_zone, "Explosive blast", DAMAGE_FLAG_EXPLODE)
+		exploding_mob.apply_damage(40, DAMAGE_BURN, def_zone, "Explosive blast", DAMAGE_FLAG_EXPLODE)
+		exploding_mob.apply_damage(15, DAMAGE_BRUTE, null, "Explosive blast", DAMAGE_FLAG_EXPLODE | DAMAGE_FLAG_DISPERSED)
+		exploding_mob.apply_damage(15, DAMAGE_BURN, null, "Explosive blast", DAMAGE_FLAG_EXPLODE | DAMAGE_FLAG_DISPERSED)
 	if(ismovable(target))
 		var/atom/movable/T = target
 		var/throwdir = get_dir(firer,target)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -476,12 +476,16 @@
 
 /obj/projectile/bullet/gauss/highex
 	name = "high-ex shell"
-	damage = 10
+	damage = 11
 	armor_penetration = 30
+	anti_materiel_potential = 9 //Just enough to be able to destroy doors with repeated hits.
 
 /obj/projectile/bullet/gauss/highex/on_hit(atom/target, blocked, def_zone)
 	. = ..()
 	explosion(get_turf(target), -1, 0, 2)
+	if(ismob(target))
+		var/mob/living/L = target
+		L.ex_act(2) //This is called directly, because a heavy explosion can destroy floors. This does heavy explosion damage just to the hit mob.
 	if(ismovable(target))
 		var/atom/movable/T = target
 		var/throwdir = get_dir(firer,target)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -484,8 +484,12 @@
 	. = ..()
 	explosion(get_turf(target), -1, 0, 2)
 	if(ismob(target))
-		var/mob/living/L = target
-		L.ex_act(2) //This is called directly, because a heavy explosion can destroy floors. This does heavy explosion damage just to the hit mob.
+		var/mob/living/L = target  //This damage is dealt directly, instead of using ex_act, so that floors aren't destroyed and the target isnt stunned.
+			apply_damage(42, DAMAGE_BRUTE, def_zone, "Explosive blast", DAMAGE_FLAG_EXPLODE)
+			apply_damage(42, DAMAGE_BURN, def_zone, "Explosive blast", DAMAGE_FLAG_EXPLODE)
+
+			apply_damage(18, DAMAGE_BRUTE, null, "Explosive blast", DAMAGE_FLAG_EXPLODE | DAMAGE_FLAG_DISPERSED)
+			apply_damage(18, DAMAGE_BURN, null, "Explosive blast", DAMAGE_FLAG_EXPLODE | DAMAGE_FLAG_DISPERSED)
 	if(ismovable(target))
 		var/atom/movable/T = target
 		var/throwdir = get_dir(firer,target)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -485,11 +485,10 @@
 	explosion(get_turf(target), -1, 0, 2)
 	if(ismob(target))
 		var/mob/living/L = target  //This damage is dealt directly, instead of using ex_act, so that floors aren't destroyed and the target isnt stunned.
-			apply_damage(40, DAMAGE_BRUTE, def_zone, "Explosive blast", DAMAGE_FLAG_EXPLODE)
-			apply_damage(40, DAMAGE_BURN, def_zone, "Explosive blast", DAMAGE_FLAG_EXPLODE)
-
-			apply_damage(15, DAMAGE_BRUTE, null, "Explosive blast", DAMAGE_FLAG_EXPLODE | DAMAGE_FLAG_DISPERSED)
-			apply_damage(15, DAMAGE_BURN, null, "Explosive blast", DAMAGE_FLAG_EXPLODE | DAMAGE_FLAG_DISPERSED)
+		apply_damage(40, DAMAGE_BRUTE, def_zone, "Explosive blast", DAMAGE_FLAG_EXPLODE)
+		apply_damage(40, DAMAGE_BURN, def_zone, "Explosive blast", DAMAGE_FLAG_EXPLODE)
+		apply_damage(15, DAMAGE_BRUTE, null, "Explosive blast", DAMAGE_FLAG_EXPLODE | DAMAGE_FLAG_DISPERSED)
+		apply_damage(15, DAMAGE_BURN, null, "Explosive blast", DAMAGE_FLAG_EXPLODE | DAMAGE_FLAG_DISPERSED)
 	if(ismovable(target))
 		var/atom/movable/T = target
 		var/throwdir = get_dir(firer,target)

--- a/html/changelogs/BuffsHiExGauss.yml
+++ b/html/changelogs/BuffsHiExGauss.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Fenodyree
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Buffs mech mounted gauss weapons with anti-armor potential, similar to the PEAC. It can now destroy doors with repeated hits."
+  - balance: "Buffs the gauss high explosive shell to do explosion damage directly to a mob it hits. It now does the same damage as a heavy explosion, without destroying the floor."


### PR DESCRIPTION
Heavy gauss now has anti-material properties, making it better in mech vs mech fights.
It can also now destroy doors with repeated (3) hits.

It also now deals roughly the same damage as calling ex_act(2) on the mob.
This is the same as if a mob was in the heavy explosion radius.
It doesn't use ex_act because that has a 70% chance to stun.
I didn't buff the explosion itself so that the mech's shots don't destroy floors.

Before:
<img width="506" height="694" alt="image" src="https://github.com/user-attachments/assets/a893b7ca-9c9a-4add-9688-70d1f15e7518" />


After:
<img width="525" height="742" alt="image" src="https://github.com/user-attachments/assets/648e0fb2-3647-471a-94ae-bcda52b944a0" />