### PR TITLE
Modlaser Fixes and material cost tweaks

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -151,6 +151,12 @@ ABSTRACT_TYPE(/obj/item/gun/energy)
 
 	addtimer(CALLBACK(src, PROC_REF(try_recharge)), recharge_time * 2 SECONDS, TIMER_UNIQUE)
 
+/obj/item/gun/energy/handle_reliability_fail(var/mob/user)
+	if(power_supply && power_supply.charge < charge_cost)
+		handle_click_empty(user)
+		return
+	..()
+
 /obj/item/gun/energy/consume_next_projectile()
 	if(!power_supply)
 		return null

--- a/code/modules/projectiles/guns/energy/modular.dm
+++ b/code/modules/projectiles/guns/energy/modular.dm
@@ -78,23 +78,36 @@
 		if(target_mob.stat != DEAD) //No improvement from shooting at dead things. Bring a doctor in to keep your target dummy alive. This also makes it harder to improve more powerful weapons, as you kill your target faster.
 			if(ishuman(target_mob))
 				var/mob/living/carbon/human/human_target = target
+
 				if (istype(modulator, /obj/item/laser_components/modulator/taser))
 					if (human_target.incapacitated()) //No benefit from tasing someone who's already incapacitated. Get the phramacist to make you oxycomorphine.
 						return
+
 				if(human_target.get_species() == SPECIES_MONKEY)
 					improvement_potential += (2  * IMPROVEMENT_MULTIPLIER) / (max(1, burst)) //Monkeys die easily, research only gets two boxes of monkey cubes without xenobiology.
 					return
+
 				if(human_target.client)
 					improvement_potential += (10  * IMPROVEMENT_MULTIPLIER) / (max(1, burst)) //10 seems like a lot, but this is a 20% improvement to 1 variable on 1 component. A 5 mod gun (8 total components), with an average of 3 improvable variables would need 120 shots on a player to max out.
 					return
 
-			if(isslime(target_mob))
+			if (istype(modulator, /obj/item/laser_components/modulator/ion))
+				if ((ismech(target_mob)) || (isbot(target_mob)) || (issilicon(target_mob))) //Shooting mechs or bots with ions.
+					improvement_potential += (5 * IMPROVEMENT_MULTIPLIER) / (max(1, burst))
+				if(!isturf(target)) //From shooting targets on the range.
+					improvement_potential += (1 * IMPROVEMENT_MULTIPLIER) / (max(1, burst))
+				return
+
+			if(isslime(target_mob)) //Slimes only give improvement if shot with freeze rays.
 				if (istype(modulator, /obj/item/laser_components/modulator/freeze))
 					improvement_potential += (2 * IMPROVEMENT_MULTIPLIER) / (max(1, burst))
-					return
+				if(!isturf(target)) //From shooting targets on the range.
+					improvement_potential += (1 * IMPROVEMENT_MULTIPLIER) / (max(1, burst))
+				return
 
 			improvement_potential += (5 * IMPROVEMENT_MULTIPLIER) / (max(1, burst)) //Mechs, protohumans, and any other human mobs without a player.
-	else if(!isturf(target))
+
+	else if(!isturf(target)) //From shooting targets on the range.
 		improvement_potential += (1 * IMPROVEMENT_MULTIPLIER) / (max(1, burst))
 
 /obj/item/gun/energy/laser/prototype/get_examine_text(mob/user, distance, is_adjacent, infix, suffix)
@@ -269,6 +282,7 @@
 
 	fire_delay = capacitor.fire_delay
 	max_shots = round(capacitor.shots)
+	max_shots *= modulator.shots
 	dispersion = focusing_lens.dispersion
 	accuracy = focusing_lens.accuracy
 	burst += round(focusing_lens.burst)

--- a/code/modules/projectiles/modular/laser_base.dm
+++ b/code/modules/projectiles/modular/laser_base.dm
@@ -382,8 +382,6 @@
 
 /obj/item/laser_assembly/examine_tags(mob/user)
 	. = ..()
-	if(stage == 1)
-		.["thick"] = "Stops or slows minor piercing effects, such as from injectors."
 
 /obj/item/laser_assembly/mechanics_hints(mob/user)
 	. = ..()

--- a/code/modules/projectiles/modular/laser_components.dm
+++ b/code/modules/projectiles/modular/laser_components.dm
@@ -187,15 +187,15 @@
 	visible_message(SPAN_WARNING("\The [src] in \the [prototype] flickers then vanishes along with everything around it!"))
 	var/turf/T = get_turf(src)
 	for (var/mob/living/M in range(round(3*max(prototype.criticality, 1),1),T))
-		empulse(get_turf(M), 0, round(max(prototype.criticality, 1)*2,1))
-		do_teleport(M, get_turf(M), rand(2,6)*round(max(prototype.criticality, 1),1), asoundin = 'sound/effects/phasein.ogg')
+		do_teleport(M, get_turf(M), rand(2,4)*round(max(prototype.criticality, 1),1), asoundin = 'sound/effects/phasein.ogg')
+		empulse(T, 0, round(max(prototype.criticality, 1)*2,1))
 	..()
 /obj/item/laser_components/capacitor/bluespace/critical_fail(var/mob/living/user, var/obj/item/gun/energy/laser/prototype/prototype)
 	visible_message(SPAN_DANGER("\The [src] in \the [prototype] implodes in a catastrophic spatial anomaly, teleporting everything around it!"))
 	var/turf/T = get_turf(src)
 	for (var/mob/living/M in range(round(6*max(prototype.criticality, 1),1),T))
