### PR TITLE
Small Weapon Sounds Fix

### DIFF
--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -66,7 +66,7 @@
 		if(use_material_name)
 			name = "[material.display_name] [initial(name)]"
 		if(use_material_sound)
-			if(sharp && !material.weapon_hitsound == 'sound/weapons/metalhit.ogg' || !sharp)
+			if((sharp && material.weapon_hitsound != 'sound/weapons/metalhit.ogg') || !sharp)
 				// wooden swords don't sound like metal swords.
 				// metalhit check is so swords when metal use their regular slice sfx.
 				hitsound = material.weapon_hitsound

--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -66,7 +66,7 @@
 		if(use_material_name)
 			name = "[material.display_name] [initial(name)]"
 		if(use_material_sound)
-			if((sharp && material.weapon_hitsound != 'sound/weapons/metalhit.ogg') || !sharp)
+			if(!sharp || material.weapon_hitsound == 'sound/weapons/metalhit.ogg')
 				// wooden swords don't sound like metal swords.
 				// metalhit check is so swords when metal use their regular slice sfx.
 				hitsound = material.weapon_hitsound

--- a/html/changelogs/hellfirejag-small-weapon-fix.yml
+++ b/html/changelogs/hellfirejag-small-weapon-fix.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed a small logic error in melee weapon sound effects."


### PR DESCRIPTION
This logic error turns into a runtime error when compiled in OpenDream, in addition to just not working at all.