### PR TITLE
Fixes the Loner Mend power

### DIFF
--- a/code/modules/psionics/abilities/mend.dm
+++ b/code/modules/psionics/abilities/mend.dm
@@ -38,115 +38,80 @@
 
 	user.visible_message(SPAN_NOTICE("[user] lays a palm on [H]..."), SPAN_NOTICE("You lay your palm on [H] and get to work."))
 	for(var/obj/item/organ/O in H.internal_organs)
-		if(do_mob(user, H, 1 SECONDS / effect_multiplier))
-			if(O.get_damage() > 0) // Fix internal damage
-				to_chat(user, SPAN_NOTICE("You flow your regenerative psionic energy through their [O.name]..."))
-				if(do_mob(user, H, 10 SECONDS / effect_multiplier))
-					if(pay_energy(30))
-						to_chat(user, SPAN_NOTICE("You mend their [O.name]'s bruising."))
-						O.heal_damage(O.get_damage())
-					else
-						return
-				else
-					return
-
-			if((O.status & ORGAN_BROKEN))
-				to_chat(user, SPAN_NOTICE("You flow your regenerative psionic energy through their [O.name]..."))
-				if(do_mob(user, H, 10 SECONDS / effect_multiplier))
-					if(pay_energy(30))
-						to_chat(user, SPAN_NOTICE("You restart their [O.name]'s functionality."))
-						O.status &= ~ORGAN_BROKEN
-					else
-						return
-				else
-					return
-
-			if(O.get_damage() <= 5 && O.organ_tag == BP_EYES && H.sdisabilities & BLIND) // Fix eyes
-				if(do_mob(user, H, 1 SECONDS / effect_multiplier))
-					to_chat(user, SPAN_NOTICE("You flow your regenerative psionic energy through their [O.name]..."))
-					if(do_mob(user, H, 10 SECONDS / effect_multiplier))
-						if(pay_energy(30))
-							to_chat(user, SPAN_NOTICE("You cure their blindness."))
-							H.sdisabilities &= ~BLIND
-						else
-							return
-					else
-						return
-
-			if(O.organ_tag == BP_HEART && H.is_asystole()) // Fix heart
-				if(do_mob(user, H, 5 SECONDS / effect_multiplier))
-					if(pay_energy(10))
-						to_chat(user, SPAN_NOTICE("You pulse psionic energy through their heart and it begins to beat again."))
-						H.resuscitate()
-					else
-						return
-				else
-					return
-		else
+		if(!do_mob(user, H, 1 SECONDS / effect_multiplier))
 			return
 
