### PR TITLE
Make Vaurca Namegen Not Trash

### DIFF
--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -219,16 +219,55 @@
 	key = "9"
 	native = 1
 	flags = WHITELISTED | HIVEMIND
-	syllables = list("vaur","uyek","uyit","avek","sc'theth","k'ztak","teth","wre'ge","lii","dra'","zo'","ra'","k'lax'","zz","vh","ik","ak",
-	"uhk","zir","sc'orth","sc'er","thc'yek","th'zirk","th'esk","k'ayek","ka'mil","sc'","ik'yir","yol","kig","k'zit","'","'","zrk","krg","isk'yet","na'k",
-	"sc'azz","th'sc","nil","n'ahk","sc'yeth","aur'sk","iy'it","azzg","a'","i'","o'","u'","a","i","o","u","zz","kr","ak","nrk")
+	syllables = list("vaur","uyek","uyit","avek","sth'ec","k'ztak","teth","wre'ge","dra","zo","ra","zz","vh","iek","ak",
+	"uhk","zir","sc'orth","sc'er","thc'yek","th'zirk","th'esk","k'aye","ka'il","sc","i'ir","yol","kig","k'z","xi'v","xa'r","zrk","krg","k'yet","na'k",
+	"sc'azz","th'sc","nil","n'ahk","sc'yeth","aur'sk","y'it","azzg","a'vl","i'or","o'ue","u'kh","agh","iv","osh","utt","zz","kr","ak","nrk")
 
-/datum/language/bug/get_random_name()
-	var/new_name = "[pick(list("Ka'","Za'","Ka'"))]"
-	new_name += "[pick(list("Akaix'","Viax'"))]"
-	new_name += "[pick(list("Uyek","Uyit","Avek","Theth","Ztak","Teth","Zir","Yek","Zirk","Ayek","Yir","Kig","Yol","'Zrk","Nazgr","Yet","Nak","Kiihr","Gruz","Guurz","Nagr","Zkk","Zohd","Norc","Agraz","Yizgr","Yinzr","Nuurg","Iii","Lix","Nhagh","Xir","Z'zit","Zhul","Zgr","Na'k","Isk'yet","Agha"))]"
-	var/list/hive_names = list("Zo'ra" = 3, "K'lax" = 1, "C'thur" = 1)
-	new_name += " [pickweight(hive_names)]"
+/datum/language/bug/get_random_name(species, hive, bound = FALSE)
+	var/new_name
+	if(!species)
+		new_name = "[pick(list("Ka'","Za'","Ka'"))]"
+	switch(species)
+		if(SPECIES_VAURCA_WORKER)
+			new_name = "Ka'"
+		if(SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_ATTENDANT, SPECIES_VAURCA_WARFORM)
+			new_name = "Za'"
+		if(SPECIES_VAURCA_BREEDER)
+			new_name = "Ta'"
+		if(SPECIES_VAURCA_BULWARK)
+			new_name = "Ra'"
+	if(bound || species == SPECIES_VAURCA_WARFORM) // Warforms are exclusively Bound
+		new_name += "Viax'"
+	else
+		new_name += "Akaix'"
+	var/list/name_sounds = list("uew", "ek", "yi", "it", "ave", "te", "theth", "zta" ,"ak","th","zi", "rr", "yek","zik","ae",
+	"ir", "kg", "yol", "rk", "azg", "wt", "nak", "kii", "ru", "uur", "aer", "ai", "ee", "eie", "ou", "oh", "oo", "yh", "yv", "yu",
+	"nag", "zkk", "zohd", "norc", "graz", "izg", "yin", "nur", "iii", "lix", "li", "dre", "dru", "fe", "fra", "je", "jv", "ge",
+	"nha", "xir", "zz", "zhul", "gr", "ak", "isk", "a", "gha", "bz", "bl", "va", "xn", "qk", "qr", "qa", "ql")
+	var/personal_name
+	if(species == SPECIES_VAURCA_BREEDER) // Ta use different names and are allowed >2 syllables
+		for(var/i in 1 to 3)
+			if(prob(50) && i < 3)
+				personal_name += "[pick(syllables)][prob(50) ? "'":""]"
+			else
+				personal_name += "[pick(name_sounds)]"
+	else if(!personal_name)
+		if(prob(40))
+			personal_name += "[pick(syllables)][prob(20) ? "'":""]" // Occasionally dip into the syllable list for extra variety
+		else
+			personal_name += "[pick(name_sounds)][prob(40) ? "'":""]"
+		personal_name += "[pick(name_sounds)]"
+	new_name += "[capitalize(personal_name)]"
+	switch(hive)
+		if("C'thur Hive")
+			new_name += "C'thur"
+		if("K'lax Hive")
+			new_name += "K'lax"
+		if("Zo'ra Hive")
+			new_name += "Zo'ra"
+		else
+			var/list/hive_names = list("Zo'ra" = 3, "K'lax" = 1, "C'thur" = 1)
+			new_name += " [pickweight(hive_names)]"
 	return new_name
 
 /datum/language/bug/broadcast(var/mob/living/speaker,var/message,var/speaker_mask)

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -86,13 +86,21 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 	internal = P
 	// Set colour, default is grey, no biggie
 	var/list/hive = splittext(name, " ")
