### PR TITLE
Integrated circuits can be recycled and charged in rechargers

### DIFF
--- a/code/game/objects/structures/machinery/recharger.dm
+++ b/code/game/objects/structures/machinery/recharger.dm
@@ -30,7 +30,8 @@
 		/obj/item/clothing/mask/smokable/ecig,
 		/obj/item/inductive_charger/handheld,
 		/obj/item/auto_cpr,
-		/obj/item/personal_shield
+		/obj/item/personal_shield,
+		/obj/item/electronic_assembly
 	)
 	var/icon_state_charged = "recharger100"
 	var/icon_state_charging = "recharger"

--- a/code/modules/fabrication/_fabricator.dm
+++ b/code/modules/fabrication/_fabricator.dm
@@ -213,7 +213,7 @@ ABSTRACT_TYPE(/obj/structure/machinery/fabricator)
 	load_lathe(attacking_item, user)
 	return TRUE
 
-/obj/structure/machinery/fabricator/autolathe/proc/recycle_rped_contents(obj/item/storage/part_replacer/R, mob/user)
+/obj/structure/machinery/fabricator/autolathe/proc/recycle_item_contents(obj/item/R, mob/user)
 	var/recycled = 0
 	var/recyclable = 0
 	var/rejected = 0
@@ -241,7 +241,6 @@ ABSTRACT_TYPE(/obj/structure/machinery/fabricator)
 	user.set_machine(src)
 	ui_interact(user)
 
-///
 /obj/structure/machinery/fabricator/proc/is_functioning()
 	. = use_power != POWER_USE_OFF && !(fab_status_flags & FAB_DISABLED)
 

--- a/code/modules/fabrication/fabricators/fabricator_autolathe.dm
+++ b/code/modules/fabrication/fabricators/fabricator_autolathe.dm
@@ -6,16 +6,13 @@
 
 /obj/structure/machinery/fabricator/autolathe/mechanics_hints(mob/user, distance, is_adjacent)
 	. = ..()
-	. += "Alt-click with a rapid part exchange device in your active hand to recycle its compatible contents."
+	. += "Alt-click with a rapid part exchange device or open circuit assembly in your active hand to recycle its compatible contents."
 
 /obj/structure/machinery/fabricator/autolathe/AltClick(mob/user)
 	. = ..()
 	if(use_check_and_message(user))
 		return
 
-	var/obj/item/storage/part_replacer/R = user.get_active_hand()
-	if(!istype(R))
-		return
 
 	if(fab_status_flags & FAB_BUSY)
 		to_chat(user, SPAN_NOTICE("\The [src] is busy. Please wait for the completion of the previous operation."))
@@ -25,7 +22,18 @@
 		to_chat(user, SPAN_WARNING("\The [src] cannot accept materials in its current state."))
 		return
 
-	recycle_rped_contents(R, user)
+	var/obj/item/electronic_assembly/recyclable_container = user.get_active_hand()
+	if(istype(recyclable_container, /obj/item/electronic_assembly))
+		var/obj/item/electronic_assembly/recyclable_circuit_assembly = recyclable_container
+		if(recyclable_circuit_assembly.opened)
+			recycle_item_contents(recyclable_container, user)
+			return
+		else
+			to_chat(user, SPAN_WARNING("\The [recyclable_circuit_assembly] must be open before it's contents can be recycled."))
+
+	if(istype(recyclable_container, /obj/item/storage/part_replacer))
+		recycle_item_contents(recyclable_container, user)
+		return
 
 /obj/structure/machinery/fabricator/autolathe/mounted
 	name = "\improper mounted autolathe"

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -11,6 +11,8 @@
 	icon_state = "setup_small"
 	item_flags = ITEM_FLAG_NO_BLUDGEON
 	light_system = MOVABLE_LIGHT
+	recyclable = TRUE
+	charge_failure_message = " is missing a powercell."
 
 	var/max_components = IC_COMPONENTS_BASE
 	var/max_complexity = IC_COMPLEXITY_BASE
@@ -42,6 +44,8 @@
 		battery = new /obj/item/cell/device(src)
 	START_PROCESSING(SSelectronics, src)
 	access_card = new /obj/item/card/id(src)
+	if (!matter) //Matter amounts might be set during the cloning process.
+		matter =  list(MATERIAL_STEEL = (round((max_complexity + max_components) / 4)) * 200)
 
 /obj/item/electronic_assembly/Destroy()
 	QDEL_NULL(battery)
@@ -373,6 +377,11 @@
 
 	for(var/atom/movable/AM in contents)
 		AM.emp_act(severity)