-	for(var/obj/item/organ/E in H.bad_external_organs) // Fix bones
-		var/obj/item/organ/external/affected = E
-		if(do_mob(user, H, 1 SECONDS / effect_multiplier))
-			if((affected.get_damage() < affected.min_broken_damage * GLOB.config.organ_health_multiplier) && (affected.status & ORGAN_BROKEN))
-				to_chat(user, SPAN_NOTICE("You flow your regenerative psionic energy through the broken bone in the [affected.name]..."))
-				if(do_mob(user, H, 10 SECONDS / effect_multiplier))
-					if(pay_energy(25))
-						affected.status &= ~ORGAN_BROKEN
-						to_chat(user, SPAN_NOTICE("You mend their [affected.name] together."))
-					else
-						return
-				else
-					return
-			if((affected.status & ORGAN_ARTERY_CUT))
-				if(do_mob(user, H, 10 SECONDS / effect_multiplier))
-					if(pay_energy(25))
-						affected.status &= ~ORGAN_ARTERY_CUT
-						to_chat(user, SPAN_NOTICE("You mend a spliced artery in their [affected.name]."))
-					else
-						return
-				else
-					return
-			if((affected.status & ORGAN_DEAD))
-				if(do_mob(user, H, 10 SECONDS / effect_multiplier))
-					if(pay_energy(25))
-						affected.status &= ~ORGAN_DEAD
-						to_chat(user, SPAN_NOTICE("You mend some necrosis from their [affected.name]."))
-					else
-						return
-				else
-					return
-			if(affected.tendon && (affected.tendon_status() & TENDON_CUT) && affected.tendon.can_recover())
-				if(do_mob(user, H, 10 SECONDS / effect_multiplier))
-					if(pay_energy(25))
-						to_chat(user, SPAN_NOTICE("You mend the damaged tendon in their [affected.name]."))
-						affected.tendon.rejuvenate()
-					else
-						return
-				else
-					return
-		else
-			return
-
-	for(var/obj/item/organ/external/external_organ in H.organs) // Fix limbs
-		if(do_mob(user, H, 1 SECONDS / effect_multiplier))
-			if(external_organ.status & ORGAN_ROBOT) // No robot parts for this.
-				continue
-			if(external_organ.get_damage() <= 0)
-				continue
-			to_chat(user, SPAN_NOTICE("You flow your regenerative psionic energy through the flesh of their [external_organ.name]..."))
-			if(do_mob(user, H, 10 SECONDS / effect_multiplier))
-				if(pay_energy(20))
-					external_organ.heal_damage(external_organ.get_brute_damage(), external_organ.get_burn_damage(), internal = FALSE, robo_repair = FALSE)
-					to_chat(user, SPAN_NOTICE("You mend their [external_organ.name]'s flesh."))
-					for(var/datum/wound/W as anything in external_organ.wounds)
-						if(LAZYLEN(W.embedded_objects))
-							to_chat(user, SPAN_WARNING("You heal what you can, but unyielding metal shrapnel in their [external_organ.name] prevent you from completing your work."))
-				else
-					return
-			else
+		if(O.get_damage() > 0) // Fix internal damage
+			to_chat(user, SPAN_NOTICE("You flow your regenerative psionic energy through their [O.name]..."))
+			if(!do_mob(user, H, 10 SECONDS / effect_multiplier) || !pay_energy(30))
 				return
-		else
+			to_chat(user, SPAN_NOTICE("You mend their [O.name]'s bruising."))
+			O.heal_damage(O.get_damage())
+
+		if((O.status & ORGAN_BROKEN))
+			to_chat(user, SPAN_NOTICE("You flow your regenerative psionic energy through their [O.name]..."))
+			if(!do_mob(user, H, 10 SECONDS / effect_multiplier) || !pay_energy(30))
+				return
+			to_chat(user, SPAN_NOTICE("You restart their [O.name]'s functionality."))
+			O.status &= ~ORGAN_BROKEN
+
+		if(O.get_damage() <= 5 && O.organ_tag == BP_EYES && H.sdisabilities & BLIND) // Fix eyes
+			to_chat(user, SPAN_NOTICE("You flow your regenerative psionic energy through their [O.name]..."))
+			if(!do_mob(user, H, 10 SECONDS / effect_multiplier) || !pay_energy(30))
+				return
+			to_chat(user, SPAN_NOTICE("You cure their blindness."))
+			H.sdisabilities &= ~BLIND
+
+		if(O.organ_tag == BP_HEART && H.is_asystole()) // Fix heart
+			if(!do_mob(user, H, 5 SECONDS / effect_multiplier) || !pay_energy(10))
+				return
+			to_chat(user, SPAN_NOTICE("You pulse psionic energy through their heart and it begins to beat again."))
+			H.resuscitate()
+
+	for(var/obj/item/organ/E in H.bad_external_organs) // Fix bones, tendons, arteries and necrosis.
+		var/obj/item/organ/external/affected = E
+		if(!do_mob(user, H, 1 SECONDS / effect_multiplier))
 			return
