### PR TITLE
Grenade from cover

### DIFF
--- a/code/game/objects/structures/barricades/_barricade.dm
+++ b/code/game/objects/structures/barricades/_barricade.dm
@@ -5,6 +5,7 @@
 	density = TRUE
 	atom_flags = ATOM_FLAG_CHECKS_BORDER
 	maxhealth = OBJECT_HEALTH_LOW
+	pass_flags_self = LETPASSTHROW
 	/// The type of stack the barricade dropped when disassembled if any.
 	var/stack_type
 	/// The amount of stack dropped when disassembled at full health

--- a/html/changelogs/Fenodyree-BarricadeGrenades.yml
+++ b/html/changelogs/Fenodyree-BarricadeGrenades.yml
@@ -1,0 +1,6 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - bugfix: "Grenades can now be thrown over barricades from the defender's side. No more accidentally grenading your team because you were one tile from the sandbags."


### PR DESCRIPTION
  - bugfix: "Grenades can now be thrown over barricades from the defender's side. No more accidentally grenading your team because you were one tile from the sandbags."
  
https://github.com/user-attachments/assets/d8fbfb9e-1d94-40c6-ad25-d6f8baa8143e

