### PR TITLE
Adds listener filtering for the journalist's microphone.

### DIFF
--- a/code/game/objects/items/devices/radio/microphone.dm
+++ b/code/game/objects/items/devices/radio/microphone.dm
@@ -57,17 +57,17 @@
 
 	if(get_dist(target, get_turf(src)) < MICROPHONE_LISTEN_RANGE)
 		if(!(target in listeners))
-			to_chat(user, SPAN_NOTICE("You angle the microphone to allow [target_mob] to speak into it."))
+			to_chat(user, SPAN_NOTICE("You angle the microphone to allow [target] to speak into it."))
 			add_listener(target)
 		else
-			to_chat(user, SPAN_NOTICE("You angle the microphone away from [target_mob]."))
+			to_chat(user, SPAN_NOTICE("You angle the microphone away from [target]."))
 			remove_listener(target)
 
 /**
  * Add a mob to the list of listeners allowed to speak into the microphone.
  */
 /obj/item/radio/microphone/proc/add_listener(mob/living/target_mob)
-	LAZYADD(listeners, target_mob)
+	LAZYDISTINCTADD(listeners, target_mob)
 	RegisterSignal(target_mob, COMSIG_MOVABLE_MOVED, PROC_REF(check_listener_distance))
 
 /**

--- a/code/game/objects/items/devices/radio/microphone.dm
+++ b/code/game/objects/items/devices/radio/microphone.dm
@@ -89,8 +89,8 @@
 			to_chat(M, SPAN_NOTICE("[source] moves away from the microphone."))
 
 /obj/item/radio/microphone/hear_talk(mob/M, msg, var/verb = "says", datum/language/speaking)
-    var/message_ending = copytext(msg, length(msg) - 1, length(msg)) //copies the last 2 letters
-    if(directed_listening && ((M in listeners) || (message_ending in word_bypasses)))
-        return ..()
+	var/message_ending = copytext(msg, length(msg) - 1, length(msg)) //copies the last 2 letters
+	if(directed_listening && ((M in listeners) || (message_ending in word_bypasses)))
+		return ..()
 
 #undef MICROPHONE_LISTEN_RANGE

--- a/code/game/objects/items/devices/radio/microphone.dm
+++ b/code/game/objects/items/devices/radio/microphone.dm
@@ -61,7 +61,7 @@
  */
 /obj/item/radio/microphone/proc/add_listener(mob/living/target_mob)
 	LAZYADD(listeners, target_mob)
