### PR TITLE
Allows duffel bags to be accessed in hands

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -39,6 +39,12 @@
 	 * If the object may be accessed while equipped anywhere on a character, including hands.
 	 */
 	var/equip_access = TRUE
+	/**
+	 * If the object should have a delay to open, for more cumbersome bags such as duffels.
+	 * If false, no delay is applied. Apply a value if a delay should be applied, and the
+	 * delay will be equal in seconds to the value of this variable.
+	 */
+	var/access_delay = 0 SECONDS
 
 /obj/item/storage/backpack/antagonist_hints(mob/user, distance, is_adjacent)
 	. += ..()
@@ -144,6 +150,8 @@
 /obj/item/storage/backpack/open(mob/user)
 	if (!worn_check())
 		return
+	if(access_delay > 0 SECONDS)
+		do_after(user, access_delay)
 	..()
 
 /obj/item/storage/backpack/proc/worn_check(no_message = FALSE)
@@ -153,7 +161,7 @@
 			return TRUE //not equipped
 		if(!worn_access && (slot_flags & SLOT_BACK) && M.get_equipped_item(slot_back) == src)
 			if(!no_message)
-				to_chat(M, SPAN_WARNING("Your arms are not long enough to open \the [src] while it is on your back!"))
+				to_chat(M, SPAN_WARNING("You cannot access the contents of \the [src] while it is on your back!"))
 				if(use_sound)
 					playsound(loc, use_sound, 50, 1, -5)
 				if(animated)
@@ -161,7 +169,7 @@
 			return FALSE
 		if(!equip_access && (ismob(loc)))
 			if(!no_message)
-				to_chat(M, SPAN_WARNING("\The [src] is too cumbersome to handle, you're going to have to set it down somewhere!"))
+				to_chat(M, SPAN_WARNING("\The [src] is too cumbersome to access in your hands, you're going to have to set it down somewhere!"))
 				if(use_sound)
 					playsound(loc, use_sound, 50, 1, -5)
 				if(animated)
@@ -630,8 +638,15 @@
 	icon_state = "duffel"
 	item_state = "duffel"
 	worn_access = FALSE
+	access_delay = 1 SECOND
 	max_storage_space = DEFAULT_DUFFELBAG_STORAGE
 	straps = TRUE
+
+/obj/item/storage/backpack/duffel/mechanics_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "Duffel bags store a greater capacity than any other kind of backpack or satchel."
+	. += "Duffel bags cannot be accessed while on a character's back, but can be accessed while in their hand or on the floor."
+	. += "Duffel bags are laborious to use! There is a short delay on accessing them in all contexts."
 
 /obj/item/storage/backpack/duffel/cap
 	name = "captain's duffel bag"

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -630,7 +630,6 @@
 	icon_state = "duffel"
 	item_state = "duffel"
 	worn_access = FALSE
-	equip_access = FALSE
 	max_storage_space = DEFAULT_DUFFELBAG_STORAGE
 	straps = TRUE
 

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -41,8 +41,8 @@
 	var/equip_access = TRUE
 	/**
 	 * If the object should have a delay to open, for more cumbersome bags such as duffels.
-	 * If set to zero, no delay is applied. Define a value in seconds if a delay should be
-	 * applied and the delay will be equal to the value of this variable.
+	 * If set to zero seconds, no delay is applied. Define a value in seconds if a delay
+	 * should be applied and the delay will be equal to the value of this variable.
 	 */
 	var/access_delay = 0 SECONDS
 

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -150,8 +150,8 @@
 /obj/item/storage/backpack/open(mob/user)
 	if (!worn_check())
 		return
-	if(access_delay > 0 SECONDS)
-		do_after(user, access_delay)
+	if(access_delay && !do_after(user, access_delay))
+		return
 	..()
 
 /obj/item/storage/backpack/proc/worn_check(no_message = FALSE)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -41,8 +41,8 @@
 	var/equip_access = TRUE
 	/**
 	 * If the object should have a delay to open, for more cumbersome bags such as duffels.
-	 * If false, no delay is applied. Apply a value if a delay should be applied, and the
-	 * delay will be equal in seconds to the value of this variable.
+	 * If set to zero, no delay is applied. Define a value in seconds if a delay should be
+	 * applied and the delay will be equal to the value of this variable.
 	 */
 	var/access_delay = 0 SECONDS
 

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -695,7 +695,6 @@
 	icon_state = "duffel-syndie"
 	item_state = "duffel-syndie"
 	worn_access = TRUE
-	equip_access = TRUE
 	empty_delay = 0.8 SECOND
 
 /obj/item/storage/backpack/duffel/cmo

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -43,6 +43,7 @@
 	 * If the object should have a delay to open, for more cumbersome bags such as duffels.
 	 * If set to zero seconds, no delay is applied. Define a value in seconds if a delay
 	 * should be applied and the delay will be equal to the value of this variable.
+	 * Only applies while on a character mob, not while the bag is on the floor.
 	 */
 	var/access_delay = 0 SECONDS
 
@@ -150,7 +151,7 @@
 /obj/item/storage/backpack/open(mob/user)
 	if (!worn_check())
 		return
-	if(access_delay && !do_after(user, access_delay))
+	if(access_delay && !isturf(loc) && !do_after(user, access_delay))
 		return
 	..()
 
@@ -646,7 +647,7 @@
 	. += ..()
 	. += "Duffel bags store a greater capacity than any other kind of backpack or satchel."
 	. += "Duffel bags cannot be accessed while on a character's back, but can be accessed while in their hand or on the floor."
-	. += "Duffel bags are laborious to use! There is a short delay on accessing them in all contexts."
+	. += "Duffel bags are laborious to use! There is a short delay on accessing them while in your hands."
 
 /obj/item/storage/backpack/duffel/cap
 	name = "captain's duffel bag"

--- a/html/changelogs/hazelmouse-duffels.yml
+++ b/html/changelogs/hazelmouse-duffels.yml
@@ -56,3 +56,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscadd: "Duffel bags can now be accessed while in your hand."
+  - rscadd: "Introduced a one second delay to opening duffel bags."

--- a/html/changelogs/hazelmouse-duffels.yml
+++ b/html/changelogs/hazelmouse-duffels.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Duffel bags can now be accessed while in your hand."


### PR DESCRIPTION
Tiny change, duffel bags can now be accessed in your hands as well as while on the floor. They still cannot be accessed while on your back. You still have to sacrifice a hand slot to use duffels, it just removes some of the busywork involved in dropping it (and makes them more useable during vents now that your own bag won't run away from you with the moving air).