### PR TITLE
window repair adhesive spray

### DIFF
--- a/code/game/objects/structures/machinery/vending/engitech.dm
+++ b/code/game/objects/structures/machinery/vending/engitech.dm
@@ -68,7 +68,8 @@
 		/obj/item/firealarm_electronics = 10,
 		/obj/item/cell/high = 10,
 		/obj/item/grenade/chem_grenade/antifuel = 5,
-		/obj/item/geiger = 5
+		/obj/item/geiger = 5,
+		/obj/item/reagent_containers/spray/cleaner/glass_glue = 8
 	)
 	contraband = list(
 		/obj/item/cell/potato = 3

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -294,3 +294,14 @@
 		return
 
 	..()
+
+/obj/item/reagent_containers/spray/cleaner/glass_glue
+	name = "single-use glass adhesive spray"
+	desc = "A small spray tube of a Hephaestus Industries ultra-strong silicate epoxy adhesive. For window and glass repair. Single-use!"
+	volume = 20
+	icon_state = "deodorant"
+	item_state = "deodorant"
+	possible_transfer_amounts = null
+	spray_size = 1
+	spray_sizes = null
+	reagents_to_add = list(/singleton/reagent/silicate = 20)

--- a/html/changelogs/kermit-window-repair-glue.yml
+++ b/html/changelogs/kermit-window-repair-glue.yml
@@ -1,0 +1,7 @@
+author: kermit
+
+delete-after: True
+
+changes:
+  - rscadd: "Added a glass repair adhesive to EngiVends for repairing window cracks without having to completely decon/recon a window."
+ 


### PR DESCRIPTION
adds window repair adhesive spray containing silicate. single use.
found in the engi-ved vending machines

for repairing cracked/damage windows without having to fully deconstuct and reconstruct them.
can also strengthen windows