### PR TITLE
retitles and adds reporter/journalist roles

### DIFF
--- a/code/game/jobs/faction/unaffiliated.dm
+++ b/code/game/jobs/faction/unaffiliated.dm
@@ -14,3 +14,7 @@
 	title_suffix = "INDEP"
 
 	ui_priority = INFINITY // bottom of the list
+
+	titles_to_loadout = list(
+		"Corporate Reporter" = /obj/outfit/job/journalistf
+	)

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -16,13 +16,24 @@
 	)
 
 	job_access = list(ACCESS_JOURNALIST, ACCESS_MAINT_TUNNELS)
-	alt_titles = list("Freelance Journalist")
+	alt_titles = list("Independent Reporter", "Corporate Journalist", "Independent Journalist", "Media Broadcaster")
 	alt_factions = list(
 		"Corporate Reporter" = list("NanoTrasen", "Idris Incorporated", "Hephaestus Industries", "Orion Express", "Zavodskoi Interstellar", "Zeng-Hu Pharmaceuticals", "Private Military Contracting Group", "Stellar Corporate Conglomerate"),
-		"Freelance Journalist" = list("Independent")
+		"Corporate Journalist" = list("NanoTrasen", "Idris Incorporated", "Hephaestus Industries", "Orion Express", "Zavodskoi Interstellar", "Zeng-Hu Pharmaceuticals", "Private Military Contracting Group", "Stellar Corporate Conglomerate"),
+		"Independent Reporter" = list("Independent"),
+		"Independent Journalist" = list("Independent"),
+		"Media Broadcaster" = list("Independent")
 	)
-	alt_outfits = list("Freelance Journalist" = /obj/outfit/job/journalistf)
-	title_accesses = list("Corporate Reporter" = list(ACCESS_MEDICAL, ACCESS_SEC_DOORS, ACCESS_RESEARCH, ACCESS_ENGINE))
+	alt_outfits = list(
+		"Independent Journalist" = /obj/outfit/job/journalistf,
+		"Independent Reporter" = /obj/outfit/job/journalistf,
+		"Media Broadcaster" = /obj/outfit/job/journalistf)
+
+	title_accesses = list(
+		"Corporate Reporter" = list(ACCESS_MEDICAL, ACCESS_SEC_DOORS, ACCESS_RESEARCH, ACCESS_ENGINE),
+		"Corporate Journalist" = list(ACCESS_MEDICAL, ACCESS_SEC_DOORS, ACCESS_RESEARCH, ACCESS_ENGINE)
+	)
+
 	outfit = /obj/outfit/job/journalist
 	blacklisted_species = list(SPECIES_VAURCA_BREEDER)
 
@@ -54,7 +65,7 @@
 	)
 
 /obj/outfit/job/journalistf
-	name = "Freelance Journalist"
+	name = "Independent Journalist"
 	jobtype = /datum/job/journalist
 
 	uniform = /obj/item/clothing/under/suit_jacket/red

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -22,12 +22,8 @@
 		"Corporate Journalist" = list("NanoTrasen", "Idris Incorporated", "Hephaestus Industries", "Orion Express", "Zavodskoi Interstellar", "Zeng-Hu Pharmaceuticals", "Private Military Contracting Group", "Stellar Corporate Conglomerate"),
 		"Independent Reporter" = list("Independent"),
 		"Independent Journalist" = list("Independent"),
-		"Media Broadcaster" = list("Independent")
+		"Media Broadcaster" = list("NanoTrasen", "Idris Incorporated", "Hephaestus Industries", "Orion Express", "Zavodskoi Interstellar", "Zeng-Hu Pharmaceuticals", "Private Military Contracting Group", "Stellar Corporate Conglomerate", "Independent")
 	)
-	alt_outfits = list(
-		"Independent Journalist" = /obj/outfit/job/journalistf,
-		"Independent Reporter" = /obj/outfit/job/journalistf,
-		"Media Broadcaster" = /obj/outfit/job/journalistf)
 
 	title_accesses = list(
 		"Corporate Reporter" = list(ACCESS_MEDICAL, ACCESS_SEC_DOORS, ACCESS_RESEARCH, ACCESS_ENGINE),

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -21,7 +21,7 @@
 
 /obj/item/clothing/accessory/badge/press
 	name = "corporate press pass"
-	desc = "A corporate reporter's pass, emblazoned with the SCC logo."
+	desc = "A corporate reporter's pass, emblazoned with a company logo."
 	icon_state = "pressbadge"
 	item_state = "pbadge"
 	overlay_state = "pbadge"
@@ -33,9 +33,9 @@
 
 /obj/item/clothing/accessory/badge/press/independent
 	name = "press pass"
-	desc = "A freelance journalist's pass."
+	desc = "An independent reporter's pass."
 	icon_state = "pressbadge-i"
-	badge_string = "Freelance Journalist"
+	badge_string = "Independent Reporter"
 
 /obj/item/clothing/accessory/badge/press/plastic
 	name = "plastic press pass"

--- a/html/changelogs/kermit-reporter-retitles.yml
+++ b/html/changelogs/kermit-reporter-retitles.yml
@@ -1,0 +1,6 @@
+author: kermit
+
+delete-after: True
+
+changes:
+  - rscadd: "Retitles or adds various reporter/journalist (alt)titles. For megacorporate factions: Corporate Reporter, Corporate Journalist. For independents: Independent Reporter, Independent Journalist, Media Broadcaster."


### PR DESCRIPTION
- **Megacorporate Factions:** Corporate Reporter, Corporate Journalist
- **Independent Faction:** Independent Reporter, Independent Journalist, Media Broadcaster

The largest change is `Freelancer` -> `Independent`, which allows independent reporters/journalists/broadcasters to represent proper news media (eg. Tau Ceti Times, Spurley, a head-canoned independent media group), instead of being lucky solo freelancers who somehow landed a position on a sensitive megacorporate vessel (though freelancers aren't excluded).

`Media Broadcaster` is new and available to both independents and megacorporate fations, mostly catering to reporters doing gimmicky talk shows etc. with the camera drone. It has no additional access like news media though, regardless of megacorporate affiliation