### PR TITLE
Mining Points Carryover

### DIFF
--- a/code/__DEFINES/mining.dm
+++ b/code/__DEFINES/mining.dm
@@ -10,3 +10,5 @@
 #define ORE_HYDROGEN	"metallic hydrogen"
 #define ORE_BAUXITE		"aluminium"
 #define ORE_GALENA		"lead"
+
+#define MINING_POINTS_CARRYOVER_MAX 15000

--- a/code/__DEFINES/persistence/cleanup.dm
+++ b/code/__DEFINES/persistence/cleanup.dm
@@ -16,6 +16,9 @@ ABSTRACT_TYPE(/singleton/persistent_type_history_expiration_rule)
 ABSTRACT_TYPE(/singleton/persistent_type_history_expiration_rule/row_count)
 	var/max_row_count = 0
 
+/singleton/persistent_type_history_expiration_rule/row_count/one
+	max_row_count = 1
+
 /singleton/persistent_type_history_expiration_rule/row_count/ten
 	max_row_count = 10
 

--- a/code/__DEFINES/persistence/types.dm
+++ b/code/__DEFINES/persistence/types.dm
@@ -25,4 +25,4 @@ CREATE_PERSISTENT_TYPE_GENERIC(horizon_overmap_position, "SCCV Horizon sector po
 // ##### Persistent history with character validation
 
 CREATE_PERSISTENT_TYPE_HISTORY_CHARACTER(mining_points, "Mining yield history", "History of mining points yield of individual miners.", /singleton/persistent_type_history_expiration_rule/age/week)
-CREATE_PERSISTENT_TYPE_HISTORY_CHARACTER(mining_point_balance, "Mining point balance", "History of unspent mining point balances of individual miners.", /singleton/persistent_type_history_expiration_rule/age/week)
+CREATE_PERSISTENT_TYPE_HISTORY_CHARACTER(mining_point_balance, "Mining point balance", "History of unspent mining point balances of individual miners.", /singleton/persistent_type_history_expiration_rule/row_count/one)

--- a/code/__DEFINES/persistence/types.dm
+++ b/code/__DEFINES/persistence/types.dm
@@ -17,6 +17,7 @@
 // ##### Persistent generics
 
 CREATE_PERSISTENT_TYPE_GENERIC(horizon_overmap_position, "SCCV Horizon sector position", "Position of the SCCV Horizon on the overmap.", FALSE)
+CREATE_PERSISTENT_TYPE_GENERIC(mining_point_balance, "Mining point balance", "Unspent mining points belonging to individual characters.", TRUE)
 
 // ##### Persistent history
 

--- a/code/__DEFINES/persistence/types.dm
+++ b/code/__DEFINES/persistence/types.dm
@@ -17,7 +17,6 @@
 // ##### Persistent generics
 
 CREATE_PERSISTENT_TYPE_GENERIC(horizon_overmap_position, "SCCV Horizon sector position", "Position of the SCCV Horizon on the overmap.", FALSE)
-CREATE_PERSISTENT_TYPE_GENERIC(mining_point_balance, "Mining point balance", "Unspent mining points belonging to individual characters.", TRUE)
 
 // ##### Persistent history
 
@@ -26,3 +25,4 @@ CREATE_PERSISTENT_TYPE_GENERIC(mining_point_balance, "Mining point balance", "Un
 // ##### Persistent history with character validation
 
 CREATE_PERSISTENT_TYPE_HISTORY_CHARACTER(mining_points, "Mining yield history", "History of mining points yield of individual miners.", /singleton/persistent_type_history_expiration_rule/age/week)
+CREATE_PERSISTENT_TYPE_HISTORY_CHARACTER(mining_point_balance, "Mining point balance", "History of unspent mining point balances of individual miners.", /singleton/persistent_type_history_expiration_rule/age/week)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -251,30 +251,24 @@
 	if(!card_owner?.character_id)
 		return
 
-	var/datum/persistent_generic/saved_balance = SSpersistence.genericLoad(
-		/singleton/persistent_type/generic/mining_point_balance,
-		"[card_owner.character_id]"
+	var/datum/persistent_record/saved_balance = SSpersistence.historyGetLastRecord(
+		/singleton/persistent_type/history/character/mining_point_balance,
+		card_owner.character_id
 	)
 	if(!saved_balance)
 		return
 
-	var/list/balance_data = saved_balance.content
-	// Newly cached generics contain encoded content, while database-loaded ones
-	// have already been decoded by the persistence subsystem.
-	if(istext(balance_data))
-		balance_data = json_decode(balance_data)
-	if(islist(balance_data))
-		mining_points = clamp(text2num(balance_data["balance"]), 0, MINING_POINTS_CARRYOVER_MAX)
+	mining_points = clamp(text2num(saved_balance.value), 0, MINING_POINTS_CARRYOVER_MAX)
 
 /obj/item/card/id/proc/save_mining_points()
 	var/mob/living/carbon/human/card_owner = mob_id?.resolve()
 	if(!card_owner?.character_id)
 		return
 
-	SSpersistence.genericSave(
-		/singleton/persistent_type/generic/mining_point_balance,
-		list("balance" = clamp(mining_points, 0, MINING_POINTS_CARRYOVER_MAX)),
-		"[card_owner.character_id]"
+	SSpersistence.historyAddCharacterRecord(
+		/singleton/persistent_type/history/character/mining_point_balance,
+		card_owner.character_id,
+		"[clamp(mining_points, 0, MINING_POINTS_CARRYOVER_MAX)]"
 	)
 
 /obj/item/card/id/proc/adjust_mining_points(amount)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -244,6 +244,42 @@
 	id_card.citizenship			= SSrecords.get_citizenship_record_name(citizenship)
 	id_card.mob_id				= WEAKREF(src)
 	id_card.employer_faction    = employer_faction
+	INVOKE_ASYNC(id_card, TYPE_PROC_REF(/obj/item/card/id, load_mining_points))
+
+/obj/item/card/id/proc/load_mining_points()
+	var/mob/living/carbon/human/card_owner = mob_id?.resolve()
+	if(!card_owner?.character_id)
+		return
+
+	var/datum/persistent_generic/saved_balance = SSpersistence.genericLoad(
+		/singleton/persistent_type/generic/mining_point_balance,
+		"[card_owner.character_id]"
+	)
+	if(!saved_balance)
+		return
+
+	var/list/balance_data = saved_balance.content
+	// Newly cached generics contain encoded content, while database-loaded ones
+	// have already been decoded by the persistence subsystem.
+	if(istext(balance_data))
+		balance_data = json_decode(balance_data)
+	if(islist(balance_data))
+		mining_points = clamp(text2num(balance_data["balance"]), 0, MINING_POINTS_CARRYOVER_MAX)
+
+/obj/item/card/id/proc/save_mining_points()
+	var/mob/living/carbon/human/card_owner = mob_id?.resolve()
+	if(!card_owner?.character_id)
+		return
+
+	SSpersistence.genericSave(
+		/singleton/persistent_type/generic/mining_point_balance,
+		list("balance" = clamp(mining_points, 0, MINING_POINTS_CARRYOVER_MAX)),
+		"[card_owner.character_id]"
+	)
+
+/obj/item/card/id/proc/adjust_mining_points(amount)
+	mining_points = max(0, mining_points + amount)
+	save_mining_points()
 
 /obj/item/card/id/proc/dat()
 	var/dat = ("<table><tr><td>")

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -189,7 +189,7 @@
 		if(ID)
 			if(params["choice"] == "claim")
 				if(points >= 0)
-					ID.mining_points += points
+					ID.adjust_mining_points(points)
 					if(points != 0)
 						ping("<b>\The [src]</b> pings, \"Point transfer complete! Transaction total: [points] points!\"")
 						var/character_id = astype(ID.mob_id.resolve(), /mob/living/carbon/human/)?.character_id

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -148,12 +148,12 @@ GLOBAL_LIST_INIT(minevendor_list, list(
 			if(prize.cost <= ID.mining_points)
 				if(prize.shuttle)
 					if(SScargo.order_mining(prize.equipment_path))
-						ID.mining_points -= prize.cost
+						ID.adjust_mining_points(-prize.cost)
 						to_chat(usr, SPAN_NOTICE("Order passed. Your order has been placed on the next available supply shuttle."))
 					else
 						to_chat(usr, SPAN_DANGER("{ERR Code: NO_SHUTTLE_SPACE} Order failed! Please try again."))
 				else
-					ID.mining_points -= prize.cost
+					ID.adjust_mining_points(-prize.cost)
 					if(prize.amount != -1)
 						prize.amount--
 					new prize.equipment_path(get_turf(src))

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -868,7 +868,7 @@
 	if(istype(attacking_item, /obj/item/card/id))
 		if(points)
 			var/obj/item/card/id/C = attacking_item
-			C.mining_points += points
+			C.adjust_mining_points(points)
 			to_chat(user, SPAN_INFO("You transfer [points] points to \the [C]."))
 			points = 0
 		else

--- a/html/changelogs/geeves-mining_points_carryover.yml
+++ b/html/changelogs/geeves-mining_points_carryover.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Mining points now carry over between rounds for each character."
+  - balance: "Mining point carryover is capped at 15,000 points."

--- a/html/changelogs/geeves-mining_points_carryover.yml
+++ b/html/changelogs/geeves-mining_points_carryover.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
   - rscadd: "Mining points now carry over between rounds for each character."
-  - balance: "Mining point carryover is capped at 15,000 points."
+  - balance: "Mining point carryover is capped at 15,000 points and expires after one week of inactivity."

--- a/html/changelogs/geeves-mining_points_carryover.yml
+++ b/html/changelogs/geeves-mining_points_carryover.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
   - rscadd: "Mining points now carry over between rounds for each character."
-  - balance: "Mining point carryover is capped at 15,000 points and expires after one week of inactivity."
+  - balance: "Mining point carryover is capped at 15,000 points."


### PR DESCRIPTION
* Mining points now carry over between rounds for each character.
* Mining point carryover is capped at 15,000 points and expires after one week of inactivity.


AI usage disclosure: The code for this was created in-part using GPT 5.6 Sol.