### PR TITLE
Modlaser betaray fix

### DIFF
--- a/code/modules/projectiles/modular/laser_components.dm
+++ b/code/modules/projectiles/modular/laser_components.dm
@@ -443,6 +443,7 @@
 	projectile = /obj/projectile/energy/floramut
 	icon_state = "somatoray"
 	firing_sound = 'sound/effects/stealthoff.ogg'
+	damage = 0.1 //This deals toxin damage. Very strong unless it has a big damage malus.
 
 /obj/item/laser_components/modulator/floramut2
 	name = "betaray modulator"
@@ -450,6 +451,7 @@
 	projectile = /obj/projectile/energy/florayield
 	icon_state = "betaray"
 	firing_sound = 'sound/effects/stealthoff.ogg'
+	damage = 0.1 //This deals toxin damage. Very strong unless it has a big damage malus.
 
 /obj/item/laser_components/modulator/xenovermin
 	name = "xenovermin modulator"
@@ -504,6 +506,7 @@
 	name = "phoron bolt modulator"
 	desc = "Modulates the beam into firing toxic phoron bolts."
 	projectile = /obj/projectile/energy/phoron
+	damage = 0.5
 	icon_state = "tox"
 	firing_sound = 'sound/effects/stealthoff.ogg'
 	origin_tech = list(TECH_COMBAT = 4, TECH_PHORON = 4)

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -95,7 +95,9 @@
 /obj/projectile/energy/phoron
 	name = "phoron bolt"
 	icon_state = "energy"
-	irradiate = 20
+	irradiate = 80 //Radiation goes up to 1000
+	check_armor = BIO
+	damage_type = DAMAGE_TOXIN
 
 /obj/projectile/energy/bfg
 	name = "distortion"

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -141,7 +141,7 @@
 	icon_state = "energy"
 	damage = 0
 	damage_type = DAMAGE_TOXIN
-	check_armor = ENERGY
+	check_armor = RAD
 
 /obj/projectile/energy/floramut/gene
 	name = "gamma somatoray"
@@ -172,7 +172,8 @@
 				M.adjustFireLoss(rand(5,15))
 				M.show_message(SPAN_WARNING("The radiation beam singes you!"))
 	else if(iscarbon(target))
-		M.show_message(SPAN_NOTICE("The radiation beam dissipates harmlessly through your body."))
+		if(damage <= 5)
+			M.show_message(SPAN_NOTICE("The radiation beam mostly dissipates harmlessly through your body."))
 	else
 		return 1
 
@@ -181,7 +182,7 @@
 	icon_state = "energy2"
 	damage = 0
 	damage_type = DAMAGE_TOXIN
-	check_armor = ENERGY
+	check_armor = RAD
 
 /obj/projectile/energy/florayield/on_hit(atom/target, blocked, def_zone)
 	. = ..()
@@ -191,10 +192,10 @@
 		if((H.species.flags & IS_PLANT) && (M.nutrition < 500))
 			M.adjustNutritionLoss(-30)
 	else if (istype(target, /mob/living/carbon/))
-		M.show_message(SPAN_NOTICE("The radiation beam dissipates harmlessly through your body."))
+		if(damage <= 5)
+			M.show_message(SPAN_NOTICE("The radiation beam mostly dissipates harmlessly through your body."))
 	else
 		return 1
-
 
 /obj/projectile/beam/mindflayer
 	name = "flayer ray"

--- a/html/changelogs/Fenodyree-RadModulatorsFix.yml
+++ b/html/changelogs/Fenodyree-RadModulatorsFix.yml
@@ -4,5 +4,5 @@ delete-after: True
 changes:
   - bugfix: "Fixes flora rays dealing full toxin damage, despite not being combat modulators. Also updates the message if they are powerful enough to deal damage."
   - bugfix: "Fixes flora rays not checking radiation armor, despite being radiation beams."
-  - bugfix: "Fixes Phoron bolts dealing the wrong damage and respecting the wrong armour type."
+  - bugfix: "Fixes Phoron bolts dealing the wrong damage and respecting the wrong armour type. They now do toxin and check bio armor. They also irradiate more, as radiation now goes up to 1000."
 

--- a/html/changelogs/Fenodyree-RadModulatorsFix.yml
+++ b/html/changelogs/Fenodyree-RadModulatorsFix.yml
@@ -1,0 +1,8 @@
+author: Fenodyree
+delete-after: True
+
+changes:
+  - bugfix: "Fixes flora rays dealing full toxin damage, despite not being combat modulators. Also updates the message if they are powerful enough to deal damage."
+  - bugfix: "Fixes flora rays not checking radiation armor, despite being radiation beams."
+  - bugfix: "Fixes Phoron bolts dealing the wrong damage and respecting the wrong armour type."
+


### PR DESCRIPTION
Phoron bolts are only used in modlasers now, so I felt comfortable editing the base projectile.
It now checks bio armor, does more radiation to match the increased radiation cap.

The two florarays got missed in being assigned damage malnuses and were absurdly lethal if you shot people with them.

changes:
  - bugfix: "Fixes flora rays dealing full toxin damage, despite not being combat modulators. Also updates the message if they are powerful enough to deal damage."
  - bugfix: "Fixes flora rays not checking radiation armor, despite being radiation beams."
  - bugfix: "Fixes Phoron bolts dealing the wrong damage and respecting the wrong armour type. They now do toxin and check bio armor. They also irradiate more, as radiation now goes up to 1000."
