### PR TITLE
IPC power core rejigging

### DIFF
--- a/code/game/objects/structures/machinery/rechargestation.dm
+++ b/code/game/objects/structures/machinery/rechargestation.dm
@@ -19,7 +19,7 @@
 	var/icon_update_tick = 0	// Used to rebuild the overlay only once every 10 ticks
 
 	///Multiplier applied to all operations of giving power to cells, represents entropy, efficiency increases with upgrades
-	var/charging_efficiency = 1.3
+	var/charging_efficiency = 2
 
 	///Watts, Power rating drawn from internal cell to recharge occupant's cell 60 kW unupgraded
 	var/charging_power
@@ -229,7 +229,7 @@
 			man_rating += P.rating
 	cell = locate(/obj/item/cell) in component_parts
 
-	charging_efficiency = 1.3 + 0.030 * cap_rating
+	charging_efficiency = 2 + 0.030 * cap_rating
 	charging_power = 30000 + 12000 * cap_rating
 	restore_power_active = 10000 + 10000 * cap_rating
 	restore_power_passive = 5000 + 1000 * cap_rating

--- a/code/modules/organs/internal/species/machine/power_core.dm
+++ b/code/modules/organs/internal/species/machine/power_core.dm
@@ -13,7 +13,7 @@
 	/// If the power core's hatch is open. Battery can be removed if TRUE.
 	var/open = FALSE
 	/// The type (and later instance) of the cell inside this organ.
-	var/obj/item/cell/cell = /obj/item/cell/super
+	var/obj/item/cell/cell = /obj/item/cell/high
 	/// The cost of movement below (check process()) is multiplied by this factor.
 	var/move_charge_factor = 1
 	/// At 0.8 completely depleted after 60ish minutes of constant walking or 130 minutes of standing still.

--- a/html/changelogs/hazelmouse-celltweak.yml
+++ b/html/changelogs/hazelmouse-celltweak.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Downgraded the standard power cell in an IPC, bringing their total capacity down by 50% and closer to their values prior to a recent refactor. Recharge stations also made more efficient."


### PR DESCRIPTION
By modifying power cell capacities, https://github.com/Aurorastation/Aurora.3/pull/21285 inadvertently tripled the amount of power available to IPCs in their roundstart power core, going from 20000 --> 60000. This drags that down to 30000 with a high-capacity power cell, still half again higher than the original value, and increases the efficiency of recharge stations a little so sitting in them is less tedious.