### PR TITLE
Slightly tweaks and documents a do_after interaction

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -672,8 +672,8 @@
 /// Instead of caching user/target's loc, we cache the turfs (inventory/turf distinction).
 #define DO_MOVE_CHECKS_TURFS FLAG(9)
 #define DO_FAIL_FEEDBACK FLAG(10)
-/// Explictly places the progress bar on mob. Useful when a target needs to be provided (see target/mob unique act) but progress bar should appear on mob.
-#define DO_PLACE_PROGRESSBAR_ON_MOB FLAG(11)
+/// Explictly places the progress bar on the user. Useful when a target needs to be provided (see target/user unique act) but progress bar should appear on the user.
+#define DO_PLACE_PROGRESSBAR_ON_USER FLAG(11)
 
 // Preset macros
 /// Both user and target allowed to move.
@@ -698,7 +698,7 @@
 /// Flags for repair and construction steps.
 #define DO_REPAIR_CONSTRUCT (DO_DEFAULT | DO_TARGET_UNIQUE_ACT)
 /// Flags for held items that can be deployed.
-#define DO_DEPLOY (DO_DEFAULT | DO_TARGET_UNIQUE_ACT | DO_PLACE_PROGRESSBAR_ON_MOB)
+#define DO_DEPLOY (DO_DEFAULT | DO_TARGET_UNIQUE_ACT | DO_PLACE_PROGRESSBAR_ON_USER)
 /// Flags for equipping/unequipping mobs. Set to allow a mob to be targeted by multiple sources, but for a source to only be able to perform one action at a time.
 #define DO_EQUIP (DO_DEFAULT | DO_USER_UNIQUE_ACT)
 

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -658,27 +658,49 @@
 //used by /proc/do_after
 #define DO_USER_CAN_MOVE FLAG(0)
 #define DO_USER_CAN_TURN FLAG(1)
+/// Locks the user from making any new do_after calls anywhere (with this flag) while the do_after proc is still running.
 #define DO_USER_UNIQUE_ACT FLAG(2)
-#define DO_USER_SAME_HAND FLAG(3)
-#define DO_USER_SAME_ZONE FLAG(4)
-#define DO_TARGET_CAN_MOVE FLAG(5)
-#define DO_TARGET_CAN_TURN FLAG(6)
-#define DO_TARGET_UNIQUE_ACT FLAG(7)
+/// Locks the target for new do_after calls from any user while the proc is still running, prevents spam calls.
+#define DO_TARGET_UNIQUE_ACT FLAG(3)
+/// User cannot swap hands.
+#define DO_USER_SAME_HAND FLAG(4)
+/// User cannot target a different body part.
+#define DO_USER_SAME_ZONE FLAG(5)
+#define DO_TARGET_CAN_MOVE FLAG(6)
+#define DO_TARGET_CAN_TURN FLAG(7)
 #define DO_SHOW_PROGRESS FLAG(8)
+/// Instead of caching user/target's loc, we cache the turfs (inventory/turf distinction).
 #define DO_MOVE_CHECKS_TURFS FLAG(9)
 #define DO_FAIL_FEEDBACK FLAG(10)
+/// Explictly places the progress bar on mob. Useful when a target needs to be provided (see target/mob unique act) but progress bar should appear on mob.
+#define DO_PLACE_PROGRESSBAR_ON_MOB FLAG(11)
 
 // Preset macros
+/// Both user and target allowed to move.
 #define DO_BOTH_CAN_MOVE (DO_USER_CAN_MOVE | DO_TARGET_CAN_MOVE)
+/// Both user and target allowed to turn.
 #define DO_BOTH_CAN_TURN (DO_USER_CAN_TURN | DO_TARGET_CAN_TURN)
 #define DO_BOTH_UNIQUE_ACT (DO_USER_UNIQUE_ACT | DO_TARGET_UNIQUE_ACT)
+/**
+ * Includes:
+ * * Progress bar.
+ * * User cannot swap hands.
+ * * User and target can turn another direction.
+ * * Fail feedback message.
+ */
 #define DO_DEFAULT (DO_SHOW_PROGRESS | DO_USER_SAME_HAND | DO_BOTH_CAN_TURN | DO_FAIL_FEEDBACK)
 
 // Preset do_after flags
