### PR TITLE
initial_generic_waypoints be optional

### DIFF
--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -185,16 +185,16 @@ GLOBAL_DATUM(map_overmap, /area/overmap)
 /obj/effect/overmap/visitable/proc/add_landmark(obj/effect/shuttle_landmark/landmark, shuttle_name)
 	landmark.sector_set(src, shuttle_name)
 	if(shuttle_name)
-		LAZYADD(restricted_waypoints[shuttle_name], landmark)
+		LAZYDISTINCTADD(restricted_waypoints[shuttle_name], landmark)
 	else
-		generic_waypoints += landmark
+		LAZYDISTINCTADD(generic_waypoints, landmark)
 
 /obj/effect/overmap/visitable/proc/remove_landmark(obj/effect/shuttle_landmark/landmark, shuttle_name)
 	if(shuttle_name)
 		var/list/shuttles = restricted_waypoints[shuttle_name]
 		LAZYREMOVE(shuttles, landmark)
 	else
-		generic_waypoints -= landmark
+		LAZYREMOVE(generic_waypoints, landmark)
 
 /obj/effect/overmap/visitable/proc/get_waypoints(var/shuttle_name)
 	. = list()

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -31,6 +31,8 @@
 	//Name of the shuttle, null for generic waypoint
 	var/shuttle_restricted
 	var/landmark_flags = 0
+	/// Automatically registers the landmark with the shuttle/sectors system if true.
+	var/auto_register = FALSE
 
 	/// Effects that show where the shuttle will land, to prevent unfair squishing
 	var/list/landing_indicators
@@ -68,13 +70,15 @@
 	else
 		base_area = locate(base_area || world.area)
 
-	if(!docking_controller)
-		return
-	var/docking_tag = docking_controller
-	if(!istype(docking_controller))
-		docking_controller = SSshuttle.docking_registry[docking_tag]
+	if(docking_controller)
+		var/docking_tag = docking_controller
 		if(!istype(docking_controller))
-			LOG_DEBUG("Could not find docking controller for shuttle waypoint '[name]', docking tag was '[docking_tag]'.")
+			docking_controller = SSshuttle.docking_registry[docking_tag]
+			if(!istype(docking_controller))
+				LOG_DEBUG("Could not find docking controller for shuttle waypoint '[name]', docking tag was '[docking_tag]'.")
+
+	var/obj/effect/overmap/visitable/map_origin = GLOB.map_sectors["[z]"]
+	map_origin.add_landmark(src, shuttle_restricted)
 
 /obj/effect/shuttle_landmark/forceMove(atom/destination)
 	var/obj/effect/overmap/visitable/map_origin = GLOB.map_sectors["[z]"]

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -77,8 +77,9 @@
 			if(!istype(docking_controller))
 				LOG_DEBUG("Could not find docking controller for shuttle waypoint '[name]', docking tag was '[docking_tag]'.")
 
-	var/obj/effect/overmap/visitable/map_origin = GLOB.map_sectors["[z]"]
-	map_origin.add_landmark(src, shuttle_restricted)
+	if(auto_register)
+		var/obj/effect/overmap/visitable/map_origin = GLOB.map_sectors["[z]"]
+		map_origin.add_landmark(src, shuttle_restricted)
 
 /obj/effect/shuttle_landmark/forceMove(atom/destination)
 	var/obj/effect/overmap/visitable/map_origin = GLOB.map_sectors["[z]"]

--- a/html/changelogs/DreamySkrell-landmarks-streamline.yml
+++ b/html/changelogs/DreamySkrell-landmarks-streamline.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Overmap sector list `initial_generic_waypoints` is now optional."
+  - refactor: "Small refactor of landmarks and docking markers on the SCC Scout Ship."

--- a/maps/away/ships/scc/scc_scout_ship.dm
+++ b/maps/away/ships/scc/scc_scout_ship.dm
@@ -15,7 +15,6 @@
 	id = "scc_scout_ship"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/scc_scout_shuttle)
 	unit_test_groups = list(3)
-	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 /singleton/submap_archetype/scc_scout_ship
 	map = "SCC Scout Ship"

--- a/maps/away/ships/scc/scc_scout_ship.dm
+++ b/maps/away/ships/scc/scc_scout_ship.dm
@@ -1,3 +1,6 @@
+
+// --------------------------------------------------- template
+
 /datum/map_template/ruin/away_site/scc_scout_ship
 	name = "SCC Scout Ship"
 	description = "A small ship commonly fielded by the Stellar Corporate Conglomerate, the Serendipity-class, Hephaestus-designed and produced. It is supposed to be a small platform, entirely self-sufficient general-purpose scouting and surveying ship, the Serendipity is equipped with both a bluespace and a warp drive and two different engines."
