### PR TITLE
reduces the skrell consular age requirement to 100

### DIFF
--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -227,8 +227,8 @@
 
 	minimum_character_age = list(
 		SPECIES_HUMAN = 30,
-		SPECIES_SKRELL = 150,
-		SPECIES_SKRELL_AXIORI = 150
+		SPECIES_SKRELL = 100,
+		SPECIES_SKRELL_AXIORI = 100
 	)
 
 	job_access = list(ACCESS_CONSULAR)

--- a/html/changelogs/kermit-skronsulars-age.yml
+++ b/html/changelogs/kermit-skronsulars-age.yml
@@ -1,0 +1,6 @@
+author: kermit
+
+delete-after: True
+
+changes:
+  - rscadd: "Reduces the skrell consular age requirement to 100."


### PR DESCRIPTION
Reduces the age for skrell consulars from 150 to 100.

- 100 is the same age requirement for Captain, and is a little past the age at which skrell can have obtained up to 3 doctorate-level qualifications (80).
- Human-skrell first contact was 138 years ago, so the 150 age requirement gates out Republic-born skrell from the consular officer role -> skrell should be able to be Republic of Biesel consulars.

approved by Pope Dave 