### PR TITLE
Local, Horizon-based Hivenet in the Sea

### DIFF
--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -235,8 +235,8 @@
 	log_say("[key_name(speaker)] : ([name]) [message]")
 
 
-	if(is_lemurian_sea_sector())
-		to_chat(speaker, SPAN_WARNING("You attempt to reach the Hivenet, but find nothing!"))
+	if(!SSatlas.current_sector.hivenet_echoes && isNotContactLevel(speaker.z))
+		to_chat(speaker, SPAN_WARNING("You attempt to reach the Hivenet, but find nothing this far from relays!"))
 		return
 
 	var/mob/living/carbon/human/H = speaker //Check for Preimminent Shaper helmet, which obscure Hive affiliation
@@ -309,7 +309,7 @@
 	return "[verb], <span class='message'><span class='[message_color]'>\"[capitalize(message)]\"</span></span>"
 
 /datum/language/bug/check_special_condition(var/mob/other)
-	if(is_lemurian_sea_sector())
+	if(!SSatlas.current_sector.hivenet_echoes && isNotContactLevel(other.z))
 		return 0
 
 	if(istype(other, /mob/living/silicon))
@@ -348,8 +348,8 @@
 	return 0
 
 /datum/language/bug/check_speech_restrict(var/mob/speaker)
-	if(is_lemurian_sea_sector())
-		to_chat(speaker, SPAN_WARNING("You attempt to reach the Hivenet, but find nothing!"))
+	if(!SSatlas.current_sector.hivenet_echoes && isNotContactLevel(speaker.z))
+		to_chat(speaker, SPAN_WARNING("You attempt to reach the Hivenet, but find nothing this far from relays!"))
 		return FALSE
 
 	var/mob/living/carbon/human/H = speaker

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1658,8 +1658,8 @@
 		to_chat(src, SPAN_DANGER("Your mind is dark, unable to communicate with the Hive."))
 		return
 
-	if(is_lemurian_sea_sector())
-		to_chat(src, SPAN_DANGER("The Fog cuts you off from the Hivenet."))
+	if(!SSatlas.current_sector.hivenet_echoes && isNotContactLevel(src.z))
+		to_chat(src, SPAN_DANGER("You're too far from any Hivenet relay."))
 		return
 
 	if(!istype(S) && !istype(V))
@@ -2054,8 +2054,8 @@
 	if(!istype(S))
 		to_chat(src, SPAN_WARNING("You require a functional neural socket to do this!"))
 		return FALSE
-	if(is_lemurian_sea_sector())
-		to_chat(src, SPAN_DANGER("The Fog cuts you off from the Hivenet."))
+	if(!SSatlas.current_sector.hivenet_echoes && isNotContactLevel(src.z))
+		to_chat(src, SPAN_DANGER("You're too far from any Hivenet relay."))
 		return FALSE
 	if(S.last_action > world.time)
 		to_chat(src, SPAN_WARNING("You must wait before attempting another Hivenet action!"))
@@ -2192,8 +2192,8 @@
 		to_chat(src, SPAN_WARNING("You are not connected to the Hivenet!"))
 		return
 
-	if(is_lemurian_sea_sector())
-		to_chat(src, SPAN_WARNING("You attempt to reach the Hivenet, but find nothing!"))
+	if(!SSatlas.current_sector.hivenet_echoes && isNotContactLevel(src.z))
+		to_chat(src, SPAN_WARNING("You attempt to reach the Hivenet, but find nothing this far from relays!"))
 		return
 
 	if(within_jamming_range(src))
@@ -2215,8 +2215,8 @@
 	set desc = "Get a list of all vaurca currently on the Hivenet."
 	set category = "Hivenet"
 
-	if(is_lemurian_sea_sector())
-		to_chat(src, SPAN_WARNING("You attempt to query the Hivenet, but find nothing."))
+	if(!SSatlas.current_sector.hivenet_echoes && isNotContactLevel(src.z))
+		to_chat(src, SPAN_WARNING("You attempt to query the Hivenet, but find nothing this far from relays."))
 		return
 
 	var/list/all_vaurca = list()

--- a/code/modules/tgui/modules/hivenet_manifest.dm
+++ b/code/modules/tgui/modules/hivenet_manifest.dm
@@ -6,7 +6,7 @@
 	all_vaurca = set_all_vaurca
 
 /datum/tgui_module/hivenet_manifest/ui_interact(var/mob/user, var/datum/tgui/ui)
-	if(is_lemurian_sea_sector())
+	if(!SSatlas.current_sector.hivenet_echoes && isNotContactLevel(user.z))
 		to_chat(user, SPAN_WARNING("You attempt to query the Hivenet, but find nothing."))
 		return
 
@@ -18,7 +18,7 @@
 /datum/tgui_module/hivenet_manifest/ui_data(mob/user)
 	var/list/data = list()
 
-	if(is_lemurian_sea_sector())
+	if(!SSatlas.current_sector.hivenet_echoes && isNotContactLevel(user.z))
 		SStgui.close_uis(src)
 		return data
 

--- a/html/changelogs/diggiez - LocalHivenet.yml
+++ b/html/changelogs/diggiez - LocalHivenet.yml
@@ -1,0 +1,12 @@
+author: diggiez
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Vaurcae can use Hivenet in the Lemurian Sea, but only on connected Horizon z-levels. This extends to any far sector with Hivenet echoes disabled."


### PR DESCRIPTION
Vaurcae can use Hivenet in the Lemurian Sea, but only on connected Horizon z-levels. This extends to any far sector with Hivenet echoes disabled (currently only Crescent Expanse Uncharted), though echoes themselves are still disabled because they mostly come from greater Hivenet.

Supported by lore staff.

Vaurcae having Hivenet fully blocked actually wasn't pre-existing canon but was allowed as an experiment. This PR is the preferred form of Hivenet restriction.

" Vaurca are known to exhibit a strong sense of dread while inside the Sea, cut off from the greater hivenet and limited only to their ship for communicating with others."

<img width="755" height="309" alt="image" src="https://github.com/user-attachments/assets/95b32658-5446-4b1f-be00-cc7476fcf051" />


Since the Fog is an anomaly already, this doesn't even have to be a retcon.