### PR TITLE
Fixes C4, dirty bombs and nuclear waste

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -52,16 +52,17 @@
 	light_color = LIGHT_COLOR_GREEN
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "greenglow"
+	var/longevity = 2 MINUTES
 
 /obj/effect/decal/cleanable/greenglow/Initialize(mapload)
 	. = ..()
 	if (!mapload)	// Round-start goo should stick around.
-		QDEL_IN(src, 2 MINUTES)
+		QDEL_IN(src, longevity)
 
 /obj/effect/decal/cleanable/greenglow/post_sweep(var/mob/user)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		H.apply_radiation(3)
+		H.rad_act(30)
 	STOP_PROCESSING(SSprocessing, src)
 
 ABSTRACT_TYPE(/obj/effect/decal/cleanable/greenglow/radioactive)
@@ -70,6 +71,13 @@ ABSTRACT_TYPE(/obj/effect/decal/cleanable/greenglow/radioactive)
 	light_range = 2
 	light_power = 0.6
 	light_color = "#64C864"
+
+/obj/effect/decal/cleanable/greenglow/radioactive/post_sweep(var/mob/user)
+	if(radioactivity)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			H.rad_act(radioactivity)
+	STOP_PROCESSING(SSprocessing, src)
 
 /obj/effect/decal/cleanable/greenglow/radioactive/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
@@ -85,6 +93,7 @@ ABSTRACT_TYPE(/obj/effect/decal/cleanable/greenglow/radioactive)
 
 /obj/effect/decal/cleanable/greenglow/radioactive/medium
 	radioactivity = RAD_LEVEL_MODERATE
+	longevity = 5 MINUTES
 
 /obj/effect/decal/cleanable/greenglow/radioactive/medium/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
@@ -93,6 +102,7 @@ ABSTRACT_TYPE(/obj/effect/decal/cleanable/greenglow/radioactive)
 
 /obj/effect/decal/cleanable/greenglow/radioactive/high
 	radioactivity = RAD_LEVEL_HIGH
+	longevity = 10 MINUTES
 
 /obj/effect/decal/cleanable/greenglow/radioactive/high/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
@@ -101,6 +111,7 @@ ABSTRACT_TYPE(/obj/effect/decal/cleanable/greenglow/radioactive)
 
 /obj/effect/decal/cleanable/greenglow/radioactive/very_high
 	radioactivity = RAD_LEVEL_VERY_HIGH
+	longevity = 15 MINUTES
 
 /obj/effect/decal/cleanable/greenglow/radioactive/very_high/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
@@ -110,6 +121,7 @@ ABSTRACT_TYPE(/obj/effect/decal/cleanable/greenglow/radioactive)
 /obj/effect/decal/cleanable/greenglow/radioactive/extreme
 	/// This is higher than radsuits can absorb! Use with caution.
 	radioactivity = RAD_LEVEL_CATASTROPHIC
+	longevity = 20 MINUTES
 
 /obj/effect/decal/cleanable/greenglow/radioactive/extreme/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
@@ -122,7 +134,6 @@ ABSTRACT_TYPE(/obj/effect/decal/cleanable/greenglow/radioactive)
 
 /obj/effect/decal/cleanable/greenglow/radioactive/process()
 	SSradiation.radiate(src, radioactivity)
-
 
 /obj/effect/decal/cleanable/cobweb
 	name = "cobweb"

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -52,12 +52,9 @@
 	light_color = LIGHT_COLOR_GREEN
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "greenglow"
-	var/longevity = 2 MINUTES
 
 /obj/effect/decal/cleanable/greenglow/Initialize(mapload)
 	. = ..()
-	if (!mapload)	// Round-start goo should stick around.
-		QDEL_IN(src, longevity)
 
 /obj/effect/decal/cleanable/greenglow/post_sweep(var/mob/user)
 	if(ishuman(user))
@@ -93,7 +90,6 @@ ABSTRACT_TYPE(/obj/effect/decal/cleanable/greenglow/radioactive)
 
 /obj/effect/decal/cleanable/greenglow/radioactive/medium
 	radioactivity = RAD_LEVEL_MODERATE
-	longevity = 5 MINUTES
 
 /obj/effect/decal/cleanable/greenglow/radioactive/medium/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
@@ -102,7 +98,6 @@ ABSTRACT_TYPE(/obj/effect/decal/cleanable/greenglow/radioactive)
 
 /obj/effect/decal/cleanable/greenglow/radioactive/high
 	radioactivity = RAD_LEVEL_HIGH
-	longevity = 10 MINUTES
 
 /obj/effect/decal/cleanable/greenglow/radioactive/high/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
@@ -111,7 +106,6 @@ ABSTRACT_TYPE(/obj/effect/decal/cleanable/greenglow/radioactive)
 
 /obj/effect/decal/cleanable/greenglow/radioactive/very_high
 	radioactivity = RAD_LEVEL_VERY_HIGH
