### PR TITLE
Even Further Processing Trimming

### DIFF
--- a/code/modules/custom_ka/cells.dm
+++ b/code/modules/custom_ka/cells.dm
@@ -92,6 +92,9 @@
 
 /obj/item/custom_ka_upgrade/cells/cell04/on_update(var/obj/item/gun/custom_ka/the_gun)
 	stored_charge = min(stored_charge + 3,cell_increase)
+	if (stored_charge == cell_increase)
+		return FALSE
+	else return TRUE
 
 /obj/item/custom_ka_upgrade/cells/cell05
 	name = "recoil reloader KA cell"
@@ -138,12 +141,13 @@
 /obj/item/custom_ka_upgrade/cells/cyborg/on_update(var/obj/item/gun/custom_ka/the_gun)
 	var/mob/living/silicon/robot/owner_robot = the_gun.loc
 	if(!istype(owner_robot))
-		return
+		return FALSE
 
 	var/obj/item/cell/external = owner_robot.cell
 	var/charge_to_give = cell_increase - stored_charge
 	if(istype(external) && external.use(charge_to_give*5))
 		stored_charge += charge_to_give
+		return TRUE
 
 /obj/item/custom_ka_upgrade/cells/exosuit
 	name = "exosuit KA cell"
@@ -166,19 +170,20 @@
 /obj/item/custom_ka_upgrade/cells/exosuit/on_update(var/obj/item/gun/custom_ka/the_gun)
 	var/charge_to_give = cell_increase - stored_charge
 	if(!charge_to_give)
-		return
+		return FALSE
 
 	var/obj/item/mecha_equipment/mounted_system/mining/kinetic_accelerator/owner_equipment = the_gun.loc
 	if(!istype(owner_equipment))
-		return
+		return FALSE
 
 	var/mob/living/heavy_vehicle/owner_exosuit = owner_equipment.loc
 	if(!istype(owner_exosuit))
-		return
+		return FALSE
 
 	var/obj/item/cell/external = owner_exosuit.get_cell()
 	if(istype(external) && external.use(charge_to_give * 5))
 		stored_charge += charge_to_give
+		return TRUE
 
 /obj/item/custom_ka_upgrade/cells/illegal
 	//Pump Action
@@ -219,7 +224,9 @@
 
 /obj/item/custom_ka_upgrade/cells/inertia_charging/on_update(var/obj/item/gun/custom_ka/the_gun)
 	stored_charge = min(stored_charge + round(stored_charge*0.2),cell_increase)
-
+	if (stored_charge == cell_increase)
+		return FALSE
+	else return TRUE
 
 /obj/item/custom_ka_upgrade/cells/loader
 	name = "phoron loading KA cell"

--- a/code/modules/custom_ka/core.dm
+++ b/code/modules/custom_ka/core.dm
@@ -114,7 +114,6 @@
 	return TRUE
 
 /obj/item/gun/custom_ka/Fire(atom/target, mob/living/user, clickparams, pointblank=0, reflex=0)
-
 	if(require_wield && !wielded)
 		to_chat(user,SPAN_WARNING("\The [src] is too heavy to fire with one hand!"))
 		return
@@ -122,6 +121,8 @@
 	if(!fire_checks(target,user,clickparams,pointblank,reflex))
 		return
 
+	// Queue the KA for processing in case it has a charging cell.
+	START_PROCESSING(SSprocessing, src)
 	//Custom fire checks
 	var/warning_message
 	var/disaster
@@ -281,12 +282,12 @@
 	return ..()
 
 /obj/item/gun/custom_ka/process()
-	if(installed_cell)
-		installed_cell.on_update(src)
-	if(installed_barrel)
-		installed_barrel.on_update(src)
-	if(installed_upgrade_chip)
-		installed_upgrade_chip.on_update(src)
+	if(!installed_cell || installed_cell.on_update(src))
+		return PROCESS_KILL
+	if(!installed_barrel || installed_barrel.on_update(src))
+		return PROCESS_KILL
+	if(!installed_upgrade_chip || installed_upgrade_chip.on_update(src))
+		return PROCESS_KILL
 
 /obj/item/gun/custom_ka/update_icon()
 	. = ..()
@@ -402,7 +403,7 @@
 /obj/item/gun/custom_ka/attackby(obj/item/attacking_item, mob/user)
 
 	. = ..()
