### PR TITLE
Lets you wear your integrated circuit PDA

### DIFF
--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -139,7 +139,8 @@
 		/obj/item/storage/box/fancy/cigarettes/dyn = HELMET_GARB_PASS_ICON,
 		/obj/item/storage/box/fancy/cigarettes/wulu = HELMET_GARB_PASS_ICON,
 		/obj/item/clothing/head/hachimaki = HELMET_GARB_PASS_ICON,
-		/obj/item/clothing/head/leader_headband = HELMET_GARB_PASS_ICON
+		/obj/item/clothing/head/leader_headband = HELMET_GARB_PASS_ICON,
+		/obj/item/electronic_assembly/default = HELMET_GARB_PASS_ICON
 	)
 	can_hold_strict = TRUE
 

--- a/code/modules/integrated_electronics/core/assemblies/generic.dm
+++ b/code/modules/integrated_electronics/core/assemblies/generic.dm
@@ -46,6 +46,8 @@
 
 /obj/item/electronic_assembly/default
 	name = "basic small circuit case"
+	desc = "A case for building small electronic assemblies. This one has a strap and clip to attach to clothing, belts or wrists."
+	slot_flags = SLOT_WRISTS | SLOT_BELT
 
 /obj/item/electronic_assembly/calc
 	name = "calculator small circuit case"
@@ -65,12 +67,14 @@
 /obj/item/electronic_assembly/hook
 	name = "belt-clip small circuit case"
 	icon_state = "setup_small_hook"
-	desc = "A case for building small electronic assemblies. This one looks like it has a belt clip, but it's purely decorative."
+	desc = "A case for building small electronic assemblies. This one looks like it has a belt clip."
+	slot_flags = SLOT_BELT
 
 /obj/item/electronic_assembly/pda
 	name = "PDA-style small circuit case"
 	icon_state = "setup_small_pda"
-	desc = "A case for building small electronic assemblies. This one resembles a PDA."
+	desc = "A case for building small electronic assemblies. This one resembles a PDA and looks like it has a wrist strap."
+	slot_flags = SLOT_WRISTS | SLOT_BELT
 
 
 // Tiny assemblies.
@@ -99,7 +103,8 @@
 /obj/item/electronic_assembly/tiny/hook
 	name = "belt-clip tiny circuit case"
 	icon_state = "setup_device_hook"
-	desc = "A case for building tiny electronic assemblies. This one looks like it has a belt clip, but it's purely decorative."
+	desc = "A case for building tiny electronic assemblies. This one looks like it has a belt clip."
+	slot_flags = SLOT_BELT
 
 /obj/item/electronic_assembly/tiny/box
 	name = "boxy tiny circuit case"

--- a/html/changelogs/WearablePDAICs.yml
+++ b/html/changelogs/WearablePDAICs.yml
@@ -1,0 +1,7 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - rscadd: "Lets some small integrated circuit designs be worn on the wrist, belt, or clipped to a helmet for helmet cameras."
+


### PR DESCRIPTION
Integrated circuits support being worn by mobs now!
Lets the circuits that previously said their clips were decorative actually be worn.

Also lets small ICs be put in the helmet slot, for expeditionary helmet cameras.
<img width="119" height="111" alt="image" src="https://github.com/user-attachments/assets/07b1f108-be8d-403d-975f-080ad3a10838" />

Hopefully getting a go-pro like sprite for it soon.