+
+/obj/item/electronic_assembly/get_cell()
+	if(battery)
+		return battery
+	return DEVICE_NO_CELL
 
 // Returns true if power was successfully drawn.
 /obj/item/electronic_assembly/proc/draw_power(amount)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -11,7 +11,7 @@
 	icon_state = "setup_small"
 	item_flags = ITEM_FLAG_NO_BLUDGEON
 	light_system = MOVABLE_LIGHT
-	recyclable = TRUE
+	recyclable = FALSE
 	charge_failure_message = " is missing a powercell."
 
 	var/max_components = IC_COMPONENTS_BASE
@@ -104,6 +104,10 @@
 	var/list/HTML = list()
 	var/effective_component_limit = get_effective_component_limit(total_complexity)
 	var/effective_complexity_limit = get_effective_complexity_limit(total_parts)
+	if (!total_parts && !total_complexity)
+		recyclable = TRUE
+	else
+		recyclable = FALSE
 
 	HTML += "<br><a href='byond://?src=[REF(src)]'>Refresh</a>  |  "
 	HTML += "<a href='byond://?src=[REF(src)];rename=1'>Rename</a><br>"
@@ -260,7 +264,7 @@
 		return FALSE
 
 	IC.assembly = src
-
+	recyclable = FALSE
 	return TRUE
 
 // Non-interactive version of above that always succeeds, intended for build-in circuits that get added on assembly initialization.

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -24,6 +24,11 @@ a creative player the means to solve many problems.  Circuits are held inside an
 	setup_io(inputs, /datum/integrated_io, inputs_default)
 	setup_io(outputs, /datum/integrated_io, outputs_default)
 	setup_io(activators, /datum/integrated_io/activate)
+	var/phoron_matter = initial(phoron_cost) * 2000
+	var/steel_matter = max(1, w_class) * 200
+	if(phoron_matter || steel_matter)
+		matter = list(MATERIAL_STEEL = steel_matter, MATERIAL_PHORON = phoron_matter)
+		recyclable = TRUE
 	. = ..()
 
 /obj/item/integrated_circuit/proc/on_data_written() //Override this for special behaviour when new data gets pushed to the circuit.

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -618,8 +618,7 @@
 			to_chat(user, SPAN_WARNING("\The [src] fails to finish the cloned assembly."))
 		return
 
-	new_clone.matter = list(MATERIAL_STEEL = cost * 200, MATERIAL_PHORON = phoron_cost * 200) //Each sheet gives the circuit printer 10, each sheet is 2000 in the autolathe.
-
+	new_clone.recyclable = FALSE //A cloned circuit will have components in it.
 	if(user)
 		to_chat(user, SPAN_NOTICE("\The [src] finishes printing \the [new_clone]."))
 
@@ -630,7 +629,6 @@
 
 	var/obj/item/integrated_circuit/IC = circuit_type
 	return max(0, initial(IC.phoron_cost) * phoron_per_sheet)
-
 
 /obj/item/integrated_circuit_printer/proc/get_clone_metal_cost(obj/item/electronic_assembly/source)
 	if(!source)

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -618,6 +618,8 @@
 			to_chat(user, SPAN_WARNING("\The [src] fails to finish the cloned assembly."))
 		return
 
+	new_clone.matter = list(MATERIAL_STEEL = cost * 200, MATERIAL_PHORON = phoron_cost * 200) //Each sheet gives the circuit printer 10, each sheet is 2000 in the autolathe.
+
 	if(user)
 		to_chat(user, SPAN_NOTICE("\The [src] finishes printing \the [new_clone]."))
 

--- a/html/changelogs/Fenodyree-MoreCircuitQOL.yml
+++ b/html/changelogs/Fenodyree-MoreCircuitQOL.yml
@@ -1,0 +1,7 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - qol: "Integrated circuit assemblies can now be recycled in autolathes. They can't be recycled in the printer, because clicking the printer with the circuit is required to scan it for cloning."
+  - qol: "Integrated circuits can now be charged in rechargers."


### PR DESCRIPTION
Also generalizes autolathe recycling so that other containers can alt click it to be recycled. Currently its still only circuits and the part exchanger.

changes:
  - qol: "Integrated circuit assemblies can now be recycled in autolathes. They can't be recycled in the printer, because clicking the printer with the circuit is required to scan it for cloning."
  - qol: "Integrated circuits can now be charged in rechargers."


https://github.com/user-attachments/assets/1b8325a8-aca0-4df0-a2a3-763eb8cec989

