### PR TITLE
Circuit printers print uncharged batteries

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -37,6 +37,11 @@
 	maxcharge = 250
 	matter = list(MATERIAL_STEEL = 70, MATERIAL_GLASS = 5)
 
+/obj/item/cell/device/empty/Initialize()
+	. = ..()
+	charge = 0
+	update_icon()
+
 /obj/item/cell/device/high
 	name = "advanced power cell"
 	desc = "A small, advanced power cell designed to power more energy demanding handheld devices."

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -40,6 +40,8 @@
 	. = ..()
 	if (!printed)
 		battery = new /obj/item/cell/device(src)
+	else
+		battery = new /obj/item/cell/device/empty(src)
 	START_PROCESSING(SSelectronics, src)
 	access_card = new /obj/item/card/id(src)
 

--- a/html/changelogs/FenodyreeCircuitQOL.yml
+++ b/html/changelogs/FenodyreeCircuitQOL.yml
@@ -1,0 +1,7 @@
+author: Fenodyree
+
+
+delete-after: True
+
+changes:
+  - qol: "Cloned circuit assemblies now spawn with uncharged batteries."


### PR DESCRIPTION
Having to manually open closed circuits and install a battery in each individual one was pain when cloning large volumes.

Now the circuit printer spawns the circuit with an uncharged battery.

If you want a better battery, or a charged one you still have to take it out.