### PR TITLE
Bugfixes for deployable shield generators

### DIFF
--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -98,6 +98,11 @@
 			visible_message(SPAN_WARNING("\The [src] shuts down."), SPAN_NOTICE("You hear a heavy droning fade out."))
 			shields_down()
 		check_delay = initial(check_delay)
+		return
+
+	if(!active)
+		check_delay = initial(check_delay)
+		return
 
 	if(malfunction)
 		if(deployed_shields.len && prob(5))
@@ -108,16 +113,17 @@
 
 	else
 		if(check_delay <= 0)
-			if(shields_up())
-				var/new_power_usage = 0
-				for(var/obj/structure/machinery/shield/shield_tile in deployed_shields)
-					new_power_usage += shield_tile.shield_sustain_power
+			create_shields()
 
-				if(new_power_usage != active_power_usage)
-					change_power_consumption(new_power_usage, POWER_USE_ACTIVE)
-					use_power_oneoff(0)
+			var/new_power_usage = 0
+			for(var/obj/structure/machinery/shield/shield_tile in deployed_shields)
+				new_power_usage += shield_tile.shield_sustain_power
 
-				check_delay = initial(check_delay)
+			if(new_power_usage != active_power_usage)
+				change_power_consumption(new_power_usage, POWER_USE_ACTIVE)
+				use_power_oneoff(0)
+
+			check_delay = initial(check_delay)
 		else
 			check_delay--
 

--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -29,11 +29,12 @@
 	var/list/owned_capacitors = list()
 	/// If this shield generator supports multi-z.
 	var/multiz = TRUE
-	///How much the manipulator rating increases the maximum field strengthen rate. This increases how fast the shield can strengthen, allowing it to recover faster.
-	var/manipulator_bonus = 0.1 //Maximum recovery rate with base components is 0.5 renwicks per second, with maxed out manipulators it's 0.9 renwicks per second.
-	///How much the capacitor rating increases the field conversion rate. This increases the efficiency of converting power into shield strength, decreasing all shield power costs.
+	/// How much the manipulator rating increases the maximum field strengthen rate. This increases how fast the shield can strengthen, allowing it to recover faster.
+	/// Maximum recovery rate with base components is 0.5 renwicks per second, with maxed out manipulators it's 0.9 renwicks per second.
+	var/manipulator_bonus = 0.1
+	/// How much the capacitor rating increases the field conversion rate. This increases the efficiency of converting power into shield strength, decreasing all shield power costs.
 	var/capacitor_bonus = 0.000005
-	///How much the micro laser rating decreased the field dissipation rate. This reduces the amount of shield strength lost per tick, reducing the shield upkeep.
+	/// How much the micro laser rating decreased the field dissipation rate. This reduces the amount of shield strength lost per tick, reducing the shield upkeep.
 	var/micro_laser_bonus = 0.002
 
 	component_types = list(
@@ -258,11 +259,11 @@
 	if(active)
 		for(var/mob/M as anything in hearers(5,src))
 			to_chat(M, SPAN_NOTICE("[icon2html(src, M)] You hear heavy droning start up."))
-			energy_field.set_shielded_turfs(get_shielded_turfs())
+		energy_field.set_shielded_turfs(get_shielded_turfs())
 	else
 		for(var/mob/M as anything in hearers(5,src))
 			to_chat(M, SPAN_NOTICE("[icon2html(src, M)] You hear heavy droning fade out."))
-			energy_field.clear_field()
+		energy_field.clear_field()
 
 /obj/structure/machinery/shield_gen/update_icon()
 	if(stat & BROKEN)

--- a/html/changelogs/Bat-Shields.yml
+++ b/html/changelogs/Bat-Shields.yml
@@ -1,0 +1,5 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - bugfix: "Guards emergency shield projectors' maintenance process() logic from inadvertently toggling projector on when anchored and inactive."
+  - bugfix: "Bubble shield projectors no longer register candidate turfs for every hearer in range. Once is enough."


### PR DESCRIPTION
changes:
  - bugfix: "Guards emergency shield projectors' maintenance process() logic from inadvertently toggling projector on when anchored and inactive."
  - bugfix: "Bubble shield projectors no longer register candidate turfs for every hearer in range. Once is enough."