### PR TITLE
Fixes double damage to structures

### DIFF
--- a/code/game/objects/structures/barricades/_barricade.dm
+++ b/code/game/objects/structures/barricades/_barricade.dm
@@ -211,8 +211,6 @@
 		return .
 
 	bullet_ping(hitting_projectile)
-	var/damage_to_take = hitting_projectile.damage * hitting_projectile.anti_materiel_potential
-	add_damage(damage_to_take, hitting_projectile.damage_flags(), hitting_projectile.damtype, hitting_projectile.armor_penetration, hitting_projectile)
 
 /obj/structure/barricade/proc/barricade_deconstruct(deconstruct)
 	if(deconstruct && is_wired)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -357,8 +357,6 @@
 		for(var/mob/living/L in contents)
 			hitting_projectile.Impact(L)
 
-	damage(proj_damage)
-
 /obj/structure/closet/attackby(obj/item/attacking_item, mob/user)
 	if(istype(attacking_item, /obj/item/closet_teleporter))
 		if(linked_teleporter)

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -126,7 +126,6 @@
 	if(. != BULLET_ACT_HIT)
 		return .
 
-	health -= hitting_projectile.get_structure_damage()
 	check_health()
 
 /obj/structure/closet/statue/attack_generic(mob/user, damage, attack_message, environment_smash, armor_penetration, attack_flags, damage_type)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -40,10 +40,6 @@
 	if(. != BULLET_ACT_HIT)
 		return .
 
-	var/damage = hitting_projectile.damage
-	if(damage)
-		add_damage(damage)
-
 /obj/structure/displaycase/on_death()
 	if(!destroyed)
 		density = FALSE

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -73,7 +73,7 @@
 /obj/structure/girder/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit)
 	//Girders only provide partial cover. There's a chance that the projectiles will just pass through. (unless you are trying to shoot the girder)
 	if(hitting_projectile.original != src && !prob(cover))
-		return BULLET_ACT_HIT //pass through
+		return BULLET_ACT_FORCE_PIERCE //pass through
 
 	var/damage = hitting_projectile.get_structure_damage()
 	if(!damage)

--- a/code/game/objects/structures/gore/core.dm
+++ b/code/game/objects/structures/gore/core.dm
@@ -30,8 +30,6 @@
 	if(. != BULLET_ACT_HIT)
 		return .
 
-	add_damage(hitting_projectile.damage)
-
 /obj/structure/gore/ex_act(severity)
 	switch(severity)
 		if(1.0)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -96,8 +96,6 @@
 
 	bullet_ping(hitting_projectile)
 
-	health -= proj_damage
-
 	if(health <= 0)
 		deflate(TRUE)
 	return

--- a/code/game/objects/structures/machinery/atmoalter/canister.dm
+++ b/code/game/objects/structures/machinery/atmoalter/canister.dm
@@ -6,6 +6,7 @@
 	density = TRUE
 	light_system = MOVABLE_LIGHT
 	maxhealth = OBJECT_HEALTH_LOW
+	should_use_health = FALSE
 	obj_flags = OBJ_FLAG_SIGNALER | OBJ_FLAG_CONDUCTABLE
 	w_class = WEIGHT_CLASS_HUGE
 

--- a/code/game/objects/structures/machinery/camera/camera.dm
+++ b/code/game/objects/structures/machinery/camera/camera.dm
@@ -157,8 +157,6 @@
 	if(. != BULLET_ACT_HIT)
 		return .
 
-	add_damage(hitting_projectile.get_structure_damage(), hitting_projectile.damage_flags(), hitting_projectile.damage_type, hitting_projectile.armor_penetration, hitting_projectile)
-
 /obj/structure/machinery/camera/ex_act(severity)
 	if(src.invuln)
 		return

--- a/code/game/objects/structures/machinery/deployable.dm
+++ b/code/game/objects/structures/machinery/deployable.dm
@@ -19,7 +19,10 @@ Deployable Kits
 	density = TRUE
 	layer = ABOVE_DOOR_LAYER // above door layer so it can appear on the airlocks like a proper barricade
 	maxhealth = OBJECT_HEALTH_LOW