-	longevity = 15 MINUTES
 
 /obj/effect/decal/cleanable/greenglow/radioactive/very_high/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
@@ -121,7 +115,6 @@ ABSTRACT_TYPE(/obj/effect/decal/cleanable/greenglow/radioactive)
 /obj/effect/decal/cleanable/greenglow/radioactive/extreme
 	/// This is higher than radsuits can absorb! Use with caution.
 	radioactivity = RAD_LEVEL_CATASTROPHIC
-	longevity = 20 MINUTES
 
 /obj/effect/decal/cleanable/greenglow/radioactive/extreme/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()

--- a/code/game/objects/effects/plastic_explosive.dm
+++ b/code/game/objects/effects/plastic_explosive.dm
@@ -7,6 +7,7 @@
 	anchored = TRUE
 	density = FALSE
 	mouse_opacity = MOUSE_OPACITY_ICON
+	layer = ABOVE_DOOR_LAYER
 	var/obj/item/plastique/parent
 
 /obj/effect/plastic_explosive/feedback_hints(mob/user, distance, is_adjacent)

--- a/code/game/objects/effects/plastic_explosive.dm
+++ b/code/game/objects/effects/plastic_explosive.dm
@@ -9,6 +9,7 @@
 	mouse_opacity = MOUSE_OPACITY_ICON
 	var/obj/item/plastique/parent
 
+
 /obj/effect/plastic_explosive/feedback_hints(mob/user, distance, is_adjacent)
 	. += ..()
 	if(is_adjacent)
@@ -16,8 +17,8 @@
 
 /obj/effect/plastic_explosive/Initialize(var/atom/owner_pos, var/atom/target, var/obj/item/plastique/c4)
 	. = ..()
+	parent = c4
 	if(parent)
-		parent = c4
 		parent.forceMove(src)
 		name = parent.name
 		desc = parent.desc
@@ -46,8 +47,8 @@
 /obj/effect/plastic_explosive/attack_hand(mob/living/user)
 	to_chat(user, SPAN_WARNING("\The [src] is solidly attached, it doesn't budge!"))
 
-/obj/effect/plastic_explosive/attackby(obj/item/attacking_item, mob/user)
-	return parent.attackby(attacking_item, user)
+/obj/effect/plastic_explosive/attackby(obj/item/attacking_item, mob/user, click_parameters)
+	return parent.attackby(attacking_item, user, click_parameters)
 
 /obj/effect/plastic_explosive/big
 	name = "bundled plastic explosives"

--- a/code/game/objects/effects/plastic_explosive.dm
+++ b/code/game/objects/effects/plastic_explosive.dm
@@ -9,7 +9,6 @@
 	mouse_opacity = MOUSE_OPACITY_ICON
 	var/obj/item/plastique/parent
 
-
 /obj/effect/plastic_explosive/feedback_hints(mob/user, distance, is_adjacent)
 	. += ..()
 	if(is_adjacent)

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -109,7 +109,7 @@
 
 	log_and_message_admins("planted [src.name] on [target.name] with [timetext] fuse", user, get_turf(target))
 
-	var/obj/effect/plastic_explosive/effect = new plastic_explosive_type(get_turf(user), target, src)
+	new plastic_explosive_type(get_turf(user), target, src)
 	to_chat(user, SPAN_WARNING("Bomb has been planted. Timer counting down from [timetext]."))
 
 	detonate_time = world.time + (timer)

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -48,7 +48,6 @@
 /obj/item/plastique/Destroy()
 	qdel(wires)
 	wires = null
-	qdel(target)
 	target = null
 	return ..()
 
@@ -110,7 +109,7 @@
 
 	log_and_message_admins("planted [src.name] on [target.name] with [timetext] fuse", user, get_turf(target))
 
-	new plastic_explosive_type(get_turf(user), target, src)
+	var/obj/effect/plastic_explosive/effect = new plastic_explosive_type(get_turf(user), target, src)
 	to_chat(user, SPAN_WARNING("Bomb has been planted. Timer counting down from [timetext]."))
 
 	detonate_time = world.time + (timer)
@@ -195,11 +194,40 @@
 	desc = "A small explosive laced with radium. The explosion is small, but the radioactive material will remain for a fair while."
 	timer = 30 SECONDS
 
-/obj/item/plastique/dirty/explode(turf/location)
+/obj/item/plastique/dirty/explode(turf/location) //Does not call parent because we need a different order of operations.
+	if(!target)
+		target = get_atom_on_turf(src)
+	if(!target)
+		target = src
+	if(target)
+		if (istype(target, /turf/simulated/wall))
+			var/turf/simulated/wall/W = target
+			W.dismantle_wall(1, no_product = TRUE)
+		else if(istype(target, /mob/living))
+			target.ex_act(2) // c4 can't gib mobs anymore.
+			target.rad_act(800) //A dirty bomb going off on top of you completely irradiates you, radsuit or not.
+		else
+			target.ex_act(1)
+
 	if(location)
