### PR TITLE
Deployable Kits, bugfixes

### DIFF
--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -37,7 +37,8 @@
 	desc = "Security Equipment"
 	region = ACCESS_REGION_SECURITY
 
-#define ACCESS_BRIG 2 // Brig timers and permabrig
+/// Brig timers and permabrig
+#define ACCESS_BRIG 2
 /datum/access/holding
 	id = ACCESS_BRIG
 	desc = "Holding Cells"
@@ -73,12 +74,14 @@
 	desc = "R&D Lab"
 	region = ACCESS_REGION_RESEARCH
 
+/// Used only for science lockers/science gun cabinets
 #define ACCESS_TOX_STORAGE 8
 /datum/access/tox_storage
 	id = ACCESS_TOX_STORAGE
 	desc = "Toxins Lab"
 	region = ACCESS_REGION_RESEARCH
 
+/// NOT CURRENT USED ANYWHERE
 #define ACCESS_GENETICS 9
 /datum/access/genetics
 	id = ACCESS_GENETICS
@@ -109,12 +112,14 @@
 	desc = "External Airlocks"
 	region = ACCESS_REGION_ENGINEERING
 
+/// NOT CURRENTLY USED ANYWHERE
 #define ACCESS_EMERGENCY_STORAGE 14
 /datum/access/emergency_storage
 	id = ACCESS_EMERGENCY_STORAGE
 	desc = "Emergency Storage"
 	region = ACCESS_REGION_ENGINEERING
 
+/// Used only in '/datum/computer_file/program/card_mod'
 #define ACCESS_CHANGE_IDS 15
 /datum/access/change_ids
 	id = ACCESS_CHANGE_IDS
@@ -187,6 +192,7 @@
 	desc = "Custodial Closet"
 	region = ACCESS_REGION_GENERAL
 
+/// Only used for morgue crematorium switch, and the only one that exists has its access vars nulled anyway.
 #define ACCESS_CREMATORIUM 27
 /datum/access/crematorium
 	id = ACCESS_CREMATORIUM
@@ -217,6 +223,7 @@
 	desc = "Cargo Bay"
 	region = ACCESS_REGION_SUPPLY
 
+/// Used only for locked welding lockers and engineering suit cyclers, weirdly.
 #define ACCESS_CONSTRUCTION 32
 /datum/access/construction
 	id = ACCESS_CONSTRUCTION
@@ -229,6 +236,7 @@
 	desc = "Pharmacy Lab"
 	region = ACCESS_REGION_MEDBAY
 
+/// NOT CURRENTLY USED ANYWHERE
 #define ACCESS_CARGO_BOT 34
 /datum/access/cargo_bot
 	id = ACCESS_CARGO_BOT
@@ -241,6 +249,7 @@
 	desc = "Hydroponics"
 	region = ACCESS_REGION_GENERAL
 
+/// NOT CURRENTLY USED ANYWHERE
 #define ACCESS_MANUFACTURING 36
 /datum/access/manufacturing
 	id = ACCESS_MANUFACTURING
@@ -259,6 +268,7 @@
 	desc = "Representative"
 	region = ACCESS_TYPE_CENTCOM
 
+/// Used only for '/obj/item/storage/lockbox/vials' and a smartfridge variant no longer mapped anywhere.
 #define ACCESS_VIROLOGY 39
 /datum/access/virology
 	id = ACCESS_VIROLOGY
@@ -283,6 +293,7 @@
 	desc = "Station Network"
 	region = ACCESS_REGION_RESEARCH
 
+/// NOT CURRENTLY USED ANYWHERE
 #define ACCESS_LEVIATHAN 43
 /datum/access/leviathan
 	id = ACCESS_LEVIATHAN
@@ -311,12 +322,14 @@
 	desc = "Mining"
 	region = ACCESS_REGION_SUPPLY
 
+/// NOT CURRENTLY USED ANYWHERE
 #define ACCESS_MINING_OFFICE 49
 /datum/access/mining_office
 	id = ACCESS_MINING_OFFICE
 	desc = "Mining Office"
 	access_type = ACCESS_TYPE_NONE
 
+/// Only used as a weird standin for Operations in camera network access.
 #define ACCESS_MAILSORTING 50
 /datum/access/mailsorting
 	id = ACCESS_MAILSORTING
@@ -331,12 +344,14 @@
 	desc = "Xenobotany"
 	region = ACCESS_REGION_RESEARCH
 