@@ -12,20 +15,33 @@
 	id = "scc_scout_ship"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/scc_scout_shuttle)
 	unit_test_groups = list(3)
+	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 /singleton/submap_archetype/scc_scout_ship
 	map = "SCC Scout Ship"
-	descriptor = "A small ship commonly fielded by the Stellar Corporate Conglomerate, the Serendipity-class, Hephaestus-designed and produced. It is supposed to be a small platform, entirely self-sufficient general-purpose scouting and surveying ship, the Serendipity is equipped with both a bluespace and a warp drive and two different engines."
+	descriptor = /datum/map_template/ruin/away_site/scc_scout_ship::description
 
-// ship
+// --------------------------------------------------- ship
 
 /obj/effect/overmap/visitable/ship/scc_scout_ship
 	name = "SCC Scout Ship"
 	class = "SCCV"
-	desc = "A small ship commonly fielded by the Stellar Corporate Conglomerate, the Serendipity-class, Hephaestus-designed and produced. It is supposed to be a small platform, entirely self-sufficient general-purpose scouting and surveying ship, the Serendipity is equipped with both a bluespace and a warp drive and two different engines."
+	desc = /datum/map_template/ruin/away_site/scc_scout_ship::description
+
+	// visual:
 	icon_state = "corvette"
 	moving_state = "corvette_moving"
 	colors = list("#cfd4ff", "#78adf8")
+
+	// functional:
+	max_speed = 1/(2 SECONDS)
+	burn_delay = 1 SECONDS
+	vessel_mass = 5000
+	vessel_size = SHIP_SIZE_SMALL
+	fore_dir = SOUTH
+	invisible_until_ghostrole_spawn = TRUE
+
+	// fluff:
 	designer = "Hephaestus Industries"
 	volume = "42 meters length, 48 meters beam/width, 23 meters vertical height"
 	drive = "First-Gen Warp Capable, Hybrid Phoron Bluespace Drive"
@@ -33,49 +49,33 @@
 	weapons = "Flak battery"
 	sizeclass = "Serendipity-class Scout Ship"
 	shiptype = "Multi-purpose scout"
-	max_speed = 1/(2 SECONDS)
-	burn_delay = 1 SECONDS
-	vessel_mass = 5000
-	vessel_size = SHIP_SIZE_SMALL
-	fore_dir = SOUTH
-	invisible_until_ghostrole_spawn = TRUE
-	initial_restricted_waypoints = list(
-		"SCC Scout Shuttle" = list("nav_scc_scout_shuttle_dock")
-	)
-	initial_generic_waypoints = list(
-		"nav_scc_scout_dock_starboard",
-		"nav_scc_scout_dock_port",
-		"nav_scc_scout_dock_aft",
-		"nav_scc_scout_catwalk_aft",
-		"nav_scc_scout_catwalk_fore_starboard",
-		"nav_scc_scout_catwalk_fore_port",
-		"nav_scc_scout_space_fore_starboard",
-		"nav_scc_scout_space_fore_port",
-		"nav_scc_scout_space_aft_starboard",
-		"nav_scc_scout_space_aft_port",
-		"nav_scc_scout_space_port_far",
-		"nav_scc_scout_space_starboard_far",
-	)
+
 
 /obj/effect/overmap/visitable/ship/scc_scout_ship/New()
-	designation = "[pick("Dew Point", "Monsoon", "Cyclogenesis", "Warm Fronts", "Moisture Deficit", "Borealis", "Surface Tension", "Precipitation", "Oscillation", "Coalescence", "Double Rainbow", "Through a Cloud, Darkly", "Relative Humidity", "Evapotranspiration", "Alluvial Plain", "Dehydration", "Hydrophobia", "The Rain Formerly Known as Purple", "Lacrimosum", "Island of Ignorance", "Intertropical", "Once in a Lullaby", "A Boat Made from a Sheet of Newspaper", "Flood Control")]"
+	designation = pick("Dew Point", "Monsoon", "Cyclogenesis", "Warm Fronts", "Moisture Deficit", "Borealis", "Surface Tension", "Precipitation", "Oscillation", "Coalescence", "Double Rainbow", "Through a Cloud, Darkly", "Relative Humidity", "Evapotranspiration", "Alluvial Plain", "Dehydration", "Hydrophobia", "The Rain Formerly Known as Purple", "Lacrimosum", "Island of Ignorance", "Intertropical", "Once in a Lullaby", "A Boat Made from a Sheet of Newspaper", "Flood Control")
 	..()
 
