### PR TITLE
Dionae movement QoL and ventcrawl split rebalance

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -520,7 +520,6 @@
 	else
 		icon_state = "walking"
 
-#define BLACKLIST_SPECIES_RUNNING list(SPECIES_DIONA, SPECIES_DIONA_COEUS)
 
 /atom/movable/screen/movement_intent/Click(location, control, params)
 	if(!usr)
@@ -543,8 +542,7 @@
 			if(M_RUN)
 				usr.m_intent = M_WALK
 			if(M_WALK)
-				if(!(usr.get_species() in BLACKLIST_SPECIES_RUNNING))
-					usr.m_intent = M_RUN
+				usr.m_intent = M_RUN
 
 		if(modifiers["button"] == "middle")
 			C.lay_down()
@@ -561,8 +559,6 @@
 				usr.m_intent = M_RUN
 		M.update_speed()
 	update_move_icon(usr)
-
-#undef BLACKLIST_SPECIES_RUNNING
 
 /// Hand slots are special to handle the handcuffs overlay
 /atom/movable/screen/inventory/hand

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -25,7 +25,7 @@
 
 	time_of_birth = world.time
 
-	add_verb(src, /mob/living/proc/ventcrawl)
+	//add_verb(src, /mob/living/proc/ventcrawl)
 	add_verb(src, /mob/living/proc/hide)
 
 	name = "[initial(name)] ([rand(1, 1000)])"

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -25,7 +25,6 @@
 
 	time_of_birth = world.time
 
-	//add_verb(src, /mob/living/proc/ventcrawl)
 	add_verb(src, /mob/living/proc/hide)
 
 	name = "[initial(name)] ([rand(1, 1000)])"

--- a/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
@@ -47,7 +47,6 @@
 	/// If set, then this nymph is inside a gestalt.
 	var/mob/living/carbon/gestalt = null
 	var/kept_clean = FALSE
-
 	/// Nymph who owns this nymph if split. AI diona nymphs will follow this nymph, and these nymphs can be controlled by the master.
 	var/mob/living/carbon/alien/diona/master_nymph
 	/// List of all related nymphs.
@@ -56,6 +55,9 @@
 	var/echo = FALSE
 	/// Whether or not the nymph is detached.
 	var/detached = FALSE
+	/// Whether the nymph can crawl through vents.
+	var/mob/living/carbon/alien/diona/dionae_vent_crawl = TRUE
+
 
 	var/datum/reagents/metabolism/ingested
 
@@ -73,6 +75,7 @@
 	setup_dionastats()
 	eat_types |= TYPE_ORGANIC
 	nutrition = 0 //We dont start with biomass
+	remove_verb(src, /mob/living/proc/ventcrawl)
 	update_verbs()
 
 /mob/living/carbon/alien/diona/Destroy()
@@ -274,16 +277,19 @@
 		add_verb(src, /mob/living/carbon/alien/diona/proc/merge)
 		add_verb(src, /mob/living/carbon/proc/absorb_nymph)
 		add_verb(src, /mob/living/carbon/alien/diona/proc/grow)
-		add_verb(src, /mob/living/proc/ventcrawl)
 		add_verb(src, /mob/living/proc/hide)
 		add_verb(src, /mob/living/carbon/proc/sample)
 		add_verb(src, /mob/living/carbon/alien/diona/proc/remove_hat)
 		add_verb(src, /mob/living/carbon/alien/diona/proc/attach_nymph_limb)
 		add_verb(src, /mob/living/carbon/alien/diona/proc/detach_nymph_limb)
+		add_verb(src, /mob/living/proc/ventcrawl)
 		remove_verb(src, /mob/living/carbon/alien/diona/proc/split) // we want to remove this one
 
 	remove_verb(src, /mob/living/carbon/alien/verb/evolve) //We don't want the old alien evolve verb
 
+
+/mob/living/carbon/alien/diona/can_ventcrawl()
+		return dionae_vent_crawl
 
 /mob/living/carbon/alien/diona/get_status_tab_items()
 	. = ..()

--- a/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
@@ -56,7 +56,7 @@
 	/// Whether or not the nymph is detached.
 	var/detached = FALSE
 	/// Whether the nymph can crawl through vents.
-	var/mob/living/carbon/alien/diona/dionae_vent_crawl = TRUE
+	var/dionae_vent_crawl = TRUE
 
 
 	var/datum/reagents/metabolism/ingested

--- a/code/modules/mob/living/carbon/human/diona_gestalt.dm
+++ b/code/modules/mob/living/carbon/human/diona_gestalt.dm
@@ -261,6 +261,7 @@ Nymphs have 100 health, so without armor there is a small possibility for each n
 	add_verb(M, /mob/living/carbon/alien/diona/proc/merge_back_to_gestalt)
 	add_verb(M, /mob/living/carbon/alien/diona/proc/switch_to_gestalt)
 	M.detached = TRUE
+	M.dionae_vent_crawl = TRUE
 	M.update_verbs(TRUE)
 	M.languages = languages.Copy()
 	M.accent = accent
@@ -345,6 +346,7 @@ Nymphs have 100 health, so without armor there is a small possibility for each n
 		for(var/mob/living/carbon/alien/diona/D in nymphos)
 			src.reagents.trans_to_mob(D, split_reag_volume, CHEM_BLOOD)
 			if(!D.mind)