+/// NOT CURRENTLY USED ANYWHERE
 #define ACCESS_HEADS_VAULT 53
 /datum/access/heads_vault
 	id = ACCESS_HEADS_VAULT
 	desc = "Main Vault"
 	region = ACCESS_REGION_COMMAND
 
+/// NOT CURRENTLY USED ANYWHERE
 #define ACCESS_MINING_STATION 54
 /datum/access/mining_station
 	id = ACCESS_MINING_STATION
@@ -367,37 +382,43 @@
 	desc = "Head of Security"
 	region = ACCESS_REGION_SECURITY
 
-#define ACCESS_RC_ANNOUNCE 59 //Requests console announcements
+/// Requests console announcements
+#define ACCESS_RC_ANNOUNCE 59
 /datum/access/RC_announce
 	id = ACCESS_RC_ANNOUNCE
 	desc = "RC Announcements"
 	region = ACCESS_REGION_COMMAND
 
-#define ACCESS_KEYCARD_AUTH 60 //Used for events which require at least two people to confirm them
+/// Used for events which require at least two people to confirm them
+#define ACCESS_KEYCARD_AUTH 60
 /datum/access/keycard_auth
 	id = ACCESS_KEYCARD_AUTH
 	desc = "Keycode Auth. Device"
 	region = ACCESS_REGION_COMMAND
 
-#define ACCESS_TCOMSAT 61 // has access to the entire telecomms satellite / machinery
+/// Has access to the interior Telecomms compartment
+#define ACCESS_TCOMSAT 61
 /datum/access/tcomsat
 	id = ACCESS_TCOMSAT
 	desc = "Telecommunications"
 	region = ACCESS_REGION_COMMAND
 
+/// NOT CURRENTLY USED ANYWHERE
 #define ACCESS_GATEWAY 62
 /datum/access/gateway
 	id = ACCESS_GATEWAY
 	desc = "Gateway"
 	region = ACCESS_REGION_COMMAND
 
-#define ACCESS_SEC_DOORS 63 // Security front doors
+/// Security front doors
+#define ACCESS_SEC_DOORS 63
 /datum/access/sec_doors
 	id = ACCESS_SEC_DOORS
 	desc = "Security"
 	region = ACCESS_REGION_SECURITY
 
-#define ACCESS_PSYCHIATRIST 64 // Psychiatrist's office
+/// Psychiatrist's office
+#define ACCESS_PSYCHIATRIST 64
 /datum/access/psychiatrist
 	id = ACCESS_PSYCHIATRIST
 	desc = "Psychiatrist's Office"
@@ -423,19 +444,22 @@
 
 // free_access_id = 68
 
+/// Used by firing pins.
 #define ACCESS_WEAPONS 69
 /datum/access/weapons
 	id = ACCESS_WEAPONS
 	desc = "Weaponry Permission"
 	region = ACCESS_REGION_SECURITY
 
-#define ACCESS_JOURNALIST 70//journalist's office access
+/// Journalist's office access
+#define ACCESS_JOURNALIST 70
 /datum/access/journalist
 	id = ACCESS_JOURNALIST
 	desc = "Journalist Office"
 	region = ACCESS_REGION_GENERAL
 
-#define ACCESS_IT 71 // allows some unique interactions with devices
+/// Allows some unique interactions with devices
+#define ACCESS_IT 71
 /datum/access/tech_support
 	id = ACCESS_IT
 	desc = "Tech Support"

--- a/html/changelogs/Bat-Deployables.yml
+++ b/html/changelogs/Bat-Deployables.yml
@@ -1,0 +1,9 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - rscadd: "Adds a Deployable Operating Table kit to the Intrepid medical compartment."
+  - rscdel: "Removes the Operating Table Circuit Board and one scanning module from the D1 Maints Workshop."
+  - qol: "Replaces many pre-assembled Industrial Floodlight structures with Deployable Floodlight Kit items so as to take up less space; adds a couple extra racks with spares."
+  - bugfix: "Fixes inconsistent janitorial door access (bypasses from #22620)."
+  - bugfix: "Fixes floating Research hallway camera."
+  - code_imp: "Miscellaneous dmdocs audit of ACCESS_* defines."

--- a/maps/sccv_horizon/sccv_horizon.dmm
+++ b/maps/sccv_horizon/sccv_horizon.dmm
@@ -15608,7 +15608,6 @@
 	icon_state = "0-4"
 	},
 /obj/structure/machinery/power/apc/shuttle/north,