-// shuttle
+// --------------------------------------------------- shuttle
 
 /obj/effect/overmap/visitable/ship/landable/scc_scout_shuttle
 	name = "SCC Scout Shuttle"
 	class = "SCCV"
 	desc = "A standard-sized exploration shuttle manufactured by Hephaestus, the Pathfinder-class is commonly used by the corporations of the SCC. Featuring well-rounded facilities and equipment, the Pathfinder is excellent, albeit pricey, platform. This one appears to be a bit of an older model, perhaps a prototype."
 	shuttle = "SCC Scout Shuttle"
+
+	// visual:
 	icon_state = "intrepid"
 	moving_state = "intrepid_moving"
 	colors = list("#cfd4ff", "#78adf8")
+
+	// functional:
 	max_speed = 1/(2 SECONDS)
 	burn_delay = 1 SECONDS
 	vessel_mass = 3000
 	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_TINY
+
+	// fluff:
 	designer = "Hephaestus Industries"
 	volume = "17 meters length, 24 meters beam/width, 6 meters vertical height"
 	sizeclass = "Pathfinder Exploration Shuttle"
@@ -88,15 +88,14 @@
 	return skybox_image
 
 /obj/effect/overmap/visitable/ship/landable/scc_scout_shuttle/New()
-	designation = "[pick("Dew Point", "Monsoon", "Cyclogenesis", "Warm Fronts", "Moisture Deficit", "Borealis", "Surface Tension", "Precipitation", "Oscillation", "Coalescence", "Double Rainbow", "Through a Cloud, Darkly", "Relative Humidity", "Evapotranspiration", "Alluvial Plain", "Dehydration", "Hydrophobia", "The Rain Formerly Known as Purple", "Lacrimosum", "Island of Ignorance", "Intertropical", "Once in a Lullaby", "A Boat Made from a Sheet of Newspaper", "Flood Control")]"
+	designation = pick("Dew Point", "Monsoon", "Cyclogenesis", "Warm Fronts", "Moisture Deficit", "Borealis", "Surface Tension", "Precipitation", "Oscillation", "Coalescence", "Double Rainbow", "Through a Cloud, Darkly", "Relative Humidity", "Evapotranspiration", "Alluvial Plain", "Dehydration", "Hydrophobia", "The Rain Formerly Known as Purple", "Lacrimosum", "Island of Ignorance", "Intertropical", "Once in a Lullaby", "A Boat Made from a Sheet of Newspaper", "Flood Control")
 	..()
 
 /obj/structure/machinery/computer/shuttle_control/explore/terminal/scc_scout_shuttle
-	name = "shuttle control console"
-	shuttle_tag = "SCC Scout Shuttle"
+	shuttle_tag = /obj/effect/overmap/visitable/ship/landable/scc_scout_shuttle::shuttle
 
 /datum/shuttle/autodock/overmap/scc_scout_shuttle
-	name = "SCC Scout Shuttle"
+	name = /obj/effect/overmap/visitable/ship/landable/scc_scout_shuttle::shuttle
 	move_time = 20
 	shuttle_area = list(/area/shuttle/scc_scout_ship_shuttle/cockpit, /area/shuttle/scc_scout_ship_shuttle/eva, /area/shuttle/scc_scout_ship_shuttle/cargo, /area/shuttle/scc_scout_ship_shuttle/medbay, /area/shuttle/scc_scout_ship_shuttle/propulsion_starboard, /area/shuttle/scc_scout_ship_shuttle/propulsion_port)
 	dock_target = "airlock_scc_scout_shuttle"
@@ -108,7 +107,7 @@
 	defer_initialisation = TRUE
 
 /obj/effect/map_effect/marker/airlock/shuttle/scc_scout_ship
-	name = "SCC Scout Shuttle"
-	shuttle_tag = "SCC Scout Shuttle"
+	name = /obj/effect/overmap/visitable/ship/landable/scc_scout_shuttle::shuttle
+	shuttle_tag = /obj/effect/overmap/visitable/ship/landable/scc_scout_shuttle::shuttle
 	master_tag = "airlock_scc_scout_shuttle"
 	cycle_to_external_air = TRUE

--- a/maps/away/ships/scc/scc_scout_ship_landmarks.dm
+++ b/maps/away/ships/scc/scc_scout_ship_landmarks.dm
@@ -4,18 +4,20 @@
 /obj/effect/shuttle_landmark/scc_scout_ship
 	base_area = /area/space
 	base_turf = /turf/space
+	auto_register = TRUE
 
 // --------------------- shuttle
 
 /obj/effect/shuttle_landmark/scc_scout_ship/shuttle_hangar