+
+		if((affected.get_damage() < affected.min_broken_damage * GLOB.config.organ_health_multiplier) && (affected.status & ORGAN_BROKEN))
+			to_chat(user, SPAN_NOTICE("You flow your regenerative psionic energy through the broken bone in the [affected.name]..."))
+			if(!do_mob(user, H, 10 SECONDS / effect_multiplier) || !pay_energy(25))
+				return
+			affected.status &= ~ORGAN_BROKEN
+			to_chat(user, SPAN_NOTICE("You mend their [affected.name] together."))
+
+		if((affected.status & ORGAN_ARTERY_CUT))
+			if(!do_mob(user, H, 10 SECONDS / effect_multiplier) || !pay_energy(25))
+				return
+			affected.status &= ~ORGAN_ARTERY_CUT
+			to_chat(user, SPAN_NOTICE("You mend a spliced artery in their [affected.name]."))
+
+		if((affected.status & ORGAN_DEAD))
+			if(!do_mob(user, H, 10 SECONDS / effect_multiplier) || !pay_energy(25))
+				return
+			affected.status &= ~ORGAN_DEAD
+			to_chat(user, SPAN_NOTICE("You mend some necrosis from their [affected.name]."))
+
+		if(affected.tendon && (affected.tendon_status() & TENDON_CUT) && affected.tendon.can_recover())
+			if(!do_mob(user, H, 10 SECONDS / effect_multiplier) || !pay_energy(25))
+				return
+			to_chat(user, SPAN_NOTICE("You mend the damaged tendon in their [affected.name]."))
+			affected.tendon.rejuvenate()
+
+	for(var/obj/item/organ/external/external_organ in H.organs) // Fix brute and burn.
+		if(!do_mob(user, H, 1 SECONDS / effect_multiplier))
+			return
+		if(external_organ.status & ORGAN_ROBOT) // No robot parts for this.
+			continue
+		if(external_organ.get_damage() <= 0)
+			continue
+		to_chat(user, SPAN_NOTICE("You flow your regenerative psionic energy through the flesh of their [external_organ.name]..."))
+		if(!do_mob(user, H, 10 SECONDS / effect_multiplier) || !pay_energy(20))
+			return
+		external_organ.heal_damage(external_organ.get_brute_damage(), external_organ.get_burn_damage(), internal = FALSE, robo_repair = FALSE)
+		to_chat(user, SPAN_NOTICE("You mend their [external_organ.name]'s flesh."))
+		for(var/datum/wound/W as anything in external_organ.wounds)
+			if(LAZYLEN(W.embedded_objects))
+				to_chat(user, SPAN_WARNING("You heal what you can, but the unyielding metal shrapnel in their [external_organ.name] prevents you from completing your work."))
 
 	user.visible_message(SPAN_NOTICE("[user] raises their palm from [H]."), SPAN_NOTICE("You raise your palm, having finished your work."))

--- a/code/modules/psionics/abilities/mend.dm
+++ b/code/modules/psionics/abilities/mend.dm
@@ -33,38 +33,120 @@
 	if(!.)
 		return
 
+	var/victim_psi_sensitivity = H.check_psi_sensitivity()  //Faster healing for psi-sensitive people, slower for psi-resistant people.
+	var/effect_multiplier = 2 ** victim_psi_sensitivity // -1 = 0.5x speed, 0 = 1x speed, 1 = 2x speed, 2 = 4x speed, etc.
+
 	user.visible_message(SPAN_NOTICE("[user] lays a palm on [H]..."), SPAN_NOTICE("You lay your palm on [H] and get to work."))
-	to_chat(user, SPAN_NOTICE("You start by flowing your regenerative psionic energy through their vital organs..."))
 	for(var/obj/item/organ/O in H.internal_organs)
-		if(do_mob(user, H, 15 SECONDS))
+		if(do_mob(user, H, 1 SECONDS / effect_multiplier))
 			if(O.get_damage() > 0) // Fix internal damage
-				to_chat(user, SPAN_NOTICE("You mend their [O]'s bruising."))
-				O.heal_damage(O.get_damage())
+				to_chat(user, SPAN_NOTICE("You flow your regenerative psionic energy through their [O.name]..."))
+				if(do_mob(user, H, 10 SECONDS / effect_multiplier))
+					if(pay_energy(30))
+						to_chat(user, SPAN_NOTICE("You mend their [O.name]'s bruising."))
+						O.heal_damage(O.get_damage())
+					else
+						return
+				else
+					return
+
 			if((O.status & ORGAN_BROKEN))
-				to_chat(user, SPAN_NOTICE("You restart their [O]'s functionality."))
-				O.status &= ~ORGAN_BROKEN
-			if(O.get_damage() <= 5 && O.organ_tag == BP_EYES) // Fix eyes
-				H.sdisabilities &= ~BLIND
+				to_chat(user, SPAN_NOTICE("You flow your regenerative psionic energy through their [O.name]..."))
+				if(do_mob(user, H, 10 SECONDS / effect_multiplier))
+					if(pay_energy(30))
+						to_chat(user, SPAN_NOTICE("You restart their [O.name]'s functionality."))
+						O.status &= ~ORGAN_BROKEN
+					else
+						return
+				else
+					return
 
