### PR TITLE
Fixes that the tajaran himean modkit can't modify industrial rigs

### DIFF
--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -238,6 +238,8 @@
 		/obj/item/clothing/suit/space/void/atmos = /obj/item/clothing/suit/space/void/atmos/himeo/tajara,
 		/obj/item/clothing/head/helmet/space/void/atmos = /obj/item/clothing/head/helmet/space/void/atmos/himeo/tajara,
 
+		/obj/item/rig/industrial = /obj/item/rig/industrial/himeo/dequipped,
+
 		/obj/item/rig_assembly/industrial = /obj/item/rig_assembly/industrial/himeo
 	)
 

--- a/html/changelogs/ModkitFix.yml
+++ b/html/changelogs/ModkitFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed the inability for the himean taj modkit to modify an assembled industrial rig."


### PR DESCRIPTION
Fixes https://github.com/Aurorastation/Aurora.3/issues/23042

A simple oversight. This allows an industrial rig (such as miners) to be made into a tajaran himean variant.