### PR TITLE
Prevents psiren omens, beckoners and the matriarch from being summoned

### DIFF
--- a/code/game/gamemodes/technomancer/spells/summon/summon_creature.dm
+++ b/code/game/gamemodes/technomancer/spells/summon/summon_creature.dm
@@ -36,9 +36,7 @@
 		"CARP"					=	/mob/living/simple_animal/hostile/carp,
 		"BEAR"					=	/mob/living/simple_animal/hostile/bear,
 		"PSIREN LASHER" 		=	/mob/living/simple_animal/hostile/psiren,
-		"PSIREN DARTER"			= 	/mob/living/simple_animal/hostile/psiren/ranged,
-		"PSIREN OMEN"			=	/mob/living/simple_animal/hostile/psiren/omen,
-		"PSIREN BECKONER"		=	/mob/living/simple_animal/hostile/psiren/omen/beckoner,
+		"PSIREN DARTER"			= 	/mob/living/simple_animal/hostile/psiren/ranged
 		)
 	cooldown = 30
 	instability_cost = 10

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1271,7 +1271,10 @@
 		/mob/living/simple_animal/hostile/mimic,
 		/mob/living/simple_animal/hostile/cavern_geist,
 		/mob/living/simple_animal/hostile/cavern_geist/augmented,
-		/mob/living/simple_animal/hostile/retaliate/pra_exploration_drone
+		/mob/living/simple_animal/hostile/retaliate/pra_exploration_drone,
+		/mob/living/simple_animal/hostile/psiren/omen,
+		/mob/living/simple_animal/hostile/psiren/omen/beckoner,
+		/mob/living/simple_animal/hostile/psiren/matriarch
 	)
 
 	var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs

--- a/html/changelogs/PsirenCalling.yml
+++ b/html/changelogs/PsirenCalling.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscdel: "The golden slime core can no longer spawn psiren omens, beckoners or the psiren matriarch."
+  - rscdel: "Technomancers can no longer summon the psiren omens or beckoners. Other psirens were untouched."


### PR DESCRIPTION
Done on behalf of @VMSolidus. The reasoning is that the morale damage of the omens and beckoners is balanced around there only being a couple, while the gold slime core and the technomancer could spawn enough to tank everyones morale damage to the ground. The matriarch was removed from the gold slime core as an unintended spawn, due to its strength.