+	src.name = src.species.get_random_name(src.gender, hive[2], TRUE) // TRUE ensures it's Viax, gender is for argument complications,
+	src.real_name = src.name
 	switch(hive[length(hive)])
 		if("K'lax")
 			change_skin_color(20, 170, 20) // Vedhra does bioresearch.
+			src.set_origin(GET_SINGLETON(/singleton/origin_item/origin/vedhra))
+			src.set_culture(GET_SINGLETON(/singleton/origin_item/culture/klax))
 		if("C'thur")
 			change_skin_color(10, 35, 55) // Vytel tolerates the SCC the most.
+			src.set_origin(GET_SINGLETON(/singleton/origin_item/origin/cthur))
+			src.set_culture(GET_SINGLETON(/singleton/origin_item/culture/cthur))
 		if("Zo'ra")
 			change_skin_color(71 ,11, 51) // Scay does bioresearch.
+			src.set_origin(GET_SINGLETON(/singleton/origin_item/origin/scay))
+			src.set_culture(GET_SINGLETON(/singleton/origin_item/culture/zora))
 
 /mob/living/carbon/human/type_b/Initialize(mapload)
 	h_style = "Classic Antennae"
@@ -110,6 +118,11 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 	. = ..(mapload, SPECIES_VAURCA_WARFORM)
 	src.gender = NEUTER
 	src.mutations |= HULK
+	src.name = src.species.get_random_name(src.gender, "Zo'ra")
+	src.real_name = src.name
+	change_skin_color(121, 0, 21) // Only Zo'ra have a lot of biped warforms on standby w/ Zoleth using them for TCAF
+	src.set_origin(GET_SINGLETON(/singleton/origin_item/origin/zoleth))
+	src.set_culture(GET_SINGLETON(/singleton/origin_item/culture/zora))
 
 /mob/living/carbon/human/type_big
 	layer = 5

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -174,6 +174,10 @@
 	mob_strength = 1.35 // Requested by Vaurca lore to make them a bit more different
 	mass_modifier = REFERENCE_MASS_VAURCA_KA / REFERENCE_MASS_HUMAN
 
+/datum/species/bug/get_random_name(gender, hive, bound = FALSE)
+	var/datum/language/L = GLOB.all_languages[name_language]
+	return L.get_random_name(name, hive, bound)
+
 /datum/species/bug/before_equip(var/mob/living/carbon/human/H)
 	. = ..()
 	H.gender = NEUTER

--- a/html/changelogs/diggiez - VaurcaNamegen.yml
+++ b/html/changelogs/diggiez - VaurcaNamegen.yml
@@ -1,0 +1,15 @@
+
+# Your name.
+author: diggiez
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Updated vaurca namegen to not be terrible: now checks for species to give an accurate caste, Warforms and Cargo drones automatically get Viax."
+  - qol: "Warforms get body color set when spawning in."


### PR DESCRIPTION
Saw Cargo drones still weren't properly named Viax and realized the namegen code hasn't been touched since it was added (bar adding C'thur in hive names)

<img width="491" height="139" alt="image" src="https://github.com/user-attachments/assets/698b9bc3-1b7a-435f-b9e8-4b697bc6c526" />

Namegen now checks species to assign caste (finally, Ta & Ra are in), Bound status is an optional override which Cargo drones use, and Warforms are automatically made Viax too. Namegen also has way more name variety now because it stitches together name parts, and occasionally the defined syllables for Hivenet (which were otherwise unused because you can't _not_ understand Hivenet)

https://github.com/user-attachments/assets/62da735c-bc17-4e12-b63c-7f2baaaceb63

Warforms also get body color set when spawning in now, they're exclusively Zoleth brood because she has the most on standby.