### PR TITLE
Roundstart Readied Morale Bonus

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -528,6 +528,7 @@
 #include "code\datums\components\eye\blueprints.dm"
 #include "code\datums\components\eye\freelook.dm"
 #include "code\datums\components\medical\medicalAnalyzer.dm"
+#include "code\datums\components\morale\moodlet_types.dm"
 #include "code\datums\components\morale\moodlets.dm"
 #include "code\datums\components\morale\morale_component.dm"
 #include "code\datums\components\multitool\_multitool.dm"

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -759,7 +759,9 @@ SUBSYSTEM_DEF(ticker)
 			else if(!player.mind.assigned_role)
 				continue
 			else
-				player.create_character()
+				var/mob/living/carbon/human/character = player.create_character()
+				var/datum/component/morale/morale = character.GetComponent(MORALE_COMPONENT)
+				morale?.load_moodlet(/datum/moodlet/roundstart_ready, 10)
 				qdel(player)
 		CHECK_TICK
 

--- a/code/datums/components/morale/moodlet_types.dm
+++ b/code/datums/components/morale/moodlet_types.dm
@@ -1,0 +1,5 @@
+// a little bonus for people who joined by readying for the round
+/datum/moodlet/roundstart_ready
+	moodlet_descriptor = SPAN_GOOD("Was early to their shift.")
+	initial_descriptor = SPAN_GOOD("You arrived early and prepared yourself for this shift.")
+	duration = 30 MINUTES

--- a/html/changelogs/geeves-early_bird.yml
+++ b/html/changelogs/geeves-early_bird.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Readying up and successfully joining the round now gives you a morale bonus that lasts for 30 minutes."


### PR DESCRIPTION
* Readying up and successfully joining the round now gives you a morale bonus that lasts for 30 minutes.


AI usage disclosure: The code for this was created in-part using GPT 5.6 Sol.