### PR TITLE
Biesel Phoronpunk Cybernetics

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -3284,6 +3284,7 @@
 #include "code\modules\organs\subtypes\augment\augments\platelet_factories.dm"
 #include "code\modules\organs\subtypes\augment\augments\psi_receiver.dm"
 #include "code\modules\organs\subtypes\augment\augments\sight_lights.dm"
+#include "code\modules\organs\subtypes\augment\augments\smes_induction_link.dm"
 #include "code\modules\organs\subtypes\augment\augments\subdermal_carapace.dm"
 #include "code\modules\organs\subtypes\augment\augments\suspension.dm"
 #include "code\modules\organs\subtypes\augment\augments\synthetic_cords.dm"

--- a/code/__DEFINES/background.dm
+++ b/code/__DEFINES/background.dm
@@ -226,6 +226,20 @@
 #define CITIZENSHIPS_ALL_IPC list(CITIZENSHIP_COALITION, CITIZENSHIP_BIESEL, CITIZENSHIP_ELYRA, CITIZENSHIP_GOLDEN, CITIZENSHIP_NONE)
 
 #define RELIGIONS_BIESEL list(RELIGION_NONE, RELIGION_CHRISTIANITY, RELIGION_ISLAM, RELIGION_BUDDHISM, RELIGION_SHINTO, RELIGION_HINDU, RELIGION_TAOISM, RELIGION_JUDAISM, RELIGION_SIKHISM, RELIGION_OTHER, RELIGION_TRINARY)
+#define ORIGINS_BIESEL list(\
+	/singleton/origin_item/origin/biesel, \
+	/singleton/origin_item/origin/new_gibson, \
+	/singleton/origin_item/origin/reade, \
+	/singleton/origin_item/origin/valkyrie, \
+	/singleton/origin_item/origin/biesel_grown, \
+	/singleton/origin_item/origin/diona_district_11, \
+	/singleton/origin_item/origin/titan_prime, \
+	/singleton/origin_item/origin/biesel_wildborn, \
+	/singleton/origin_item/origin/ipc_tau_ceti, \
+	/singleton/origin_item/origin/skrell_biesel, \
+	/singleton/origin_item/origin/little_adhomai, \
+	/singleton/origin_item/origin/little_adhomai/zhan, \
+	/singleton/origin_item/origin/little_adhomai/msai)
 #define CITIZENSHIPS_BIESEL list(CITIZENSHIP_BIESEL, CITIZENSHIP_ERIDANI, CITIZENSHIP_COALITION)
 
 #define RELIGIONS_COALITION list(RELIGION_NONE, RELIGION_CHRISTIANITY, RELIGION_ISLAM, RELIGION_BUDDHISM, RELIGION_SHINTO, RELIGION_HINDU, RELIGION_TAOISM, RELIGION_JUDAISM, RELIGION_SIKHISM, RELIGION_OTHER, RELIGION_TRINARY)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -211,6 +211,7 @@
 #define BP_AUG_PSI                "psionic receiver"
 #define BP_AUG_RADIO              "integrated radio"
 #define BP_AUG_SIGHTLIGHTS        "ocular installed sightlights"
+#define BP_AUG_SMES_INDUCTOR	  "SMES induction link"
 #define BP_AUG_SUBDERMAL_CARAPACE "subdermal carapace"
 #define BP_AUG_SUSPENSION         "calf suspension"
 #define BP_AUG_TASTE_BOOSTER      "taste booster"

