### PR TITLE
A bunch of circuit and other fixes

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/miscboards.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/miscboards.dm
@@ -143,8 +143,20 @@
 	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 3)
 	board_type = BOARD_MACHINE
 	req_components = list(
-			"/obj/item/stock_parts/capacitor" = 2,
+			"/obj/item/stock_parts/capacitor" = 3,
 			"/obj/item/stock_parts/micro_laser" = 1,
+			"/obj/item/stack/cable_coil" = 5
+	)
+
+/obj/item/circuitboard/microwave
+	name = T_BOARD("microwave")
+	desc = "The circuitboard for a microwave."
+	build_path = /obj/structure/machinery/appliance/cooker/microwave
+	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 3)
+	board_type = BOARD_MACHINE
+	req_components = list(
+			"/obj/item/stock_parts/capacitor" = 3,
+			"/obj/item/stock_parts/scanning_module" = 1,
 			"/obj/item/stack/cable_coil" = 5
 	)
 

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -574,7 +574,7 @@
 
 	var/open = 0 // Is the box open?
 	var/ismessy = 0 // Fancy mess on the lid
-	var/obj/item/reagent_containers/food/snacks/sliceable/pizza/pizza // Content pizza
+	var/obj/item/reagent_containers/food/snacks/pizza // Content pizza
 	var/pizza_type
 	var/list/boxes = list() // If the boxes are stacked, they come here
 	var/boxtag = ""
@@ -699,7 +699,7 @@
 
 		return
 
-	if(istype(attacking_item, /obj/item/reagent_containers/food/snacks/sliceable/pizza/)) // Long ass fucking object name
+	if(istype(attacking_item, /obj/item/reagent_containers/food/snacks/sliceable/pizza/) || istype(attacking_item, /obj/item/reagent_containers/food/snacks/variable/pizza)) // Long ass fucking object name
 
 		if(src.open)
 			user.drop_from_inventory(attacking_item, src)

--- a/code/modules/cargo/bounties/bot.dm
+++ b/code/modules/cargo/bounties/bot.dm
@@ -8,11 +8,10 @@
 
 /datum/bounty/item/bot/farmbot
 	name = "Farmbot"
-	description = "After a k'ois incident multiple botanists were hospitalized. Provide a few farmbots to handle their duties while they recover."
+	description = "After a k'ois incident multiple botanists were hospitalized. Provide a farmbot to handle their duties while they recover."
 	reward_low = 370
 	reward_high = 430
-	required_count = 3
-	random_count = 1
+	required_count = 1
 	wanted_types = list(/mob/living/bot/farmbot)
 
 /datum/bounty/item/bot/medbot

--- a/code/modules/cooking/machinery/cooking_machines/fryer.dm
+++ b/code/modules/cooking/machinery/cooking_machines/fryer.dm
@@ -22,6 +22,12 @@
 		/obj/item/reagent_containers/cooking_container/fryer
 	)
 
+	component_types = list(
+		/obj/item/circuitboard/fryer,
+		/obj/item/stock_parts/capacitor = 3,
+		/obj/item/stock_parts/scanning_module = 1,
+		/obj/item/stock_parts/matter_bin = 2)
+
 	var/datum/reagents/oil
 	var/optimal_oil = 9000//90 litres of cooking oil
 

--- a/code/modules/cooking/machinery/cooking_machines/microwave.dm
+++ b/code/modules/cooking/machinery/cooking_machines/microwave.dm
@@ -30,6 +30,12 @@
 	/// Multiplier for break chance
 	var/break_multiplier = 1.0
 
+	component_types = list(
+		/obj/item/circuitboard/microwave,
+		/obj/item/stock_parts/capacitor = 3,
+		/obj/item/stock_parts/scanning_module = 1,
+		/obj/item/stock_parts/matter_bin = 2)
+
 	starts_with = list(
 		/obj/item/reagent_containers/cooking_container/microwave_plate
 	)

--- a/code/modules/cooking/machinery/cooking_machines/oven.dm
+++ b/code/modules/cooking/machinery/cooking_machines/oven.dm
@@ -26,6 +26,13 @@
 	var/door_open_overlay = "ovenopen_on"
 	var/door_closed_overlay = "ovenclosed_on"
 
