### PR TITLE
Flags/banners with custom names and descriptions now keep these when hung up/deployed

### DIFF
--- a/code/game/objects/structures/flags_banners.dm
+++ b/code/game/objects/structures/flags_banners.dm
@@ -174,6 +174,9 @@
 		var/obj/structure/sign/flag/F = new flag_structure(user.loc, user.dir, deploy = TRUE, item_flag_path = flag_path)
 		F.name = src.name
 		F.desc = src.desc
+			if(F.linked_flag)
+			F.linked_flag.name = src.name
+			F.linked_flag.desc = src.desc
 		qdel(src)
 
 /obj/item/flag/afterattack(var/atom/A, var/mob/user, var/adjacent)
@@ -200,7 +203,6 @@
 	if(F.linked_flag)
 		F.linked_flag.name = src.name
 		F.linked_flag.desc = src.desc
-
 	qdel(src)
 
 

--- a/code/game/objects/structures/flags_banners.dm
+++ b/code/game/objects/structures/flags_banners.dm
@@ -174,7 +174,7 @@
 		var/obj/structure/sign/flag/F = new flag_structure(user.loc, user.dir, deploy = TRUE, item_flag_path = flag_path)
 		F.name = src.name
 		F.desc = src.desc
-			if(F.linked_flag)
+		if(F.linked_flag)
 			F.linked_flag.name = src.name
 			F.linked_flag.desc = src.desc
 		qdel(src)

--- a/code/game/objects/structures/flags_banners.dm
+++ b/code/game/objects/structures/flags_banners.dm
@@ -171,7 +171,9 @@
 	if(isfloor(user.loc))
 		user.visible_message(SPAN_NOTICE("\The [user] deploys \the [src] on \the [get_turf(loc)]."), SPAN_NOTICE("You deploy \the [src] on \the [get_turf(loc)]."))
 		user.drop_from_inventory(src)
-		new flag_structure(user.loc, user.dir, deploy = TRUE, item_flag_path = flag_path)
+		var/obj/structure/sign/flag/F = new flag_structure(user.loc, user.dir, deploy = TRUE, item_flag_path = flag_path)
+		F.name = src.name
+		F.desc = src.desc
 		qdel(src)
 
 /obj/item/flag/afterattack(var/atom/A, var/mob/user, var/adjacent)
@@ -192,7 +194,13 @@
 
 	user.visible_message(SPAN_NOTICE("\The [user] fastens \the [src] to \the [A]."), SPAN_NOTICE("You fasten \the [src] to \the [A]."))
 	user.drop_from_inventory(src)
-	new flag_structure(user.loc, placement_dir, deploy = TRUE, item_flag_path = flag_path)
+	var/obj/structure/sign/flag/F = new flag_structure(user.loc, user.dir, deploy = TRUE, item_flag_path = flag_path)
+	F.name = src.name
+	F.desc = src.desc
+	if(F.linked_flag)
+		F.linked_flag.name = src.name
+		F.linked_flag.desc = src.desc
+
 	qdel(src)
 
 
@@ -222,6 +230,8 @@
 		else
 			user.visible_message(SPAN_NOTICE("\The [user] unfastens \the [src] and folds it back up."), SPAN_NOTICE("You unfasten \the [src] and fold it back up."))
 		var/obj/item/flag/F = new flag_item(get_turf(user))
+		F.name = src.name
+		F.desc = src.desc
 		user.put_in_hands(F)
 	else
 		user.visible_message(SPAN_NOTICE("\The [user] unfastens the tattered remnants of \the [src]."), SPAN_NOTICE("You unfasten the tattered remains of \the [src]."))

--- a/html/changelogs/omi-flagstuff.yml
+++ b/html/changelogs/omi-flagstuff.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Flags and banners with custom names and descriptions now keep these custom names and descriptions when deployed."


### PR DESCRIPTION
See title. Players have been able to assign a custom description to the loadout flag/banner selection since forever, but it never persisted over to actual 'hung up' flag object and was essentially erased if ever used.

<img width="777" height="600" alt="image" src="https://github.com/user-attachments/assets/6b80b6f0-a120-4ba2-a46d-a680b7e5fff5" />