### PR TITLE
Fixes IPC Endoskeleton Repair Message

### DIFF
--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -94,7 +94,7 @@
 				if (application_in_progress == FALSE)
 					application_in_progress = TRUE
 					user.visible_message(SPAN_NOTICE("\The [user] begins to apply nanite past to the broken support systems of [user != target_mob ? " \the [target_mob]'s" : "\the [user]'s"] endoskeleton..."), \
-						SPAN_NOTICE("You begin to apply nanite paste to the broken support systems of [user != target_mob ? " \the [target_mob]'s" : "your"] [endoskeleton]..."))
+						SPAN_NOTICE("You begin to apply nanite paste to the broken support systems of [user != target_mob ? " \the [target_mob]'s" : "your"] endoskeleton..."))
 					if(do_mob(user, target_mob, application_time))
 						SEND_SIGNAL(target_mob, COMSIG_SYNTH_ENDOSKELETON_REPAIR, rand(15, 30))
 						user.visible_message(SPAN_NOTICE("\The [user] mends the broken links in [user != target_mob ? " \the [target_mob]'s" : "\the [user]'s"] endoskeleton with \the [src]."),\

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -98,7 +98,7 @@
 					if(do_mob(user, target_mob, application_time))
 						SEND_SIGNAL(target_mob, COMSIG_SYNTH_ENDOSKELETON_REPAIR, rand(15, 30))
 						user.visible_message(SPAN_NOTICE("\The [user] mends the broken links in [user != target_mob ? " \the [target_mob]'s" : "\the [user]'s"] endoskeleton with \the [src]."),\
-												SPAN_NOTICE("You successfully mend the broken links in[user == target_mob ? "your" : "[target_mob]'s"] endoskeleton with \the [src]."))
+												SPAN_NOTICE("You successfully mend the broken links in [user == target_mob ? "your" : "[target_mob]'s"] endoskeleton with \the [src]."))
 						use(1)
 					application_in_progress = FALSE
 

--- a/html/changelogs/diggiez - EndoFix.yml
+++ b/html/changelogs/diggiez - EndoFix.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: diggiez
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Repairing an IPC's endoskeleton with nanopaste no longer says the datum path"


### PR DESCRIPTION
Fixed this
<img width="566" height="48" alt="image" src="https://github.com/user-attachments/assets/7109a7e6-b46d-412b-b597-0c2c038017b6" />

It now says endoskeleton instead of the datum path. Also fixed the spacing of the name in that bottom message.