-/obj/structure/machinery/floodlight,
 /turf/simulated/floor/plating,
 /area/horizon/shuttle/intrepid/port_compartment)
 "bZX" = (
@@ -19306,7 +19305,6 @@
 /obj/item/stock_parts/micro_laser,
 /obj/item/stock_parts/micro_laser,
 /obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/scanning_module,
 /obj/item/stock_parts/scanning_module,
 /obj/item/stock_parts/scanning_module,
 /obj/item/stock_parts/console_screen,
@@ -24159,7 +24157,16 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/engineering/reactor/indra/mainchamber)
 "dfN" = (
-/obj/structure/machinery/floodlight,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack,
+/obj/item/deployable_kit{
+	pixel_y = 12
+	},
+/obj/item/deployable_kit{
+	pixel_y = 6
+	},
+/obj/item/deployable_kit,
+/obj/effect/floor_decal/industrial/outline/operations,
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/horizon/maintenance/deck_1/main/starboard)
@@ -37126,16 +37133,6 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/horizon/hallway/primary/deck_2/central)
-"eMG" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 9
-	},
-/obj/structure/machinery/camera/network/research{
-	c_tag = "Research - Corridor Camera 4";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/rnd/hallway/secondary)
 "eMH" = (
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/machinery/atmospherics/unary/vent_scrubber/on{
@@ -49502,6 +49499,9 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
+/obj/structure/machinery/camera/network/research{
+	c_tag = "Research - Corridor Camera 4"
+	},
 /turf/simulated/floor/grass/no_edge,
 /area/horizon/rnd/hallway/secondary)
 "guM" = (
@@ -58742,8 +58742,8 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/machinery/floodlight,
 /obj/effect/floor_decal/industrial/outline/operations,
+/obj/structure/table/rack,
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/maintenance/deck_1/wing/starboard)
 "hDy" = (
@@ -62980,7 +62980,7 @@
 	},
 /obj/structure/machinery/door/airlock/research{
 	name = "Research Maintenance Conduit";
-	req_access = list(47);
+	req_access = list(7);
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -68271,11 +68271,6 @@
 /obj/structure/table/reinforced/steel,
 /turf/unsimulated/floor/plating,
 /area/centcom/specops)
-"iQj" = (
-/obj/structure/machinery/floodlight,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/plating,
-/area/horizon/hangar/auxiliary)
 "iQk" = (
 /obj/structure/table/stone/marble,
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -73294,10 +73289,10 @@
 /area/horizon/security/interrogation_2)
 "jxL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/random/maintenance_junk_or_loot,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
+/obj/random/maintenance_junk_or_loot,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/maintenance/deck_1/wing/starboard)
 "jxS" = (
@@ -94823,8 +94818,15 @@
 /turf/unsimulated/floor/plating,
 /area/centcom/ferry)
 "mjX" = (
-/obj/structure/machinery/alarm/west,
-/obj/structure/machinery/floodlight,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack,
+/obj/item/deployable_kit{
+	pixel_y = 12
+	},
+/obj/item/deployable_kit{
+	pixel_y = 6
+	},
+/obj/item/deployable_kit,
 /obj/effect/floor_decal/industrial/outline/operations,
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/maintenance/deck_1/wing/starboard)
@@ -95462,7 +95464,7 @@
 	},
 /obj/structure/machinery/door/airlock/research{
 	name = "Research Maintenance Conduit";
-	req_access = list(47);
+	req_access = list(7);
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch_door/yellow,
@@ -97400,6 +97402,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/engineering/atmos/turbine)
+"mDy" = (
+/turf/simulated/floor/tiled/dark,
+/area/horizon/maintenance/deck_1/wing/starboard)
 "mDz" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/horizon/hangar/intrepid)
