### PR TITLE
Greimorian Egg Clades - Fairness Patch

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -83,7 +83,7 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 20
 	armor_penetration = 30
-	venom_per_bite = 1
+	venom_per_bite = 8
 	speed = -2
 	venom_type = /singleton/reagent/toxin/greimorian_eggs
 	fed = 1

--- a/code/modules/organs/subtypes/parasite/greim_eggs.dm
+++ b/code/modules/organs/subtypes/parasite/greim_eggs.dm
@@ -8,8 +8,8 @@
 	parent_organ = BP_CHEST
 	subtle = 1
 
-	/// ~3 minutes/stage (at two seconds/tick)
-	stage_interval = 90
+	/// ~4 minutes/stage (at two seconds/tick)
+	stage_interval = 120
 
 	max_stage = 5
 
@@ -44,25 +44,25 @@
 		to_chat(affecting_organ.owner, SPAN_NOTICE("Your [affecting_organ.name] itches."))
 
 	if(prob(33))
-		owner.adjustNutritionLoss(3)
+		owner.adjustNutritionLoss(2)
 
 	if(stage >= 2)
-		if(prob(8))
+		if(prob(6))
 			gestating_spiderlings += 1
 
 		if(prob(33))
-			owner.adjustNutritionLoss(4)
+			owner.adjustNutritionLoss(3)
 		if(prob(5))
 			owner.emote("whimper")
 		if(prob(2))
 			to_chat(owner, SPAN_WARNING(pick("You feel nauseous and hungry at the same time.", "You feel a burning pain in your [parent_organ].", "Your sense of balance seems broken.")))
 
 	if(stage >= 3)
-		if(prob(6))
+		if(prob(4))
 			gestating_spiderlings += 1
 
 		if(prob(33))
-			owner.adjustNutritionLoss(5)
+			owner.adjustNutritionLoss(4)
 		if(prob(10))
 			affecting_organ.take_damage(rand(1,3))
 			owner.adjustHalLoss(8)
@@ -75,11 +75,10 @@
 			owner.seizure(0.4)
 
 	if(stage >= 4)
-		if(prob(6))
+		if(prob(5))
 			gestating_spiderlings += rand(1,2)
 
 		if(prob(5))
-			owner.reagents.add_reagent(/singleton/reagent/toxin/greimorian_eggs, (gestating_spiderlings / 3))
 			owner.adjustHalLoss(12)
 			to_chat(owner, SPAN_WARNING(pick("A sharp, caustic pain boils out from your [affecting_organ.name]!", "You can feel the flesh of your [affecting_organ.name] beginning to bulge!", "It's going to burst! Your [affecting_organ.name] is going to burst!")))
 		if(prob(5))
@@ -91,7 +90,7 @@
 
 		if(prob(10))
 			owner.seizure(0.6)
-		if(prob(5))
+		if(prob(4))
 			ruptured = TRUE
 			owner.adjustHalLoss(75)
 			owner.seizure()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -1054,28 +1054,31 @@
 
 		victim.add_chemical_effect(CE_PULSE, -2)
 		var/dose = victim.chem_doses[type]
-		if(dose > 2)
+		if(dose > 2) // at least 1 bite
 			if(ishuman(victim) && (dose == metabolism * 2 || prob(3)))
 				victim.emote("yawn")
-		if(dose > 20)
+		if(dose > 10) // at least 3 bites
 			victim.eye_blurry = max(victim.eye_blurry, 10)
-		if(dose > 40)
+		if(dose > 18) // at least 5 bites
 			victim.Weaken(1)
 			victim.drowsiness = max(victim.drowsiness, 20)
 
 		if(victim.chem_effects[CE_ANTIPARASITE])
 			return
 
