### PR TITLE
TWILIGHT OF PEACE #1: Extreme Canonicity

### DIFF
--- a/code/__DEFINES/canonicity.dm
+++ b/code/__DEFINES/canonicity.dm
@@ -9,6 +9,8 @@
 #define ANTAGONIST_ACTIONS_NOT_CANON	1
 /// Antagonist actions are canon during this round.
 #define ANTAGONIST_ACTIONS_CANON		2
+/// Be warned... It's gonna get hot! Hot as hell! Antagonists are going to play to kill you if they have to.
+#define ANTAGONIST_ACTIONS_EXTREME_CANON 3
 
 
 /// Character deaths are automatically not-canon. Usually the case in non-canon events.

--- a/code/__DEFINES/canonicity.dm
+++ b/code/__DEFINES/canonicity.dm
@@ -17,6 +17,8 @@
 #define LIMITED_CHARACTER_DEATH			1
 /// If players are FORCED to keep character deaths canon. In this case, ALL CHARACTER DEATHS MUST GO THROUGH HEADMINS AND LOREMASTERS TO BE RETCONNED. THERE ARE NO EXCEPTIONS!
 #define FORCED_CHARACTER_DEATH			2
+/// Players are FORCED to keep character deaths canon, and NO retcons will be handed out barring extreme bug-caused cases.
+#define EXTREME_CHARACTER_DEATH			3
 
 /// Away sites are NOT canon in this round.
 #define AWAY_SITE_NOT_CANON				0

--- a/code/datums/round_canonicity.dm
+++ b/code/datums/round_canonicity.dm
@@ -87,6 +87,8 @@
 /singleton/canonicity/proc/character_death_canon_info()
 	. = list()
 	switch(character_death_canon)
+		if(NO_CHARACTER_DEATH)
+			. += "Character deaths are not canon during this round."
 		if(LIMITED_CHARACTER_DEATH)
 			. += "Character deaths are limited during this round. If all involved parties agree, character deaths can be retconned. If you would like to contest a death, or determine if a party counts as involved, please adminhelp."
 			. += "To count as involved, a player has to be an active participant of your death, meaning that they must have intentionally contributed to it. As an example, if you die to a carp on an expedition, you can retcon this death without asking others."
@@ -94,8 +96,10 @@
 			. += "Character deaths are forced canon during this round. All character deaths must go through headmins and loremasters to be retconned, no exceptions!"
 			. += "All injuries sustained as part of this round are immediately and fully canon, and should be roleplayed to the best of your ability, both in this round and the following. \
 				Do not ignore an injury you have obtained without explicit approval from administration. You are expected to roleplay its consequences believably, even extending to following rounds."
-		if(NO_CHARACTER_DEATH)
-			. += "Character deaths are not canon during this round."
+		if(EXTREME_CHARACTER_DEATH)
+			. += "Character deaths are forced canon during this round. All character deaths will be canon, and the only retcons accepted will be SOLELY in extreme, bug-related deaths!"
+			. += "All injuries sustained as part of this round are immediately and fully canon, and should be roleplayed to the best of your ability, both in this round and the following. \
+				Do not ignore an injury you have obtained without explicit approval from administration. You are expected to roleplay its consequences believably, even extending to following rounds."
 
 /singleton/canonicity/proc/away_site_canon_info()
 	. = list()
@@ -162,3 +166,12 @@
 	character_death_canon = NO_CHARACTER_DEATH
 	away_site_canon = AWAY_SITE_NOT_CANON
 	offship_canon = OFFSHIP_NOT_CANON
+
+/singleton/canonicity/extreme
+	name = "Extreme Canon"
+	desc = "This type of canon is in place for events where you are expected to play as realistically and as carefully as possible. All your actions will have permanent consequences."
+	round_canon = ROUND_FULL_CANON
+	antagonist_actions_canon = ANTAGONIST_ACTIONS_CANON
+	character_death_canon = EXTREME_CHARACTER_DEATH
+	away_site_canon = AWAY_SITE_CANON_FULL
+	offship_canon = OFFSHIP_CANON_FULL

--- a/code/datums/round_canonicity.dm
+++ b/code/datums/round_canonicity.dm
@@ -68,21 +68,25 @@
 /singleton/canonicity/proc/round_canon_info()
 	. = list()
 	switch(round_canon)
-		if(ROUND_FULL_CANON)
-			. += "This round is canon. All actions taken by non-antagonists during this round are considered canon."
 		if(ROUND_NON_CANON)
 			. += "This round is non-canon. All actions taken during this round are considered non-canon."
+		if(ROUND_FULL_CANON)
+			. += "This round is canon. All actions taken by non-antagonists during this round are considered canon."
 
 /singleton/canonicity/proc/antagonist_actions_canon_info()
 	. = list()
 	switch(antagonist_actions_canon)
 		if(ANTAGONIST_ACTIONS_NOT_EXPECTED)
 			. += "Antagonist actions are not expected during this round."
-		if(ANTAGONIST_ACTIONS_CANON)
-			. += "Antagonist actions are canon during this round. This includes event antagonists."
 		if(ANTAGONIST_ACTIONS_NOT_CANON)
 			. += "Antagonist actions are not canon during this round."
 			. += "This includes actions by non-antagonists directly influenced by antagonists."
+		if(ANTAGONIST_ACTIONS_CANON)
+			. += "Antagonist actions are canon during this round. This includes event antagonists."
+		if(ANTAGONIST_ACTIONS_EXTREME_CANON)
+			. += "Antagonist actions are canon during this round. This includes event antagonists."
+			. += "Event antagonists will NOT pull any punches. You are expected and extremely encouraged to play carefully and to the best of your ability."
+			. += "All characters are liable to be killed if it is deemed appropriate for the story."
 
 /singleton/canonicity/proc/character_death_canon_info()
 	. = list()
@@ -169,7 +173,8 @@
 
 /singleton/canonicity/extreme
 	name = "Extreme Canon"
-	desc = "This type of canon is in place for events where you are expected to play as realistically and as carefully as possible. All your actions will have permanent consequences."
+	desc = "This type of canon is in place for events where you are expected to play as realistically and as carefully as possible. All your actions will have permanent consequences. Volunteers will play \
+			antagonists to the best of their ability, without holding back."
 	round_canon = ROUND_FULL_CANON
 	antagonist_actions_canon = ANTAGONIST_ACTIONS_CANON
 	character_death_canon = EXTREME_CHARACTER_DEATH

--- a/html/changelogs/mattatlas-extremecanon.yml
+++ b/html/changelogs/mattatlas-extremecanon.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added an Extreme Canonicity for the TWILIGHT OF PEACE lore arc."


### PR DESCRIPTION
Adds a new type of canonicity that will be used for the TWILIGHT OF PEACE lore arc.

The main differences are:

- Event antagonists will NOT pull any punches. You are expected and extremely encouraged to play carefully and to the best of your ability. All characters are liable to be killed if it is deemed appropriate for the story.

and

- Character deaths are forced canon during this round. All character deaths will be canon, and the only retcons accepted will be SOLELY in extreme, bug-related deaths!