### PR TITLE
Stasis Cages - Bugfixes & QoL

### DIFF
--- a/code/datums/wires/stasis_cage.dm
+++ b/code/datums/wires/stasis_cage.dm
@@ -26,7 +26,7 @@
 		. += "The panel is unpowered."
 	else
 		. += "The panel is powered."
-		. += "The biometric safety sensors are [(WIRE_SAFETY in cut_wires) ? "connected" : "disconnected"]."
+		. += "The biometric safety sensors are [(WIRE_SAFETY in cut_wires) ? "disconnected" : "connected"]."
 		. += "The cage's emergency auto-release mechanism is [(WIRE_RELEASE in cut_wires) ? "disabled" : "enabled"]."
 		. += "The cage lid motors are [(WIRE_LOCK in cut_wires) ? "overriden" : "nominal"]."
 

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -524,6 +524,7 @@
 		unbuckle()
 		return
 
+	capturing_mob.captured = TRUE
 	captured = WEAKREF(capturing_mob)
 
 	playsound(src, 'sound/weapons/beartrap_shut.ogg', 100, 1)
@@ -674,10 +675,10 @@
 	if(captured_mob)
 		captured_mob.bullet_act(arglist(args))
 
-/obj/item/trap/animal/proc/release(var/mob/user, var/turf/target)
+/obj/item/trap/animal/proc/release(var/mob/user, var/turf/target, var/transferring = FALSE)
 	if(!target)
 		target = src.loc
-	if(user)
+	if(user && !transferring)
 		visible_message(SPAN_NOTICE("[user] opens \the [src]."))
 
 	var/mob/captured_mob = captured ? captured.resolve() : null
@@ -690,10 +691,12 @@
 		var/mob/living/living_mob = captured_mob
 		msg = SPAN_WARNING("[living_mob] runs out of \the [src].")
 
+	captured_mob.captured = FALSE
 	unbuckle()
 	captured = null
-	visible_message(msg)
-	shake_animation()
+	if(!transferring)
+		visible_message(msg)
+		shake_animation()
 	update_icon()
 	layer = initial(layer)
 
@@ -778,6 +781,17 @@
 	. = ..()
 	if(.)
 		sync_captured_mob()
+
+/obj/item/trap/animal/post_buckle(atom/movable/MA)
+	if(MA == buckled || !isliving(MA))
+		return
+
+	var/mob/living/released_mob = MA
+	released_mob.captured = FALSE
+	if(captured?.resolve() == released_mob)
+		captured = null
+	layer = initial(layer)
+	update_icon()
 
 /obj/item/trap/animal/attack_hand(mob/user)
 	if(user.loc == src || captured)

--- a/code/game/objects/structures/machinery/stasis_cage.dm
+++ b/code/game/objects/structures/machinery/stasis_cage.dm
@@ -69,7 +69,10 @@
 	return ..()
 
 /obj/structure/machinery/stasis_cage/process(seconds_per_tick)
-	if (use_power || !cell || !cell.charge)
+	if (!use_power || !cell || !cell.charge)
+		if (isanimal(contained))
+			var/mob/living/simple_animal/SA = contained
+			SA.in_stasis = FALSE
 		return
 	cell.use(2 * seconds_per_tick)
 	if (contained)
@@ -100,7 +103,10 @@
 		release()
 
 /obj/structure/machinery/stasis_cage/proc/release()
-	if (contained)
+	if(contained)
+		if(isanimal(contained))
+			var/mob/living/simple_animal/SA = contained
+			SA.in_stasis = FALSE
 		contained.dropInto(src)
 		contained = null
 		playsound(get_turf(src), 'sound/machines/airlock.ogg', 40)
@@ -249,6 +255,8 @@
 	playsound(src, 'sound/machines/AirlockClose.ogg', 100)
 	add_fingerprint(user)
 	if (do_after(user, 2 SECONDS, src))
+		if(QDELETED(target) || contained || broken || !use_power)
+			return
 		if(target.buckled_to)
 			if(istype(target.buckled_to, /obj/item/trap/animal))
 				var/obj/item/trap/animal/animal_trap = target.buckled_to