-
+	START_PROCESSING(SSprocessing, src)
 	if(istype(attacking_item, /obj/item/pen))
 		custom_name = sanitize( tgui_input_text(user, "Enter a custom name for your [name]", "Set Name") )
 		to_chat(user,"You label \the [name] as \"[custom_name]\"")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -518,6 +518,9 @@
  */
 /mob/living/carbon/proc/add_chemical_effect(var/effect, var/magnitude = 1)
 	SHOULD_NOT_SLEEP(TRUE)
+	for (var/obj/item/organ/internal/internal_organ in internal_organs)
+		if (effect == internal_organ.toxin_type)
+			START_PROCESSING(SSprocessing, internal_organ)
 
 	if(effect in chem_effects)
 		chem_effects[effect] += magnitude
@@ -534,6 +537,9 @@
  */
 /mob/living/carbon/proc/add_up_to_chemical_effect(var/effect, var/magnitude = 1)
 	SHOULD_NOT_SLEEP(TRUE)
+	for (var/obj/item/organ/internal/internal_organ in internal_organs)
+		if (effect == internal_organ.toxin_type)
+			START_PROCESSING(SSprocessing, internal_organ)
 
 	if(effect in chem_effects)
 		chem_effects[effect] = max(magnitude, chem_effects[effect])

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -15,6 +15,10 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 	GLOB.living_mob_list -= src
 	GLOB.dead_mob_list -= src
 	GLOB.human_mob_list -= src
+	for (var/datum/datum in contents)
+		// Nope, literally nothing inside a mannequin needs to process.
+		STOP_PROCESSING(SSprocessing, src)
+
 	delete_inventory()
 
 /mob/living/carbon/human/dummy/mannequin/Destroy()

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -151,21 +151,13 @@
 			. = "necrotic and dead [.]"
 	. = "[.][name]"
 
-/obj/item/organ/internal/process(seconds_per_tick)
-	..()
-	if(!owner)
-		return
-
-	if(owner.stasis_value > 0)
-		// Putting a body in stasis will simultaneously slow down the rate at which organs die
-		// while also slowing down the rate at which they are healed.
-		seconds_per_tick /= owner.stasis_value
-
-	if(toxin_type in owner.chem_effects)
+/obj/item/organ/internal/need_process(seconds_per_tick)
+	. = ..()
+	if (toxin_type in owner.chem_effects)
 		take_damage(owner.chem_effects[toxin_type] * seconds_per_tick)
-
-	handle_regeneration(seconds_per_tick)
-	tick_surge_damage(seconds_per_tick) //Yes, this is intentional.
+		. = TRUE
+	if (handle_regeneration(seconds_per_tick))
+		return TRUE
 
 /obj/item/organ/internal/proc/handle_regeneration(seconds_per_tick)
 	SHOULD_CALL_PARENT(TRUE)
@@ -175,4 +167,4 @@
 	var/repair_modifier = owner.chem_effects[CE_ORGANREPAIR] || organ_self_heal_per_second
 	if(damage < repair_modifier*max_damage)
 		heal_damage(repair_modifier * seconds_per_tick)
-	return TRUE // regeneration is allowed
+	return damage // True if there's any damage left to heal on the next tick

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -169,8 +169,9 @@
 	damage_threshold_value = round(max_damage / damage_threshold_count)
 
 /obj/item/organ/internal/brain/process(seconds_per_tick)
+	. = ..()
 	if(!owner)
-		return ..()
+		return
 
 	if(damage > (max_damage * 0.75) && healed_threshold)
 		handle_severe_brain_damage()
@@ -182,7 +183,7 @@
 
 	// Brain damage from low oxygenation or lack of blood.
 	if(!owner.should_have_organ(BP_HEART))
-		return ..()
+		return
 
 	// Adjust the rate of brain healing and damage over time if the owner is in stasis.
 	if(owner.stasis_value > 0)
@@ -236,7 +237,12 @@
 			owner.eye_blurry = max(owner.eye_blurry,6)
 			dammod = owner.chem_effects[CE_STABLE] ? dying_stabilized_mod : dying_unstable_mod
 			take_internal_damage(brain_damage_amount * dammod * dying_damage_modifier)
