### PR TITLE
Adds hardsuit press to machinist's office

### DIFF
--- a/html/changelogs/Fenodyree-HardsuitPress.yml
+++ b/html/changelogs/Fenodyree-HardsuitPress.yml
@@ -1,0 +1,6 @@
+author: Fenodyree
+delete-after: True
+
+changes:
+  - rscadd: "Adds a hardsuit module press to the machinist's office."
+


### PR DESCRIPTION
Doesn't make sense that only miners get access to a tool explicitly for creating hardsuit modules.

changes:
  - rscadd: "Adds a hardsuit module press to the machinist's office."
<img width="523" height="476" alt="image" src="https://github.com/user-attachments/assets/27eeec56-7ed0-4670-aac2-d22d12b35c55" />