-		if(!victim.internal_organs_by_name[BP_GREIMORIAN_EGGCLUSTER] && prob(20))
-			var/obj/item/organ/external/affected = pick(victim.organs)
-			if(BP_IS_ROBOTIC(affected))
-				return
-			// Give the victim an extra chance to NOT get an eggsac in their head; reroll. Ditto mechanical limbs.
-			if(affected == BP_HEAD)
-				affected = pick(victim.organs)
-			var/obj/item/organ/internal/parasite/greimorian_eggcluster/infest = new()
-			infest.parent_organ = affected.limb_name
-			infest.replaced(victim, affected)
+		if(dose > 10) // at least 3 bites
+			if(!victim.internal_organs_by_name[BP_GREIMORIAN_EGGCLUSTER] && prob(20))
+				var/obj/item/organ/external/affected = pick(victim.organs)
+				if(BP_IS_ROBOTIC(affected))
+					return
+				// Give the victim an extra chance to NOT get an eggsac somewhere that will insta-kill them; reroll. Ditto mechanical limbs.
+				if(affected == BP_HEAD || affected == BP_CHEST || affected == BP_GROIN)
+					affected = pick(victim.organs)
+				var/obj/item/organ/internal/parasite/greimorian_eggcluster/infest = new()
+				infest.parent_organ = affected.limb_name
+				infest.replaced(victim, affected)
+
+				victim.chem_doses[type] = dose / 2
 
 /singleton/reagent/toxin/malignant_tumour_cells
 	name = "Malignant Tumour Cells"

--- a/html/changelogs/Bat-GreimEggs.yml
+++ b/html/changelogs/Bat-GreimEggs.yml
@@ -1,0 +1,6 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - balance: "Extends minimum time to organ rupture due to Greimorian egg implantation by 33%."
+  - balance: "Removes egg spread chance from Greimorian egg implantation stage 4."
+  - balance: "Minor other adjustments to Greimorian egg behavior (ensures increased duration does not increase final larva count, etc.)"

--- a/html/changelogs/Bat-GreimEggs.yml
+++ b/html/changelogs/Bat-GreimEggs.yml
@@ -2,5 +2,6 @@ author: Batrachophrenoboocosmomachia
 delete-after: True
 changes:
   - balance: "Extends minimum time to organ rupture due to Greimorian egg implantation by 33%."
+  - balance: "Adds chest and groin organ choice in Greimorian egg implantation to reroll chance target, like head, to reduce instakill chance."
   - balance: "Removes egg spread chance from Greimorian egg implantation stage 4."
   - balance: "Minor other adjustments to Greimorian egg behavior (ensures increased duration does not increase final larva count, etc.)"

--- a/html/changelogs/Bat-GreimEggs.yml
+++ b/html/changelogs/Bat-GreimEggs.yml
@@ -2,6 +2,7 @@ author: Batrachophrenoboocosmomachia
 delete-after: True
 changes:
   - balance: "Extends minimum time to organ rupture due to Greimorian egg implantation by 33%."
-  - balance: "Adds chest and groin organ choice in Greimorian egg implantation to reroll chance target, like head, to reduce instakill chance."
+  - balance: "Adds chest and groin organ choice in Greimorian egg implantation to reroll chance target, like head, to reduce effectively-end-your-round chance."
   - balance: "Removes egg spread chance from Greimorian egg implantation stage 4."
   - balance: "Minor other adjustments to Greimorian egg behavior (ensures increased duration does not increase final larva count, etc.)"
+  - balance: "Gives Greimorian Servant (playable worker) greater venom per bite than standard workers."


### PR DESCRIPTION
Makes Greimorian egg implantation a little more fair, without removing the intense danger factor.

1. Increases total incubation time by 33%.
2. Organ reroll chance is now not just for the head, but chest and groin too (reduces odds of instakill, though still does not remove it.)
3. Removes late-stage reinfection chance from incubation stage 4.

NOTE: Helmizole is not just a medicine for curing greimorian parasites. It's also an inoculation. So long as you have it in your system, greimorian eggs might make you hungry and sleepy, but they WON'T be able to start incubating, and they will be removed normally by your liver (or by tox medicine).

Hey ISD! Tell Medical to make you medicine! It's their job!