-	..()
+
+/// Brain, Heart, and Lungs should always process if they have a living owner.
+/obj/item/organ/internal/brain/need_process(seconds_per_tick)
+	. = ..()
+	if(owner && owner.stat != DEAD || !(status & ORGAN_DEAD))
+		return TRUE
 
 /obj/item/organ/internal/brain/proc/handle_severe_brain_damage()
 	set waitfor = FALSE

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -13,6 +13,15 @@
 	var/list/eye_colour = list(0,0,0)
 	var/singular_name = "eye"
 
+/obj/item/organ/internal/eyes/replaced(mob/living/carbon/human/target)
+	// Apply our eye colour to the target.
+	if(istype(target) && eye_colour)
+		target.r_eyes = eye_colour[1]
+		target.g_eyes = eye_colour[2]
+		target.b_eyes = eye_colour[3]
+		target.update_eyes()
+	..()
+
 /obj/item/organ/internal/eyes/proc/update_colour()
 	if(!owner)
 		return
@@ -72,14 +81,18 @@
 
 	return TRUE
 
-/obj/item/organ/internal/eyes/process() //Eye damage replaces the old eye_stat var.
-	..()
-	if(!owner)
+/obj/item/organ/internal/eyes/need_process(seconds_per_tick)
+	. = ..()
+	if (!owner || owner.stat == DEAD)
 		return
-	if(is_bruised())
-		owner.eye_blurry = 20
-	if(is_broken())
+
+	if (is_broken())
 		owner.eye_blind = 20
+		return TRUE
+
+	if (is_bruised())
+		owner.eye_blurry = 20
+		return TRUE
 
 /obj/item/organ/internal/eyes/do_surge_effects()
 	if(owner)

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -118,8 +118,9 @@
 	var/blood_spray_distance = 2
 
 /obj/item/organ/internal/heart/process(seconds_per_tick)
+	. = ..()
 	if(!owner)
-		return ..()
+		return
 	if(owner.stasis_value > 0) // Decrease the effective tickrate when in stasis.
 		seconds_per_tick /= owner.stasis_value
 	handle_pulse()
@@ -130,7 +131,12 @@
 			take_internal_damage(heart_fibrillation_damage * seconds_per_tick)
 		handle_heartbeat()
 	handle_blood()
-	..()
+
+/// Brain, Heart, and Lungs should always process if they have a living owner.
+/obj/item/organ/internal/heart/need_process(seconds_per_tick)
+	. = ..()
+	if(owner && owner.stat != DEAD || !(status & ORGAN_DEAD))
+		return TRUE
 
 /obj/item/organ/internal/heart/proc/handle_pulse()
 	if(owner.stat == DEAD || (species && species.flags & NO_BLOOD) || BP_IS_ROBOTIC(src)) //No heart, no pulse, buddy. Or if the heart is robotic. Or you're dead.

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -70,8 +70,7 @@
 	var/liver_regeneration_broken = 0
 
 /obj/item/organ/internal/liver/process(seconds_per_tick)
-
-	..()
+	. = ..()
 
 	if(!owner)
 		return
@@ -120,6 +119,17 @@
 	if(toxin_type in owner.chem_effects)
 		// Hepatoxic(liver damaging) chems start dealing lethal damage to the patient once the liver is broken.
 		owner.adjustToxLoss(max(0, (owner.chem_effects[toxin_type] - filter_strength)) * seconds_per_tick) // as actual organ damage is handled elsewhere
+
+/obj/item/organ/internal/liver/need_process(seconds_per_tick)
+	. = ..()
+	if (!owner || owner.stat == DEAD)
+		return
+	if (germ_level)
+		return TRUE
+	if (owner.intoxication)
+		return TRUE
+	if (damage && (toxin_type in owner.chem_effects))
+		return TRUE
 
 /// Liver damage + alcohol = bad time.
 /obj/item/organ/internal/liver/proc/handle_alcohol_poisoning(var/filter_effect, var/filter_strength, var/seconds_per_tick)

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -43,7 +43,7 @@
 	return round((oxygen_deprivation/species.total_health)*100)
 
 /obj/item/organ/internal/lungs/process()
-	..()
+	. = ..()
 
 	if(!owner || owner.stat == DEAD)
 		return
@@ -79,6 +79,12 @@
 				to_chat(owner, SPAN_WARNING("It feels hard to breathe, and something in your chest is whistling..."))
 				if (owner.losebreath < 2)
 					owner.losebreath = min(owner.losebreath + 1, 2)