-	RegisterSignal(target_mob, COMSIG_MOVABLE_MOVED, check_listener_distance())
+	RegisterSignal(target_mob, COMSIG_MOVABLE_MOVED, PROC_REF(check_listener_distance))
 
 /**
  * Remove a mob from the list of listeners allowed to speak into the microphone.

--- a/code/game/objects/items/devices/radio/microphone.dm
+++ b/code/game/objects/items/devices/radio/microphone.dm
@@ -5,6 +5,7 @@
 	icon_state = "microphone"
 	item_state = "microphone"
 	canhear_range = MICROPHONE_LISTEN_RANGE
+	item_flags = ITEM_FLAG_NO_BLUDGEON
 	/// If we have specific people we want to be able to speak into the microphone.
 	var/directed_listening = TRUE
 	/// A lazylist of the people allowed to talk into the microphone. Essentially acts as a filter.
@@ -21,7 +22,7 @@
 	LAZYNULL(listeners)
 	return ..()
 
-/obj/item/radio/microphone/attack_hand(mob/user)
+/obj/item/radio/microphone/AltClick(mob/user)
 	. = ..()
 	directed_listening = !directed_listening
 	to_chat(user, SPAN_NOTICE("You are now [directed_listening ? "" : "no longer "]listening to specific people."))
@@ -29,12 +30,15 @@
 /obj/item/radio/microphone/get_examine_text(mob/user, distance, is_adjacent, infix, suffix, get_extended)
 	. = ..()
 	. += SPAN_NOTICE("You are [directed_listening ? "" : SPAN_BOLD("not ")]listening to specific people with the microphone.")
-	if(LAZYLEN(listeners))
-		. += SPAN_NOTICE("You are angling the microphone specifically towards the following people: [SPAN_BOLD(english_list(listeners))].")
+	if(directed_listening)
+		if(LAZYLEN(listeners))
+			. += SPAN_NOTICE("You are angling the microphone specifically towards the following people: [SPAN_BOLD(english_list(listeners))].")
+		else
+			. += SPAN_NOTICE("You are not angling the microphone towards anyone.")
 
 /obj/item/radio/microphone/mechanics_hints(mob/user, distance, is_adjacent)
 	. = ..()
-	. += "By default, your microphone will not allow anyone other than you to speak into it."
+	. += "By default, your microphone will not allow anyone other than you to speak into it. [SPAN_BOLD("Alt-Click")] to disable this functionality."
 	. += "You can [SPAN_BOLD("click")] someone with the microphone in hand to allow them to speak into it. [SPAN_BOLD("Click")] them again to disallow them again."
 	. += "If someone moves more than 5 tiles away from your microphone, they will automatically be removed from the list."
 
@@ -46,15 +50,18 @@
 	. = ..()
 	remove_listener(user)
 
-/obj/item/radio/microphone/attack(mob/living/target_mob, mob/living/user, target_zone)
+/obj/item/radio/microphone/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
-	if(get_dist(target_mob, get_turf(src)) < MICROPHONE_LISTEN_RANGE)
-		if(!(target_mob in listeners))
+	if(!isliving(target))
+		return
+
+	if(get_dist(target, get_turf(src)) < MICROPHONE_LISTEN_RANGE)
+		if(!(target in listeners))
 			to_chat(user, SPAN_NOTICE("You angle the microphone to allow [target_mob] to speak into it."))
-			add_listener(target_mob)
+			add_listener(target)
 		else
 			to_chat(user, SPAN_NOTICE("You angle the microphone away from [target_mob]."))
-			remove_listener(target_mob)
+			remove_listener(target)
 
 /**
  * Add a mob to the list of listeners allowed to speak into the microphone.

--- a/code/game/objects/items/devices/radio/microphone.dm
+++ b/code/game/objects/items/devices/radio/microphone.dm
@@ -1,10 +1,89 @@
+#define MICROPHONE_LISTEN_RANGE 5
 /obj/item/radio/microphone
 	name = "handheld microphone"
 	desc = "A handheld microphone, used for on-the-fly interviewing. Pose for the fans!"
 	icon_state = "microphone"
 	item_state = "microphone"
+	canhear_range = MICROPHONE_LISTEN_RANGE
+	/// If we have specific people we want to be able to speak into the microphone.
+	var/directed_listening = TRUE
+	/// A lazylist of the people allowed to talk into the microphone. Essentially acts as a filter.
+	var/list/mob/living/listeners
+	/// If the messages end with these endings, bypass the listener check.
+	var/static/list/word_bypasses = list("!", "!!", "?!", "!?")
 
 /obj/item/radio/microphone/Initialize()
 	. = ..()
 	set_frequency(ENT_FREQ)
 	internal_channels = list(num2text(ENT_FREQ) = list())
+
+/obj/item/radio/microphone/Destroy()
+	LAZYNULL(listeners)
+	return ..()
+
+/obj/item/radio/microphone/attack_hand(mob/user)
+	. = ..()
+	directed_listening = !directed_listening
+	to_chat(user, SPAN_NOTICE("You are now [directed_listening ? "" : "no longer "]listening to specific people."))
+
+/obj/item/radio/microphone/get_examine_text(mob/user, distance, is_adjacent, infix, suffix, get_extended)
+	. = ..()
+	. += SPAN_NOTICE("You are [directed_listening ? "" : SPAN_BOLD("not ")]listening to specific people with the microphone.")
+	if(LAZYLEN(listeners))
+		. += SPAN_NOTICE("You are angling the microphone specifically towards the following people: [SPAN_BOLD(english_list(listeners))].")
+
+/obj/item/radio/microphone/mechanics_hints(mob/user, distance, is_adjacent)
+	. = ..()
+	. += "By default, your microphone will not allow anyone other than you to speak into it."
+	. += "You can [SPAN_BOLD("click")] someone with the microphone in hand to allow them to speak into it. [SPAN_BOLD("Click")] them again to disallow them again."
+	. += "If someone moves more than 5 tiles away from your microphone, they will automatically be removed from the list."
+
+/obj/item/radio/microphone/pickup(mob/user)
+	. = ..()
+	add_listener(user)
+
+/obj/item/radio/microphone/dropped(mob/user)
+	. = ..()
+	remove_listener(user)
+
+/obj/item/radio/microphone/attack(mob/living/target_mob, mob/living/user, target_zone)
+	. = ..()
+	if(get_dist(target_mob, get_turf(src)) < MICROPHONE_LISTEN_RANGE)
+		if(!(target_mob in listeners))
+			to_chat(user, SPAN_NOTICE("You angle the microphone to allow [target_mob] to speak into it."))
+			add_listener(target_mob)
+		else
+			to_chat(user, SPAN_NOTICE("You angle the microphone away from [target_mob]."))
+			remove_listener(target_mob)
+
+/**
+ * Add a mob to the list of listeners allowed to speak into the microphone.
+ */
+/obj/item/radio/microphone/proc/add_listener(mob/living/target_mob)
+	LAZYADD(listeners, target_mob)
+	RegisterSignal(target_mob, COMSIG_MOVABLE_MOVED, check_listener_distance())
+
+/**
+ * Remove a mob from the list of listeners allowed to speak into the microphone.
+ */
+/obj/item/radio/microphone/proc/remove_listener(mob/living/target_mob)
+	UnregisterSignal(target_mob, COMSIG_MOVABLE_MOVED)
+	LAZYREMOVE(listeners, target_mob)
+
+/**
+ * Checks if the mob is too far from the microphone, at which point we stop listening to them.
+ **/
+/obj/item/radio/microphone/proc/check_listener_distance(datum/source)
+	SIGNAL_HANDLER
+	if(get_dist(source, get_turf(src)) > MICROPHONE_LISTEN_RANGE)
+		LAZYREMOVE(listeners, source)
+		if(ismob(loc))
+			var/mob/M = loc
+			to_chat(M, SPAN_NOTICE("[source] moves away from the microphone."))
+
+/obj/item/radio/microphone/hear_talk(mob/M, msg, var/verb = "says", datum/language/speaking)
+    var/message_ending = copytext(msg, length(msg) - 1, length(msg)) //copies the last 2 letters
+    if(directed_listening && ((M in listeners) || (message_ending in word_bypasses)))
+        return ..()
+
+#undef MICROPHONE_LISTEN_RANGE