-		SSradiation.radiate(src, 250)
-		new /obj/effect/decal/cleanable/greenglow/radioactive/medium(get_turf(src))
-	..()
+		explosion(location, devastation_range, heavy_impact_range, light_impact_range, 3, spreading = 0)
+		SSradiation.radiate(location, 250)
+		new /obj/effect/decal/cleanable/greenglow/radioactive/extreme(location)
+
+		for(var/turf/T in RANGE_TURFS(4, location))
+			if(T == location)
+				continue
+
+			if(T in RANGE_TURFS(1, location)) //High radioactive puddles 1 tile from the epicenter, medium up to 4 tiles away.
+				if(prob(75))
+					new /obj/effect/decal/cleanable/greenglow/radioactive/high(T)
+			else if(prob(25))
+				new /obj/effect/decal/cleanable/greenglow/radioactive/medium(T)
+
+	var/obj/effect/plastic_explosive/effect = locate(/obj/effect/plastic_explosive) in get_turf(src)
+	if(effect)
+		qdel(effect)
+	qdel(src)
 
 /obj/item/plastique/strong
 	name = "bundled plastic explosives"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -161,7 +161,7 @@
 	affect_ingest(M, alien, removed, holder)
 
 /singleton/reagent/uranium/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	M.apply_damage(5 * removed, DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED)
+	M.apply_damage(5 * removed, DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED, armor_pen = 100) //Radiation in the blood shouldn't check your radsuit.
 
 /singleton/reagent/uranium/touch_turf(var/turf/T, var/amount, var/datum/reagents/holder)
 	if(amount >= 3)
@@ -186,7 +186,7 @@
 
 /singleton/reagent/radioactive_waste/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	var/rad_damage = min(75, 40 * removed)
-	M.apply_effect(rad_damage, DAMAGE_RADIATION, blocked = 0)
+	M.apply_damage(rad_damage, DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED, armor_pen = 100)
 
 /singleton/reagent/radioactive_waste/touch_turf(var/turf/T, var/amount, var/datum/reagents/holder)
 	if(amount >= 3)

--- a/html/changelogs/Fenodyree-FixesC4AndDirtyBombs.yml
+++ b/html/changelogs/Fenodyree-FixesC4AndDirtyBombs.yml
@@ -1,0 +1,7 @@
+author: Fenodyree
+delete-after: True
+changes:
+  - bugfix: "Fixes C4 effects not correctly getting their parent item."
+  - bugfix: "Fixes C4 not being placed correctly."
+  - bugfix: "Fixes Dirty Bombs deleting their own radiation source."
+  - bugfix: "Fixes Dirty Bomb goop puddles disapearing long before the radiation does."

--- a/html/changelogs/Fenodyree-FixesC4AndDirtyBombs.yml
+++ b/html/changelogs/Fenodyree-FixesC4AndDirtyBombs.yml
@@ -5,4 +5,4 @@ changes:
   - bugfix: "Fixes C4 not being placed correctly."
   - bugfix: "Fixes Dirty Bombs deleting their own radiation source."
   - bugfix: "Fixes Dirty Bomb goop puddles disapearing long before the radiation does."
-  - bugfix: "Fixes drinking radioactive waste not irradiatin you."
+  - bugfix: "Fixes drinking radioactive waste not irradiating you."

--- a/html/changelogs/Fenodyree-FixesC4AndDirtyBombs.yml
+++ b/html/changelogs/Fenodyree-FixesC4AndDirtyBombs.yml
@@ -5,3 +5,4 @@ changes:
   - bugfix: "Fixes C4 not being placed correctly."
   - bugfix: "Fixes Dirty Bombs deleting their own radiation source."
   - bugfix: "Fixes Dirty Bomb goop puddles disapearing long before the radiation does."
+  - bugfix: "Fixes drinking radioactive waste not irradiatin you."


### PR DESCRIPTION
changes:
  - bugfix: "Fixes C4 effects not correctly getting their parent item."
  - bugfix: "Fixes C4 not being placed correctly."
  - bugfix: "Fixes Dirty Bombs deleting their own radiation source."
  - bugfix: "Fixes Dirty Bomb goop puddles disapearing long before the radiation does."
  - bugfix: "Fixes drinking radioactive waste not irradiating you."

3 dirty bombs set off. One on a floor, one on a wall one on a machine.
<img width="1191" height="1182" alt="image" src="https://github.com/user-attachments/assets/584e7572-441c-4937-8e0e-7203010fcd54" />