-	name = "Shuttle Dock"
-	landmark_tag = "nav_scc_scout_shuttle_dock"
-	docking_controller = "airlock_scc_scout_shuttle_dock"
+	name				= "Shuttle Dock"
+	landmark_tag		= "nav_scc_scout_shuttle_dock"
+	docking_controller	= "airlock_scc_scout_shuttle_dock"
+	shuttle_restricted	= /obj/effect/overmap/visitable/ship/landable/scc_scout_shuttle::name
 
 /obj/effect/map_effect/marker/airlock/docking/scc_scout_ship/shuttle_hangar
-	name = "Shuttle Dock"
-	landmark_tag = "nav_scc_scout_shuttle_dock"
-	master_tag = "airlock_scc_scout_shuttle_dock"
+	name			= /obj/effect/shuttle_landmark/scc_scout_ship/shuttle_hangar::name
+	landmark_tag	= /obj/effect/shuttle_landmark/scc_scout_ship/shuttle_hangar::landmark_tag
+	master_tag		= /obj/effect/shuttle_landmark/scc_scout_ship/shuttle_hangar::docking_controller
 
 // ----
 
@@ -23,42 +25,43 @@
 	name = "In transit"
 	landmark_tag = "nav_scc_scout_shuttle_transit"
 	base_turf = /turf/space/transit
+	auto_register = FALSE
 
 // --------------------- docks
 
 /obj/effect/shuttle_landmark/scc_scout_ship/dock/starboard
-	name = "Dock, Starboard"
-	landmark_tag = "nav_scc_scout_dock_starboard"
-	docking_controller = "airlock_scc_scout_dock_starboard"
+	name 				= "Dock, Starboard"
+	landmark_tag 		= "nav_scc_scout_dock_starboard"
+	docking_controller 	= "airlock_scc_scout_dock_starboard"
 
 /obj/effect/map_effect/marker/airlock/docking/scc_scout_ship/dock/starboard
-	name = "Dock, Starboard"
-	landmark_tag = "nav_scc_scout_dock_starboard"
-	master_tag = "airlock_scc_scout_dock_starboard"
+	name 			= /obj/effect/shuttle_landmark/scc_scout_ship/dock/starboard::name
+	landmark_tag 	= /obj/effect/shuttle_landmark/scc_scout_ship/dock/starboard::landmark_tag
+	master_tag 		= /obj/effect/shuttle_landmark/scc_scout_ship/dock/starboard::docking_controller
 
 // ----
 
 /obj/effect/shuttle_landmark/scc_scout_ship/dock/port
-	name = "Dock, Port"
-	landmark_tag = "nav_scc_scout_dock_port"
-	docking_controller = "airlock_scc_scout_dock_port"
+	name 				= "Dock, Port"
+	landmark_tag 		= "nav_scc_scout_dock_port"
+	docking_controller 	= "airlock_scc_scout_dock_port"
 
 /obj/effect/map_effect/marker/airlock/docking/scc_scout_ship/dock/port
-	name = "Dock, Port"
-	landmark_tag = "nav_scc_scout_dock_port"
-	master_tag = "airlock_scc_scout_dock_port"
+	name 			= /obj/effect/shuttle_landmark/scc_scout_ship/dock/port::name
+	landmark_tag 	= /obj/effect/shuttle_landmark/scc_scout_ship/dock/port::landmark_tag
+	master_tag 		= /obj/effect/shuttle_landmark/scc_scout_ship/dock/port::docking_controller
 
 // ----
 
 /obj/effect/shuttle_landmark/scc_scout_ship/dock/aft
-	name = "Dock, Aft"
-	landmark_tag = "nav_scc_scout_dock_aft"
-	docking_controller = "airlock_scc_scout_dock_aft"
+	name 				= "Dock, Aft"
+	landmark_tag 		= "nav_scc_scout_dock_aft"
+	docking_controller 	= "airlock_scc_scout_dock_aft"
 
 /obj/effect/map_effect/marker/airlock/docking/scc_scout_ship/dock/aft
-	name = "Dock, Aft"
-	landmark_tag = "nav_scc_scout_dock_aft"
-	master_tag = "airlock_scc_scout_dock_aft"
+	name 			= /obj/effect/shuttle_landmark/scc_scout_ship/dock/aft::name
+	landmark_tag 	= /obj/effect/shuttle_landmark/scc_scout_ship/dock/aft::landmark_tag
+	master_tag 		= /obj/effect/shuttle_landmark/scc_scout_ship/dock/aft::docking_controller
 
 // --------------------- catwalk
 


### PR DESCRIPTION
```
changes:
  - rscadd: "Overmap sector list `initial_generic_waypoints` is now optional."
  - refactor: "Small refactor of landmarks and docking markers on the SCC Scout Ship."
```

The `initial_generic_waypoints` could maybe be removed from all maps in the future, but I didn't want a giga huge diff on this PR.