+
+/// Brain, Heart, and Lungs should always process if they have a living owner.
+/obj/item/organ/internal/lungs/need_process(seconds_per_tick)
+	. = ..()
+	if(owner && owner.stat != DEAD || !(status & ORGAN_DEAD))
+		return TRUE
 
 /obj/item/organ/internal/lungs/proc/rupture()
 	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -50,8 +50,12 @@
 		owner.vomit(deliberate = TRUE)
 		refresh_action_button()
 
-/obj/item/organ/internal/stomach/proc/can_eat_atom(var/atom/movable/food)
-	return !isnull(get_devour_time(food))
+/obj/item/organ/internal/stomach/proc/can_eat_atom(atom/movable/food)
+	if (!get_devour_time(food))
+		return FALSE
+
+	START_PROCESSING(SSprocessing, src)
+	return TRUE
 
 /obj/item/organ/internal/stomach/proc/is_full(var/atom/movable/food)
 	var/total = FLOOR(ingested.total_volume / 10, 1)
@@ -100,7 +104,7 @@
 		ingested.metabolize()
 
 /obj/item/organ/internal/stomach/process()
-	..()
+	. = ..()
 	if(!owner)
 		return
 
@@ -135,6 +139,14 @@
 		var/vomit_probability = (effective_volume / stomach_volume) ** 6
 		if(prob(vomit_probability))
 			owner.vomit()
+
+/obj/item/organ/internal/stomach/need_process(seconds_per_tick)
+	. = ..()
+	if (!owner || owner.stat == DEAD)
+		return
+
+	if (!is_usable() || length(contents) || should_process_alcohol && REAGENT_VOLUME(ingested, /singleton/reagent/alcohol))
+		return TRUE
 
 /obj/item/organ/internal/stomach/proc/digest_mob(mob/M)
 	if(!QDELETED(M))

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -162,15 +162,13 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 /obj/item/organ/process(seconds_per_tick)
 	if(loc != owner)
 		owner = null
+	if(owner.stasis_value > 0)
+		// Putting a body in stasis will simultaneously slow down the rate at which organs die
+		// while also slowing down the rate at which they are healed.
+		seconds_per_tick /= owner.stasis_value
 
-	if (QDELETED(src))
-		LOG_DEBUG("QDELETED organ [DEBUG_REF(src)] had process() called!")
-		STOP_PROCESSING(SSprocessing, src)
-		return
-
-	//dead already, no need for more processing
-	if(status & ORGAN_DEAD)
-		return
+	if (!need_process(seconds_per_tick))
+		return PROCESS_KILL
 	// Don't process if we're in a freezer, an MMI or a stasis bag.or a freezer or something I dunno
 	if(istype(loc,/obj/item/mmi))
 		return
@@ -181,8 +179,6 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	if (is_immune)
 		germ_level = 0
 
-	if((BP_IS_ROBOTIC(src) || robotic >= ROBOTIC_MECHANICAL) && surge_damage)
-		tick_surge_damage(seconds_per_tick)
 
 	if(!owner)
 		if (QDELETED(reagents))
@@ -216,6 +212,31 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	if(damage >= max_damage)
 		die()
 