-
+	armor = list(
+		MELEE = ARMOR_MELEE_RESISTANT,
+		BULLET = ARMOR_BALLISTIC_PISTOL
+	)
 	var/force_material
 
 /obj/structure/blocker/Initialize(mapload, var/material_name)
@@ -46,13 +49,6 @@ Deployable Kits
 	if(. != BULLET_ACT_HIT)
 		return .
 
-	var/damage_modifier = 0.4
-	switch(hitting_projectile.damage_type)
-		if(DAMAGE_BURN)
-			damage_modifier = 1
-		if(DAMAGE_BRUTE)
-			damage_modifier = 0.75
-	health -= hitting_projectile.damage * damage_modifier
 	if(!check_dismantle())
 		visible_message(SPAN_WARNING("\The [src] is hit by \the [hitting_projectile]!"))
 
@@ -76,11 +72,6 @@ Deployable Kits
 			return TRUE
 	else
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		switch(attacking_item.damtype)
-			if(DAMAGE_BURN)
-				src.health -= attacking_item.force * 1
-			if(DAMAGE_BRUTE)
-				src.health -= attacking_item.force * 0.75
 		shake_animation()
 		playsound(src.loc, material.hitsound, attacking_item.get_clamped_volume(), 1)
 		if(check_dismantle())

--- a/code/game/objects/structures/machinery/portable_turret.dm
+++ b/code/game/objects/structures/machinery/portable_turret.dm
@@ -500,8 +500,6 @@
 	if(. != BULLET_ACT_HIT)
 		return .
 
-	add_damage(damage)
-
 /obj/structure/machinery/porta_turret/emp_act(severity)
 	. = ..()
 

--- a/code/game/objects/structures/simple_doors.dm
+++ b/code/game/objects/structures/simple_doors.dm
@@ -202,7 +202,6 @@
 	if(. != BULLET_ACT_HIT)
 		return .
 
-	health -= hitting_projectile.damage
 	bullet_ping(hitting_projectile)
 	CheckHealth()
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -114,8 +114,6 @@
 	if(. != BULLET_ACT_HIT)
 		return .
 
-	add_damage(proj_damage, hitting_projectile.damage_flags(), hitting_projectile.damage_type, hitting_projectile.armor_penetration, hitting_projectile)
-
 /obj/structure/window/ex_act(severity)
 	switch(severity)
 		if(1)

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -509,8 +509,6 @@
 	if(. != BULLET_ACT_HIT)
 		return .
 
-	take_damage(hitting_projectile.get_structure_damage())
-
 /obj/structure/machinery/shipsensors/proc/toggle()
 	if(use_power) // reset desired range when turning off
 		set_desired_range(1)

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -182,7 +182,7 @@
 		return .
 
 	visible_message(SPAN_WARNING("\The [src] is hit by \the [hitting_projectile]!"))
-	health_check(hitting_projectile.damage)
+	health_check()
 
 /obj/structure/machinery/power/smes/buildable/proc/health_check(var/health_reduction = 0)
 	health -= health_reduction

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -362,7 +362,6 @@
 	if(. != BULLET_ACT_HIT)
 		return .
 
-	health -= hitting_projectile.get_structure_damage()
 	check_failure()
 	opacity = TRUE
 	addtimer(CALLBACK(src, PROC_REF(update_opacity), FALSE), 2 SECONDS)

--- a/html/changelogs/Fenodyree-FixesStructureDoubleDamage.yml
+++ b/html/changelogs/Fenodyree-FixesStructureDoubleDamage.yml
@@ -1,0 +1,6 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed many instances where structures took double damage in error.

--- a/html/changelogs/Fenodyree-FixesStructureDoubleDamage.yml
+++ b/html/changelogs/Fenodyree-FixesStructureDoubleDamage.yml
@@ -3,4 +3,4 @@ author: Fenodyree
 delete-after: True
 
 changes:
-  - bugfix: "Fixed many instances where structures took double damage in error.
+  - bugfix: "Fixed many instances where structures took double damage in error."


### PR DESCRIPTION
Atom health added damage handling at the base obj/structure level.

Many structures had their own damage handling code in bullet_act.
Bullet act requires that you call it's parent.

Fixes all of the double damage instances I could find, trying to keep the behavior as close to the old as possible.

Added armour to a few things that had snowflake damage reductions.