+	component_types = list(
+		/obj/item/circuitboard/oven,
+		/obj/item/stock_parts/capacitor = 3,
+		/obj/item/stock_parts/scanning_module = 1,
+		/obj/item/stock_parts/matter_bin = 2)
+
+
 	starts_with = list(
 		/obj/item/reagent_containers/cooking_container/oven,
 		/obj/item/reagent_containers/cooking_container/oven,

--- a/code/modules/cooking/machinery/cooking_machines/stove.dm
+++ b/code/modules/cooking/machinery/cooking_machines/stove.dm
@@ -22,6 +22,12 @@
 
 	stat = POWEROFF	//Starts turned off
 
+	component_types = list(
+		/obj/item/circuitboard/stove,
+		/obj/item/stock_parts/capacitor = 3,
+		/obj/item/stock_parts/scanning_module = 1,
+		/obj/item/stock_parts/matter_bin = 2)
+
 	starts_with = list(
 		/obj/item/reagent_containers/cooking_container/skillet,
 		/obj/item/reagent_containers/cooking_container/pot,

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -790,7 +790,7 @@
 		return FALSE
 
 	user.visible_message(SPAN_WARNING("[user] starts harvesting \the [display_name]"))
-	if (doafter > 0 && !do_after(user, doafter))
+	if (doafter > 0 && !do_after(user, doafter, do_flags = DO_BOTH_UNIQUE_ACT | DO_USER_SAME_HAND | DO_SHOW_PROGRESS))
 		to_chat(user, SPAN_DANGER("You were interrupted while trying to harvest \the [display_name]"))
 		return FALSE
 

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -249,6 +249,9 @@
 		to_chat(user, SPAN_WARNING("You can't seem to add the '[IC.name]', since this setup's too complicated for the case."))
 		return FALSE
 
+	if(!user.unEquip(IC))
+		return FALSE
+
 	if(!IC.forceMove(src))
 		return FALSE
 
@@ -267,9 +270,6 @@
 
 /obj/item/electronic_assembly/attackby(obj/item/attacking_item, mob/user)
 	if(istype(attacking_item, /obj/item/integrated_circuit))
-		if(!user.unEquip(attacking_item))
-			return FALSE
-
 		if(add_circuit(attacking_item, user))
 			to_chat(user, SPAN_NOTICE("You slide \the [attacking_item] inside \the [src]."))
 			playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -200,8 +200,11 @@
 
 /obj/item/electronic_assembly/feedback_hints(mob/user, distance, is_adjacent)
 	. = ..()
-	if(is_adjacent && opened)
-		for(var/obj/item/integrated_circuit/IC in contents)
+	for(var/obj/item/integrated_circuit/IC in contents)
+		var/examined = IC.external_examine()
+		if(length(examined))
+			. += examined
+		if(is_adjacent && opened)
 			. += SPAN_NOTICE("It contains \a [IC].")
 
 /obj/item/electronic_assembly/proc/get_part_complexity()

--- a/code/modules/integrated_electronics/core/assemblies/electronic_radio_headset.dm
+++ b/code/modules/integrated_electronics/core/assemblies/electronic_radio_headset.dm
@@ -64,13 +64,12 @@
 /obj/item/radio/headset/circuitry/feedback_hints(mob/user, distance, is_adjacent)
 	. = ..()
 
-	if(distance <= 1 && !circuit_assembly?.opened)
-		return
-
 	var/obj/item/electronic_assembly/E = get_cloneable_assembly()
 	if(E)
-		for(var/obj/item/integrated_circuit/IC in E.contents)
-			. += SPAN_NOTICE("It contains \a [IC].")
+		for(var/obj/item/integrated_circuit/IC in contents)
+			IC.external_examine()
+			if(is_adjacent && circuit_assembly?.opened)
+				. += SPAN_NOTICE("It contains \a [IC].")
 
 /obj/item/radio/headset/circuitry/proc/clone_with_integrated_assembly(atom/location, obj/item/integrated_circuit_printer/printer, obj/item/electronic_assembly/source_assembly)
 	if(!location || !printer || !source_assembly)

--- a/code/modules/integrated_electronics/core/assemblies/generic.dm
+++ b/code/modules/integrated_electronics/core/assemblies/generic.dm
@@ -284,9 +284,11 @@
 	if(get_dist(on_wall, user) > 1)
 		return
 
-	var/ndir = get_dir(on_wall, user)
+	var/ndir = get_dir(user, on_wall)
 	if(!(ndir in GLOB.cardinals))
 		return
+
+	dir = ndir
 
 	var/turf/T = get_turf(user)
 	if(!istype(T, /turf/simulated/floor))

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -302,6 +302,8 @@ a creative player the means to solve many problems.  Circuits are held inside an
 		disconnect_all()
 		var/turf/T = get_turf(src)
 		forceMove(T)
+		if(Adjacent(usr, src))
+			usr.put_in_hands(src)
 		assembly = null
 		playsound(T, 'sound/items/crowbar_pry.ogg', 50, 1)
 		to_chat(usr, SPAN_NOTICE("You pop \the [src] out of the case, and slide it out."))

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -5,12 +5,12 @@ a creative player the means to solve many problems.  Circuits are held inside an
 
 /obj/item/integrated_circuit/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
 	interact(user)
-	external_examine(user)
+	. += external_examine(user)
 	. = ..()
 
 // This should be used when someone is examining from an 'outside' perspective, e.g. reading a screen or LED.
 /obj/item/integrated_circuit/proc/external_examine(mob/user)
-	any_examine(user)
+	return any_examine(user)
 
 /obj/item/integrated_circuit/proc/any_examine(mob/user)
 	. = list()

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -499,11 +499,14 @@
 
 		metal -= cost
 		phoron -= phoron_cost
-
+		var/new_build
 		if(is_printed_assembly_container)
-			new build_type(get_turf(loc), TRUE)
+			new_build = new build_type(get_turf(loc), TRUE)
 		else
-			new build_type(get_turf(loc))
+			new_build = new build_type(get_turf(loc))
+
+		if(Adjacent(usr, src))
+			usr.put_in_hands(new_build)
 
 		return TRUE
 

--- a/code/modules/integrated_electronics/core/tools.dm
+++ b/code/modules/integrated_electronics/core/tools.dm
@@ -234,8 +234,9 @@
 		/obj/item/electronic_assembly,
 		/obj/item/integrated_electronics,
 		/obj/item/crowbar,
-		/obj/item/screwdriver,
-		/obj/item/multitool
+		/obj/item/integrated_electronics/wirer,
+		/obj/item/integrated_electronics/debugger,
+		/obj/item/integrated_electronics/detailer
 	)
 	make_exact_fit = TRUE
 
@@ -255,8 +256,9 @@
 	new /obj/item/electronic_assembly(src)
 	new /obj/item/assembly/electronic_assembly(src)
 	new /obj/item/assembly/electronic_assembly(src)
-	new /obj/item/multitool(src)
-	new /obj/item/screwdriver(src)
+	new /obj/item/integrated_electronics/wirer(src)
+	new /obj/item/integrated_electronics/debugger(src)
+	new /obj/item/integrated_electronics/detailer(src)
 	new /obj/item/crowbar(src)
 
 /obj/item/storage/bag/circuits/all/fill()
@@ -281,6 +283,7 @@
 	new /obj/item/electronic_assembly/drone(src)
 	new /obj/item/integrated_electronics/wirer(src)
 	new /obj/item/integrated_electronics/debugger(src)
+	new /obj/item/integrated_electronics/detailer(src)
 	new /obj/item/crowbar(src)
 
 /obj/item/storage/bag/circuits/mini

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -27,7 +27,6 @@
 		. += "There is a little screen labeled '[displayed_name]', which displays [!isnull(stuff_to_display) ? "'[stuff_to_display]'" : "nothing"]."
 	else
 		. += "There is an unlabelled little screen, which displays [!isnull(stuff_to_display) ? "'[stuff_to_display]'" : "nothing"]."
-	return .
 
 /obj/item/integrated_circuit/output/screen/do_work()
 	var/datum/integrated_io/I = inputs[1]

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -27,6 +27,7 @@
 		. += "There is a little screen labeled '[displayed_name]', which displays [!isnull(stuff_to_display) ? "'[stuff_to_display]'" : "nothing"]."
 	else
 		. += "There is an unlabelled little screen, which displays [!isnull(stuff_to_display) ? "'[stuff_to_display]'" : "nothing"]."
+	return .
 
 /obj/item/integrated_circuit/output/screen/do_work()
 	var/datum/integrated_io/I = inputs[1]

--- a/html/changelogs/FixesAndFixes.yml
+++ b/html/changelogs/FixesAndFixes.yml
@@ -1,0 +1,62 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: TheGreyWikf
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Integrated circuits can now display screen text and other examine related things."
+  - bugfix: "Fixed the direction of the wall mounted integrated circuit when placed."
+  - bugfix: "Fixed that the integrated circuit kit had the wrong tools."
+  - bugfix: "Fixed that the integrated circuit printer put things on the turf instead of in hand."
+  - bugfix: "Fixed that removing integrated circuit components put them on the turf, and that they were dropped if they did not fit inside the device."

--- a/html/changelogs/FixesAndFixes.yml
+++ b/html/changelogs/FixesAndFixes.yml
@@ -1,59 +1,7 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes:
-#   bugfix
-#     - (fixes bugs)
-#   wip
-#     - (work in progress)
-#   qol
-#     - (quality of life)
-#   soundadd
-#     - (adds a sound)
-#   sounddel
-#     - (removes a sound)
-#   rscadd
-#     - (adds a feature)
-#   rscdel
-#     - (removes a feature)
-#   imageadd
-#     - (adds an image or sprite)
-#   imagedel
-#     - (removes an image or sprite)
-#   spellcheck
-#     - (fixes spelling or grammar)
-#   experiment
-#     - (experimental change)
-#   balance
-#     - (balance changes)
-#   code_imp
-#     - (misc internal code change)
-#   refactor
-#     - (refactors code)
-#   config
-#     - (makes a change to the config files)
-#   admin
-#     - (makes changes to administrator tools)
-#   server
-#     - (miscellaneous changes to server)
-#################################
-
-# Your name.
 author: TheGreyWikf
 
-# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
 
-# Any changes you've made.  See valid prefix list above.
-# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
-# SCREW THIS UP AND IT WON'T WORK.
-# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
-# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - bugfix: "Integrated circuits can now display screen text and other examine related things."
   - bugfix: "Fixed the direction of the wall mounted integrated circuit when placed."

--- a/html/changelogs/FixesAndFixes.yml
+++ b/html/changelogs/FixesAndFixes.yml
@@ -60,3 +60,4 @@ changes:
   - bugfix: "Fixed that the integrated circuit kit had the wrong tools."
   - bugfix: "Fixed that the integrated circuit printer put things on the turf instead of in hand."
   - bugfix: "Fixed that removing integrated circuit components put them on the turf, and that they were dropped if they did not fit inside the device."
+  - bugfix: "Harvesting a plant multiple times by clicking it repeatedly before it finishes is no longer possible."

--- a/html/changelogs/FixesAndFixes.yml
+++ b/html/changelogs/FixesAndFixes.yml
@@ -63,3 +63,4 @@ changes:
   - bugfix: "Harvesting a plant multiple times by clicking it repeatedly before it finishes is no longer possible."
   - bugfix: "The kitchen machinery can now be upgraded."
   - bugfix: "The farmbot requirement in bounties was reduced."
+  - bugfix: "Fixes the inability to put custom pizzas in the pizza box."

--- a/html/changelogs/FixesAndFixes.yml
+++ b/html/changelogs/FixesAndFixes.yml
@@ -62,3 +62,4 @@ changes:
   - bugfix: "Fixed that removing integrated circuit components put them on the turf, and that they were dropped if they did not fit inside the device."
   - bugfix: "Harvesting a plant multiple times by clicking it repeatedly before it finishes is no longer possible."
   - bugfix: "The kitchen machinery can now be upgraded."
+  - bugfix: "The farmbot requirement in bounties was reduced."

--- a/html/changelogs/FixesAndFixes.yml
+++ b/html/changelogs/FixesAndFixes.yml
@@ -61,3 +61,4 @@ changes:
   - bugfix: "Fixed that the integrated circuit printer put things on the turf instead of in hand."
   - bugfix: "Fixed that removing integrated circuit components put them on the turf, and that they were dropped if they did not fit inside the device."
   - bugfix: "Harvesting a plant multiple times by clicking it repeatedly before it finishes is no longer possible."
+  - bugfix: "The kitchen machinery can now be upgraded."


### PR DESCRIPTION
Fixes https://github.com/Aurorastation/Aurora.3/issues/22959
Fixes https://github.com/Aurorastation/Aurora.3/issues/22960

changes:
  - bugfix: "Integrated circuits can now display screen text and other examine related things."
  - bugfix: "Fixed the direction of the wall mounted integrated circuit when placed."
  - bugfix: "Fixed that the integrated circuit kit had the wrong tools."
  - bugfix: "Fixed that the integrated circuit printer put things on the turf instead of in hand."
  - bugfix: "Fixed that removing integrated circuit components put them on the turf, and that they were dropped if they did not fit inside the device."
  - bugfix: "Harvesting a plant multiple times by clicking it repeatedly before it finishes is no longer possible."
  - bugfix: "The kitchen machinery can now be upgraded."
  - bugfix: "The farmbot requirement in bounties was reduced."
  - bugfix: "Fixes the inability to put custom pizzas in the pizza box."