--- a/html/changelogs/mattatlas-damedame.yml
+++ b/html/changelogs/mattatlas-damedame.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "The journalist's microphone by default no longer allows everyone to speak into it. Click someone with the microphone in hand to allow the microphone to pick up their voice. You can activate the microphone in hand to disable this functionality. If you move more than 5 tiles away from the microphone, you will automatically be de-registered from its allowed listeners. People screaming will bypass the allowed listeners."

--- a/html/changelogs/mattatlas-damedame.yml
+++ b/html/changelogs/mattatlas-damedame.yml
@@ -55,4 +55,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "The journalist's microphone by default no longer allows everyone to speak into it. Click someone with the microphone in hand to allow the microphone to pick up their voice. You can activate the microphone in hand to disable this functionality. If you move more than 5 tiles away from the microphone, you will automatically be de-registered from its allowed listeners. People screaming will bypass the allowed listeners."
+  - rscadd: "The journalist's microphone by default no longer allows everyone to speak into it. Click someone with the microphone in hand to allow the microphone to pick up their voice. You can alt-click the microphone to disable this functionality. If you move more than 5 tiles away from the microphone, you will automatically be de-registered from its allowed listeners. People screaming will bypass the allowed listeners."


### PR DESCRIPTION
The journalist's microphone by default no longer allows everyone to speak into it. Click someone with the microphone in hand to allow the microphone to pick up their voice. If you move more than 5 tiles away from the microphone, you will automatically be de-registered from its allowed listeners. People screaming will bypass the allowed listeners.

You can alt click the microphone to disable this functionality.