### PR TITLE
Permit voting on red alert

### DIFF
--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -122,19 +122,32 @@ SUBSYSTEM_DEF(vote)
 		return
 	if(!voter?.ckey)
 		return
-	if(FALSE && voter.stat == DEAD && !voter.client?.holder) //Used to be "CONFIG_GET(flag/no_dead_vote)"
+	if(FALSE && voter.stat == DEAD && !voter.client?.holder)
 		return
 
-	// If user has already voted, remove their specific vote
+	// Do not accept a choice that does not belong to the current vote.
+	if(!(their_vote in current_vote.choices))
+		return
+
+	// If the user has already voted, remove the weight that was originally
+	// applied to their previous choice.
 	if(voter.ckey in current_vote.choices_by_ckey)
 		var/their_old_vote = current_vote.choices_by_ckey[voter.ckey]
-		current_vote.choices[their_old_vote]--
+		var/their_old_weight = current_vote.weights_by_ckey[voter.ckey]
+
+		if(isnull(their_old_weight))
+			their_old_weight = 1
+
+		current_vote.choices[their_old_vote] -= their_old_weight
 
 	else
 		voted += voter.ckey
 
+	var/their_new_weight = current_vote.get_vote_weight(voter)
+
 	current_vote.choices_by_ckey[voter.ckey] = their_vote
-	current_vote.choices[their_vote]++
+	current_vote.weights_by_ckey[voter.ckey] = their_new_weight
+	current_vote.choices[their_vote] += their_new_weight
 
 	return TRUE
 

--- a/code/datums/votes/_vote_datum.dm
+++ b/code/datums/votes/_vote_datum.dm
@@ -24,6 +24,8 @@
 	var/list/choices = list()
 	/// A assoc list of [ckey] to [what they voted for in the current running vote].
 	var/list/choices_by_ckey = list()
+	/// An associative list of voter ckeys to the weight applied to their current vote.
+	var/list/weights_by_ckey = list()
 	/// The world time this vote was started.
 	var/started_time
 	/// The time remaining in this vote's run.
@@ -45,6 +47,15 @@
 	return !!length(default_choices)
 
 /**
+ * Returns how much influence a voter's selection has.
+ *
+ * Vote subtypes may override this to assign different weights
+ * to different kinds of voters.
+ */
+/datum/vote/proc/get_vote_weight(mob/voter)
+	return 1
+
+/**
  * Resets our vote to its default state.
  */
 /datum/vote/proc/reset()
@@ -52,6 +63,7 @@
 
 	choices.Cut()
 	choices_by_ckey.Cut()
+	weights_by_ckey.Cut()
 	started_time = null
 	time_remaining = null
 

--- a/code/datums/votes/crew_transfer.dm
+++ b/code/datums/votes/crew_transfer.dm
@@ -24,7 +24,7 @@ GLOBAL_VAR(last_transfer_vote)
 	if(forced)
 		return TRUE
 
-	if(GLOB.security_level >= SEC_LEVEL_RED)
+	if(GLOB.security_level >= SEC_LEVEL_DELTA)
 		to_chat(by_who, "The current alert status is too high to call for a crew transfer!")
 		return FALSE
 
@@ -72,3 +72,16 @@ GLOBAL_VAR(last_transfer_vote)
 
 	if(winning_option == "Initiate Crew Transfer")
 		init_shift_change(null, TRUE)
+
+/**
+ * Observers and players who have not entered the round count as half a vote
+ * during crew-transfer votes.
+ */
+/datum/vote/crewtransfer/get_vote_weight(mob/voter)
+	if(GLOB.security_level >= SEC_LEVEL_RED)
+		if(isobserver(voter) || isnewplayer(voter))
+			return 0.5
+		else
+			return 0.5
+
+	return 1

--- a/html/changelogs/RedAlertVote.yml
+++ b/html/changelogs/RedAlertVote.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Transfer votes can now be called on red alert, but observers only get half vote weight during them."


### PR DESCRIPTION
And during red alerts, ghosts have half the voting power.
This probably needs a testmerge, as I can't quite get it tested locally.