### PR TITLE
OpenDream Static Type Checking

### DIFF
--- a/.github/workflows/byond.yml
+++ b/.github/workflows/byond.yml
@@ -258,7 +258,7 @@ jobs:
       #Run OpenDream on the DME
       - name: Run OpenDream
         run: |
-          dotnet $HOME/DMCompiler_linux-x64/DMCompiler.dll --suppress-unimplemented aurorastation.dme
+          dotnet $HOME/DMCompiler_linux-x64/DMCompiler.dll --suppress-unimplemented --skip-anything-typecheck aurorastation.dme
 
   ###########################################
   ############### TGUI LINTING ##############

--- a/code/__HELPERS/sorts/helpers.dm
+++ b/code/__HELPERS/sorts/helpers.dm
@@ -39,7 +39,7 @@
  *
  * @param {int} toIndex - The index to stop sorting at. Default: 0.
  */
-/proc/sortTim(list/to_sort, cmp = GLOBAL_PROC_REF(cmp_numeric_asc), associative = FALSE, fromIndex = 1, toIndex = 0) as /list
+/proc/sortTim(list/to_sort, cmp = GLOBAL_PROC_REF(cmp_numeric_asc), associative = FALSE, fromIndex = 1, toIndex = 0) as list
 	CREATE_SORT_INSTANCE(to_sort, cmp, associative, fromIndex, toIndex)
 
 	sorter.timSort(fromIndex, toIndex)

--- a/code/__HELPERS/sorts/helpers.dm
+++ b/code/__HELPERS/sorts/helpers.dm
@@ -39,7 +39,7 @@
  *
  * @param {int} toIndex - The index to stop sorting at. Default: 0.
  */
-/proc/sortTim(list/to_sort, cmp = GLOBAL_PROC_REF(cmp_numeric_asc), associative = FALSE, fromIndex = 1, toIndex = 0) as list
+/proc/sortTim(list/to_sort, cmp = GLOBAL_PROC_REF(cmp_numeric_asc), associative = FALSE, fromIndex = 1, toIndex = 0) as /list
 	CREATE_SORT_INSTANCE(to_sort, cmp, associative, fromIndex, toIndex)
 
 	sorter.timSort(fromIndex, toIndex)

--- a/code/__HELPERS/sorts/helpers.dm
+++ b/code/__HELPERS/sorts/helpers.dm
@@ -39,7 +39,7 @@
  *
  * @param {int} toIndex - The index to stop sorting at. Default: 0.
  */
-/proc/sortTim(list/to_sort, cmp = GLOBAL_PROC_REF(cmp_numeric_asc), associative = FALSE, fromIndex = 1, toIndex = 0) as /list
+/proc/sortTim(list/to_sort, cmp = GLOBAL_PROC_REF(cmp_numeric_asc), associative = FALSE, fromIndex = 1, toIndex = 0)
 	CREATE_SORT_INSTANCE(to_sort, cmp, associative, fromIndex, toIndex)
 
 	sorter.timSort(fromIndex, toIndex)

--- a/code/___linters/odlint.dm
+++ b/code/___linters/odlint.dm
@@ -28,7 +28,7 @@
 #pragma DanglingVarType error
 #pragma MissingInterpolatedExpression error
 #pragma AmbiguousResourcePath error
-#pragma InvalidVarType warning
+#pragma InvalidVarType notice
 #pragma InvalidReturnType error
 //3000-3999
 #pragma EmptyBlock error

--- a/code/___linters/odlint.dm
+++ b/code/___linters/odlint.dm
@@ -28,7 +28,7 @@
 #pragma DanglingVarType error
 #pragma MissingInterpolatedExpression error
 #pragma AmbiguousResourcePath error
-#pragma InvalidVarType notice
+#pragma InvalidVarType error
 #pragma InvalidReturnType error
 //3000-3999
 #pragma EmptyBlock error

--- a/code/___linters/odlint.dm
+++ b/code/___linters/odlint.dm
@@ -28,7 +28,8 @@
 #pragma DanglingVarType error
 #pragma MissingInterpolatedExpression error
 #pragma AmbiguousResourcePath error
-
+#pragma InvalidVarType error
+#pragma InvalidReturnType
 //3000-3999
 #pragma EmptyBlock error
 #pragma SuspiciousSwitchCase error

