### PR TITLE
Fixes RIGs with no boots suffering slowdown for not deploying boots

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -943,15 +943,6 @@
 			if(!wearer || wearer.back != src) ///Prevents an edge case where a suit with a storage module can be removed while deploying, causing a runtime.
 				piece_being_deployed = FALSE
 				return FALSE
-			// If we're deploying the chest, we also try to deploy boots. If we can't also deploy boots, the entire thing fails.
-			if(use_obj == chest)
-				var/obj/item/boots_slot = wearer.shoes
-				var/obj/item/boots_obj = boots
-				if(boots_slot != boots_obj)
-					to_chat(initiator, SPAN_DANGER("You are unable to deploy \the [piece] as the boots were unable to also deploy!"))
-					playsound(src, 'sound/items/rfd_empty.ogg', 20, FALSE)
-					piece_being_deployed = FALSE
-					return FALSE
 			use_obj.forceMove(wearer)
 			if(src.color)
 				use_obj.color = src.color

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -11,7 +11,7 @@
 		MELEE = ARMOR_MELEE_MAJOR,
 		BULLET = ARMOR_BALLISTIC_SMALL,
 		LASER = ARMOR_LASER_RIFLE,
-		energy = ARMOR_MELEE_MINOR,
+		ENERGY = ARMOR_MELEE_MINOR,
 		BOMB = ARMOR_BOMB_PADDED
 	)
 	emp_protection = 100
@@ -27,6 +27,16 @@
 	helm_type =  /obj/item/clothing/head/helmet/space/rig/light
 	boot_type =  /obj/item/clothing/shoes/magboots/rig/light
 	glove_type = /obj/item/clothing/gloves/rig/light
+
+/obj/item/rig/light/update_slowdown() //Light rigs do not suffer a penalty for undeployed boots
+	var/new_slowdown = initial(slowdown)
+
+	if(offline)
+		new_slowdown = offline_slowdown
+
+	if(slowdown != new_slowdown)
+		slowdown = new_slowdown
+		wearer?.update_equipment_speed_mods() //This should only proc if worn, but just in case we check.
 
 /obj/item/clothing/suit/space/rig/light
 	name = "suit"

--- a/html/changelogs/Fenodyree-LightRigSlowdownFix.yml
+++ b/html/changelogs/Fenodyree-LightRigSlowdownFix.yml
@@ -1,0 +1,6 @@
+author: Fenodyree
+delete-after: True
+
+changes:
+  - bugfix: "Fixes light rigs getting slowdown from having undeployed boots."
+  - bugfix: "Fixes light rigs having no energy armour."

--- a/html/changelogs/Fenodyree-LightRigSlowdownFix.yml
+++ b/html/changelogs/Fenodyree-LightRigSlowdownFix.yml
@@ -4,3 +4,4 @@ delete-after: True
 changes:
   - bugfix: "Fixes light rigs getting slowdown from having undeployed boots."
   - bugfix: "Fixes light rigs having no energy armour."
+  - bugfix: "Fixes one more no chest deployment without boots check."


### PR DESCRIPTION
Some light rigs don't even have boots to deploy, so they shouldn't get slowdown because of it.
Decided just to make all light RIGs have no slowdown, as none of them had footstep sounds anyway.

changes:
  - bugfix: "Fixes light rigs getting slowdown from having undeployed boots."
  - bugfix: "Fixes light rigs having no energy armour."