--- a/code/modules/client/preference_setup/loadout/items/augments.dm
+++ b/code/modules/client/preference_setup/loadout/items/augments.dm
@@ -379,3 +379,19 @@
 	path = /obj/item/organ/internal/augment/bioaug/head_fluff/lhand_fluff
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 	whitelisted = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_DIONA, SPECIES_DIONA_COEUS, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_ATTENDANT, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER, SPECIES_UNATHI)
+
+/datum/gear/augment/smes_induction_link
+	display_name = "SMES induction link"
+	description = "A miniaturized, superconductive energy storage (SMES) cell utilizing phoronic magnet coils installed in the user's palms. " \
+		+ "The SMES feeds into an induction link, which can wirelessly charge the cell of a held object. It has NanoTrasen Corporation branding."
+	path = /obj/item/organ/internal/augment/smes_induction_link
+	cost = 4
+	origin_restriction = ORIGINS_BIESEL
+	whitelisted = null
+
+/datum/gear/augment/smes_induction_link/New()
+	..()
+	var/list/augs = list()
+	augs["SMES induction link, right hand"] = /obj/item/organ/internal/augment/smes_induction_link
+	augs["SMES induction link, left hand"] = /obj/item/organ/internal/augment/smes_induction_link/left
+	gear_tweaks += new /datum/gear_tweak/path(augs)

--- a/code/modules/organs/subtypes/augment/augments/smes_induction_link.dm
+++ b/code/modules/organs/subtypes/augment/augments/smes_induction_link.dm
@@ -1,0 +1,42 @@
+/obj/item/organ/internal/augment/smes_induction_link
+	name = "SMES induction link"
+	desc = "A miniaturized, superconductive energy storage (SMES) cell utilizing phoronic magnet coils installed in the user's palms. " \
+		+ "The SMES feeds into an induction link, which can wirelessly charge the cell of a held object. It has NanoTrasen Corporation branding."
+	action_button_name = "Induction Charge"
+	action_button_icon = "combipen"
+	activable = TRUE
+	organ_tag = BP_AUG_SMES_INDUCTOR
+	parent_organ = BP_R_HAND
+	cooldown = 10 MINUTES
+	/// String used for messages.
+	var/hand_string = "right hand"
+	/// Hand slot to check.
+	var/hand_slot = slot_r_hand
+	/// Amount to transfer (in Kilojoules)
+	var/transfer_amount = 4000.0 / 3.0 // 1/3rd of a standard laser rifle cell.
+
+/obj/item/organ/internal/augment/smes_induction_link/left
+	parent_organ = BP_L_HAND
+	hand_slot = slot_l_hand
+	hand_string = "left hand"
+
+/obj/item/organ/internal/augment/smes_induction_link/attack_self(mob/user)
+	. = ..()
+	if (!. || !user)
+		return
+	var/obj/item/target = user.get_equipped_item(hand_slot)
+	if (!istype(target))
+		to_chat(user, SPAN_WARNING("You have nothing in your [hand_string] to charge!"))
+		return
+
+	var/obj/item/cell/obj_cell = target.get_cell()
+	if(!istype(obj_cell))
+		to_chat(user, SPAN_WARNING("\The [target] doesn't contain a cell!"))
+		return
+	if(obj_cell.fully_charged())
+		to_chat(user, SPAN_WARNING("\The [obj_cell] is already fully charged!"))
+		return
+
+	var/charge_amount = min(obj_cell.maxcharge - obj_cell.charge, transfer_amount)
+	obj_cell.give(charge_amount)
+	user.visible_message("otherMessage", SPAN_NOTICE("You transmit [charge_amount] units of power to \the [target] from your [src]."))

--- a/html/changelogs/hellfirejag-phoronpunk-cybernetics.yml
+++ b/html/changelogs/hellfirejag-phoronpunk-cybernetics.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "Added new Republic of Biesel origin exclusive cybernetics to loadouts."


### PR DESCRIPTION
Requested by Kermit on behalf of Megacorporate lore.

This PR adds new "Phoronpunk" themed cybernetics that are exclusive to Republic of Biesel related origins. This PR is in draft for now. TODO:

- [x] SMES Induction Link
- [ ] Superconductive MagAttract
- [ ] NT PhoronBoost Neural Wiring
- [ ] Superconductive MagAttact (Antag)
- [ ] NT PhoronBoost Neural Wiring (Antag)
- [ ] Bluespace FTLCast
- [ ] Organophoronic Fangs
- [ ] Integrated SuperECM Emitter
- [ ] Actually getting sprites for these.