-		empulse(get_turf(M), 0, round(max(prototype.criticality, 1)*4,1))
-		do_teleport(M, get_turf(M), rand(4,12)*round(max(prototype.criticality, 1),1), asoundin = 'sound/effects/phasein.ogg')
+		do_teleport(M, get_turf(M), rand(3,6)*round(max(prototype.criticality, 1),1), asoundin = 'sound/effects/phasein.ogg')
+		empulse(T, 0, round(max(prototype.criticality, 1)*4,1))
 	..()
 
 //Lenses
@@ -302,7 +302,7 @@
 	burst = 10
 	damage = 2 //With the way armour works, splitting the damage across multiple shots actually reduces the overall damage, so we compensate by increasing it.
 	fire_delay = 10
-	chargetime = 3
+	chargetime = 2
 	accuracy = -1
 	icon_state = "rotating_lens"
 	increasable_stats = list()

--- a/code/modules/research/designs/protolathe/modular_gun_designs.dm
+++ b/code/modules/research/designs/protolathe/modular_gun_designs.dm
@@ -60,7 +60,7 @@
 
 /datum/design/item/modular_weapon/modular_teranium
 	req_tech = list(TECH_POWER = 6, TECH_ENGINEERING = 4, TECH_MAGNET = 6)
-	materials = list(MATERIAL_STEEL = 4000, MATERIAL_GLASS = 1000, MATERIAL_URANIUM = 500)
+	materials = list(MATERIAL_STEEL = 4000, MATERIAL_GLASS = 1000, MATERIAL_GOLD = 500)
 	build_path = /obj/item/laser_components/capacitor/teranium
 
 /datum/design/item/modular_weapon/modular_phoron
@@ -70,7 +70,7 @@
 
 /datum/design/item/modular_weapon/modular_bs
 	req_tech = list(TECH_POWER = 7, TECH_ENGINEERING = 7, TECH_PHORON = 6, TECH_BLUESPACE = 5)
-	materials = list(MATERIAL_STEEL = 4000, MATERIAL_PHORON = 3000, MATERIAL_URANIUM = 500, MATERIAL_DIAMOND = 1000)
+	materials = list(MATERIAL_STEEL = 4000, MATERIAL_PHORON = 3000, MATERIAL_SILVER = 500, MATERIAL_DIAMOND = 1000)
 	build_path = /obj/item/laser_components/capacitor/bluespace
 
 /datum/design/item/modular_weapon/modular_lens
@@ -125,7 +125,7 @@
 
 /datum/design/item/modular_weapon/modular_gatling
 	req_tech = list(TECH_COMBAT = 6, TECH_PHORON = 5, TECH_MATERIAL = 6, TECH_POWER = 3)
-	materials = list(MATERIAL_STEEL = 750, MATERIAL_GLASS = 3000, MATERIAL_PHORON = 2000, MATERIAL_SILVER = 2000, MATERIAL_DIAMOND = 1000)
+	materials = list(MATERIAL_STEEL = 750, MATERIAL_GLASS = 3000, MATERIAL_PHORON = 2000, MATERIAL_SILVER = 2000, MATERIAL_GOLD = 1000)
 	build_path = /obj/item/laser_components/modifier/gatling
 
 /datum/design/item/modular_weapon/modular_scope

--- a/html/changelogs/Fenodyree-ModlaserTweaksAndFixes.yml
+++ b/html/changelogs/Fenodyree-ModlaserTweaksAndFixes.yml
@@ -1,0 +1,12 @@
+# Your name.
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - balance: "Buffs gattling laser modifier charge time from 3 to 2 seconds. It took so long to charge multiple people thought it was bugged."
+  - balance: "Tweaks material costs, replacing uranium with silver and gold. Uranium was previously used everywhere."
+  - bugfix: "Fixed a bug where energy guns would not properly handle reliability failures when the gun was out of charge."
+  - bugfix: "Fixed improvement potential calculations for ions and slimes. You no longer gain improvement shooting monkeys with ions, or for shooting slimes with lasers."
+  - bugfix: "Fixed a bug with bluespace capacitors teleporting items in teleport inhibitor range. This was due to the EMP happening before the teleport and destroying the inhibitor."
+  - bugfix: "Fixed Ion modulators not correctly decreasing the number of shots."


### PR DESCRIPTION
  - balance: "Buffs gattling laser modifier charge time from 3 to 2 seconds. It took so long to charge multiple people thought it was bugged."

This modifier was simply a downgrade, you'd be dead by the time it fired. Often people handed gattling guns would think they are bugged and unable to fire. This might help a bit.


  - balance: "Tweaks material costs, replacing uranium with silver and gold. Uranium was previously used everywhere."

Everything used uranium, even things that really didn't make sense. As uranium spawns on station in engineering and the machinists, this is a slight nerf.


  - bugfix: "Fixed a bug where energy guns would not properly handle reliability failures when the gun was out of charge."
  - bugfix: "Fixed improvement potential calculations for ions and slimes. You no longer gain improvement shooting monkeys with ions, or for shooting slimes with lasers."
  - bugfix: "Fixed a bug with bluespace capacitors teleporting items in teleport inhibitor range. This was due to the EMP happening before the teleport and destroying the inhibitor."
  - bugfix: "Fixed Ion modulators not correctly decreasing the number of shots."
 
Fixes: #22850 