### PR TITLE
Persistent liquid tank refactor

### DIFF
--- a/code/modules/cargo/items/engineering.dm
+++ b/code/modules/cargo/items/engineering.dm
@@ -421,7 +421,7 @@
 	name = "fuel tank"
 	supplier = "hephaestus"
 	description = "A tank filled with welding fuel."
-	price = 10
+	price = 600
 	items = list(
 		/obj/structure/reagent_dispensers/fueltank
 	)
@@ -435,7 +435,7 @@
 	name = "extinguisher tank"
 	supplier = "hephaestus"
 	description = "A tank filled with extinguisher fluid."
-	price = 10
+	price = 600
 	items = list(
 		/obj/structure/reagent_dispensers/extinguisher
 	)
@@ -809,20 +809,6 @@
 	)
 	access = 0
 	container_type = "crate"
-	groupable = TRUE
-	spawn_amount = 1
-
-/singleton/cargo_item/watertank
-	category = "engineering"
-	name = "watertank"
-	supplier = "hephaestus"
-	description = "A tank filled with water."
-	price = 10
-	items = list(
-		/obj/structure/reagent_dispensers/watertank
-	)
-	access = ACCESS_ENGINE
-	container_type = "box"
 	groupable = TRUE
 	spawn_amount = 1
 

--- a/code/modules/cargo/items/miscellaneous.dm
+++ b/code/modules/cargo/items/miscellaneous.dm
@@ -12,6 +12,20 @@
 	groupable = TRUE
 	spawn_amount = 1
 
+/singleton/cargo_item/watertank
+	category = "miscellaneous"
+	name = "water tank"
+	supplier = "orion"
+	description = "A tank filled with water."
+	price = 350
+	items = list(
+		/obj/structure/reagent_dispensers/watertank
+	)
+	access = 0
+	container_type = "box"
+	groupable = TRUE
+	spawn_amount = 1
+
 /singleton/cargo_item/sculptingblock
 	category = "miscellaneous"
 	name = "sculpting block"
@@ -70,19 +84,5 @@
 	)
 	access = 0
 	container_type = "crate"
-	groupable = TRUE
-	spawn_amount = 1
-
-/singleton/cargo_item/watertank
-	category = "miscellaneous"
-	name = "water tank"
-	supplier = "orion"
-	description = "A tank filled with water."
-	price = 10
-	items = list(
-		/obj/structure/reagent_dispensers/watertank
-	)
-	access = 0
-	container_type = "box"
 	groupable = TRUE
 	spawn_amount = 1

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -45,7 +45,8 @@
 	src.y = y
 	src.z = z
 	if(!content["remaining_volume"] || content["remaining_volume"] <= 0)
-		qdel(src)
+		reagents_to_add = null
+		return
 
 	if(!LAZYLEN(reagents_to_add))
 		return
@@ -79,9 +80,6 @@
 			return
 		if (usr.a_intent == I_HELP)
 			RG.standard_dispenser_refill(user,src)
-			if(!reagents || !reagents.total_volume)
-				SSpersistence.objectsDeregisterTrack(src)
-				return
 			playsound(src.loc, 'sound/machines/reagent_dispense.ogg', 25, 1)
 		else
 			if(!accept_any_reagent)

--- a/html/changelogs/fabiank3-liquid-tank-pricing-fix.yml
+++ b/html/changelogs/fabiank3-liquid-tank-pricing-fix.yml
@@ -1,0 +1,8 @@
+author: fabiank3
+
+delete-after: True
+
+changes:
+  - balance: "Adjusted cargo import pricing for liquid tanks so fuel, extinguisher foam, and water tanks now cost more to import than they can be sold for, matching the existing export-value logic."
+  - bugfix: "Removed the duplicate miscellaneous water tank cargo definition."
+  - bugfix: "Stopped empty persistent reagent tanks from being deleted."

--- a/html/changelogs/fabiank3-liquid-tank-pricing-fix.yml
+++ b/html/changelogs/fabiank3-liquid-tank-pricing-fix.yml
@@ -1,4 +1,4 @@
-author: fabiank3
+author: FabianK3
 
 delete-after: True
 


### PR DESCRIPTION
# Summary

This PR adjust the import cost of the newly added persistent tanks, makes empty tanks retain persistent and removes the duplicate water tank entry.

Import cost is adjusted based of export cost with liquid in them, preventing money printing.