### PR TITLE
Removes the access restriction on fuel tanks from ops

### DIFF
--- a/code/modules/cargo/items/engineering.dm
+++ b/code/modules/cargo/items/engineering.dm
@@ -425,7 +425,7 @@
 	items = list(
 		/obj/structure/reagent_dispensers/fueltank
 	)
-	access = ACCESS_ENGINE
+	access = 0
 	container_type = "box"
 	groupable = TRUE
 	spawn_amount = 1

--- a/html/changelogs/FuelTankAccess.yml
+++ b/html/changelogs/FuelTankAccess.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "The fuel tank from the cargo ordering program is no longer access restricted."


### PR DESCRIPTION
Now with fuel tanks being persistent and https://github.com/Aurorastation/Aurora.3/pull/23027 making the welding packs start empty, machinists need a way to get welding fuel. As the fuel tanks from ops are locked to engineering, it is creating a barrier for them to get it. Hence the removal of the access restriction.