### PR TITLE
Fix sort by key number

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -436,7 +436,7 @@
 	if(L.len < 2)
 		return L
 	var/middle = L.len / 2 + 1
-	return mergeKeyedLists(sortByKeyText(L.Copy(0, middle), key), sortByKeyText(L.Copy(middle), key), key, value_is_number = TRUE)
+	return mergeKeyedLists(sortByKeyNumber(L.Copy(0, middle), key), sortByKeyNumber(L.Copy(middle), key), key, value_is_number = TRUE)
 
 /proc/mergeKeyedLists(var/list/L, var/list/R, var/key, var/value_is_number = FALSE)
 	var/Li=1

--- a/html/changelogs/fabiank3-fix-sort-by-key-number.yml
+++ b/html/changelogs/fabiank3-fix-sort-by-key-number.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed dictionary number sort."


### PR DESCRIPTION
# Summary

This PR fixes the dictionary sorting for num-values.  
The number sort version didn't call itself during sort and fell back to text search which isn't valid of number sorting operations.