-	to_chat(user, SPAN_NOTICE("You continue by flowing your regenerative psionic energy through their limbs..."))
-	for(var/obj/item/organ/external/O in H.organs) // Fix limbs
-		if(!O.robotic < ORGAN_ROBOT) // No robot parts for this.
-			continue
-		if(do_mob(user, H, 15 SECONDS))
-			to_chat(user, SPAN_NOTICE("You mend their [O]'s bruising."))
-			O.heal_damage(0, O.get_damage(), internal = TRUE, robo_repair = FALSE)
+			if(O.get_damage() <= 5 && O.organ_tag == BP_EYES && H.sdisabilities & BLIND) // Fix eyes
+				if(do_mob(user, H, 1 SECONDS / effect_multiplier))
+					to_chat(user, SPAN_NOTICE("You flow your regenerative psionic energy through their [O.name]..."))
+					if(do_mob(user, H, 10 SECONDS / effect_multiplier))
+						if(pay_energy(30))
+							to_chat(user, SPAN_NOTICE("You cure their blindness."))
+							H.sdisabilities &= ~BLIND
+						else
+							return
+					else
+						return
 
-	to_chat(user, SPAN_NOTICE("Finally, you begin flowing your regenerative psionic energy through their broken limbs..."))
+			if(O.organ_tag == BP_HEART && H.is_asystole()) // Fix heart
+				if(do_mob(user, H, 5 SECONDS / effect_multiplier))
+					if(pay_energy(10))
+						to_chat(user, SPAN_NOTICE("You pulse psionic energy through their heart and it begins to beat again."))
+						H.resuscitate()
+					else
+						return
+				else
+					return
+		else
+			return
+
 	for(var/obj/item/organ/E in H.bad_external_organs) // Fix bones
 		var/obj/item/organ/external/affected = E
-		if(do_mob(user, H, 10 SECONDS))
+		if(do_mob(user, H, 1 SECONDS / effect_multiplier))
 			if((affected.get_damage() < affected.min_broken_damage * GLOB.config.organ_health_multiplier) && (affected.status & ORGAN_BROKEN))
-				to_chat(user, SPAN_NOTICE("You mend their [affected] together."))
-				affected.status &= ~ORGAN_BROKEN
+				to_chat(user, SPAN_NOTICE("You flow your regenerative psionic energy through the broken bone in the [affected.name]..."))
+				if(do_mob(user, H, 10 SECONDS / effect_multiplier))
+					if(pay_energy(25))
+						affected.status &= ~ORGAN_BROKEN
+						to_chat(user, SPAN_NOTICE("You mend their [affected.name] together."))
+					else
+						return
+				else
+					return
 			if((affected.status & ORGAN_ARTERY_CUT))
-				to_chat(user, SPAN_NOTICE("You mend a spliced artery in their [affected]."))
-				affected.status &= ~ORGAN_ARTERY_CUT
+				if(do_mob(user, H, 10 SECONDS / effect_multiplier))
+					if(pay_energy(25))
+						affected.status &= ~ORGAN_ARTERY_CUT
+						to_chat(user, SPAN_NOTICE("You mend a spliced artery in their [affected.name]."))
+					else
+						return
+				else
+					return
 			if((affected.status & ORGAN_DEAD))
