### PR TITLE
Fix mineral asteroid position

### DIFF
--- a/html/changelogs/fabiank3-mineral-asteroid-loc-fix.yml
+++ b/html/changelogs/fabiank3-mineral-asteroid-loc-fix.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed the mineral asteroid position not being updated after the Horizon's persistent position was applied."

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -178,12 +178,45 @@
 		var/area/overmap/map = GLOB.map_overmap
 		// Set Horizon location
 		var/obj/effect/overmap/visitable/ship/sccv_horizon/ship = locate(/obj/effect/overmap/visitable/ship/sccv_horizon) in map
-		ship.x = horizon_location_generic.content["x"]
-		ship.y = horizon_location_generic.content["y"]
-		// Make safe space for the Horizon
-		for(var/obj/effect/overmap/hazard in map)
-			if(hazard.x == ship.x && hazard.y == ship.y && istype(hazard, /obj/effect/overmap/event/)) // Ions, dust, carps, meteors, etc.
-				qdel(hazard)
+		if(ship)
+			ship.x = horizon_location_generic.content["x"]
+			ship.y = horizon_location_generic.content["y"]
+
+			// Make safe space for the Horizon
+			for(var/obj/effect/overmap/hazard in map)
+				if(hazard.x == ship.x && hazard.y == ship.y && istype(hazard, /obj/effect/overmap/event/)) // Ions, dust, carps, meteors, etc.
+					qdel(hazard)
+
+			// Move mineral asteroid to a nearby location
+			var/obj/effect/overmap/visitable/sector/exoplanet/barren/asteroid/mining_asteroid = locate(/obj/effect/overmap/visitable/sector/exoplanet/barren/asteroid) in map
+			if(mining_asteroid)
+				for(var/dir in shuffle(GLOB.cardinals))
+					var/candidate_x = ship.x
+					var/candidate_y = ship.y
+					if(dir & NORTH)
+						candidate_y += 1
+					if(dir & SOUTH)
+						candidate_y -= 1
+					if(dir & EAST)
+						candidate_x += 1
+					if(dir & WEST)
+						candidate_x -= 1
+
+					if(candidate_x < 0 || candidate_y < 0 || candidate_x > overmap_size || candidate_y > overmap_size)
+						continue // Location out of bounds
+
+					for(var/obj/effect/overmap/visitable/sector/exoplanet/exoplanet in map)
+						if(exoplanet.x == candidate_x && exoplanet.y == candidate_y)
+							continue // Location occupied
+
+					mining_asteroid.x = candidate_x
+					mining_asteroid.y = candidate_y
+					break
+
+				// Make safe space for the asteroid
+				for(var/obj/effect/overmap/hazard in map)
+					if(hazard.x == mining_asteroid.x && hazard.y == mining_asteroid.y && istype(hazard, /obj/effect/overmap/event/)) // Ions, dust, carps, meteors, etc.
+						qdel(hazard)
 
 	// ##### Send different faxes after slight delay
 	var/faxes_send_delay = rand(60 SECONDS , 180 SECONDS)


### PR DESCRIPTION
# Summary

This PR fixes the mineral asteroids position not being updated after the Horizons persistent position was applied, resulting in the asteroid being too far away.

## Issues

- Fixes #23037
- Fixes #23039