### PR TITLE
Revert vent ambience

### DIFF
--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -50,8 +50,6 @@
 
 	var/broadcast_status_next_process = FALSE
 
-	var/datum/looping_sound/ventilation_humming/ventilation_humming
-
 /obj/structure/machinery/atmospherics/unary/vent_pump/mechanics_hints(mob/user, distance, is_adjacent)
 	. += ..()
 	. += "This pumps the contents of the attached pipe out into the atmosphere, if needed."
@@ -120,7 +118,6 @@
 		assign_uid()
 		id_tag = num2text(uid)
 	setup_radio()
-	ventilation_humming = new(src)
 
 /obj/structure/machinery/atmospherics/unary/vent_pump/proc/setup_radio()
 	//some vents work his own special way
@@ -222,12 +219,7 @@
 
 	if (!node)
 		update_use_power(POWER_USE_OFF)
-	if(can_pump())
-		if(ventilation_humming && !ventilation_humming.loop_started)
-			ventilation_humming.start()
-	else
-		if(ventilation_humming && ventilation_humming.loop_started)
-			ventilation_humming.stop()
+	if(!can_pump())
 		return 0
 
 	if(!loc) return FALSE

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -31,8 +31,6 @@
 
 	var/broadcast_status_next_process = FALSE
 
-	var/datum/looping_sound/ventilation_humming/ventilation_humming
-
 /obj/structure/machinery/atmospherics/unary/vent_scrubber/mechanics_hints(mob/user, distance, is_adjacent)
 	. += ..()
 	. += "This filters the atmosphere of harmful gas. Filtered gas goes to the pipes connected to it, typically a scrubber pipe."
@@ -62,7 +60,6 @@
 		LAZYADD(T.blueprints, I)
 
 	. = ..()
-	ventilation_humming = new(src)
 	air_contents.volume = ATMOS_DEFAULT_VOLUME_FILTER
 
 	initial_loc = get_area(loc)
@@ -198,12 +195,7 @@
 		broadcast_status_next_process = FALSE
 
 	if((!use_power || (stat & (NOPOWER|BROKEN)) || !loc) || welded)
-		if(ventilation_humming && ventilation_humming.loop_started)
-			ventilation_humming.stop()
 		return 0
-	else
-		if(ventilation_humming && !ventilation_humming.loop_started)
-			ventilation_humming.start()
 
 	var/datum/gas_mixture/environment = loc.return_air()
 

--- a/html/changelogs/fabiank3-revert-vent-ambience.yml
+++ b/html/changelogs/fabiank3-revert-vent-ambience.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - rscdel: "Removed the ambience sounds from vents and scrubbers. The amount of sounds degrade performance. The sound files added with it are still available."


### PR DESCRIPTION
# Summary

This PR removes the ambience sounds introduced in https://github.com/Aurorastation/Aurora.3/pull/22789. Due to performance degradation by the sheer amount of active sounds, these are removed again. The sounds added in the original PR stay for re-use.