### PR TITLE
Buff Premade Hardsuit Cells

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -50,7 +50,7 @@
 	var/helm_type =  /obj/item/clothing/head/helmet/space/rig
 	var/boot_type =  /obj/item/clothing/shoes/magboots/rig
 	var/glove_type = /obj/item/clothing/gloves/rig
-	var/cell_type =  /obj/item/cell/high
+	var/cell_type =  /obj/item/cell/hyper
 	var/air_type =   /obj/item/tank/oxygen
 
 	//Component/device holders.

--- a/html/changelogs/fyni-hardsuit-buff.yml
+++ b/html/changelogs/fyni-hardsuit-buff.yml
@@ -1,0 +1,4 @@
+author: fyni
+delete-after: True
+changes:
+  - balance: "Triples the size of the starting cell in premade hardsuits."


### PR DESCRIPTION
Swaps the starting cell from premade hardsuits to the hypercell - tripling their capacity.

Premade suits are used by antags, ghost roles and the rare ERT. As it stands, a hardsuit will drain passively to an extreme amount requiring multiple recharges - not to mention extra drain from using the hardsuit modules, as an operative is expected to do.

90,000j can still run dry if over stressed, but a constant need to charge should no longer be an issue for those above.