--- a/code/game/objects/structures/machinery/stasis_cage.dm
+++ b/code/game/objects/structures/machinery/stasis_cage.dm
@@ -250,5 +250,9 @@
 	add_fingerprint(user)
 	if (do_after(user, 2 SECONDS, src))
 		if(target.buckled_to)
-			target.buckled_to.unbuckle()
+			if(istype(target.buckled_to, /obj/item/trap/animal))
+				var/obj/item/trap/animal/animal_trap = target.buckled_to
+				animal_trap.release(transferring = TRUE)
+			else
+				target.buckled_to.unbuckle()
 		contain(user, target)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -369,6 +369,9 @@ ABSTRACT_TYPE(/mob/living/simple_animal/hostile)
 /mob/living/simple_animal/hostile/proc/OpenFire(atom/target, ignore_visibility = FALSE)
 	set waitfor = FALSE
 
+	if(!isturf(loc) || captured)
+		return
+
 	if(QDELETED(target))
 		LoseTarget()
 		return
@@ -415,6 +418,8 @@ ABSTRACT_TYPE(/mob/living/simple_animal/hostile)
 	return target_hit
 
 /mob/living/simple_animal/hostile/proc/shoot_wrapper(atom/target, location, user)
+	if(!isturf(loc))
+		return
 	Shoot(target, location, user)
 	if(casingtype)
 		new casingtype(loc)

--- a/html/changelogs/Bat-CageStuff.yml
+++ b/html/changelogs/Bat-CageStuff.yml
@@ -1,7 +1,7 @@
 author: Batrachophrenoboocosmomachia
 delete-after: True
 changes:
-  - qol: "Mobs in animal traps can now be transfered directly to Stasis Cages by click-dragging rather than requiring them to be in a net."
+  - qol: "Mobs in animal traps can now be transferred directly to Stasis Cages by click-dragging rather than requiring them to be in a net."
   - bugfix: "Mobs can no longer use their ranged attacks while contained inside objects (including animal traps)."
   - bugfix: "Stasis cages now apply stasis only while powered and correctly clear it when releasing simplemobs."
   - bugfix: "Fixes stasis cage transfers race condition freeing trapped animals randomly."

--- a/html/changelogs/Bat-CageStuff.yml
+++ b/html/changelogs/Bat-CageStuff.yml
@@ -1,0 +1,5 @@
+author: Batrachophrenoboocosmomachia
+delete-after: True
+changes:
+  - rscadd: "Mobs in animal traps can now be transfered to Stasis Cages by click-dragging rather than requiring them to be in a net."
+  - bugfix: "Mobs can no longer use their ranged attacks while contained inside objects (including animal traps)."

--- a/html/changelogs/Bat-CageStuff.yml
+++ b/html/changelogs/Bat-CageStuff.yml
@@ -1,5 +1,8 @@
 author: Batrachophrenoboocosmomachia
 delete-after: True
 changes:
-  - rscadd: "Mobs in animal traps can now be transfered to Stasis Cages by click-dragging rather than requiring them to be in a net."
+  - qol: "Mobs in animal traps can now be transfered directly to Stasis Cages by click-dragging rather than requiring them to be in a net."
   - bugfix: "Mobs can no longer use their ranged attacks while contained inside objects (including animal traps)."
+  - bugfix: "Stasis cages now apply stasis only while powered and correctly clear it when releasing simplemobs."
+  - bugfix: "Fixes stasis cage transfers race condition freeing trapped animals randomly."
+  - bugfix: "Corrects stasis cage safety-wire status display."


### PR DESCRIPTION
changes:
  - qol: "Mobs in animal traps can now be transferred directly to Stasis Cages by click-dragging rather than requiring them to be in a net."
  - bugfix: "Mobs can no longer use their ranged attacks while contained inside objects (including animal traps)."
  - bugfix: "Stasis cages now apply stasis only while powered and correctly clear it when releasing simplemobs."
  - bugfix: "Fixes stasis cage transfers race condition freeing trapped animals randomly."
  - bugfix: "Corrects stasis cage safety-wire status display."