### PR TITLE
Radiant Eye Damage

### DIFF
--- a/code/game/objects/items/tools/tools.dm
+++ b/code/game/objects/items/tools/tools.dm
@@ -531,7 +531,7 @@
 	if(!welding_turf)
 		return
 
-	var/list/potential_viewers = viewers(world.view, welding_turf)
+	var/list/potential_viewers = viewers(2, welding_turf)
 	// Preserve the existing behaviour for the user if their container keeps them out of viewers().
 	if(!(user in potential_viewers))
 		potential_viewers += user

--- a/code/game/objects/items/tools/tools.dm
+++ b/code/game/objects/items/tools/tools.dm
@@ -509,7 +509,7 @@
 /obj/item/weldingtool/proc/get_fuel()
 	return REAGENT_VOLUME(reagents, /singleton/reagent/fuel)
 
-//Removes fuel from the welding tool. If a mob is passed, it will perform an eyecheck on the mob.
+//Removes fuel from the welding tool. If a mob is passed, it will expose nearby onlookers to the welding arc.
 /obj/item/weldingtool/use(var/amount = 1, var/mob/M = null, var/colourChange = TRUE)
 	if(!welding)
 		return 0
@@ -518,12 +518,28 @@
 	if(get_fuel() >= amount)
 		reagents.remove_reagent(/singleton/reagent/fuel, amount)
 		if(M && produces_flash)
-			M.flash_act(FLASH_PROTECTION_MAJOR)
+			flash_welding_arc(M)
 		return 1
 	else
 		if(M)
 			to_chat(M, SPAN_NOTICE("You need more welding fuel to complete this task."))
 		return 0
+
+/// Damages the eyes of the welder and any visible living mobs looking towards the welding arc.
+/obj/item/weldingtool/proc/flash_welding_arc(mob/living/user)
+	var/turf/welding_turf = get_turf(src)
+	if(!welding_turf)
+		return
+
+	var/list/potential_viewers = viewers(world.view, welding_turf)
+	// Preserve the existing behaviour for the user if their container keeps them out of viewers().
+	if(!(user in potential_viewers))
+		potential_viewers += user
+
+	for(var/mob/living/onlooker in potential_viewers)
+		// Someone sharing the arc's turf cannot meaningfully look away from it.
+		if(get_turf(onlooker) == welding_turf || (onlooker.dir & get_dir(onlooker, welding_turf)))
+			onlooker.flash_act(FLASH_PROTECTION_MAJOR)
 
 /obj/item/weldingtool/use_resource(mob/user, var/use_amount)
 	if(get_fuel() >= use_amount)
@@ -951,4 +967,3 @@
 	var/mutable_appearance/handle = mutable_appearance('icons/obj/tools.dmi', "hammer_handle")
 	handle.color = pick(COLOR_BLUE, COLOR_RED, COLOR_PURPLE, COLOR_BROWN, COLOR_GREEN, COLOR_CYAN, COLOR_YELLOW)
 	AddOverlays(handle)
-

--- a/html/changelogs/geeves-radiant_eye_damage.yml
+++ b/html/changelogs/geeves-radiant_eye_damage.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - balance: "Welding arcs now damage the eyes of visible onlookers who are facing the welder and are not wearing eye protection."

--- a/html/changelogs/geeves-radiant_eye_damage.yml
+++ b/html/changelogs/geeves-radiant_eye_damage.yml
@@ -3,4 +3,4 @@ author: Geeves
 delete-after: True
 
 changes:
-  - balance: "Welding arcs now damage the eyes of visible onlookers who are facing the welder and are not wearing eye protection."
+  - balance: "Welding arcs now damage the eyes of visible onlookers within two tiles who are facing the welder and are not wearing eye protection."


### PR DESCRIPTION
* Welding arcs now damage the eyes of visible onlookers within two tiles who are facing the welder and are not wearing eye protection.


AI usage disclosure: The code for this was created in-part using GPT 5.6 Sol.