### PR TITLE
Megaphones now create floating chat and use accent/lang

### DIFF
--- a/code/datums/langchat/langchat.dm
+++ b/code/datums/langchat/langchat.dm
@@ -154,10 +154,15 @@
 
 	if(length(text_to_display) > LANGCHAT_LONGEST_TEXT)
 		text_to_display = copytext_char(text_to_display, 1, LANGCHAT_LONGEST_TEXT + 1) + "..."
-	if(styles.Find("emote"))
+	if("emote" in styles)
 		styles.Remove("emote")
 		use_mob_style = FALSE
 		var/image/r_icon = image('icons/mob/chat_icons.dmi', icon_state = "emote")
+		text_to_display = "\icon[r_icon]&zwsp;[text_to_display]"
+	if("radio" in styles)
+		styles.Remove("radio")
+		use_mob_style = FALSE
+		var/image/r_icon = image('icons/mob/chat_icons.dmi', icon_state = "radio")
 		text_to_display = "\icon[r_icon]&zwsp;[text_to_display]"
 
 	return "<span class='center [styles.Join(" ")] [use_mob_style ? langchat_styles : ""] langchat'>[text_to_display]</span>"

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -47,12 +47,12 @@
 				return
 		if(emagged)
 			if(insults)
-				user.audible_message("<B>[user]</B> broadcasts, <FONT size=5>\"[pick(insultmsg)]\"</FONT>", "<B>[user]</B> speaks into \the [src].", 14)
+				speak(pick(insultmsg), user)
 				insults--
 			else
 				to_chat(user, SPAN_WARNING("*BZZZZzzzzzt*"))
 		else
-			user.audible_message("<B>[user]</B> broadcasts, <FONT size=5>\"[message]\"</FONT>", "<B>[user]</B> speaks into \the [src].", 14)
+			speak(message, user)
 		if(activation_sound)
 			playsound(loc, activation_sound, 100, 0, 1)
 		for (var/mob/living/carbon/human/C in range(user, 2) - user)
@@ -62,6 +62,9 @@
 				C.earpain(2, TRUE, 2)
 		spamcheck = world.time + 50
 		return
+
+/obj/item/megaphone/proc/speak(var/msg, var/mob/living/user)
+	user.say(msg, user.get_default_language(), "broadcasts")
 
 /obj/item/megaphone/emag_act(var/remaining_charges, var/mob/user)
 	if(!emagged)

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -24,7 +24,7 @@
 	var/list/exclaim_verb = list("exclaims")
 
 	/// Used when a sentence ends in !!
-	var/list/shout_verb = list("shouts", "yells", "screams")
+	var/list/shout_verb = list("shouts", "yells", "screams", "broadcasts")
 
 	/// Optional. When not specified speech_verb + quietly/softly is used instead.
 	var/list/whisper_verb = null

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -241,7 +241,8 @@ var/list/channel_to_radio_key = new
 		to_chat(src, SPAN_WARNING("You try to speak, but nothing comes out!"))
 		return
 
-	var/message_mode = parse_message_mode(text, "headset")
+	var/is_broadcast = verb == "broadcasts"
+	var/message_mode = is_broadcast ? null : parse_message_mode(text, "headset")
 
 	var/regex/emote = regex("^(\[\\*^\])\[^*\]+$")
 
@@ -325,7 +326,7 @@ var/list/channel_to_radio_key = new
 	msg.speech_sound = handle_v[1]
 	msg.sound_vol = handle_v[2]
 	msg.italics = handle_v[3]
-	msg.font_size = get_font_size_modifier()
+	msg.font_size = is_broadcast ? FONT_SIZE_HUGE : get_font_size_modifier()
 
 	//speaking into radios
 	if(length(used_radios))
@@ -384,6 +385,8 @@ var/list/channel_to_radio_key = new
 		langchat_styles = list("langchat_italic")
 	if(is_shouting)
 		langchat_styles = list("langchat_yell")
+	if(is_broadcast)
+		langchat_styles += "radio"
 
 	langchat_say_message(msg, get_hearers_in_view(msg.message_range, src), additional_styles = langchat_styles)
 

--- a/html/changelogs/Banditoz-megaphone-runechat.yml
+++ b/html/changelogs/Banditoz-megaphone-runechat.yml
@@ -1,0 +1,4 @@
+author: Banditoz
+delete-after: True
+changes:
+  - rscadd: "Megaphones now use your accent, language, and create floating text when used."


### PR DESCRIPTION
Megaphones now use your accent, language, and create floating text when used.

<img width="2560" height="1400" alt="dreamseeker_V1ntU7aL2j" src="https://github.com/user-attachments/assets/36828048-9e5b-4c6d-bad9-974d8880adef" />

Port of https://github.com/Baystation12/Baystation12/pull/35232 but only in spirit.