-				to_chat(user, SPAN_NOTICE("You mend some necrosis from their [affected]."))
-				affected.status &= ~ORGAN_DEAD
+				if(do_mob(user, H, 10 SECONDS / effect_multiplier))
+					if(pay_energy(25))
+						affected.status &= ~ORGAN_DEAD
+						to_chat(user, SPAN_NOTICE("You mend some necrosis from their [affected.name]."))
+					else
+						return
+				else
+					return
+			if(affected.tendon && (affected.tendon_status() & TENDON_CUT) && affected.tendon.can_recover())
+				if(do_mob(user, H, 10 SECONDS / effect_multiplier))
+					if(pay_energy(25))
+						to_chat(user, SPAN_NOTICE("You mend the damaged tendon in their [affected.name]."))
+						affected.tendon.rejuvenate()
+					else
+						return
+				else
+					return
+		else
+			return
+
+	for(var/obj/item/organ/external/external_organ in H.organs) // Fix limbs
+		if(do_mob(user, H, 1 SECONDS / effect_multiplier))
+			if(external_organ.status & ORGAN_ROBOT) // No robot parts for this.
+				continue
+			if(external_organ.get_damage() <= 0)
+				continue
+			to_chat(user, SPAN_NOTICE("You flow your regenerative psionic energy through the flesh of their [external_organ.name]..."))
+			if(do_mob(user, H, 10 SECONDS / effect_multiplier))
+				if(pay_energy(20))
+					external_organ.heal_damage(external_organ.get_brute_damage(), external_organ.get_burn_damage(), internal = FALSE, robo_repair = FALSE)
+					to_chat(user, SPAN_NOTICE("You mend their [external_organ.name]'s flesh."))
+					for(var/datum/wound/W as anything in external_organ.wounds)
+						if(LAZYLEN(W.embedded_objects))
+							to_chat(user, SPAN_WARNING("You heal what you can, but unyielding metal shrapnel in their [external_organ.name] prevent you from completing your work."))
+				else
+					return
+			else
+				return
+		else
+			return
+
 	user.visible_message(SPAN_NOTICE("[user] raises their palm from [H]."), SPAN_NOTICE("You raise your palm, having finished your work."))

--- a/html/changelogs/Fenodyree-LonerMendFix.yml
+++ b/html/changelogs/Fenodyree-LonerMendFix.yml
@@ -1,0 +1,10 @@
+author: Fenodyree
+delete-after: True
+
+changes:
+  - bugfix: "Fixes the Mend power taking 15 seconds to scan every organ, even if the organ is healthy."
+  - bugfix: "Fixes the Mend power not being able to fix blindness."
+  - bugfix: "Fixes the Mend power not being able to fix heat attacks."
+  - bugfix: "Fixes the Mend power not being able to fix brute or burn damage."
+  - bugfix: "Fixes the Mend power not respecting psychic sensitivity."
+  - bugfix: "Fixes the Mend power thinking every external organ is robotic."

--- a/html/changelogs/Fenodyree-LonerMendFix.yml
+++ b/html/changelogs/Fenodyree-LonerMendFix.yml
@@ -4,7 +4,9 @@ delete-after: True
 changes:
   - bugfix: "Fixes the Mend power taking 15 seconds to scan every organ, even if the organ is healthy."
   - bugfix: "Fixes the Mend power not being able to fix blindness."
-  - bugfix: "Fixes the Mend power not being able to fix heat attacks."
+  - bugfix: "Fixes the Mend power not being able to fix heart attacks."
   - bugfix: "Fixes the Mend power not being able to fix brute or burn damage."
+  - bugfix: "Fixes the Mend power not being able to fix tendons."
   - bugfix: "Fixes the Mend power not respecting psychic sensitivity."
   - bugfix: "Fixes the Mend power thinking every external organ is robotic."
+


### PR DESCRIPTION
Split this off the larger PR coming that adds the new psychic damage mechanics to loner, as this is nearly a pure bugfix.

Limitations, mend can't interact with anything not organic, it won't fix prosthetics, or wounds with embedded objects.

This can leave bleeding wounds if there are serious wounds with shrapnel in them, I added a message to make it clear that this is intentional behavior.

The limb-processing PR means that sometimes limbs can get stuck with pain, which happens occasionally when using mend, but this is fixed in #22847 so I didn't address it.

changes:
  - bugfix: "Fixes the Mend power taking 15 seconds to scan every organ, even if the organ is healthy."
  - bugfix: "Fixes the Mend power not being able to fix blindness."
  - bugfix: "Fixes the Mend power not being able to fix heart attacks."
  - bugfix: "Fixes the Mend power not being able to fix brute or burn damage."
  - bugfix: "Fixes the Mend power not being able to fix tendons."
  - bugfix: "Fixes the Mend power not respecting psychic sensitivity."
  - bugfix: "Fixes the Mend power thinking every external organ is robotic."
