### PR TITLE
Fix horizon overmap loc

### DIFF
--- a/html/changelogs/fabiank3-fix-horizon-overmap-loc.yml
+++ b/html/changelogs/fabiank3-fix-horizon-overmap-loc.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed persistent overmap location of the Horizon."

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -167,7 +167,7 @@
 	if(SSatlas.current_map.use_overmap)
 		var/obj/effect/overmap/visitable/ship/sccv_horizon/ship = locate(/obj/effect/overmap/visitable/ship/sccv_horizon) in GLOB.map_overmap
 		if(ship)
-			SSpersistence.genericSave(/singleton/persistent_type/generic/horizon_overmap_position, list("x" = ship.x, "y" = ship.y), 1)
+			SSpersistence.genericSave(/singleton/persistent_type/generic/horizon_overmap_position, list("x" = ship.x, "y" = ship.y))
 
 /datum/map/sccv_horizon/post_gamemode_setup()
 	// ##### Set persistent Horizon position on the overmap


### PR DESCRIPTION
# Summary

This PR fixes the persistent overmap location of the Horizon not being applied correctly.

<sub>Not me searching for a ", 1" for ages...</sub>

Re-created from #22990 due to branching mistake.