--- a/code/___linters/odlint.dm
+++ b/code/___linters/odlint.dm
@@ -28,8 +28,8 @@
 #pragma DanglingVarType error
 #pragma MissingInterpolatedExpression error
 #pragma AmbiguousResourcePath error
-#pragma InvalidVarType error
-#pragma InvalidReturnType
+#pragma InvalidVarType warning
+#pragma InvalidReturnType error
 //3000-3999
 #pragma EmptyBlock error
 #pragma SuspiciousSwitchCase error

--- a/code/modules/mob/abstract/freelook/eye.dm
+++ b/code/modules/mob/abstract/freelook/eye.dm
@@ -122,7 +122,7 @@
 			return
 		return loc
 
-/mob/proc/EyeMove(n, direct)
+/mob/proc/EyeMove(n, direct) as num
 	if(!eyeobj)
 		return
 

--- a/code/modules/mob/abstract/freelook/eye.dm
+++ b/code/modules/mob/abstract/freelook/eye.dm
@@ -122,13 +122,13 @@
 			return
 		return loc
 
-/mob/proc/EyeMove(n, direct) as num
+/mob/proc/EyeMove(n, direct)
 	if(!eyeobj)
 		return
 
 	return eyeobj.EyeMove(n, direct)
 
-/mob/abstract/eye/EyeMove(n, direct)
+/mob/abstract/eye/EyeMove(n, direct) as num
 	var/initial = initial(sprint)
 	var/max_sprint = 50
 

--- a/code/modules/mob/abstract/freelook/eye.dm
+++ b/code/modules/mob/abstract/freelook/eye.dm
@@ -128,7 +128,7 @@
 
 	return eyeobj.EyeMove(n, direct)
 
-/mob/abstract/eye/EyeMove(n, direct) as num
+/mob/abstract/eye/EyeMove(n, direct)
 	var/initial = initial(sprint)
 	var/max_sprint = 50
 

--- a/code/modules/mob/abstract/freelook/eye.dm
+++ b/code/modules/mob/abstract/freelook/eye.dm
@@ -36,9 +36,10 @@
 	return ..()
 
 /mob/abstract/eye/Move(n, direct)
-	if(owner == src)
-		return EyeMove(n, direct)
-	return 0
+	if(owner != src)
+		return FALSE
+
+	EyeMove(n, direct)
 
 /mob/abstract/eye/can_ztravel(var/direction)
 	return TRUE
@@ -128,7 +129,7 @@
 
 	return eyeobj.EyeMove(n, direct)
 
-/mob/abstract/eye/EyeMove(n, direct) as num
+/mob/abstract/eye/EyeMove(n, direct)
 	var/initial = initial(sprint)
 	var/max_sprint = 50
 

--- a/code/modules/mob/abstract/freelook/eye.dm
+++ b/code/modules/mob/abstract/freelook/eye.dm
@@ -128,7 +128,7 @@
 
 	return eyeobj.EyeMove(n, direct)
 
-/mob/abstract/eye/EyeMove(n, direct)
+/mob/abstract/eye/EyeMove(n, direct) as num
 	var/initial = initial(sprint)
 	var/max_sprint = 50
 

--- a/html/changelogs/hellfirejag-od-lint-extensions.yml
+++ b/html/changelogs/hellfirejag-od-lint-extensions.yml
@@ -1,4 +1,4 @@
 author: Hellfirejag
 delete-after: True
 changes:
-  - code_imp: "Tweaked the OpenDream linter to perform static type analysis for proc callsites and returns."
+  - code_imp: "Tweaked the OpenDream linter to perform static type analysis for proc returns (Call sites not working yet pending OD changes)."

--- a/html/changelogs/hellfirejag-od-lint-extensions.yml
+++ b/html/changelogs/hellfirejag-od-lint-extensions.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - code_imp: "Tweaked the OpenDream linter to perform static type analysis for proc callsites and returns."


### PR DESCRIPTION
Just enabling an OpenDream feature for the OD linter to perform static type checking at Proc Callsites and Proc Returns. 
This PR is going to produce 59 errors when the OD linter fails to compile. I'll be opening this up for review after I fix them all.