### PR TITLE
Door damage fixes

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -120,10 +120,11 @@
 	if(. != BULLET_ACT_HIT)
 		return .
 
-	if(hitting_projectile.get_structure_damage() > 5)
+	var/structure_damage = hitting_projectile.get_structure_damage()
+	if(structure_damage > 5)
 		bullet_ping(hitting_projectile)
 
-	add_damage(hitting_projectile.damage, hitting_projectile.damage_flags(), hitting_projectile.damage_type, hitting_projectile.armor_penetration, hitting_projectile)
+	add_damage(structure_damage, hitting_projectile.damage_flags(), hitting_projectile.damage_type, hitting_projectile.armor_penetration, hitting_projectile)
 
 /obj/structure/proc/climb_on()
 

--- a/code/game/objects/structures/machinery/doors/airlock.dm
+++ b/code/game/objects/structures/machinery/doors/airlock.dm
@@ -523,6 +523,12 @@
 	explosion_resistance = 20
 	secured_wires = TRUE
 	maxhealth = OBJECT_HEALTH_EXTREMELY_HIGH
+	destroy_hits = 30
+	armor = list(
+		MELEE = ARMOR_MELEE_RESISTANT,
+		BULLET = ARMOR_BALLISTIC_PISTOL,
+		LASER = ARMOR_LASER_MEDIUM
+	)
 	features_powerloss_manual_override = FALSE
 	ai_bolting_delay = 10
 	ai_unbolt_delay = 5

--- a/code/game/objects/structures/machinery/doors/blast_door.dm
+++ b/code/game/objects/structures/machinery/doors/blast_door.dm
@@ -17,6 +17,12 @@
 	dir = 1
 	closed_layer = ABOVE_DOOR_LAYER
 	explosion_resistance = 25
+	destroy_hits = 40
+	armor = list(
+		MELEE = ARMOR_MELEE_MAJOR,
+		BULLET = ARMOR_BALLISTIC_MEDIUM,
+		LASER = ARMOR_LASER_RIFLE
+	)
 	pass_flags_self = PASSDOORS
 	rad_resistance_modifier = 6
 
@@ -255,6 +261,12 @@
 	icon_state = "shutter1"
 	damage = SHUTTER_CRUSH_DAMAGE
 	closed_layer = CLOSED_DOOR_LAYER
+	destroy_hits = 20
+	armor = list(
+		MELEE = ARMOR_MELEE_RESISTANT,
+		BULLET = ARMOR_BALLISTIC_PISTOL,
+		LASER = ARMOR_LASER_MEDIUM
+	)
 
 /obj/structure/machinery/door/blast/shutters/open
 	icon_state = "shutter0"

--- a/code/game/objects/structures/machinery/doors/door.dm
+++ b/code/game/objects/structures/machinery/doors/door.dm
@@ -255,20 +255,24 @@
 	var/damage = hitting_projectile.get_structure_damage()
 
 	// Emitter Blasts - these will eventually completely destroy the door, given enough time.
-	if (damage > 90)
-		destroy_hits -= (1 * hitting_projectile.anti_materiel_potential)
+	if (damage >= 30 && health <= 0) //Midlaser damage.
+		if (damage > 90)
+			destroy_hits -= max(1, (1 * hitting_projectile.anti_materiel_potential)) //Double dip for strong projectiles, like emitters or the PEAC.
+		destroy_hits -= max(1, (1 * hitting_projectile.anti_materiel_potential))
 		if (destroy_hits <= 0)
 			visible_message(SPAN_DANGER("\The [src.name] disintegrates!"))
 			switch (hitting_projectile.damage_type)
 				if(DAMAGE_BRUTE)
-					new /obj/item/stack/material/steel(src.loc, 2)
-					new /obj/item/stack/rods(src.loc, 3)
+					for(var/i = 1 to 3)
+						if(prob(50))
+							new /obj/item/stack/material/steel(src.loc, 2)
+						else
+							new /obj/item/material/shard(src.loc, MATERIAL_STEEL)
 				if(DAMAGE_BURN)
 					new /obj/effect/decal/cleanable/ash(src.loc) // Turn it to ashes!
+					new /obj/item/material/shard(src.loc, MATERIAL_STEEL)
+			new /obj/particle_emitter/door_destruction(loc, 2 SECONDS)
 			qdel(src)
-
-	if(damage)
-		add_damage(damage)
 
 /obj/structure/machinery/door/hitby(atom/movable/hitting_atom, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 	..()
@@ -419,6 +423,8 @@
 	update_icon()
 
 /obj/structure/machinery/door/on_death(damage, damage_flags, damage_type, armor_penetration, obj/weapon)
+	if(stat & BROKEN)
+		return
 	set_broken()
 
 /obj/structure/machinery/door/proc/set_broken()

--- a/code/modules/effects/particles/native_particles.dm
+++ b/code/modules/effects/particles/native_particles.dm
@@ -16,6 +16,21 @@
 	icon = 'icons/effects/native_particles.dmi'
 	icon_state = "cooking_smoke"
 
+/particles/door_destruction
+	name = "door destruction"
+	width = 256
+	height = 256
+	count = 150
+	spawning = 12
+	lifespan = 20
+	fade = 12
+	position = generator("box", list(-24, -8, 0), list(24, 16, 48))
+	gravity = list(0.5, 0)
+	friction = 0.2
+	drift = generator("sphere", 0, 1.5)
+	icon = 'icons/effects/native_particles.dmi'
+	icon_state = "cooking_smoke"
+
 /particles/bar_smoke
 	width = 256
 	height = 256
@@ -111,6 +126,9 @@
 	particle_type = "heat"
 	render_target = HEAT_EFFECT_PLATE_RENDER_TARGET
 	appearance_flags = PIXEL_SCALE | NO_CLIENT_COLOR
+
+/obj/particle_emitter/door_destruction
+	particle_type = "door destruction"
 
 
 /obj/particle_emitter/heat/Initialize()

--- a/html/changelogs/Fenodyree-FixUnbreakableDoors.yml
+++ b/html/changelogs/Fenodyree-FixUnbreakableDoors.yml
@@ -1,0 +1,10 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - bugfix: "Doors and blast doors can be destroyed again with enough sustained damage."
+  - bugfix: "Fixes doors 'breaking' repeatedly, when hit at 0 health."
+  - bugfix: "Fixes doors taking damage twice when hit by projectiles. This also fixes projectiles ignoring a door's armour."
+  - balance: "Increased the armor values on blast doors and vault doors."
+  - rscadd: "Added a brief particle effect when a door is destroyed."


### PR DESCRIPTION
I had accidentally made doors unbreakable, except by anti_material weapons, like the PEAC and ship weapons. This fixes that.

Two PEAC shots will still destroy any normal door.

This is mostly a bugfix, the increase to door armour only compensates for them being mortal again. PEAC basically ignore armor with their 35AP and 100+ damage to structures.

Regular weapons weaker than a laser rifle still cannot completely destroy a door.

It takes an STS ~90 rounds to destroy a blast door.

https://github.com/user-attachments/assets/840514c1-b3a5-4de7-bd81-8651781502dd

changes:
  - bugfix: "Doors and blast doors can be destroyed again with enough sustained damage."
  - bugfix: "Fixes doors 'breaking' repeatedly, when hit at 0 health."
  - bugfix: "Fixes doors taking damage twice when hit by projectiles. This also fixes projectiles ignoring a door's armour."
  - balance: "Increased the armor values on blast doors and vault doors."
  - rscadd: "Added a brief particle effect when a door is destroyed."