+/**
+ * Returns TRUE if there's any condition for which the organ should continue processing.
+ * And return TRUE for the first valid condition to state that they must process.
+ * Children should only be trying to return true if they have a valid condition to continue processing.
+ */
+/obj/item/organ/proc/need_process(seconds_per_tick)
+	SHOULD_CALL_PARENT(TRUE)
+	ENFORCE_CALCULUS(seconds_per_tick)
+	if (QDELETED(src))
+		LOG_DEBUG("QDELETED organ [DEBUG_REF(src)] had process() called!")
+		STOP_PROCESSING(SSprocessing, src)
+		return FALSE
+
+	//dead already, no need for more processing
+	if(status & ORGAN_DEAD)
+		return FALSE
+
+	if (surge_damage && (BP_IS_ROBOTIC(src) || robotic >= ROBOTIC_MECHANICAL || (status & ORGAN_ASSISTED)))
+		return tick_surge_damage(seconds_per_tick)
+
+	if (rejecting)
+		return TRUE
+
+	if (damage)
+		return TRUE
 /**
  * Handles per-second EMP damage effects.
  * returns FALSE if there's no EMP effects left.
@@ -294,6 +315,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 
 /obj/item/organ/proc/rejuvenate()
 	damage = 0
+	START_PROCESSING(SSprocessing, src)
 
 /obj/item/organ/proc/heal_damage(amount)
 	if(can_recover())
@@ -385,6 +407,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 
 //Note: external organs have their own version of this proc
 /obj/item/organ/proc/take_damage(var/amount, var/silent = 0)
+	START_PROCESSING(SSprocessing, src)
 	if(src.status & ORGAN_ROBOT)
 		src.damage = between(0, src.damage + (amount * 0.8), max_damage)
 	else
@@ -505,15 +528,6 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 		set_dna(owner.dna)
 	return TRUE
 
-/obj/item/organ/internal/eyes/replaced(var/mob/living/carbon/human/target)
-
-	// Apply our eye colour to the target.
-	if(istype(target) && eye_colour)
-		target.r_eyes = eye_colour[1]
-		target.g_eyes = eye_colour[2]
-		target.b_eyes = eye_colour[3]
-		target.update_eyes()
-	..()
 
 /obj/item/organ/attack(mob/living/target_mob, mob/living/user, target_zone)
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -779,9 +779,8 @@ This function completely restores a damaged organ to perfect condition.
 	return FALSE
 
 //Determines if we even need to process this organ.
-/obj/item/organ/external/proc/need_process()
-	if(BP_IS_ROBOTIC(src))
-		return surge_damage
+/obj/item/organ/external/need_process()
+	. = ..()
 	if(get_pain() || status & (ORGAN_CUT_AWAY|ORGAN_BLEEDING|ORGAN_BROKEN|ORGAN_DESTROYED|ORGAN_SPLINTED|ORGAN_DEAD|ORGAN_MUTATED|ORGAN_ARTERY_CUT) || brute_dam || burn_dam)
 		return TRUE
 	if(last_dam != brute_dam + burn_dam) // Process when we are fully healed up.
@@ -789,13 +788,11 @@ This function completely restores a damaged organ to perfect condition.
 		return TRUE
 	else
 		last_dam = brute_dam + burn_dam
-	return germ_level
+	if (germ_level)
+		return TRUE
 
 /obj/item/organ/external/process(seconds_per_tick)
 	. = ..()
-	if (!need_process())
-		return PROCESS_KILL
-
 	if(!owner)
 		return
 
@@ -813,8 +810,6 @@ This function completely restores a damaged organ to perfect condition.
 	if(!(status & ORGAN_BROKEN))
 		perma_injury = 0
 
-	if(surge_damage && (status & ORGAN_ASSISTED))
-		tick_surge_damage(seconds_per_tick) //Yes, this being here is intentional since this proc does not call ..() unless the owner is null.
 
 	//Infections
 	update_germs()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -207,7 +207,7 @@ ABSTRACT_TYPE(/singleton/reagent/alcohol)
 			M.adjustToxLoss(3 * removed * (strength / 100))
 
 		if (has_valid_aug | alien != IS_UNATHI)
-			for (var/organ as anything in M.internal_organs)
+			for (var/datum/organ as anything in M.internal_organs)
 				if (istype(organ, /obj/item/organ/internal/stomach) || istype(organ, /obj/item/organ/internal/liver))
 					START_PROCESSING(SSprocessing, organ)
 			M.intoxication += (strength / 100) * removed * 6
@@ -284,7 +284,7 @@ ABSTRACT_TYPE(/singleton/reagent/alcohol)
 
 /singleton/reagent/alcohol/butanol/affect_ingest(var/mob/living/carbon/human/M, var/alien, var/removed, var/datum/reagents/holder)
 	if (alien == IS_UNATHI)
-		for (var/organ as anything in M.internal_organs)
+		for (var/datum/organ as anything in M.internal_organs)
 			if (istype(organ, /obj/item/organ/internal/stomach) || istype(organ, /obj/item/organ/internal/liver))
 				START_PROCESSING(SSprocessing, organ)
 		M.intoxication += (strength / 100) * removed * 6

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -207,6 +207,9 @@ ABSTRACT_TYPE(/singleton/reagent/alcohol)
 			M.adjustToxLoss(3 * removed * (strength / 100))
 
 		if (has_valid_aug | alien != IS_UNATHI)
+			for (var/organ as anything in M.internal_organs)
+				if (istype(organ, /obj/item/organ/internal/stomach) || istype(organ, /obj/item/organ/internal/liver))
+					START_PROCESSING(SSprocessing, organ)
 			M.intoxication += (strength / 100) * removed * 6
 			if (druggy != 0)
 				M.druggy = max(M.druggy, druggy)
@@ -281,6 +284,9 @@ ABSTRACT_TYPE(/singleton/reagent/alcohol)
 
 /singleton/reagent/alcohol/butanol/affect_ingest(var/mob/living/carbon/human/M, var/alien, var/removed, var/datum/reagents/holder)
 	if (alien == IS_UNATHI)
+		for (var/organ as anything in M.internal_organs)
+			if (istype(organ, /obj/item/organ/internal/stomach) || istype(organ, /obj/item/organ/internal/liver))
+				START_PROCESSING(SSprocessing, organ)
 		M.intoxication += (strength / 100) * removed * 6
 		if (druggy != 0)
 			M.druggy = max(M.druggy, druggy)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drink/food_drink_species_vaurca.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drink/food_drink_species_vaurca.dm
@@ -149,7 +149,7 @@
 	if(!istype(M))
 		return
 	if(alien == IS_VAURCA)
-		for (var/organ as anything in M.internal_organs)
+		for (var/datum/organ as anything in M.internal_organs)
 			if (istype(organ, /obj/item/organ/internal/stomach) || istype(organ, /obj/item/organ/internal/liver))
 				START_PROCESSING(SSprocessing, organ)
 		M.intoxication += (strength / 100) * removed * 6

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drink/food_drink_species_vaurca.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drink/food_drink_species_vaurca.dm
@@ -149,6 +149,9 @@
 	if(!istype(M))
 		return
 	if(alien == IS_VAURCA)
+		for (var/organ as anything in M.internal_organs)
+			if (istype(organ, /obj/item/organ/internal/stomach) || istype(organ, /obj/item/organ/internal/liver))
+				START_PROCESSING(SSprocessing, organ)
 		M.intoxication += (strength / 100) * removed * 6
 
 /singleton/reagent/drink/toothpaste/cold_gate

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drink/generic_ingredients.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drink/generic_ingredients.dm
@@ -69,6 +69,9 @@
 
 /singleton/reagent/nutriment/coating/beerbatter/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	..()
+	for (var/organ as anything in M.internal_organs)
+		if (istype(organ, /obj/item/organ/internal/stomach) || istype(organ, /obj/item/organ/internal/liver))
+			START_PROCESSING(SSprocessing, organ)
 	M.intoxication += removed*0.02 //Very slightly alcoholic
 
 //

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drink/generic_ingredients.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drink/generic_ingredients.dm
@@ -69,7 +69,7 @@
 
 /singleton/reagent/nutriment/coating/beerbatter/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	..()
-	for (var/organ as anything in M.internal_organs)
+	for (var/datum/organ as anything in M.internal_organs)
 		if (istype(organ, /obj/item/organ/internal/stomach) || istype(organ, /obj/item/organ/internal/liver))
 			START_PROCESSING(SSprocessing, organ)
 	M.intoxication += removed*0.02 //Very slightly alcoholic

--- a/html/changelogs/hellfirejag-organ-process-trimming.yml
+++ b/html/changelogs/hellfirejag-organ-process-trimming.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - rscadd: "Made nearly all organs no longer require always-processing."

--- a/html/changelogs/hellfirejag-organ-process-trimming.yml
+++ b/html/changelogs/hellfirejag-organ-process-trimming.yml
@@ -2,3 +2,4 @@ author: Hellfirejag
 delete-after: True
 changes:
   - rscadd: "Made nearly all organs no longer require always-processing."
+  - rscadd: "Made kinetic accelerators no longer require always-processing."


### PR DESCRIPTION
This PR even further kills the organ processing list, this time by making the need_process() call generic at the level of all organs. 
There is a special cutout for the Heart/Lungs/Brain to always process if their owner is alive, as they're co-dependent on each other to always process. This PR definitely isn't exhaustive, and doing something like this is bound to create lots of exciting new bugs that I could not catch in testing.

Please do not merge this PR without testmerging it first.