-#define DO_UNIQUE (DO_DEFAULT | DO_BOTH_UNIQUE_ACT) // Common flags for actions that should be unique
-#define DO_EXERCISE (DO_USER_UNIQUE_ACT | DO_USER_SAME_HAND) // Flags for exercises. Doesn't show progress, or give any failure feedback.
-#define DO_REPAIR_CONSTRUCT (DO_DEFAULT | DO_TARGET_UNIQUE_ACT) // Flags for repair and construction steps
-#define DO_EQUIP (DO_DEFAULT | DO_USER_UNIQUE_ACT) // Flags for equipping/unequipping mobs. Set to allow a mob to be targeted by multiple sources, but for a source to only be able to perform one action at a time.
+/// Common flags for actions that should be unique.
+#define DO_UNIQUE (DO_DEFAULT | DO_BOTH_UNIQUE_ACT)
+/// Flags for exercises. Doesn't show progress, or give any failure feedback.
+#define DO_EXERCISE (DO_USER_UNIQUE_ACT | DO_USER_SAME_HAND)
+/// Flags for repair and construction steps.
+#define DO_REPAIR_CONSTRUCT (DO_DEFAULT | DO_TARGET_UNIQUE_ACT)
+/// Flags for held items that can be deployed.
+#define DO_DEPLOY (DO_DEFAULT | DO_TARGET_UNIQUE_ACT | DO_PLACE_PROGRESSBAR_ON_MOB)
+/// Flags for equipping/unequipping mobs. Set to allow a mob to be targeted by multiple sources, but for a source to only be able to perform one action at a time.
+#define DO_EQUIP (DO_DEFAULT | DO_USER_UNIQUE_ACT)
 
 // Extra errors
 #define DO_MISSING_USER (-1)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -685,7 +685,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 	var/datum/progressbar/progbar
 	if ((do_flags & DO_SHOW_PROGRESS) && user.client && (user.client.prefs.toggles_secondary & PROGRESS_BARS))
-		var/progbar_pos = (do_flags & DO_PLACE_PROGRESSBAR_ON_MOB) ? user : (target || user)
+		var/progbar_pos = (do_flags & DO_PLACE_PROGRESSBAR_ON_USER) ? user : (target || user)
 		progbar = new(user, delay, progbar_pos)
 
 	SEND_SIGNAL(user, COMSIG_DO_AFTER_BEGAN)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -685,7 +685,8 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 	var/datum/progressbar/progbar
 	if ((do_flags & DO_SHOW_PROGRESS) && user.client && (user.client.prefs.toggles_secondary & PROGRESS_BARS))
-		progbar = new(user, delay, target || user)
+		var/progbar_pos = (do_flags & DO_PLACE_PROGRESSBAR_ON_MOB) ? user : (target || user)
+		progbar = new(user, delay, progbar_pos)
 
 	SEND_SIGNAL(user, COMSIG_DO_AFTER_BEGAN)
 

--- a/code/game/objects/structures/machinery/deployable.dm
+++ b/code/game/objects/structures/machinery/deployable.dm
@@ -271,7 +271,7 @@ Deployable Kits
 
 /obj/item/deployable_kit/attack_self(mob/user)
 	to_chat(user, SPAN_NOTICE("You start assembling \the [src]..."))
-	if(do_after(user, assembly_time, src, DO_REPAIR_CONSTRUCT))
+	if(do_after(user, assembly_time, src, DO_DEPLOY))
 		assemble_kit(user)
 		qdel(src)
 

--- a/html/changelogs/kano-deploy-progress-bar.yml
+++ b/html/changelogs/kano-deploy-progress-bar.yml
@@ -1,0 +1,4 @@
+author: kano
+delete-after: True
+changes:
+  - qol: "Deployable kits now show the progress bar on the mob."


### PR DESCRIPTION
Adds a new `do_after` flag for progress bar placement. Previously it was placing the bar on `target` if it was provided in the arguments (required by do_unique flags), with this flag we're now able to put the bar on the user

This particular change fixes deployable kits not showing a progress bar. Also documented some flags on the way