+				D.dionae_vent_crawl = FALSE
 				D.master_nymph = bestNymph
 				D.birds_of_feather += nymphos
 				D.pixel_y += rand(-10,10)

--- a/code/modules/mob/living/carbon/human/species/species_hud.dm
+++ b/code/modules/mob/living/carbon/human/species/species_hud.dm
@@ -81,7 +81,7 @@
 /datum/hud_data/diona
 	has_hydration = FALSE
 	has_internals = FALSE
-	has_m_intent = FALSE
+	has_m_intent = TRUE
 	gear = list(
 		"i_clothing" =   list("loc" = ui_iclothing, "name" = "uniform",      "slot" = slot_w_uniform, "state" = "center", "toggle" = 1),
 		"o_clothing" =   list("loc" = ui_oclothing, "name" = "suit",         "slot" = slot_wear_suit, "state" = "suit",   "toggle" = 1),

--- a/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
@@ -73,6 +73,7 @@ They are very slow, reasonably strong, and quite durable. They also require ligh
 		MELEE = ARMOR_MELEE_MEDIUM
 	)
 
+
 	pain_mod = 0.5
 	grab_mod = 0.6 // Viney Tentacles and shit to cling onto
 	resist_mod = 1.5 // Reasonably stronk, not moreso than an Unathi or robot.
@@ -191,7 +192,7 @@ They are very slow, reasonably strong, and quite durable. They also require ligh
 		if((!D.client && !D.mind) || D.stat == DEAD)
 			qdel(D)
 
-//This handles nymphs, which are the only diona specie that can run, since they don't breathe they just take pain damage instead
+//used to just handle running for nymphs. Dionae take pain damage the longer they run, no lungs.
 /datum/species/diona/handle_sprint_cost(mob/living/carbon/human/H, cost, pre_move)
 	if(!pre_move)
 		H.adjustHalLoss(cost*0.3)

--- a/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
@@ -73,7 +73,6 @@ They are very slow, reasonably strong, and quite durable. They also require ligh
 		MELEE = ARMOR_MELEE_MEDIUM
 	)
 
-
 	pain_mod = 0.5
 	grab_mod = 0.6 // Viney Tentacles and shit to cling onto
 	resist_mod = 1.5 // Reasonably stronk, not moreso than an Unathi or robot.

--- a/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
@@ -192,7 +192,7 @@ They are very slow, reasonably strong, and quite durable. They also require ligh
 		if((!D.client && !D.mind) || D.stat == DEAD)
 			qdel(D)
 
-//used to just handle running for nymphs. Dionae take pain damage the longer they run, no lungs.
+//Used to just handle running for nymphs. Dionae take pain damage the longer they run, no lungs.
 /datum/species/diona/handle_sprint_cost(mob/living/carbon/human/H, cost, pre_move)
 	if(!pre_move)
 		H.adjustHalLoss(cost*0.3)

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -96,7 +96,7 @@ GLOBAL_LIST_INIT(can_enter_vent_with, list(
 	return 1
 
 /mob/living/carbon/alien/can_ventcrawl()
-	return 1
+	return 0
 
 /mob/living/carbon/alien/ventcrawl_carry()
 	return 1

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -96,7 +96,7 @@ GLOBAL_LIST_INIT(can_enter_vent_with, list(
 	return 1
 
 /mob/living/carbon/alien/can_ventcrawl()
-	return 0
+	return FALSE
 
 /mob/living/carbon/alien/ventcrawl_carry()
 	return 1

--- a/html/changelogs/Karakamenk-Dionae_movement_patch.yml
+++ b/html/changelogs/Karakamenk-Dionae_movement_patch.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Karakamenk
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Gives dionae the ability to run"
+  - balance: "prevents nymph ventcrawling upon splitting"

--- a/html/changelogs/Karakamenk-Dionae_movement_patch.yml
+++ b/html/changelogs/Karakamenk-Dionae_movement_patch.yml
@@ -55,5 +55,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - qol: "Gives dionae the ability to run"
-  - balance: "prevents nymph ventcrawling upon splitting"
+  - qol: "Gives dionae the ability to run."
+  - balance: "Prevents nymph ventcrawling upon splitting."


### PR DESCRIPTION
Dionae currently have their movement capped at walk speed. For Gera Dionae in particular, this makes them movement impaired by the standards of job accessibility guidelines, and a liability to play in roles that aren't mostly stationary. This PR flips all the flags used to prevent them from running in the first place.

In the interest of balance, Dionae have their own unique function for sprint cost that applies pain damage instead of stamina drain. This originally was just for handling nymph sprinting, I see nothing wrong with keeping it as is: Dionae have enough regeneration, damage type immunity, and base resistances that they can handle it. From a balance standpoint, the movement speed is there so that Dionae characters can move around the map responding to radio requests in a reasonable time frame, not lag behind in expeditions, and for Gera Dionae to keep up with other duty officers in security. Dionae should be bad at getting out of fights they're losing, especially if they started one alone.

In the spirit of this, whenever a Dionae splits from too much damage or otherwise, the nymphs will be unable to vent crawl until the gestalt reforms. This was never a popular mechanic, this was never fun to fight against, and its powerful enough by itself to be an ability locked behind TC. Instead of splitting being a get out of jail free card, it's now basically a vulnerable bleedout/recovery state that leaves them at the mercy of whoever broke them, particularly on the Horizon due to its enclosed nature. Escape or recovery requires help from a 3rd party.