@@ -98645,11 +98650,18 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/checkpoint)
 "mKI" = (
-/obj/structure/machinery/floodlight,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack,
+/obj/item/deployable_kit{
+	pixel_y = 12
+	},
+/obj/item/deployable_kit{
+	pixel_y = 6
+	},
+/obj/item/deployable_kit,
 /turf/simulated/floor/plating,
 /area/horizon/shuttle/intrepid/port_compartment)
 "mKO" = (
@@ -104139,8 +104151,14 @@
 /obj/structure/machinery/light/spot{
 	dir = 1
 	},
-/obj/structure/machinery/floodlight,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/deployable_kit{
+	pixel_y = 10
+	},
+/obj/item/deployable_kit{
+	pixel_y = 4
+	},
 /turf/simulated/floor/plating,
 /area/horizon/hangar/auxiliary)
 "nyt" = (
@@ -108594,6 +108612,10 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/structure/table/rack/folding_table,
+/obj/item/deployable_kit/surgery_table{
+	pixel_y = 11
+	},
 /turf/simulated/floor/tiled/white,
 /area/horizon/shuttle/intrepid/medical)
 "ocj" = (
@@ -111287,9 +111309,6 @@
 	icon_state = "1-4"
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/structure/machinery/light/small{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/horizon/maintenance/substation/engineering/lower)
 "otK" = (
@@ -133810,7 +133829,7 @@
 /obj/structure/machinery/door/airlock/maintenance{
 	dir = 1;
 	name = "Security Maintenance";
-	req_access = list(63)
+	req_access = list(1)
 	},
 /obj/structure/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch_door/red{
@@ -135193,10 +135212,6 @@
 "rxJ" = (
 /turf/simulated/floor/tiled,
 /area/horizon/security/office)
-"rxL" = (
-/obj/random/keg,
-/turf/simulated/floor/tiled/dark,
-/area/horizon/maintenance/deck_1/wing/starboard)
 "rxO" = (
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -138623,7 +138638,7 @@
 	dir = 1;
 	id_tag = "server_door_lock";
 	name = "Server Room";
-	req_access = list(47)
+	req_access = list(7)
 	},
 /obj/structure/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -141721,7 +141736,7 @@
 	},
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/machinery/firealarm/north,
-/obj/structure/roller_rack/two,
+/obj/structure/roller_rack/three,
 /turf/simulated/floor/tiled/white,
 /area/horizon/shuttle/intrepid/medical)
 "sms" = (
@@ -159220,8 +159235,14 @@
 /obj/structure/machinery/camera/network/first_deck{
 	c_tag = "First Deck - Hangar 15"
 	},
-/obj/structure/machinery/floodlight,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/deployable_kit{
+	pixel_y = 10
+	},
+/obj/item/deployable_kit{
+	pixel_y = 4
+	},
 /turf/simulated/floor/plating,
 /area/horizon/hangar/auxiliary)
 "uzw" = (
@@ -163252,6 +163273,15 @@
 "uZl" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/machinery/light,
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/operations,
+/obj/item/deployable_kit{
+	pixel_y = 12
+	},
+/obj/item/deployable_kit{
+	pixel_y = 6
+	},
+/obj/item/deployable_kit,
 /turf/simulated/floor/tiled,
 /area/horizon/maintenance/deck_2/research)
 "uZt" = (
@@ -166629,8 +166659,7 @@
 /turf/simulated/floor/tiled/white,
 /area/horizon/operations/machinist)
 "vyC" = (
-/obj/structure/machinery/floodlight,
-/obj/effect/floor_decal/industrial/outline/operations,
+/obj/random/keg,
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/maintenance/deck_1/wing/starboard)
 "vyE" = (
@@ -187620,7 +187649,6 @@
 /obj/item/circuitboard/rtg,
 /obj/item/circuitboard/recharge_station,
 /obj/item/circuitboard/mech_recharger,
-/obj/item/circuitboard/optable,
 /obj/item/circuitboard/security/engineering,
 /obj/item/circuitboard/grill,
 /obj/structure/machinery/light/small{
@@ -211631,8 +211659,8 @@ uXq
 gTw
 qrM
 rHt
+mDy
 afe
-rxL
 wlr
 wlr
 sxT
@@ -215458,7 +215486,7 @@ lYY
 rBt
 bOZ
 tJJ
-dfN
+wYB
 iue
 tQU
 nkB
@@ -228350,7 +228378,7 @@ lrd
 aZr
 ktX
 uzu
-iQj
+pzf
 wpi
 nws
 fqO
@@ -228607,7 +228635,7 @@ mQp
 lje
 ktX
 nyr
-iQj
+pzf
 wpi
 nws
 fqO
@@ -295143,7 +295171,7 @@ uXi
 cwC
 gbF
 qcY
-eMG
+gbF
 gbF
 eRe
 twD


### PR DESCRIPTION
Fixes https://github.com/Aurorastation/Aurora.3/issues/22620

We have deployable kits in code, they work, so now we use some.
changes:
  - rscadd: "Adds a Deployable Operating Table kit to the Intrepid medical compartment."
  - rscdel: "Removes the Operating Table Circuit Board and one scanning module from the D1 Maints Workshop."
  - qol: "Replaces many pre-assembled Industrial Floodlight structures with Deployable Floodlight Kit items so as to take up less space; adds a couple extra racks with spares."
  - bugfix: "Fixes inconsistent janitorial door access (bypasses from #22620)."
  - bugfix: "Fixes floating Research hallway camera."
  - code_imp: "Miscellaneous dmdocs audit of ACCESS_* defines."