### PR TITLE
External Airlock Marker

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -2338,6 +2338,7 @@
 #include "code\modules\effects\map_effects\marker\_marker.dm"
 #include "code\modules\effects\map_effects\marker\airlock_.dm"
 #include "code\modules\effects\map_effects\marker\airlock_docking.dm"
+#include "code\modules\effects\map_effects\marker\airlock_external.dm"
 #include "code\modules\effects\map_effects\marker\airlock_helper.dm"
 #include "code\modules\effects\map_effects\marker\airlock_shuttle.dm"
 #include "code\modules\effects\map_effects\marker\door_paint.dm"

--- a/code/modules/effects/map_effects/marker/airlock_.dm
+++ b/code/modules/effects/map_effects/marker/airlock_.dm
@@ -1,8 +1,8 @@
 
 /// Airlock marker that, when placed above airlock components, actually sets them up to make it functional.
-/// This is a simple exterior access airlock, not used for docking.
 /// See `maps/helpers/guidelines_airlocks.dmm` for examples of good and bad airlocks.
-/obj/effect/map_effect/marker/airlock
+/// This is the abstract type; see the external, docking, and shuttle subtypes.
+ABSTRACT_TYPE(/obj/effect/map_effect/marker/airlock)
 	name = "airlock marker"
 	desc = "See comments/documentation in code."
 	icon = 'icons/effects/map_effects.dmi'
@@ -31,105 +31,3 @@
 /obj/effect/map_effect/marker/airlock/Initialize(mapload, ...)
 	..()
 	return INITIALIZE_HINT_LATELOAD
-
-/obj/effect/map_effect/marker/airlock/LateInitialize()
-	if(!master_tag || !frequency)
-		return
-
-	var/is_interior = locate(/obj/effect/map_effect/marker_helper/airlock/interior) in loc
-	var/is_exterior = locate(/obj/effect/map_effect/marker_helper/airlock/exterior) in loc
-	var/is_out = locate(/obj/effect/map_effect/marker_helper/airlock/out) in loc
-	var/found_controller = FALSE
-
-	// iterate over airlock components under this marker
-	// and actually set them up
-	for(var/thing in loc)
-		// Check for an advanced controller to set up.
-		var/obj/structure/machinery/embedded_controller/radio/airlock/advanced_airlock_controller/advanced_controller = thing
-		if(istype(advanced_controller))
-			// common controller vars
-			found_controller = TRUE
-			advanced_controller.set_frequency(frequency)
-			advanced_controller.id_tag = MARKER_AIRLOCK_TAG_MASTER
-			advanced_controller.tag_airpump = MARKER_AIRLOCK_TAG_AIRPUMP_CHAMBER
-			advanced_controller.tag_chamber_sensor = MARKER_AIRLOCK_TAG_SENSOR_CHAMBER
-			advanced_controller.tag_exterior_sensor = MARKER_AIRLOCK_TAG_SENSOR_EXTERIOR
-			advanced_controller.tag_exterior_door = MARKER_AIRLOCK_TAG_DOOR_EXTERIOR
-			advanced_controller.tag_interior_door = MARKER_AIRLOCK_TAG_DOOR_INTERIOR
-			advanced_controller.cycle_to_external_air = cycle_to_external_air
-			advanced_controller.req_access = req_access
-			advanced_controller.req_one_access = req_one_access
-			// controller subtype specific vars
-			advanced_controller.program = new /datum/computer/file/embedded_program/airlock(advanced_controller)
-			continue
-
-		// If we didn't find an advanced controller, fall back to the basic kind
-		var/obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller/controller = thing
-		if(istype(controller) && !found_controller)
-			// common controller vars
-			found_controller = TRUE
-			controller.set_frequency(frequency)
-			controller.id_tag = MARKER_AIRLOCK_TAG_MASTER
-			controller.tag_airpump = MARKER_AIRLOCK_TAG_AIRPUMP_CHAMBER
-			controller.tag_chamber_sensor = MARKER_AIRLOCK_TAG_SENSOR_CHAMBER
-			controller.tag_exterior_sensor = MARKER_AIRLOCK_TAG_SENSOR_EXTERIOR
-			controller.tag_exterior_door = MARKER_AIRLOCK_TAG_DOOR_EXTERIOR
-			controller.tag_interior_door = MARKER_AIRLOCK_TAG_DOOR_INTERIOR
-			controller.cycle_to_external_air = cycle_to_external_air
-			controller.req_access = req_access
-			controller.req_one_access = req_one_access
-			// controller subtype specific vars
-			controller.program = new /datum/computer/file/embedded_program/airlock(controller)
-			continue
-
-		// Now all the other airlock components
-		var/obj/structure/machinery/door/airlock/door = thing
-		if(istype(door))
-			door.set_frequency(frequency)
-			door.req_access = req_access
-			door.req_one_access = req_one_access
-			door.lock()
-			if(is_interior)
-				door.id_tag = MARKER_AIRLOCK_TAG_DOOR_INTERIOR
-			else if(is_exterior)
-				door.id_tag = MARKER_AIRLOCK_TAG_DOOR_EXTERIOR
-			continue
-
-		var/obj/structure/machinery/airlock_sensor/sensor = thing
-		if(istype(sensor))
-			sensor.req_access = req_access
-			sensor.req_one_access = req_one_access
-			sensor.set_frequency(frequency)
-			sensor.master_tag = MARKER_AIRLOCK_TAG_MASTER
-			if(is_interior)
-				sensor.id_tag = MARKER_AIRLOCK_TAG_SENSOR_INTERIOR
-			else if(is_exterior)
-				sensor.id_tag = MARKER_AIRLOCK_TAG_SENSOR_EXTERIOR
-			else
-				sensor.id_tag = MARKER_AIRLOCK_TAG_SENSOR_CHAMBER
-			continue
-
-		var/obj/structure/machinery/atmospherics/unary/vent_pump/pump = thing
-		if(istype(pump))
-			pump.frequency = frequency
-			unregister_radio(pump, frequency)
-			pump.setup_radio()
-			if(is_exterior)
-				pump.id_tag = MARKER_AIRLOCK_TAG_AIRPUMP_OUT_EXTERNAL
-			else if(is_out)
-				pump.id_tag = MARKER_AIRLOCK_TAG_AIRPUMP_OUT_INTERNAL
-			else
-				pump.id_tag = MARKER_AIRLOCK_TAG_AIRPUMP_CHAMBER
-			continue
-
-		var/obj/structure/machinery/access_button/button = thing
-		if(istype(button))
-			button.set_frequency(frequency)
-			button.master_tag = MARKER_AIRLOCK_TAG_MASTER
-			button.req_access = req_access
-			button.req_one_access = req_one_access
-			if(is_interior)
-				button.command = "cycle_interior"
-			else if(is_exterior)
-				button.command = "cycle_exterior"
-			continue

--- a/code/modules/effects/map_effects/marker/airlock_external.dm
+++ b/code/modules/effects/map_effects/marker/airlock_external.dm
@@ -1,0 +1,108 @@
+
+/// External airlock marker, for non-docking non-shuttle airlocks.
+/// Just a plain external access airlock.
+/obj/effect/map_effect/marker/airlock/external
+	name = "external airlock marker"
+
+/obj/effect/map_effect/marker/airlock/external/LateInitialize()
+	if(!master_tag || !frequency)
+		return
+
+	var/is_interior = locate(/obj/effect/map_effect/marker_helper/airlock/interior) in loc
+	var/is_exterior = locate(/obj/effect/map_effect/marker_helper/airlock/exterior) in loc
+	var/is_out = locate(/obj/effect/map_effect/marker_helper/airlock/out) in loc
+	var/found_controller = FALSE
+
+	// iterate over airlock components under this marker
+	// and actually set them up
+	for(var/thing in loc)
+		// Check for an advanced controller to set up.
+		var/obj/structure/machinery/embedded_controller/radio/airlock/advanced_airlock_controller/advanced_controller = thing
+		if(istype(advanced_controller))
+			// common controller vars
+			found_controller = TRUE
+			advanced_controller.set_frequency(frequency)
+			advanced_controller.id_tag = MARKER_AIRLOCK_TAG_MASTER
+			advanced_controller.tag_airpump = MARKER_AIRLOCK_TAG_AIRPUMP_CHAMBER
+			advanced_controller.tag_chamber_sensor = MARKER_AIRLOCK_TAG_SENSOR_CHAMBER
+			advanced_controller.tag_exterior_sensor = MARKER_AIRLOCK_TAG_SENSOR_EXTERIOR
+			advanced_controller.tag_exterior_door = MARKER_AIRLOCK_TAG_DOOR_EXTERIOR
+			advanced_controller.tag_interior_door = MARKER_AIRLOCK_TAG_DOOR_INTERIOR
+			advanced_controller.cycle_to_external_air = cycle_to_external_air
+			advanced_controller.req_access = req_access
+			advanced_controller.req_one_access = req_one_access
+			// controller subtype specific vars
+			advanced_controller.program = new /datum/computer/file/embedded_program/airlock(advanced_controller)
+			continue
+
+		// If we didn't find an advanced controller, fall back to the basic kind
+		var/obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller/controller = thing
+		if(istype(controller) && !found_controller)
+			// common controller vars
+			found_controller = TRUE
+			controller.set_frequency(frequency)
+			controller.id_tag = MARKER_AIRLOCK_TAG_MASTER
+			controller.tag_airpump = MARKER_AIRLOCK_TAG_AIRPUMP_CHAMBER
+			controller.tag_chamber_sensor = MARKER_AIRLOCK_TAG_SENSOR_CHAMBER
+			controller.tag_exterior_sensor = MARKER_AIRLOCK_TAG_SENSOR_EXTERIOR
+			controller.tag_exterior_door = MARKER_AIRLOCK_TAG_DOOR_EXTERIOR
+			controller.tag_interior_door = MARKER_AIRLOCK_TAG_DOOR_INTERIOR
+			controller.cycle_to_external_air = cycle_to_external_air
+			controller.req_access = req_access
+			controller.req_one_access = req_one_access
+			// controller subtype specific vars
+			controller.program = new /datum/computer/file/embedded_program/airlock(controller)
+			continue
+
+		// and all the other airlock components
+
+		var/obj/structure/machinery/door/airlock/door = thing
+		if(istype(door))
+			door.set_frequency(frequency)
+			door.req_access = req_access
+			door.req_one_access = req_one_access
+			door.lock()
+			if(is_interior)
+				door.id_tag = MARKER_AIRLOCK_TAG_DOOR_INTERIOR
+			else if(is_exterior)
+				door.id_tag = MARKER_AIRLOCK_TAG_DOOR_EXTERIOR
+			continue
+
+		var/obj/structure/machinery/airlock_sensor/sensor = thing
+		if(istype(sensor))
+			sensor.req_access = req_access
+			sensor.req_one_access = req_one_access
+			sensor.set_frequency(frequency)
+			sensor.master_tag = MARKER_AIRLOCK_TAG_MASTER
+			if(is_interior)
+				sensor.id_tag = MARKER_AIRLOCK_TAG_SENSOR_INTERIOR
+			else if(is_exterior)
+				sensor.id_tag = MARKER_AIRLOCK_TAG_SENSOR_EXTERIOR
+			else
+				sensor.id_tag = MARKER_AIRLOCK_TAG_SENSOR_CHAMBER
+			continue
+
+		var/obj/structure/machinery/atmospherics/unary/vent_pump/pump = thing
+		if(istype(pump))
+			pump.frequency = frequency
+			unregister_radio(pump, frequency)
+			pump.setup_radio()
+			if(is_exterior)
+				pump.id_tag = MARKER_AIRLOCK_TAG_AIRPUMP_OUT_EXTERNAL
+			else if(is_out)
+				pump.id_tag = MARKER_AIRLOCK_TAG_AIRPUMP_OUT_INTERNAL
+			else
+				pump.id_tag = MARKER_AIRLOCK_TAG_AIRPUMP_CHAMBER
+			continue
+
+		var/obj/structure/machinery/access_button/button = thing
+		if(istype(button))
+			button.set_frequency(frequency)
+			button.master_tag = MARKER_AIRLOCK_TAG_MASTER
+			button.req_access = req_access
+			button.req_one_access = req_one_access
+			if(is_interior)
+				button.command = "cycle_interior"
+			else if(is_exterior)
+				button.command = "cycle_exterior"
+			continue

--- a/html/changelogs/DreamySkrell-external-airlock-marker.yml
+++ b/html/changelogs/DreamySkrell-external-airlock-marker.yml
@@ -1,0 +1,7 @@
+
+author: DreamySkrell
+
+delete-after: True
+
+changes:
+  - refactor: "External airlock marker."

--- a/maps/away/away_site/abandoned_casino/abandoned_casino.dmm
+++ b/maps/away/away_site/abandoned_casino/abandoned_casino.dmm
@@ -58,7 +58,7 @@
 /area/abandoned_casino/reception)
 "ag" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars,
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars,
 /turf/simulated/floor/plating,
 /area/abandoned_casino/maintenance/solar_wing)
 "ah" = (
@@ -322,7 +322,7 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark/damaged,
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars,
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars,
 /turf/simulated/floor/plating,
 /area/abandoned_casino/maintenance/solar_wing)
 "aT" = (
@@ -914,7 +914,7 @@
 	pixel_y = -31;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars,
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars,
 /turf/simulated/floor/tiled/dark/full,
 /area/abandoned_casino/maintenance/solar_wing)
 "cf" = (
@@ -3098,7 +3098,7 @@
 /obj/structure/machinery/light/small/emergency{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars,
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars,
 /turf/simulated/floor/plating,
 /area/abandoned_casino/maintenance/solar_wing)
 "hG" = (
@@ -5262,7 +5262,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars,
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars,
 /turf/simulated/floor/plating,
 /area/abandoned_casino/maintenance/solar_wing)
 "mR" = (
@@ -6115,7 +6115,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars,
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars,
 /turf/simulated/floor/tiled/dark/full,
 /area/abandoned_casino/maintenance/solar_wing)
 "qG" = (
@@ -8718,7 +8718,7 @@
 "Do" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/decal/cleanable/cobweb2,
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars,
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars,
 /turf/simulated/floor/plating,
 /area/abandoned_casino/maintenance/solar_wing)
 "Dq" = (
@@ -8779,7 +8779,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars,
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars,
 /turf/simulated/floor/tiled/dark/full,
 /area/abandoned_casino/maintenance/solar_wing)
 "DE" = (
@@ -9066,7 +9066,7 @@
 /obj/structure/machinery/light/small/emergency{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars,
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars,
 /turf/simulated/floor/plating,
 /area/abandoned_casino/maintenance/solar_wing)
 "Fb" = (
@@ -9084,7 +9084,7 @@
 /area/abandoned_casino/staff/breakroom)
 "Fe" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark/damaged,
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars,
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars,
 /turf/simulated/floor/plating,
 /area/abandoned_casino/maintenance/solar_wing)
 "Fi" = (
@@ -9166,7 +9166,7 @@
 	pixel_y = -30;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars,
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars,
 /turf/simulated/floor/tiled/dark/full,
 /area/abandoned_casino/maintenance/solar_wing)
 "FH" = (
@@ -9778,7 +9778,7 @@
 "IR" = (
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars,
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars,
 /turf/simulated/floor/tiled/dark/full,
 /area/abandoned_casino/maintenance/solar_wing)
 "IS" = (
@@ -9997,7 +9997,7 @@
 "JS" = (
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars,
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars,
 /turf/simulated/floor/tiled/dark/full,
 /area/abandoned_casino/maintenance/solar_wing)
 "JU" = (
@@ -10347,7 +10347,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars,
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars,
 /turf/simulated/floor/plating,
 /area/abandoned_casino/maintenance/solar_wing)
 "Ln" = (
@@ -11193,7 +11193,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars,
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars,
 /turf/simulated/floor/plating,
 /area/abandoned_casino/maintenance/solar_wing)
 "PM" = (
@@ -11985,7 +11985,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars,
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars,
 /turf/simulated/floor/plating,
 /area/abandoned_casino/maintenance/solar_wing)
 "TA" = (

--- a/maps/away/away_site/abandoned_casino/abandoned_casino_landmarks.dm
+++ b/maps/away/away_site/abandoned_casino/abandoned_casino_landmarks.dm
@@ -90,6 +90,6 @@
 // Non-docking airlock landmarks
 // ----
 
-/obj/effect/map_effect/marker/airlock/abandoned_casino/solars
+/obj/effect/map_effect/marker/airlock/external/abandoned_casino/solars
 	name = "Solar Array Access"
 	master_tag = "airlock_abandoned_casino_solar"

--- a/maps/away/away_site/abandoned_diner/abandoned_diner.dmm
+++ b/maps/away/away_site/abandoned_diner/abandoned_diner.dmm
@@ -2771,7 +2771,7 @@
 	pixel_y = 28;
 	pixel_x = 5
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "diner_engi";
 	master_tag = "diner_engi"
 	},
@@ -3726,7 +3726,7 @@
 	pixel_y = 22;
 	pixel_x = -24
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "diner_engi";
 	master_tag = "diner_engi"
 	},
@@ -3832,7 +3832,7 @@
 	pixel_x = 12;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "diner_engi";
 	master_tag = "diner_engi"
 	},

--- a/maps/away/away_site/abandoned_propellant_depot/abandoned_propellant_depot.dmm
+++ b/maps/away/away_site/abandoned_propellant_depot/abandoned_propellant_depot.dmm
@@ -597,7 +597,7 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_1";
 	name = "airlock_abandoned_propellant_depot_1"
 	},
@@ -1509,7 +1509,7 @@
 	dir = 4;
 	pixel_y = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_5";
 	name = "airlock_abandoned_propellant_depot_5"
 	},
@@ -1991,7 +1991,7 @@
 	dir = 4;
 	pixel_y = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_4";
 	name = "airlock_abandoned_propellant_depot_4"
 	},
@@ -2070,7 +2070,7 @@
 /area/abandoned_propellant_depot/atmos_propellant)
 "gq" = (
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_3";
 	name = "airlock_abandoned_propellant_depot_3"
 	},
@@ -2453,7 +2453,7 @@
 	icon_state = "2-8"
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_5";
 	name = "airlock_abandoned_propellant_depot_5"
 	},
@@ -3361,7 +3361,7 @@
 /area/abandoned_propellant_depot/maint_storage)
 "kF" = (
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_6";
 	name = "airlock_abandoned_propellant_depot_6"
 	},
@@ -3774,7 +3774,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_5";
 	name = "airlock_abandoned_propellant_depot_5"
 	},
@@ -5457,7 +5457,7 @@
 	pixel_y = -6;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_2";
 	name = "airlock_abandoned_propellant_depot_2"
 	},
@@ -5536,7 +5536,7 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_4";
 	name = "airlock_abandoned_propellant_depot_4"
 	},
@@ -6073,7 +6073,7 @@
 	pixel_x = 28
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_3";
 	name = "airlock_abandoned_propellant_depot_3"
 	},
@@ -6514,7 +6514,7 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_6";
 	name = "airlock_abandoned_propellant_depot_6"
 	},
@@ -6792,7 +6792,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_2";
 	name = "airlock_abandoned_propellant_depot_2"
 	},
@@ -7501,7 +7501,7 @@
 	pixel_y = -6;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_5";
 	name = "airlock_abandoned_propellant_depot_5"
 	},
@@ -7892,7 +7892,7 @@
 	dir = 4
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_4";
 	name = "airlock_abandoned_propellant_depot_4"
 	},
@@ -8040,7 +8040,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_2";
 	name = "airlock_abandoned_propellant_depot_2"
 	},
@@ -8387,7 +8387,7 @@
 	pixel_y = 6;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_6";
 	name = "airlock_abandoned_propellant_depot_6"
 	},
@@ -8416,7 +8416,7 @@
 	dir = 4;
 	pixel_y = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_3";
 	name = "airlock_abandoned_propellant_depot_3"
 	},
@@ -9611,7 +9611,7 @@
 	pixel_y = -6;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_1";
 	name = "airlock_abandoned_propellant_depot_1"
 	},
@@ -10202,7 +10202,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_6";
 	name = "airlock_abandoned_propellant_depot_6"
 	},
@@ -11019,7 +11019,7 @@
 	pixel_x = -28
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_4";
 	name = "airlock_abandoned_propellant_depot_4"
 	},
@@ -11096,7 +11096,7 @@
 	pixel_x = -28
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_5";
 	name = "airlock_abandoned_propellant_depot_5"
 	},
@@ -11247,7 +11247,7 @@
 	dir = 4;
 	pixel_y = -6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_6";
 	name = "airlock_abandoned_propellant_depot_6"
 	},
@@ -11645,7 +11645,7 @@
 	dir = 8;
 	pixel_y = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_1";
 	name = "airlock_abandoned_propellant_depot_1"
 	},
@@ -11806,7 +11806,7 @@
 	dir = 4
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_1";
 	name = "airlock_abandoned_propellant_depot_1"
 	},
@@ -11833,7 +11833,7 @@
 	dir = 8;
 	pixel_y = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_2";
 	name = "airlock_abandoned_propellant_depot_2"
 	},
@@ -11977,7 +11977,7 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_4";
 	name = "airlock_abandoned_propellant_depot_4"
 	},
@@ -12926,7 +12926,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_4";
 	name = "airlock_abandoned_propellant_depot_4"
 	},
@@ -15011,7 +15011,7 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_3";
 	name = "airlock_abandoned_propellant_depot_3"
 	},
@@ -15317,7 +15317,7 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_5";
 	name = "airlock_abandoned_propellant_depot_5"
 	},
@@ -15660,7 +15660,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_3";
 	name = "airlock_abandoned_propellant_depot_3"
 	},
@@ -15841,7 +15841,7 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_1";
 	name = "airlock_abandoned_propellant_depot_1"
 	},
@@ -15874,7 +15874,7 @@
 	pixel_y = -6;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_abandoned_propellant_depot_3";
 	name = "airlock_abandoned_propellant_depot_3"
 	},

--- a/maps/away/away_site/cult_base/cult_base.dmm
+++ b/maps/away/away_site/cult_base/cult_base.dmm
@@ -184,7 +184,7 @@
 	pixel_y = 28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_1";
 	name = "airlock_cult_base_1"
 	},
@@ -249,7 +249,7 @@
 	dir = 4
 	},
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_1";
 	name = "airlock_cult_base_1"
 	},
@@ -408,7 +408,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_2";
 	name = "airlock_cult_base_2"
 	},
@@ -447,7 +447,7 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_5";
 	name = "airlock_cult_base_5"
 	},
@@ -488,7 +488,7 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_5";
 	name = "airlock_cult_base_5"
 	},
@@ -1103,7 +1103,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_4";
 	name = "airlock_cult_base_4"
 	},
@@ -1118,7 +1118,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_5";
 	name = "airlock_cult_base_5"
 	},
@@ -1688,7 +1688,7 @@
 	pixel_y = -28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_3";
 	name = "airlock_cult_base_3"
 	},
@@ -1766,7 +1766,7 @@
 	pixel_y = 28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_1";
 	name = "airlock_cult_base_1"
 	},
@@ -2090,7 +2090,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_1";
 	name = "airlock_cult_base_1"
 	},
@@ -2125,7 +2125,7 @@
 /obj/structure/machinery/access_button{
 	pixel_x = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_3";
 	name = "airlock_cult_base_3"
 	},
@@ -2271,7 +2271,7 @@
 /area/cult_base/hallways_north)
 "aiE" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_1";
 	name = "airlock_cult_base_1"
 	},
@@ -2516,7 +2516,7 @@
 	dir = 4;
 	pixel_y = -6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_2";
 	name = "airlock_cult_base_2"
 	},
@@ -2628,7 +2628,7 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_4";
 	name = "airlock_cult_base_4"
 	},
@@ -2662,7 +2662,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_1";
 	name = "airlock_cult_base_1"
 	},
@@ -3207,7 +3207,7 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_4";
 	name = "airlock_cult_base_4"
 	},
@@ -3641,7 +3641,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_5";
 	name = "airlock_cult_base_5"
 	},
@@ -4478,7 +4478,7 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_5";
 	name = "airlock_cult_base_5"
 	},
@@ -4623,7 +4623,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_4";
 	name = "airlock_cult_base_4"
 	},
@@ -5238,7 +5238,7 @@
 	pixel_y = 6;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_2";
 	name = "airlock_cult_base_2"
 	},
@@ -5574,7 +5574,7 @@
 	pixel_y = -28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_2";
 	name = "airlock_cult_base_2"
 	},
@@ -6566,7 +6566,7 @@
 	dir = 4;
 	pixel_y = -6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_3";
 	name = "airlock_cult_base_3"
 	},
@@ -6932,7 +6932,7 @@
 /obj/structure/machinery/access_button{
 	pixel_x = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_2";
 	name = "airlock_cult_base_2"
 	},
@@ -7062,7 +7062,7 @@
 	pixel_y = 6;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_3";
 	name = "airlock_cult_base_3"
 	},
@@ -7251,7 +7251,7 @@
 	dir = 1
 	},
 /obj/random/junk,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_1";
 	name = "airlock_cult_base_1"
 	},
@@ -7456,7 +7456,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/cee,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_4";
 	name = "airlock_cult_base_4"
 	},
@@ -8552,7 +8552,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_2";
 	name = "airlock_cult_base_2"
 	},
@@ -9314,7 +9314,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/cee,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_5";
 	name = "airlock_cult_base_5"
 	},
@@ -10158,7 +10158,7 @@
 /obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_4";
 	name = "airlock_cult_base_4"
 	},
@@ -10289,7 +10289,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_2";
 	name = "airlock_cult_base_2"
 	},
@@ -10580,7 +10580,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_2";
 	name = "airlock_cult_base_2"
 	},
@@ -10789,7 +10789,7 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_5";
 	name = "airlock_cult_base_5"
 	},
@@ -11676,7 +11676,7 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_4";
 	name = "airlock_cult_base_4"
 	},
@@ -12151,7 +12151,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/cee,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_5";
 	name = "airlock_cult_base_5"
 	},
@@ -12336,7 +12336,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/cee,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_4";
 	name = "airlock_cult_base_4"
 	},
@@ -12525,7 +12525,7 @@
 /area/cult_base/hallways_south)
 "uIq" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_cult_base_1";
 	name = "airlock_cult_base_1"
 	},

--- a/maps/away/away_site/pirate_base/pirate_base.dmm
+++ b/maps/away/away_site/pirate_base/pirate_base.dmm
@@ -332,7 +332,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/cee,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_main";
 	name = "airlock_pirate_base_main"
 	},
@@ -374,7 +374,7 @@
 	pixel_x = -28
 	},
 /obj/structure/machinery/atmospherics/pipe/simple/visible,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_shuttle";
 	name = "airlock_pirate_base_shuttle"
 	},
@@ -511,7 +511,7 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_maint";
 	name = "airlock_pirate_base_maint"
 	},
@@ -810,7 +810,7 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_main";
 	name = "airlock_pirate_base_main"
 	},
@@ -2040,7 +2040,7 @@
 /area/piratebase/living)
 "jK" = (
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_maint";
 	name = "airlock_pirate_base_maint"
 	},
@@ -2590,7 +2590,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_maint";
 	name = "airlock_pirate_base_maint"
 	},
@@ -3808,7 +3808,7 @@
 "rZ" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_main";
 	name = "airlock_pirate_base_main"
 	},
@@ -4907,7 +4907,7 @@
 	pixel_x = 28;
 	pixel_y = 12
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_shuttle";
 	name = "airlock_pirate_base_shuttle"
 	},
@@ -5730,7 +5730,7 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_main";
 	name = "airlock_pirate_base_main"
 	},
@@ -5747,7 +5747,7 @@
 "Df" = (
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_main";
 	name = "airlock_pirate_base_main"
 	},
@@ -6714,7 +6714,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/cee,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_main";
 	name = "airlock_pirate_base_main"
 	},
@@ -7079,7 +7079,7 @@
 "JH" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_main";
 	name = "airlock_pirate_base_main"
 	},
@@ -7486,7 +7486,7 @@
 	pixel_y = -6
 	},
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_shuttle";
 	name = "airlock_pirate_base_shuttle"
 	},
@@ -8657,7 +8657,7 @@
 	dir = 4
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_main";
 	name = "airlock_pirate_base_main"
 	},
@@ -8940,7 +8940,7 @@
 "Sv" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_main";
 	name = "airlock_pirate_base_main"
 	},
@@ -9018,7 +9018,7 @@
 "SH" = (
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden/aux,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_main";
 	name = "airlock_pirate_base_main"
 	},
@@ -9203,7 +9203,7 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_main";
 	name = "airlock_pirate_base_main"
 	},
@@ -10560,7 +10560,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_pirate_base_maint";
 	name = "airlock_pirate_base_maint"
 	},

--- a/maps/away/away_site/quarantined_outpost/quarantined_outpost.dmm
+++ b/maps/away/away_site/quarantined_outpost/quarantined_outpost.dmm
@@ -1920,7 +1920,7 @@
 /area/quarantined_outpost/dorm_hallway)
 "bro" = (
 /obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance,
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance,
 /obj/structure/bed/handrail{
 	dir = 8
 	},
@@ -4040,7 +4040,7 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance,
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/quarantined_outpost/entrance_lobby)
@@ -6125,7 +6125,7 @@
 /area/quarantined_outpost/cafeteria)
 "eio" = (
 /obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance,
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance,
 /obj/structure/bed/handrail{
 	dir = 8
 	},
@@ -10858,7 +10858,7 @@
 /area/quarantined_outpost/extraction_lab)
 "hrr" = (
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance,
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
 /turf/simulated/floor/plating,
 /area/quarantined_outpost/entrance_lobby)
@@ -12588,7 +12588,7 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance,
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance,
 /obj/effect/floor_decal/industrial/outline_door/yellow{
 	dir = 8
 	},
@@ -14969,7 +14969,7 @@
 /area/quarantined_outpost/medbay)
 "kha" = (
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance,
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance,
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 23;
 	pixel_x = 5
@@ -17216,7 +17216,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance,
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance,
 /obj/effect/floor_decal/industrial/outline_door/yellow,
 /obj/random/dirt_75,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -17713,7 +17713,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/quarantined_outpost/reception)
 "lUw" = (
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance,
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance,
 /obj/effect/floor_decal/industrial/outline_door/yellow{
 	dir = 8
 	},
@@ -18917,7 +18917,7 @@
 /area/quarantined_outpost/engineering)
 "mGz" = (
 /obj/structure/lattice/catwalk/indoor/grate/damaged,
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance,
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance,
 /obj/structure/bed/handrail{
 	dir = 8
 	},
@@ -19724,7 +19724,7 @@
 /area/quarantined_outpost/engineering/atmospherics)
 "nkm" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance,
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance,
 /obj/structure/machinery/light/small/maybe_broken/decayed,
 /turf/simulated/floor/plating,
 /area/quarantined_outpost/entrance_lobby)
@@ -21258,7 +21258,7 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance,
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance,
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/plating,
 /area/quarantined_outpost/entrance_lobby)
@@ -25624,7 +25624,7 @@
 /area/quarantined_outpost/cargo_bay)
 "qXN" = (
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance,
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance,
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
@@ -25867,7 +25867,7 @@
 "rfu" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance,
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance,
 /obj/structure/machinery/access_button{
 	pixel_x = 28
 	},
@@ -30207,7 +30207,7 @@
 /turf/simulated/floor/tiled/gunmetal,
 /area/quarantined_outpost/engineering)
 "tVV" = (
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance,
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance,
 /obj/effect/floor_decal/industrial/outline_door/yellow,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -33389,7 +33389,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance,
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance,
 /obj/structure/machinery/access_button{
 	dir = 8;
 	pixel_x = -8;
@@ -35489,7 +35489,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance,
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/quarantined_outpost/entrance_lobby)

--- a/maps/away/away_site/quarantined_outpost/quarantined_outpost_landmarks.dm
+++ b/maps/away/away_site/quarantined_outpost/quarantined_outpost_landmarks.dm
@@ -106,11 +106,11 @@
 
 // Airlocks
 
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/entrance
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/entrance
 	name = "Entrance"
 	master_tag = "airlock_quarantined_outpost_entrance"
 
-/obj/effect/map_effect/marker/airlock/quarantined_outpost/mining
+/obj/effect/map_effect/marker/airlock/external/quarantined_outpost/mining
 	name = "Excavation Sector"
 	master_tag = "airlock_quarantined_outpost_mining"
 

--- a/maps/away/away_site/sensor_relay/hegemony_waypoint/hegemony_waypoint.dmm
+++ b/maps/away/away_site/sensor_relay/hegemony_waypoint/hegemony_waypoint.dmm
@@ -61,7 +61,7 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/south,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/south,
 /turf/simulated/floor/plating,
 /area/hegemony_waypoint/hallway)
 "cd" = (
@@ -74,7 +74,7 @@
 	pixel_y = 28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/east,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/east,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/random/dirt_75,
 /obj/effect/landmark/entry_point/port{
@@ -167,7 +167,7 @@
 	pixel_y = 28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/west,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/west,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -203,7 +203,7 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/north,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/north,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/hegemony_waypoint/hallway)
@@ -238,7 +238,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/north,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/north,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -505,7 +505,7 @@
 	pixel_y = -28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/maintenance3,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/maintenance3,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -788,7 +788,7 @@
 	pixel_y = 28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/west,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/west,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -877,7 +877,7 @@
 	pixel_x = 24;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/south,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/south,
 /turf/simulated/floor/plating,
 /area/hegemony_waypoint/hallway)
 "qC" = (
@@ -1062,7 +1062,7 @@
 	pixel_y = 8;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/north,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/north,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -1077,7 +1077,7 @@
 	pixel_x = 28;
 	pixel_y = -6
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/south,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/south,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/tiled/dark/full,
 /area/hegemony_waypoint/hallway)
@@ -1126,7 +1126,7 @@
 	pixel_x = 24;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/north,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/north,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/hegemony_waypoint/hallway)
@@ -1144,7 +1144,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/west,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/west,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -1242,7 +1242,7 @@
 	pixel_y = 28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/south,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/south,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/dark/full,
 /area/hegemony_waypoint/hallway)
@@ -1316,7 +1316,7 @@
 	pixel_x = 5;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/west,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/west,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/hegemony_waypoint/hallway)
@@ -1407,7 +1407,7 @@
 	pixel_y = 28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/east,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/east,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -1432,7 +1432,7 @@
 	pixel_y = -28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/maintenance3,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/maintenance3,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -1486,7 +1486,7 @@
 	pixel_x = -8
 	},
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/maintenance2,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/maintenance2,
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
@@ -1499,7 +1499,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/east,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/east,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -1534,7 +1534,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/maintenance2,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/maintenance2,
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/machinery/light/small{
 	dir = 8
@@ -1565,7 +1565,7 @@
 	pixel_y = 27;
 	pixel_x = -8
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/maintenance3,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/maintenance3,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/hegemony_waypoint/hallway)
@@ -1675,7 +1675,7 @@
 "Gu" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/north,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/north,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/random/dirt_75,
 /obj/effect/landmark/entry_point/aft{
@@ -1702,7 +1702,7 @@
 	dir = 4
 	},
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux,
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/west,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/west,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -1771,7 +1771,7 @@
 	pixel_y = 28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/maintenance2,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/maintenance2,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -1812,7 +1812,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/south,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/south,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/dark/full,
 /area/hegemony_waypoint/hallway)
@@ -1824,7 +1824,7 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/west,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/west,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/hegemony_waypoint/hallway)
@@ -2039,7 +2039,7 @@
 	pixel_y = 27;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/maintenance1,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/maintenance1,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -2107,7 +2107,7 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/east,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/east,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/hegemony_waypoint/hallway)
@@ -2135,7 +2135,7 @@
 "My" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/south,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/south,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/landmark/entry_point/north{
 	name = "north, south airlock"
@@ -2203,7 +2203,7 @@
 	pixel_y = 28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/maintenance2,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/maintenance2,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -2247,7 +2247,7 @@
 	pixel_x = -7;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/east,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/east,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/hegemony_waypoint/hallway)
@@ -2296,7 +2296,7 @@
 	pixel_x = -26;
 	pixel_y = 26
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/maintenance1,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/maintenance1,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -2418,7 +2418,7 @@
 	pixel_y = -28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/north,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/north,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -2709,7 +2709,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/east,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/east,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -2803,7 +2803,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/maintenance2,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/maintenance2,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
@@ -2822,7 +2822,7 @@
 	pixel_y = 27;
 	pixel_x = -8
 	},
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/maintenance1,
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/maintenance1,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/hegemony_waypoint/hallway)

--- a/maps/away/away_site/sensor_relay/hegemony_waypoint/hegemony_waypoint_landmarks.dm
+++ b/maps/away/away_site/sensor_relay/hegemony_waypoint/hegemony_waypoint_landmarks.dm
@@ -36,30 +36,30 @@
 	landmark_tag = "hegemony_waypoint_n_space"
 
 // Airlocks
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/south
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/south
 	name = "South Airlock"
 	master_tag = "hegemony_waypoint_south"
 
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/north
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/north
 	name = "North Airlock"
 	master_tag = "hegemony_waypoint_north"
 
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/west
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/west
 	name = "West Airlock"
 	master_tag = "hegemony_waypoint_west"
 
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/east
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/east
 	name = "East Airlock"
 	master_tag = "hegemony_waypoint_east"
 
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/maintenance1
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/maintenance1
 	name = "Maintenance Airlock #1"
 	master_tag = "hegemony_waypoint_maintenance1"
 
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/maintenance2
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/maintenance2
 	name = "Maintenance Airlock #2"
 	master_tag = "hegemony_waypoint_maintenance2"
 
-/obj/effect/map_effect/marker/airlock/hegemony_waypoint/maintenance3
+/obj/effect/map_effect/marker/airlock/external/hegemony_waypoint/maintenance3
 	name = "Maintenance Airlock #3"
 	master_tag = "hegemony_waypoint_maintenance3"

--- a/maps/away/away_site/sensor_relay/solarian_prewar/sensor_relay.dmm
+++ b/maps/away/away_site/sensor_relay/solarian_prewar/sensor_relay.dmm
@@ -2681,7 +2681,7 @@
 /area/sensor_relay)
 "csG" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_eng";
 	name = "sensor_relay_eng";
 	req_one_access = null
@@ -2722,7 +2722,7 @@
 /area/space)
 "cPG" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_eng";
 	name = "sensor_relay_eng";
 	req_one_access = null
@@ -2799,7 +2799,7 @@
 /area/sensor_relay/workshop)
 "drD" = (
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_int";
 	name = "sensor_relay_int";
 	req_one_access = null
@@ -2861,7 +2861,7 @@
 /area/sensor_relay/quarters)
 "dMq" = (
 /obj/structure/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_ext";
 	name = "sensor_relay_ext";
 	req_one_access = null
@@ -2914,7 +2914,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_ext";
 	name = "sensor_relay_ext";
 	req_one_access = null
@@ -2927,7 +2927,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_ext";
 	name = "sensor_relay_ext";
 	req_one_access = null
@@ -2945,7 +2945,7 @@
 	},
 /area/sensor_relay/airlocks)
 "elW" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_int";
 	name = "sensor_relay_int";
 	req_one_access = null
@@ -3115,7 +3115,7 @@
 /turf/simulated/floor/tiled,
 /area/sensor_relay)
 "gpi" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_int";
 	name = "sensor_relay_int";
 	req_one_access = null
@@ -3128,7 +3128,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_ext";
 	name = "sensor_relay_ext";
 	req_one_access = null
@@ -3157,7 +3157,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_ext";
 	name = "sensor_relay_ext";
 	req_one_access = null
@@ -3350,7 +3350,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_ext";
 	name = "sensor_relay_ext";
 	req_one_access = null
@@ -3398,7 +3398,7 @@
 /turf/template_noop,
 /area/space)
 "njD" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_eng";
 	name = "sensor_relay_eng";
 	req_one_access = null
@@ -3529,7 +3529,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_int";
 	name = "sensor_relay_int";
 	req_one_access = null
@@ -3558,7 +3558,7 @@
 /area/sensor_relay)
 "pnq" = (
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden/cyan,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_ext";
 	name = "sensor_relay_ext";
 	req_one_access = null
@@ -3588,7 +3588,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_int";
 	name = "sensor_relay_int";
 	req_one_access = null
@@ -3745,7 +3745,7 @@
 /turf/simulated/floor/airless,
 /area/sensor_relay)
 "scO" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_ext";
 	name = "sensor_relay_ext";
 	req_one_access = null
@@ -3880,7 +3880,7 @@
 /turf/simulated/floor/carpet/green,
 /area/sensor_relay/quarters)
 "tSw" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_int";
 	name = "sensor_relay_int";
 	req_one_access = null
@@ -4008,7 +4008,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_int";
 	name = "sensor_relay_int";
 	req_one_access = null
@@ -4055,7 +4055,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sensor_relay_int";
 	name = "sensor_relay_int";
 	req_one_access = null

--- a/maps/away/away_site/shady/shady.dm
+++ b/maps/away/away_site/shady/shady.dm
@@ -22,7 +22,7 @@
 	desc = "An asteroid with a hangar carved out inside it. Scans detect an unregistered structure within, with multiple lifeforms present."
 	icon_state = "object"
 
-/obj/effect/map_effect/marker/airlock/shady
+/obj/effect/map_effect/marker/airlock/external/shady
 	name = "Entrance Airlock"
 	master_tag = "airlock_shady"
 

--- a/maps/away/away_site/shady/shady.dmm
+++ b/maps/away/away_site/shady/shady.dmm
@@ -874,7 +874,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/shady,
+/obj/effect/map_effect/marker/airlock/external/shady,
 /turf/simulated/floor/tiled,
 /area/hideout)
 "mj" = (
@@ -987,7 +987,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/shady,
+/obj/effect/map_effect/marker/airlock/external/shady,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/full,
@@ -1346,7 +1346,7 @@
 /obj/effect/decal/cleanable/blood/no_dry,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock/shady,
+/obj/effect/map_effect/marker/airlock/external/shady,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/access_button{
 	pixel_x = -26;
@@ -1497,7 +1497,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/shady,
+/obj/effect/map_effect/marker/airlock/external/shady,
 /obj/structure/machinery/airlock_sensor{
 	pixel_x = -24;
 	dir = 4;
@@ -2480,7 +2480,7 @@
 /obj/effect/decal/cleanable/blood/no_dry,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock/shady,
+/obj/effect/map_effect/marker/airlock/external/shady,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/full,
@@ -2759,7 +2759,7 @@
 /area/hideout)
 "Qv" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock/shady,
+/obj/effect/map_effect/marker/airlock/external/shady,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/access_button{
 	pixel_x = 33;
@@ -2785,7 +2785,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/shady,
+/obj/effect/map_effect/marker/airlock/external/shady,
 /obj/structure/machinery/light/small{
 	dir = 4
 	},

--- a/maps/away/away_site/sol_bunker/bunker.dm
+++ b/maps/away/away_site/sol_bunker/bunker.dm
@@ -20,7 +20,7 @@
 	name = "lone asteroid"
 	desc = "A lone asteroid. Strange signals are coming from this one."
 
-/obj/effect/map_effect/marker/airlock/sol_bunker
+/obj/effect/map_effect/marker/airlock/external/sol_bunker
 	name = "Entrance Airlock"
 	master_tag = "airlock_sol_bunker"
 

--- a/maps/away/away_site/sol_bunker/bunker.dmm
+++ b/maps/away/away_site/sol_bunker/bunker.dmm
@@ -59,7 +59,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/map_effect/marker/airlock/sol_bunker,
+/obj/effect/map_effect/marker/airlock/external/sol_bunker,
 /obj/structure/machinery/light/small/red{
 	dir = 4
 	},
@@ -352,7 +352,7 @@
 	pixel_y = -6
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/sol_bunker,
+/obj/effect/map_effect/marker/airlock/external/sol_bunker,
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/full,
 /area/sol_bunker)
@@ -502,7 +502,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/map_effect/marker/airlock/sol_bunker,
+/obj/effect/map_effect/marker/airlock/external/sol_bunker,
 /turf/simulated/floor/tiled/full,
 /area/sol_bunker)
 "od" = (
@@ -675,7 +675,7 @@
 "sI" = (
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/sol_bunker,
+/obj/effect/map_effect/marker/airlock/external/sol_bunker,
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/full,
 /area/sol_bunker)
@@ -817,7 +817,7 @@
 	},
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/sol_bunker,
+/obj/effect/map_effect/marker/airlock/external/sol_bunker,
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/full,
 /area/sol_bunker)
@@ -843,7 +843,7 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/map_effect/marker/airlock/sol_bunker,
+/obj/effect/map_effect/marker/airlock/external/sol_bunker,
 /turf/simulated/floor/tiled/full,
 /area/sol_bunker)
 "xW" = (
@@ -855,7 +855,7 @@
 	pixel_y = -6
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/map_effect/marker/airlock/sol_bunker,
+/obj/effect/map_effect/marker/airlock/external/sol_bunker,
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 7;
 	dir = 4;
@@ -1254,7 +1254,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/sol_bunker,
+/obj/effect/map_effect/marker/airlock/external/sol_bunker,
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/full,
 /area/sol_bunker)

--- a/maps/away/away_site/tajara/peoples_station/peoples_station.dmm
+++ b/maps/away/away_site/tajara/peoples_station/peoples_station.dmm
@@ -724,7 +724,7 @@
 	pixel_x = -10
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "peoples_station_solars";
 	name = "peoples_station_solars";
@@ -3880,7 +3880,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = 32
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "peoples_station_solars";
 	name = "peoples_station_solars";
@@ -4450,7 +4450,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "peoples_station_solars";
 	name = "peoples_station_solars";

--- a/maps/away/away_site/tajara/pra_satellite/pra_satellite.dm
+++ b/maps/away/away_site/tajara/pra_satellite/pra_satellite.dm
@@ -51,18 +51,18 @@
 	landmark_tag = "nav_hadiist_satellite_3"
 
 // Airlock Markers
-/obj/effect/map_effect/marker/airlock/pra_satellite
+/obj/effect/map_effect/marker/airlock/external/pra_satellite
 	frequency = 1004
 
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/starboard
 	name = "airlock_pra_satellite_starboard"
 	master_tag = "airlock_pra_satellite_starboard"
 
-/obj/effect/map_effect/marker/airlock/pra_satellite/port
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/port
 	name = "airlock_pra_satellite_port"
 	master_tag = "airlock_pra_satellite_port"
 
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/aft
 	name = "airlock_pra_satellite_aft"
 	master_tag = "airlock_pra_satellite_aft"
 

--- a/maps/away/away_site/tajara/pra_satellite/pra_satellite.dmm
+++ b/maps/away/away_site/tajara/pra_satellite/pra_satellite.dmm
@@ -126,7 +126,7 @@
 	},
 /area/pra_satellite)
 "bh" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/starboard,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -139,7 +139,7 @@
 	},
 /area/pra_satellite)
 "bp" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/port,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/access_button/airlock_exterior{
 	pixel_x = 8;
@@ -227,7 +227,7 @@
 	},
 /area/pra_satellite)
 "ci" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/port,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = 25
@@ -776,7 +776,7 @@
 	},
 /area/pra_satellite)
 "my" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/port,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -807,7 +807,7 @@
 	},
 /area/pra_satellite)
 "on" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/starboard,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/access_button/airlock_exterior{
 	pixel_x = -8;
@@ -937,7 +937,7 @@
 	},
 /area/pra_satellite)
 "qF" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/aft,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
@@ -958,7 +958,7 @@
 	},
 /area/pra_satellite)
 "qW" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/starboard,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
@@ -968,7 +968,7 @@
 	},
 /area/pra_satellite)
 "rl" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/starboard,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
@@ -977,7 +977,7 @@
 	},
 /area/pra_satellite)
 "rH" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/aft,
 /obj/structure/machinery/airlock_sensor{
 	pixel_x = 20;
 	dir = 8;
@@ -1018,7 +1018,7 @@
 	},
 /area/pra_satellite)
 "sS" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/port,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
@@ -1074,7 +1074,7 @@
 	},
 /area/pra_satellite)
 "tV" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/aft,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
@@ -1279,7 +1279,7 @@
 	},
 /area/pra_satellite)
 "zP" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/starboard,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = 25
@@ -1328,7 +1328,7 @@
 	},
 /area/pra_satellite)
 "AP" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/starboard,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
@@ -1379,7 +1379,7 @@
 	},
 /area/pra_satellite)
 "CB" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/starboard,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 25
@@ -1469,7 +1469,7 @@
 /area/pra_satellite)
 "FB" = (
 /obj/structure/machinery/light/small,
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/port,
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor{
 	temperature = 278.15
@@ -1641,7 +1641,7 @@
 /area/space)
 "Ks" = (
 /obj/structure/machinery/light/small,
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/starboard,
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor{
 	temperature = 278.15
@@ -1675,13 +1675,13 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/aft,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
 "LD" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/aft,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor{
 	temperature = 278.15
@@ -1734,7 +1734,7 @@
 	},
 /area/pra_satellite)
 "Nu" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/aft,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/machinery/door/airlock/external,
@@ -1772,7 +1772,7 @@
 	},
 /area/pra_satellite)
 "Pp" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/aft,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/access_button{
 	pixel_x = -28;
@@ -1836,7 +1836,7 @@
 	},
 /area/pra_satellite)
 "QG" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/port,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
@@ -1876,7 +1876,7 @@
 	},
 /area/pra_satellite)
 "Sd" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/port,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 25
@@ -1886,7 +1886,7 @@
 	},
 /area/pra_satellite)
 "Su" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/port,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
@@ -1988,7 +1988,7 @@
 	},
 /area/pra_satellite)
 "WI" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/effect/map_effect/marker/airlock/external/pra_satellite/aft,
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor{
 	temperature = 278.15

--- a/maps/away/away_site/tajara/saniorios_outpost/saniorios_outpost.dmm
+++ b/maps/away/away_site/tajara/saniorios_outpost/saniorios_outpost.dmm
@@ -118,7 +118,7 @@
 	},
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "saniorios_airlock_1"
 	},
 /turf/simulated/floor/plating{
@@ -255,7 +255,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "saniorios_airlock_1"
 	},
 /obj/structure/machinery/light/small/emergency{
@@ -634,7 +634,7 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/saniorios_outpost)
 "iD" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "saniorios_airlock_1"
 	},
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden/aux,
@@ -657,7 +657,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "saniorios_airlock_1"
 	},
 /turf/simulated/floor/plating{
@@ -1016,7 +1016,7 @@
 	},
 /area/saniorios_outpost/armory)
 "ok" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "saniorios_airlock_1"
 	},
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
@@ -1566,7 +1566,7 @@
 	pixel_x = 20;
 	pixel_y = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "saniorios_airlock_1"
 	},
 /turf/simulated/floor/plating{
@@ -2233,7 +2233,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "saniorios_airlock_1"
 	},
 /turf/simulated/floor/plating{
@@ -2485,7 +2485,7 @@
 	req_access = list(214)
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "saniorios_airlock_1"
 	},
 /turf/simulated/floor/plating{
@@ -2546,7 +2546,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "saniorios_airlock_1"
 	},
 /turf/simulated/floor/plating{
@@ -2741,7 +2741,7 @@
 /turf/simulated/floor/airless,
 /area/saniorios_outpost/gun)
 "Mp" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "saniorios_airlock_1"
 	},
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
@@ -3442,7 +3442,7 @@
 /area/space)
 "Zx" = (
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "saniorios_airlock_1"
 	},
 /turf/simulated/floor/plating{

--- a/maps/away/away_site/tajara/scrapper/scrapper.dmm
+++ b/maps/away/away_site/tajara/scrapper/scrapper.dmm
@@ -159,7 +159,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_ship_2"
 	},
 /turf/simulated/floor/plating{
@@ -189,7 +189,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_ship_2"
 	},
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -386,7 +386,7 @@
 /area/scrapper_base/quarters)
 "en" = (
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_ship_1"
 	},
 /turf/simulated/floor/plating{
@@ -608,7 +608,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_ship_2"
 	},
 /turf/simulated/floor/plating{
@@ -709,7 +709,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_ship_2"
 	},
 /turf/simulated/floor/plating{
@@ -791,7 +791,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 5
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_2"
 	},
 /turf/simulated/floor/plating{
@@ -808,7 +808,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_2"
 	},
 /turf/simulated/floor/plating{
@@ -971,7 +971,7 @@
 "lE" = (
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_2"
 	},
 /turf/simulated/floor/plating{
@@ -1128,7 +1128,7 @@
 "ni" = (
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_2"
 	},
 /turf/simulated/floor/plating{
@@ -1463,7 +1463,7 @@
 	},
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_ship_1"
 	},
 /turf/simulated/floor/plating{
@@ -1483,7 +1483,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_ship_1"
 	},
 /turf/simulated/floor/plating{
@@ -1539,7 +1539,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_1"
 	},
 /turf/simulated/floor/plating{
@@ -1653,7 +1653,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_ship_2"
 	},
 /turf/simulated/floor/plating{
@@ -1676,7 +1676,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_2"
 	},
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -1743,7 +1743,7 @@
 "uC" = (
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_1"
 	},
 /turf/simulated/floor/plating{
@@ -1871,7 +1871,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_2"
 	},
 /turf/simulated/floor/plating{
@@ -2123,7 +2123,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_3"
 	},
 /turf/simulated/floor/plating{
@@ -2171,7 +2171,7 @@
 /area/shuttle/scrapper_ship/bridge)
 "zx" = (
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_ship_1"
 	},
 /turf/simulated/floor/plating{
@@ -2212,7 +2212,7 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_3"
 	},
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -2508,7 +2508,7 @@
 	pixel_x = -28
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_1"
 	},
 /turf/simulated/floor/plating{
@@ -2871,7 +2871,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_1"
 	},
 /turf/simulated/floor/plating{
@@ -2889,7 +2889,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_2"
 	},
 /turf/simulated/floor/plating{
@@ -3154,7 +3154,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_ship_1"
 	},
 /turf/simulated/floor/plating{
@@ -3179,7 +3179,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_ship_2"
 	},
 /turf/simulated/floor/plating{
@@ -3351,7 +3351,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_ship_2"
 	},
 /turf/simulated/floor/plating{
@@ -3361,7 +3361,7 @@
 "OW" = (
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_1"
 	},
 /turf/simulated/floor/plating{
@@ -3394,7 +3394,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_1"
 	},
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -3424,7 +3424,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_3"
 	},
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux,
@@ -3450,7 +3450,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_ship_1"
 	},
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -3474,7 +3474,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_2"
 	},
 /turf/simulated/floor/plating{
@@ -3488,7 +3488,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_ship_2"
 	},
 /turf/simulated/floor/plating{
@@ -3520,7 +3520,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 5
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_1"
 	},
 /turf/simulated/floor/plating{
@@ -3547,7 +3547,7 @@
 	},
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_1"
 	},
 /turf/simulated/floor/plating{
@@ -3836,7 +3836,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_ship_1"
 	},
 /turf/simulated/floor/plating{
@@ -4159,7 +4159,7 @@
 	pixel_x = -28
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "scrapper_ship_1"
 	},
 /turf/simulated/floor/plating{

--- a/maps/away/away_site/uueoaesa/reclamation/ihss_reclamation.dmm
+++ b/maps/away/away_site/uueoaesa/reclamation/ihss_reclamation.dmm
@@ -198,7 +198,7 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_ihss_solars";
 	name = "airlock_ihss_solars";
@@ -4326,7 +4326,7 @@
 	pixel_x = -6;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3919;
 	master_tag = "airlock_ihss_aft";
 	name = "airlock_ihss_aft"
@@ -5188,7 +5188,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ihss_reclamation/southhall)
 "yR" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3919;
 	master_tag = "airlock_ihss_aft";
 	name = "airlock_ihss_aft"
@@ -5830,7 +5830,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3919;
 	master_tag = "airlock_ihss_aft";
 	name = "airlock_ihss_aft"
@@ -5865,7 +5865,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3919;
 	master_tag = "airlock_ihss_aft";
 	name = "airlock_ihss_aft"
@@ -6190,7 +6190,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_ihss_solars";
 	name = "airlock_ihss_solars"
@@ -7181,7 +7181,7 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3919;
 	master_tag = "airlock_ihss_aft";
 	name = "airlock_ihss_aft"
@@ -7479,7 +7479,7 @@
 /area/ihss_reclamation/dock)
 "KM" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_ihss_solars";
 	name = "airlock_ihss_solars"
@@ -7667,7 +7667,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3919;
 	master_tag = "airlock_ihss_aft";
 	name = "airlock_ihss_aft"
@@ -9453,7 +9453,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ihss_reclamation/dock)
 "TO" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3919;
 	master_tag = "airlock_ihss_aft";
 	name = "airlock_ihss_aft"
@@ -10759,7 +10759,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3919;
 	master_tag = "airlock_ihss_aft";
 	name = "airlock_ihss_aft"

--- a/maps/away/away_site/uueoaesa/tret/tret_industrial_complex.dmm
+++ b/maps/away/away_site/uueoaesa/tret/tret_industrial_complex.dmm
@@ -25,7 +25,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_5";
 	name = "airlock_tret_industrial_outpost_east_5";
 	req_one_access = list(216);
@@ -42,7 +42,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_4";
 	name = "airlock_tret_industrial_outpost_west_4";
 	req_one_access = null;
@@ -120,7 +120,7 @@
 /turf/simulated/floor/exoplanet/plating/tret,
 /area/tret_industrial/outside/surface)
 "aaw" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_2";
 	name = "airlock_tret_industrial_outpost_east_2";
 	req_one_access = null;
@@ -132,7 +132,7 @@
 /turf/simulated/floor/plating,
 /area/tret_industrial/inside/hallway_comms)
 "aax" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_3";
 	name = "airlock_tret_industrial_outpost_east_3";
 	req_one_access = null;
@@ -340,7 +340,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_4";
 	name = "airlock_tret_industrial_outpost_west_4";
 	req_one_access = null;
@@ -580,7 +580,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_1";
 	name = "airlock_tret_industrial_outpost_east_1";
 	req_one_access = null;
@@ -656,7 +656,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_3";
 	name = "airlock_tret_industrial_outpost_east_3";
 	req_one_access = null;
@@ -2177,7 +2177,7 @@
 /area/tret_industrial/inside/hallway_botany)
 "ajo" = (
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_3";
 	name = "airlock_tret_industrial_outpost_east_3";
 	req_one_access = null;
@@ -2927,7 +2927,7 @@
 "aqV" = (
 /obj/structure/machinery/door/airlock/external,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_4";
 	name = "airlock_tret_industrial_outpost_west_4";
 	req_one_access = null;
@@ -3375,7 +3375,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_3";
 	name = "airlock_tret_industrial_outpost_west_3";
 	req_one_access = null;
@@ -3971,7 +3971,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_2";
 	name = "airlock_tret_industrial_outpost_east_2";
 	req_one_access = null;
@@ -4165,7 +4165,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_5";
 	name = "airlock_tret_industrial_outpost_east_5";
 	req_one_access = list(216);
@@ -4252,7 +4252,7 @@
 /area/tret_industrial/inside/crew)
 "aCQ" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_3";
 	name = "airlock_tret_industrial_outpost_east_3";
 	req_one_access = null;
@@ -4423,7 +4423,7 @@
 "aDE" = (
 /obj/structure/machinery/door/airlock/external,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_2";
 	name = "airlock_tret_industrial_outpost_east_2";
 	req_one_access = null;
@@ -4500,7 +4500,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_1";
 	name = "airlock_tret_industrial_outpost_east_1";
 	req_one_access = null;
@@ -4535,7 +4535,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_1";
 	name = "airlock_tret_industrial_outpost_east_1";
 	req_one_access = null;
@@ -4830,7 +4830,7 @@
 	pixel_y = 28;
 	pixel_x = 5
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_shuttle_side";
 	name = "airlock_tret_industrial_outpost_shuttle_side";
 	req_one_access = null;
@@ -4868,7 +4868,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_5";
 	name = "airlock_tret_industrial_outpost_east_5";
 	req_one_access = list(216);
@@ -4985,7 +4985,7 @@
 /area/tret_industrial/inside/hallway_smelting)
 "aIb" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_2";
 	name = "airlock_tret_industrial_outpost_east_2";
 	req_one_access = null;
@@ -5159,7 +5159,7 @@
 /area/tret_industrial/inside/botany)
 "aJq" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_5";
 	name = "airlock_tret_industrial_outpost_east_5";
 	req_one_access = list(216);
@@ -5327,7 +5327,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_shuttle_side";
 	name = "airlock_tret_industrial_outpost_shuttle_side";
 	req_one_access = null;
@@ -6292,7 +6292,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_5";
 	name = "airlock_tret_industrial_outpost_east_5";
 	req_one_access = list(216);
@@ -6420,7 +6420,7 @@
 /area/tret_industrial/inside/storage_smelting)
 "aUP" = (
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_2";
 	name = "airlock_tret_industrial_outpost_east_2";
 	req_one_access = null;
@@ -6457,7 +6457,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/tret_industrial/inside/hallway_botany)
 "aVp" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_3";
 	name = "airlock_tret_industrial_outpost_west_3";
 	req_one_access = null;
@@ -7058,7 +7058,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_3";
 	name = "airlock_tret_industrial_outpost_west_3";
 	req_one_access = null;
@@ -7143,7 +7143,7 @@
 /area/tret_industrial/inside/smelting_west)
 "bHQ" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_1";
 	name = "airlock_tret_industrial_outpost_west_1";
 	req_one_access = null;
@@ -7169,7 +7169,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/tret_industrial/inside/hallway_medical)
 "bJS" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_2";
 	name = "airlock_tret_industrial_outpost_west_2";
 	req_one_access = null;
@@ -7238,7 +7238,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_1";
 	name = "airlock_tret_industrial_outpost_east_1";
 	req_one_access = null;
@@ -7258,7 +7258,7 @@
 /area/tret_industrial/inside/canteen)
 "cgU" = (
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_1";
 	name = "airlock_tret_industrial_outpost_west_1";
 	req_one_access = null;
@@ -7490,7 +7490,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/tret_industrial/inside/hallway_comms)
 "cZg" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_3";
 	name = "airlock_tret_industrial_outpost_east_3";
 	req_one_access = null;
@@ -7574,7 +7574,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_3";
 	name = "airlock_tret_industrial_outpost_east_3";
 	req_one_access = null;
@@ -7620,7 +7620,7 @@
 /turf/simulated/floor/exoplanet/plating/tret,
 /area/tret_industrial/outside/surface)
 "dJB" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_3";
 	name = "airlock_tret_industrial_outpost_west_3";
 	req_one_access = null;
@@ -7651,7 +7651,7 @@
 	pixel_y = 28;
 	pixel_x = -6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_shuttle_side";
 	name = "airlock_tret_industrial_outpost_shuttle_side";
 	req_one_access = null;
@@ -7721,7 +7721,7 @@
 "ecL" = (
 /obj/structure/machinery/door/airlock/external,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_4";
 	name = "airlock_tret_industrial_outpost_east_4";
 	req_one_access = null;
@@ -7760,7 +7760,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/tret_industrial/inside/hallway_comms)
 "eiK" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_4";
 	name = "airlock_tret_industrial_outpost_west_4";
 	req_one_access = null;
@@ -8011,7 +8011,7 @@
 /area/shuttle/tret_industrial/main)
 "flS" = (
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_2";
 	name = "airlock_tret_industrial_outpost_east_2";
 	req_one_access = null;
@@ -8105,7 +8105,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_3";
 	name = "airlock_tret_industrial_outpost_east_3";
 	req_one_access = null;
@@ -8130,7 +8130,7 @@
 /area/tret_industrial/inside/maint_center)
 "fRP" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_4";
 	name = "airlock_tret_industrial_outpost_west_4";
 	req_one_access = null;
@@ -8235,7 +8235,7 @@
 /turf/simulated/floor/tiled/gunmetal,
 /area/shuttle/tret_industrial/main)
 "gdY" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_4";
 	name = "airlock_tret_industrial_outpost_west_4";
 	req_one_access = null;
@@ -8284,7 +8284,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_1";
 	name = "airlock_tret_industrial_outpost_west_1";
 	req_one_access = null;
@@ -8314,7 +8314,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_4";
 	name = "airlock_tret_industrial_outpost_east_4";
 	req_one_access = null;
@@ -8323,7 +8323,7 @@
 /turf/simulated/floor/plating,
 /area/tret_industrial/inside/hallway_botany)
 "gqH" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_4";
 	name = "airlock_tret_industrial_outpost_east_4";
 	req_one_access = null;
@@ -8776,7 +8776,7 @@
 "hZW" = (
 /obj/structure/machinery/door/airlock/external,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_2";
 	name = "airlock_tret_industrial_outpost_west_2";
 	req_one_access = null;
@@ -8898,7 +8898,7 @@
 /turf/simulated/lava/tret,
 /area/tret_industrial/outside/surface)
 "iCP" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_2";
 	name = "airlock_tret_industrial_outpost_east_2";
 	req_one_access = null;
@@ -8989,7 +8989,7 @@
 /area/tret_industrial/inside/crew)
 "iZQ" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_2";
 	name = "airlock_tret_industrial_outpost_east_2";
 	req_one_access = null;
@@ -9196,7 +9196,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_4";
 	name = "airlock_tret_industrial_outpost_west_4";
 	req_one_access = null;
@@ -9318,7 +9318,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_4";
 	name = "airlock_tret_industrial_outpost_east_4";
 	req_one_access = null;
@@ -9372,7 +9372,7 @@
 /area/tret_industrial/inside/storage_smelting)
 "jRW" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_3";
 	name = "airlock_tret_industrial_outpost_west_3";
 	req_one_access = null;
@@ -9413,7 +9413,7 @@
 /turf/simulated/floor/tiled/slate,
 /area/tret_industrial/inside/canteen)
 "jUr" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_2";
 	name = "airlock_tret_industrial_outpost_east_2";
 	req_one_access = null;
@@ -9548,7 +9548,7 @@
 /turf/simulated/floor/plating,
 /area/tret_industrial/inside/engineering)
 "kAW" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_4";
 	name = "airlock_tret_industrial_outpost_west_4";
 	req_one_access = null;
@@ -9673,7 +9673,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_1";
 	name = "airlock_tret_industrial_outpost_west_1";
 	req_one_access = null;
@@ -10157,7 +10157,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/tret_industrial/main)
 "nmL" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_3";
 	name = "airlock_tret_industrial_outpost_east_3";
 	req_one_access = null;
@@ -10225,7 +10225,7 @@
 /area/tret_industrial/outside/surface)
 "nDQ" = (
 /obj/effect/map_effect/map_helper/ruler_tiles_3,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_4";
 	name = "airlock_tret_industrial_outpost_west_4";
 	req_one_access = null;
@@ -10320,7 +10320,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_3";
 	name = "airlock_tret_industrial_outpost_east_3";
 	req_one_access = null;
@@ -10397,7 +10397,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/tret_industrial/inside/hallway_smelting)
 "odS" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_2";
 	name = "airlock_tret_industrial_outpost_east_2";
 	req_one_access = null;
@@ -10514,7 +10514,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_shuttle_side";
 	name = "airlock_tret_industrial_outpost_shuttle_side";
 	req_one_access = null;
@@ -10790,7 +10790,7 @@
 /turf/simulated/floor/exoplanet/plating/tret,
 /area/tret_industrial/inside/hallway_docks)
 "pUL" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_3";
 	name = "airlock_tret_industrial_outpost_west_3";
 	req_one_access = null;
@@ -10817,7 +10817,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_2";
 	name = "airlock_tret_industrial_outpost_west_2";
 	req_one_access = null;
@@ -10851,7 +10851,7 @@
 /turf/simulated/floor/plating,
 /area/tret_industrial/inside/hallway_docks)
 "qhF" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_1";
 	name = "airlock_tret_industrial_outpost_west_1";
 	req_one_access = null;
@@ -10961,7 +10961,7 @@
 /turf/simulated/floor/exoplanet/basalt/tret,
 /area/tret_industrial/outside/surface)
 "quT" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_2";
 	name = "airlock_tret_industrial_outpost_west_2";
 	req_one_access = null;
@@ -11000,7 +11000,7 @@
 /area/tret_industrial/inside/crew)
 "qyX" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_2";
 	name = "airlock_tret_industrial_outpost_west_2";
 	req_one_access = null;
@@ -11054,7 +11054,7 @@
 /turf/simulated/floor/exoplanet/plating/tret,
 /area/tret_industrial/outside/surface)
 "qNt" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_1";
 	name = "airlock_tret_industrial_outpost_east_1";
 	req_one_access = null;
@@ -11082,7 +11082,7 @@
 /turf/simulated/floor/plating,
 /area/tret_industrial/inside/maint_center)
 "qPU" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_3";
 	name = "airlock_tret_industrial_outpost_east_3";
 	req_one_access = null;
@@ -11443,7 +11443,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_3";
 	name = "airlock_tret_industrial_outpost_west_3";
 	req_one_access = null;
@@ -11569,7 +11569,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_2";
 	name = "airlock_tret_industrial_outpost_east_2";
 	req_one_access = null;
@@ -11584,7 +11584,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_4";
 	name = "airlock_tret_industrial_outpost_west_4";
 	req_one_access = null;
@@ -11652,7 +11652,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/green,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_shuttle_side";
 	name = "airlock_tret_industrial_outpost_shuttle_side";
 	req_one_access = null;
@@ -11725,7 +11725,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 10
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_2";
 	name = "airlock_tret_industrial_outpost_east_2";
 	req_one_access = null;
@@ -11821,7 +11821,7 @@
 /area/tret_industrial/inside/storage_engineering)
 "sSg" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_3";
 	name = "airlock_tret_industrial_outpost_east_3";
 	req_one_access = null;
@@ -11912,7 +11912,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/tret_industrial/inside/hallway_smelting)
 "sYN" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_3";
 	name = "airlock_tret_industrial_outpost_east_3";
 	req_one_access = null;
@@ -11995,7 +11995,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_1";
 	name = "airlock_tret_industrial_outpost_west_1";
 	req_one_access = null;
@@ -12296,7 +12296,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_3";
 	name = "airlock_tret_industrial_outpost_west_3";
 	req_one_access = null;
@@ -12427,7 +12427,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_1";
 	name = "airlock_tret_industrial_outpost_west_1";
 	req_one_access = null;
@@ -12473,7 +12473,7 @@
 /turf/simulated/floor/plating,
 /area/tret_industrial/inside/hallway_medical)
 "vGD" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_4";
 	name = "airlock_tret_industrial_outpost_east_4";
 	req_one_access = null;
@@ -12560,7 +12560,7 @@
 /area/tret_industrial/outside/surface)
 "vUX" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_3";
 	name = "airlock_tret_industrial_outpost_west_3";
 	req_one_access = null;
@@ -12667,7 +12667,7 @@
 	},
 /area/shuttle/tret_industrial/main)
 "wny" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_1";
 	name = "airlock_tret_industrial_outpost_east_1";
 	req_one_access = null;
@@ -12807,7 +12807,7 @@
 /area/shuttle/tret_industrial/main)
 "wKu" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_2";
 	name = "airlock_tret_industrial_outpost_east_2";
 	req_one_access = null;
@@ -12902,7 +12902,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_3";
 	name = "airlock_tret_industrial_outpost_east_3";
 	req_one_access = null;
@@ -12952,7 +12952,7 @@
 /turf/simulated/floor/plating,
 /area/tret_industrial/inside/hallway_botany)
 "xnV" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_west_3";
 	name = "airlock_tret_industrial_outpost_west_3";
 	req_one_access = null;
@@ -12963,7 +12963,7 @@
 /turf/simulated/floor/plating,
 /area/tret_industrial/inside/hallway_docks)
 "xoH" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tret_industrial_outpost_east_5";
 	name = "airlock_tret_industrial_outpost_east_5";
 	req_one_access = list(216);

--- a/maps/away/scenarios/decrepit_shipyard/decrepit_shipyard.dm
+++ b/maps/away/scenarios/decrepit_shipyard/decrepit_shipyard.dm
@@ -116,13 +116,13 @@
 // Shuttle non-docking airlocks
 
 // Port
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard_shuttle/port
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard_shuttle/port
 	name = "Port Airlock"
 	master_tag = "airlock_decrepit_shipyard_shuttle_port"
 	cycle_to_external_air = TRUE
 
 // Starboard
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard_shuttle/starboard
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard_shuttle/starboard
 	name = "Starboard Airlock"
 	master_tag = "airlock_decrepit_shipyard_shuttle_starboard"
 	cycle_to_external_air = TRUE

--- a/maps/away/scenarios/decrepit_shipyard/decrepit_shipyard.dmm
+++ b/maps/away/scenarios/decrepit_shipyard/decrepit_shipyard.dmm
@@ -162,7 +162,7 @@
 	},
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/secondary,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/secondary,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/west_dry_dock_west_maintenance)
 "agK" = (
@@ -618,7 +618,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/upper/west,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/upper/west,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/north_west_maintenance)
 "avU" = (
@@ -1270,7 +1270,7 @@
 /obj/structure/lattice/catwalk/indoor/urban,
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/structure/machinery/meter,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor,
 /area/decrepit_shipyard/workshop)
 "aXL" = (
@@ -2357,7 +2357,7 @@
 /obj/structure/machinery/light/small/emergency{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/secondary,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/secondary,
 /turf/simulated/floor,
 /area/decrepit_shipyard/west_dry_dock_west_maintenance)
 "bHJ" = (
@@ -3012,7 +3012,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/workshop,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/workshop,
 /turf/simulated/floor,
 /area/decrepit_shipyard/main_workshop)
 "cgf" = (
@@ -3163,7 +3163,7 @@
 /obj/structure/lattice/catwalk/indoor/urban,
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor,
 /area/decrepit_shipyard/workshop)
 "clB" = (
@@ -3203,7 +3203,7 @@
 	},
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/secondary,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/secondary,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/west_dry_dock_west_maintenance)
 "cmg" = (
@@ -3963,7 +3963,7 @@
 	},
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/workshop)
 "cGj" = (
@@ -4683,7 +4683,7 @@
 	},
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/workshop,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/workshop,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/main_workshop)
 "dju" = (
@@ -5038,7 +5038,7 @@
 	dir = 4;
 	pixel_y = 7
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/secondary,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/secondary,
 /turf/simulated/floor,
 /area/decrepit_shipyard/west_dry_dock_west_maintenance)
 "dwH" = (
@@ -5659,7 +5659,7 @@
 	pixel_y = 30;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/upper/north_east,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/upper/north_east,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/engineering_north_maintenance)
 "dSq" = (
@@ -6215,7 +6215,7 @@
 /obj/effect/decal/curb,
 /obj/structure/lattice/catwalk/indoor/urban,
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor,
 /area/decrepit_shipyard/workshop)
 "eoQ" = (
@@ -6389,7 +6389,7 @@
 	},
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/workshop,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/workshop,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/main_workshop)
 "exJ" = (
@@ -7212,7 +7212,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/structure/machinery/light/small/emergency,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/south,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/south,
 /turf/simulated/floor,
 /area/decrepit_shipyard/transport_tunnels_south)
 "fbp" = (
@@ -8065,7 +8065,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/south,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/south,
 /turf/simulated/floor,
 /area/decrepit_shipyard/transport_tunnels_south)
 "fDA" = (
@@ -9259,7 +9259,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/upper/west,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/upper/west,
 /obj/structure/machinery/light/small/emergency{
 	dir = 1
 	},
@@ -9916,7 +9916,7 @@
 	},
 /obj/structure/lattice/ceiling,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor,
 /area/decrepit_shipyard/workshop)
 "gNT" = (
@@ -9998,7 +9998,7 @@
 	dir = 1;
 	pixel_y = 11
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/workshop)
 "gQc" = (
@@ -11788,7 +11788,7 @@
 /obj/structure/machinery/light/small/emergency{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/workshop,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/workshop,
 /turf/simulated/floor,
 /area/decrepit_shipyard/main_workshop)
 "hZM" = (
@@ -12808,7 +12808,7 @@
 /obj/structure/railing/mapped/no_density/low{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor,
 /area/decrepit_shipyard/workshop)
 "iJf" = (
@@ -12960,7 +12960,7 @@
 /obj/structure/lattice/ceiling,
 /obj/structure/railing/mapped/no_density/low,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor,
 /area/decrepit_shipyard/workshop)
 "iOW" = (
@@ -13246,7 +13246,7 @@
 	pixel_x = -7;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/upper/north_east,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/upper/north_east,
 /turf/simulated/floor,
 /area/decrepit_shipyard/engineering_north_maintenance)
 "iXZ" = (
@@ -14993,7 +14993,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/south,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/south,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/transport_tunnels_south)
 "kbM" = (
@@ -15541,7 +15541,7 @@
 	pixel_x = -22;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/secondary,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/secondary,
 /turf/simulated/floor,
 /area/decrepit_shipyard/west_dry_dock_west_maintenance)
 "kwF" = (
@@ -16260,7 +16260,7 @@
 	pixel_x = -30;
 	pixel_y = -2
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/workshop,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/workshop,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/main_workshop)
 "ldK" = (
@@ -16384,7 +16384,7 @@
 	pixel_x = -30;
 	pixel_y = -3
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/workshop)
 "lgd" = (
@@ -18140,7 +18140,7 @@
 /obj/structure/railing/mapped/no_density/low{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor,
 /area/decrepit_shipyard/workshop)
 "mqg" = (
@@ -18750,7 +18750,7 @@
 /obj/structure/machinery/light/small/emergency{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/upper/north_east,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/upper/north_east,
 /turf/simulated/floor,
 /area/decrepit_shipyard/engineering_north_maintenance)
 "mKc" = (
@@ -19127,7 +19127,7 @@
 	pixel_x = 7
 	},
 /obj/structure/machinery/light/small/emergency,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/upper/south_east,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/upper/south_east,
 /turf/simulated/floor,
 /area/decrepit_shipyard/engineering_south_maintenance)
 "mYe" = (
@@ -19146,7 +19146,7 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor,
 /area/decrepit_shipyard/workshop)
 "mYx" = (
@@ -19190,7 +19190,7 @@
 	pixel_y = -28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/upper/south_east,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/upper/south_east,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/engineering_south_maintenance)
 "mZD" = (
@@ -20016,7 +20016,7 @@
 	pixel_y = 28;
 	pixel_x = -7
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/upper/south_east,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/upper/south_east,
 /turf/simulated/floor,
 /area/decrepit_shipyard/engineering_south_maintenance)
 "nzo" = (
@@ -21438,7 +21438,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/secondary,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/secondary,
 /turf/simulated/floor,
 /area/decrepit_shipyard/west_dry_dock_west_maintenance)
 "otC" = (
@@ -21469,7 +21469,7 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor,
 /area/decrepit_shipyard/workshop)
 "ovc" = (
@@ -22845,7 +22845,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/workshop)
 "poI" = (
@@ -23274,7 +23274,7 @@
 	pixel_x = 30;
 	pixel_y = -6
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/secondary,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/secondary,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/west_dry_dock_west_maintenance)
 "pGw" = (
@@ -23564,7 +23564,7 @@
 	dir = 4;
 	pixel_y = 7
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/workshop,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/workshop,
 /turf/simulated/floor,
 /area/decrepit_shipyard/main_workshop)
 "pRK" = (
@@ -24667,7 +24667,7 @@
 	dir = 4;
 	pixel_y = 30
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/secondary,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/secondary,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/west_dry_dock_west_maintenance)
 "qKK" = (
@@ -25259,7 +25259,7 @@
 /obj/effect/decal/curb,
 /obj/structure/lattice/catwalk/indoor/urban,
 /obj/structure/lattice/ceiling,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor,
 /area/decrepit_shipyard/workshop)
 "rhh" = (
@@ -25694,7 +25694,7 @@
 	pixel_x = -22;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/workshop,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/workshop,
 /turf/simulated/floor,
 /area/decrepit_shipyard/main_workshop)
 "rvx" = (
@@ -26298,7 +26298,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch_small/grey,
 /obj/structure/railing/mapped/no_density/low,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor,
 /area/decrepit_shipyard/workshop)
 "rSg" = (
@@ -27190,7 +27190,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor,
 /area/decrepit_shipyard/workshop)
 "sxe" = (
@@ -28467,7 +28467,7 @@
 	pixel_y = -28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/upper/north_east,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/upper/north_east,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/engineering_north_maintenance)
 "tzT" = (
@@ -28930,7 +28930,7 @@
 /obj/effect/floor_decal/industrial/hatch_small/grey,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor,
 /area/decrepit_shipyard/workshop)
 "tUX" = (
@@ -29641,7 +29641,7 @@
 	pixel_y = 30;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/upper/south_east,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/upper/south_east,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/engineering_south_maintenance)
 "uzI" = (
@@ -30507,7 +30507,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/upper/west,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/upper/west,
 /turf/simulated/floor,
 /area/decrepit_shipyard/north_west_maintenance)
 "viP" = (
@@ -30780,7 +30780,7 @@
 /obj/effect/floor_decal/industrial/hatch_small/grey,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor,
 /area/decrepit_shipyard/workshop)
 "vsq" = (
@@ -30798,7 +30798,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/workshop)
 "vsS" = (
@@ -31083,7 +31083,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/workshop)
 "vDi" = (
@@ -32100,7 +32100,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/workshop)
 "wvr" = (
@@ -32492,7 +32492,7 @@
 	pixel_y = 10;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/workshop,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/workshop,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/main_workshop)
 "wII" = (
@@ -32547,7 +32547,7 @@
 /obj/structure/machinery/light/small/emergency,
 /obj/structure/railing/mapped/no_density/low,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor,
 /area/decrepit_shipyard/workshop)
 "wLH" = (
@@ -32802,7 +32802,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/upper/west,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/upper/west,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/north_west_maintenance)
@@ -33003,7 +33003,7 @@
 /obj/structure/lattice/ceiling,
 /obj/structure/railing/mapped/no_density/low,
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor,
 /area/decrepit_shipyard/workshop)
 "xaF" = (
@@ -34085,7 +34085,7 @@
 	pixel_y = 30;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/workshop)
 "xRE" = (
@@ -34350,7 +34350,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/south,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/south,
 /turf/simulated/floor/tiled/dark/full,
 /area/decrepit_shipyard/transport_tunnels_south)
 "ydc" = (

--- a/maps/away/scenarios/decrepit_shipyard/decrepit_shipyard_landmarks.dm
+++ b/maps/away/scenarios/decrepit_shipyard/decrepit_shipyard_landmarks.dm
@@ -163,32 +163,32 @@
 
 // Upper deck
 
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/upper/west
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/upper/west
 	name = "West Airlock"
 	master_tag = "airlock_decrepit_shipyard_upper_west"
 
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/upper/north_east
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/upper/north_east
 	name = "North-East Airlock"
 	master_tag = "airlock_decrepit_shipyard_upper_north_east"
 
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/upper/south_east
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/upper/south_east
 	name = "South-East Airlock"
 	master_tag = "airlock_decrepit_shipyard_upper_south_east"
 
 // Lower deck
 
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/main
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/main
 	name = "Dry Dock Supply Airlock"
 	master_tag = "airlock_decrepit_shipyard_lower_main"
 
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/secondary
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/secondary
 	name = "Dry Dock Secondary Airlock"
 	master_tag = "airlock_decrepit_shipyard_lower_secondary"
 
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/south
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/south
 	name = "South Airlock"
 	master_tag = "airlock_decrepit_shipyard_lower_south"
 
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard/lower/workshop
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard/lower/workshop
 	name = "Dry Dock Workshop Airlock"
 	master_tag = "airlock_decrepit_shipyard_lower_workshop"

--- a/maps/away/scenarios/decrepit_shipyard/decrepit_shipyard_submaps.dmm
+++ b/maps/away/scenarios/decrepit_shipyard/decrepit_shipyard_submaps.dmm
@@ -385,7 +385,7 @@
 	pixel_y = 28;
 	pixel_x = 7
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard_shuttle/port,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard_shuttle/port,
 /turf/simulated/floor,
 /area/shuttle/decrepit_shipyard_shuttle)
 "gt" = (
@@ -423,7 +423,7 @@
 	pixel_y = -28;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard_shuttle/starboard,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard_shuttle/starboard,
 /turf/simulated/floor,
 /area/shuttle/decrepit_shipyard_shuttle)
 "hd" = (
@@ -612,7 +612,7 @@
 	pixel_y = 30;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard_shuttle/starboard,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard_shuttle/starboard,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/decrepit_shipyard_shuttle)
 "lC" = (
@@ -724,7 +724,7 @@
 	pixel_y = -30;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard_shuttle/port,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard_shuttle/port,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/decrepit_shipyard_shuttle)
 "nS" = (
@@ -824,7 +824,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard_shuttle/port,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard_shuttle/port,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/decrepit_shipyard_shuttle)
 "pt" = (
@@ -939,7 +939,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard_shuttle/starboard,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard_shuttle/starboard,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/decrepit_shipyard_shuttle)
 "sc" = (
@@ -1295,7 +1295,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard_shuttle/starboard,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard_shuttle/starboard,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/decrepit_shipyard_shuttle)
 "zl" = (
@@ -1407,7 +1407,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard_shuttle/port,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard_shuttle/port,
 /turf/simulated/floor,
 /area/shuttle/decrepit_shipyard_shuttle)
 "AL" = (
@@ -1569,7 +1569,7 @@
 	pixel_y = 30;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard_shuttle/port,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard_shuttle/port,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/decrepit_shipyard_shuttle)
 "CZ" = (
@@ -2065,7 +2065,7 @@
 	pixel_y = 30;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard_shuttle/starboard,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard_shuttle/starboard,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/decrepit_shipyard_shuttle)
 "NP" = (
@@ -2149,7 +2149,7 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard_shuttle/starboard,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard_shuttle/starboard,
 /turf/simulated/floor,
 /area/shuttle/decrepit_shipyard_shuttle)
 "PZ" = (
@@ -2345,7 +2345,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/decrepit_shipyard_shuttle/port,
+/obj/effect/map_effect/marker/airlock/external/decrepit_shipyard_shuttle/port,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/decrepit_shipyard_shuttle)
 "Sj" = (

--- a/maps/away/scenarios/ruined_propellant_depot/ruined_propellant_depot.dmm
+++ b/maps/away/scenarios/ruined_propellant_depot/ruined_propellant_depot.dmm
@@ -607,7 +607,7 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_1";
 	name = "airlock_ruined_propellant_depot_1";
 	req_one_access = null
@@ -1554,7 +1554,7 @@
 	dir = 4;
 	pixel_y = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_5";
 	name = "airlock_ruined_propellant_depot_5";
 	req_one_access = null
@@ -2048,7 +2048,7 @@
 	dir = 4;
 	pixel_y = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_4";
 	name = "airlock_ruined_propellant_depot_4";
 	req_one_access = null
@@ -2130,7 +2130,7 @@
 /area/ruined_propellant_depot/atmos_propellant)
 "gq" = (
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_3";
 	name = "airlock_ruined_propellant_depot_3";
 	req_one_access = null
@@ -2520,7 +2520,7 @@
 	icon_state = "2-8"
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_5";
 	name = "airlock_ruined_propellant_depot_5";
 	req_one_access = null
@@ -3448,7 +3448,7 @@
 /area/ruined_propellant_depot/maint_storage)
 "kF" = (
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_6";
 	name = "airlock_ruined_propellant_depot_6";
 	req_one_access = null
@@ -3872,7 +3872,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_5";
 	name = "airlock_ruined_propellant_depot_5";
 	req_one_access = null
@@ -5615,7 +5615,7 @@
 	pixel_y = -6;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_2";
 	name = "airlock_ruined_propellant_depot_2";
 	req_one_access = null
@@ -5697,7 +5697,7 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_4";
 	name = "airlock_ruined_propellant_depot_4";
 	req_one_access = null
@@ -6260,7 +6260,7 @@
 	pixel_x = 28
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_3";
 	name = "airlock_ruined_propellant_depot_3";
 	req_one_access = null
@@ -6729,7 +6729,7 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_6";
 	name = "airlock_ruined_propellant_depot_6";
 	req_one_access = null
@@ -7007,7 +7007,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_2";
 	name = "airlock_ruined_propellant_depot_2";
 	req_one_access = null
@@ -7739,7 +7739,7 @@
 	pixel_y = -6;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_5";
 	name = "airlock_ruined_propellant_depot_5";
 	req_one_access = null
@@ -8163,7 +8163,7 @@
 	dir = 4
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_4";
 	name = "airlock_ruined_propellant_depot_4";
 	req_one_access = null
@@ -8319,7 +8319,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_2";
 	name = "airlock_ruined_propellant_depot_2";
 	req_one_access = null
@@ -8702,7 +8702,7 @@
 	pixel_y = 6;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_6";
 	name = "airlock_ruined_propellant_depot_6";
 	req_one_access = null
@@ -8734,7 +8734,7 @@
 	dir = 4;
 	pixel_y = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_3";
 	name = "airlock_ruined_propellant_depot_3";
 	req_one_access = null
@@ -9965,7 +9965,7 @@
 	pixel_y = -6;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_1";
 	name = "airlock_ruined_propellant_depot_1";
 	req_one_access = null
@@ -10592,7 +10592,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_6";
 	name = "airlock_ruined_propellant_depot_6";
 	req_one_access = null
@@ -11426,7 +11426,7 @@
 	pixel_x = -28
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_4";
 	name = "airlock_ruined_propellant_depot_4";
 	req_one_access = null
@@ -11505,7 +11505,7 @@
 	pixel_x = -28
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_5";
 	name = "airlock_ruined_propellant_depot_5";
 	req_one_access = null
@@ -11670,7 +11670,7 @@
 	dir = 4;
 	pixel_y = -6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_6";
 	name = "airlock_ruined_propellant_depot_6";
 	req_one_access = null
@@ -12079,7 +12079,7 @@
 	dir = 8;
 	pixel_y = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_1";
 	name = "airlock_ruined_propellant_depot_1";
 	req_one_access = null
@@ -12251,7 +12251,7 @@
 	dir = 4
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_1";
 	name = "airlock_ruined_propellant_depot_1";
 	req_one_access = null
@@ -12279,7 +12279,7 @@
 	dir = 8;
 	pixel_y = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_2";
 	name = "airlock_ruined_propellant_depot_2";
 	req_one_access = null
@@ -12426,7 +12426,7 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_4";
 	name = "airlock_ruined_propellant_depot_4";
 	req_one_access = null
@@ -13394,7 +13394,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_4";
 	name = "airlock_ruined_propellant_depot_4";
 	req_one_access = null
@@ -15524,7 +15524,7 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_3";
 	name = "airlock_ruined_propellant_depot_3";
 	req_one_access = null
@@ -15844,7 +15844,7 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_5";
 	name = "airlock_ruined_propellant_depot_5";
 	req_one_access = null
@@ -16210,7 +16210,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_3";
 	name = "airlock_ruined_propellant_depot_3";
 	req_one_access = null
@@ -16401,7 +16401,7 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_1";
 	name = "airlock_ruined_propellant_depot_1";
 	req_one_access = null
@@ -16435,7 +16435,7 @@
 	pixel_y = -6;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_ruined_propellant_depot_3";
 	name = "airlock_ruined_propellant_depot_3";
 	req_one_access = null

--- a/maps/away/ships/biesel/tcaf_corvette/tcaf_corvette.dmm
+++ b/maps/away/ships/biesel/tcaf_corvette/tcaf_corvette.dmm
@@ -1470,7 +1470,7 @@
 	pixel_x = 27;
 	pixel_y = 25
 	},
-/obj/effect/map_effect/marker/airlock/tcaf_corvette/port_small_aft,
+/obj/effect/map_effect/marker/airlock/external/tcaf_corvette/port_small_aft,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
@@ -1935,7 +1935,7 @@
 	pixel_x = -27;
 	pixel_y = 25
 	},
-/obj/effect/map_effect/marker/airlock/tcaf_corvette/starboard_small_aft,
+/obj/effect/map_effect/marker/airlock/external/tcaf_corvette/starboard_small_aft,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
@@ -2379,7 +2379,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/tcaf_corvette/port_small_fore,
+/obj/effect/map_effect/marker/airlock/external/tcaf_corvette/port_small_fore,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/access_button{
 	pixel_x = -32;
@@ -3331,7 +3331,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/tcaf_corvette/starboard_small_fore,
+/obj/effect/map_effect/marker/airlock/external/tcaf_corvette/starboard_small_fore,
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = -23;
 	dir = 1;
@@ -3456,7 +3456,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/tcaf_corvette/port_small_aft,
+/obj/effect/map_effect/marker/airlock/external/tcaf_corvette/port_small_aft,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/access_button{
 	pixel_x = -32;
@@ -4277,7 +4277,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/tcaf_corvette/port_small_fore,
+/obj/effect/map_effect/marker/airlock/external/tcaf_corvette/port_small_fore,
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = -23;
 	dir = 1;
@@ -5436,7 +5436,7 @@
 	pixel_y = -25;
 	pixel_x = -7
 	},
-/obj/effect/map_effect/marker/airlock/tcaf_corvette/port_small_aft,
+/obj/effect/map_effect/marker/airlock/external/tcaf_corvette/port_small_aft,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/tcaf_corvette/engine)
@@ -6074,7 +6074,7 @@
 	pixel_y = -25;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/tcaf_corvette/starboard_small_aft,
+/obj/effect/map_effect/marker/airlock/external/tcaf_corvette/starboard_small_aft,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/dark/full,
 /area/tcaf_corvette/engine)
@@ -6848,7 +6848,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/tcaf_corvette/starboard_small_fore,
+/obj/effect/map_effect/marker/airlock/external/tcaf_corvette/starboard_small_fore,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/access_button{
 	pixel_y = -30;
@@ -9067,7 +9067,7 @@
 	pixel_y = -25;
 	pixel_x = -7
 	},
-/obj/effect/map_effect/marker/airlock/tcaf_corvette/starboard_small_aft,
+/obj/effect/map_effect/marker/airlock/external/tcaf_corvette/starboard_small_aft,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/tcaf_corvette/engine)
@@ -11943,7 +11943,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/tcaf_corvette/starboard_small_fore,
+/obj/effect/map_effect/marker/airlock/external/tcaf_corvette/starboard_small_fore,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/access_button{
 	pixel_x = 32;
@@ -12440,7 +12440,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/tcaf_corvette/port_small_fore,
+/obj/effect/map_effect/marker/airlock/external/tcaf_corvette/port_small_fore,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/access_button{
 	pixel_y = -30;

--- a/maps/away/ships/biesel/tcaf_corvette/tcaf_corvette_landmarks.dm
+++ b/maps/away/ships/biesel/tcaf_corvette/tcaf_corvette_landmarks.dm
@@ -65,19 +65,19 @@
 	landmark_tag = "tcaf_corvette_fore_dock"
 
 // Non-docking airlock markers, for the small airlocks on deck two.
-/obj/effect/map_effect/marker/airlock/tcaf_corvette/starboard_small_aft
+/obj/effect/map_effect/marker/airlock/external/tcaf_corvette/starboard_small_aft
 	name = "Starboard Aft, Small"
 	master_tag = "airlock_tcaf_starboard_aft"
 
-/obj/effect/map_effect/marker/airlock/tcaf_corvette/port_small_aft
+/obj/effect/map_effect/marker/airlock/external/tcaf_corvette/port_small_aft
 	name = "Port Aft, Small"
 	master_tag = "airlock_tcaf_port_aft"
 
-/obj/effect/map_effect/marker/airlock/tcaf_corvette/starboard_small_fore
+/obj/effect/map_effect/marker/airlock/external/tcaf_corvette/starboard_small_fore
 	name = "Starboard Fore, Small"
 	master_tag = "airlock_tcaf_starboard_fore"
 
-/obj/effect/map_effect/marker/airlock/tcaf_corvette/port_small_fore
+/obj/effect/map_effect/marker/airlock/external/tcaf_corvette/port_small_fore
 	name = "Port Fore, Small"
 	master_tag = "airlock_tcaf_port_fore"
 

--- a/maps/away/ships/coc/coc_scarab/coc_scarab.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab.dmm
@@ -332,7 +332,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/machinery/light/small,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_starboard_fore";
 	master_tag = "airlock_scarab_starboard_fore"
 	},
@@ -438,7 +438,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/bed/handrail,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_port";
 	master_tag = "airlock_scarab_port"
 	},
@@ -1662,7 +1662,7 @@
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_deck_one";
 	master_tag = "airlock_scarab_deck_one"
 	},
@@ -1870,7 +1870,7 @@
 	pixel_y = -28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_starboard";
 	master_tag = "airlock_scarab_starboard"
 	},
@@ -1959,7 +1959,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_starboard";
 	master_tag = "airlock_scarab_starboard"
 	},
@@ -2031,7 +2031,7 @@
 	pixel_y = -28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_port_aft";
 	master_tag = "airlock_scarab_port_aft"
 	},
@@ -2336,7 +2336,7 @@
 	pixel_y = 28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_starboard_fore";
 	master_tag = "airlock_scarab_starboard_fore"
 	},
@@ -2473,7 +2473,7 @@
 	pixel_y = -25
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_port_aft";
 	master_tag = "airlock_scarab_port_aft"
 	},
@@ -3235,7 +3235,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_port";
 	master_tag = "airlock_scarab_port"
 	},
@@ -3925,7 +3925,7 @@
 	pixel_y = -28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_starboard_aft";
 	master_tag = "airlock_scarab_starboard_aft"
 	},
@@ -3984,7 +3984,7 @@
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_deck_one";
 	master_tag = "airlock_scarab_deck_one"
 	},
@@ -4025,7 +4025,7 @@
 	pixel_y = -28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_port";
 	master_tag = "airlock_scarab_port"
 	},
@@ -4180,7 +4180,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/bed/handrail,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_starboard";
 	master_tag = "airlock_scarab_starboard"
 	},
@@ -4277,7 +4277,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/machinery/light/small,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_port_aft";
 	master_tag = "airlock_scarab_port_aft"
 	},
@@ -4330,7 +4330,7 @@
 "rT" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_starboard";
 	master_tag = "airlock_scarab_starboard"
 	},
@@ -5014,7 +5014,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_port";
 	master_tag = "airlock_scarab_port"
 	},
@@ -5260,7 +5260,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_starboard_fore";
 	master_tag = "airlock_scarab_starboard_fore"
 	},
@@ -5533,7 +5533,7 @@
 	pixel_y = 28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_port_fore";
 	master_tag = "airlock_scarab_port_fore"
 	},
@@ -5888,7 +5888,7 @@
 	pixel_y = -28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_port";
 	master_tag = "airlock_scarab_port"
 	},
@@ -6768,7 +6768,7 @@
 	pixel_x = 25
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_deck_one";
 	master_tag = "airlock_scarab_deck_one"
 	},
@@ -6826,7 +6826,7 @@
 	},
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_deck_one";
 	master_tag = "airlock_scarab_deck_one"
 	},
@@ -7023,7 +7023,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/machinery/light/small,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_port_fore";
 	master_tag = "airlock_scarab_port_fore"
 	},
@@ -7393,7 +7393,7 @@
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_starboard";
 	master_tag = "airlock_scarab_starboard"
 	},
@@ -9501,7 +9501,7 @@
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_port";
 	master_tag = "airlock_scarab_port"
 	},
@@ -9537,7 +9537,7 @@
 	pixel_y = -25
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_port_fore";
 	master_tag = "airlock_scarab_port_fore"
 	},
@@ -9759,7 +9759,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/machinery/light/small,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_starboard_aft";
 	master_tag = "airlock_scarab_starboard_aft"
 	},
@@ -10060,7 +10060,7 @@
 /obj/effect/landmark/entry_point/aft{
 	name = "aft, hangar aft"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_deck_one";
 	master_tag = "airlock_scarab_deck_one"
 	},
@@ -10359,7 +10359,7 @@
 	pixel_x = -28;
 	pixel_y = 26
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_port_aft";
 	master_tag = "airlock_scarab_port_aft"
 	},
@@ -10430,7 +10430,7 @@
 	dir = 9
 	},
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_deck_one";
 	master_tag = "airlock_scarab_deck_one"
 	},
@@ -10529,7 +10529,7 @@
 	pixel_y = -25
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_starboard_aft";
 	master_tag = "airlock_scarab_starboard_aft"
 	},
@@ -10675,7 +10675,7 @@
 	pixel_y = -25
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_starboard_fore";
 	master_tag = "airlock_scarab_starboard_fore"
 	},
@@ -10760,7 +10760,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_starboard";
 	master_tag = "airlock_scarab_starboard"
 	},
@@ -11556,7 +11556,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = -25
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_port";
 	master_tag = "airlock_scarab_port"
 	},
@@ -11638,7 +11638,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = -25
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_starboard";
 	master_tag = "airlock_scarab_starboard"
 	},
@@ -11717,7 +11717,7 @@
 	pixel_y = 28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_port_fore";
 	master_tag = "airlock_scarab_port_fore"
 	},
@@ -11753,7 +11753,7 @@
 	pixel_x = 28;
 	pixel_y = 26
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_starboard_aft";
 	master_tag = "airlock_scarab_starboard_aft"
 	},
@@ -11795,7 +11795,7 @@
 "UD" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_port";
 	master_tag = "airlock_scarab_port"
 	},
@@ -12200,7 +12200,7 @@
 	pixel_x = -27
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_deck_one";
 	master_tag = "airlock_scarab_deck_one"
 	},
@@ -12333,7 +12333,7 @@
 	pixel_y = -28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_starboard";
 	master_tag = "airlock_scarab_starboard"
 	},
@@ -12361,7 +12361,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_scarab_deck_one";
 	master_tag = "airlock_scarab_deck_one"
 	},

--- a/maps/away/ships/coc/gadpathur_patrol/gadpathur_patrol.dmm
+++ b/maps/away/ships/coc/gadpathur_patrol/gadpathur_patrol.dmm
@@ -21,7 +21,7 @@
 	pixel_x = -9;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_gadpathurian_corvette_aft_starboard";
 	name = "airlock_gadpathurian_corvette_aft_starboard";
 	req_one_access = list(223,224)
@@ -1899,7 +1899,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_gadpathurian_corvette_aft_starboard";
 	name = "airlock_gadpathurian_corvette_aft_starboard";
 	req_one_access = list(223,224)
@@ -2728,7 +2728,7 @@
 	pixel_x = -22;
 	pixel_y = 26
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_gadpathurian_corvette_fore_starboard";
 	name = "airlock_gadpathurian_corvette_fore_starboard";
 	req_one_access = list(223,224)
@@ -3828,7 +3828,7 @@
 	pixel_x = -9;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_gadpathurian_corvette_aft_port";
 	name = "airlock_gadpathurian_corvette_aft_port";
 	req_one_access = list(223,224)
@@ -4155,7 +4155,7 @@
 	dir = 4;
 	pixel_x = 9
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_gadpathurian_corvette_aft_port";
 	name = "airlock_gadpathurian_corvette_aft_port";
 	req_one_access = list(223,224)
@@ -4782,7 +4782,7 @@
 	pixel_y = -19
 	},
 /obj/structure/machinery/light/small,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_gadpathurian_corvette_aft_starboard";
 	name = "airlock_gadpathurian_corvette_aft_starboard";
 	req_one_access = list(223,224)
@@ -5070,7 +5070,7 @@
 	},
 /obj/structure/machinery/light/small,
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_gadpathurian_corvette_aft_port";
 	name = "airlock_gadpathurian_corvette_aft_port";
 	req_one_access = list(223,224)
@@ -5705,7 +5705,7 @@
 /area/ship/gadpathur_patrol/eva)
 "SC" = (
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_gadpathurian_corvette_fore_starboard";
 	name = "airlock_gadpathurian_corvette_fore_starboard";
 	req_one_access = list(223,224)
@@ -5741,7 +5741,7 @@
 	pixel_x = -26;
 	pixel_y = -7
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_gadpathurian_corvette_fore_starboard";
 	name = "airlock_gadpathurian_corvette_fore_starboard";
 	req_one_access = list(223,224)
@@ -6227,7 +6227,7 @@
 	pixel_x = 22
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_gadpathurian_corvette_fore_starboard";
 	name = "airlock_gadpathurian_corvette_fore_starboard";
 	req_one_access = list(223,224)

--- a/maps/away/ships/dominia/dominian_corvette/dominian_corvette.dmm
+++ b/maps/away/ships/dominia/dominian_corvette/dominian_corvette.dmm
@@ -699,7 +699,7 @@
 	dir = 1;
 	req_access = list(212)
 	},
-/obj/effect/map_effect/marker/airlock/dominian_corvette/aft_starboard,
+/obj/effect/map_effect/marker/airlock/external/dominian_corvette/aft_starboard,
 /obj/structure/machinery/door/blast/regular/open{
 	id = "dominia_airlock";
 	dir = 4
@@ -1566,7 +1566,7 @@
 "cRo" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock/dominian_corvette/aft_starboard,
+/obj/effect/map_effect/marker/airlock/external/dominian_corvette/aft_starboard,
 /obj/structure/machinery/airlock_sensor/airlock_exterior{
 	pixel_y = 6;
 	pixel_x = 25;
@@ -3454,7 +3454,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/dominian_corvette/aft_hangar,
+/obj/effect/map_effect/marker/airlock/external/dominian_corvette/aft_hangar,
 /obj/structure/machinery/door/blast/regular/open{
 	id = "dominia_airlock";
 	dir = 4
@@ -3948,7 +3948,7 @@
 	req_access = list(212)
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/dominian_corvette/aft_hangar,
+/obj/effect/map_effect/marker/airlock/external/dominian_corvette/aft_hangar,
 /obj/structure/machinery/door/blast/regular/open{
 	id = "dominia_airlock";
 	dir = 4
@@ -4644,7 +4644,7 @@
 	pixel_y = -6;
 	req_access = list(212)
 	},
-/obj/effect/map_effect/marker/airlock/dominian_corvette/aft_hangar,
+/obj/effect/map_effect/marker/airlock/external/dominian_corvette/aft_hangar,
 /turf/simulated/floor,
 /area/dominian_corvette/hangar)
 "inN" = (
@@ -5985,7 +5985,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/dominian_corvette/aft_hangar,
+/obj/effect/map_effect/marker/airlock/external/dominian_corvette/aft_hangar,
 /obj/structure/machinery/door/blast/regular/open{
 	id = "dominia_airlock";
 	dir = 4
@@ -6572,7 +6572,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/dominian_corvette/aft_starboard,
+/obj/effect/map_effect/marker/airlock/external/dominian_corvette/aft_starboard,
 /obj/structure/machinery/access_button{
 	pixel_x = -26;
 	pixel_y = -28;
@@ -10723,7 +10723,7 @@
 	dir = 1;
 	req_access = list(212)
 	},
-/obj/effect/map_effect/marker/airlock/dominian_corvette/aft_port,
+/obj/effect/map_effect/marker/airlock/external/dominian_corvette/aft_port,
 /obj/structure/machinery/door/blast/regular/open{
 	id = "dominia_airlock";
 	dir = 4
@@ -11101,7 +11101,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/dominian_corvette/aft_port,
+/obj/effect/map_effect/marker/airlock/external/dominian_corvette/aft_port,
 /obj/structure/machinery/access_button{
 	pixel_x = 26;
 	pixel_y = -28;
@@ -11681,7 +11681,7 @@
 	req_access = list(212)
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/dominian_corvette/aft_hangar,
+/obj/effect/map_effect/marker/airlock/external/dominian_corvette/aft_hangar,
 /obj/structure/machinery/door/blast/regular/open{
 	id = "dominia_airlock";
 	dir = 4
@@ -12436,7 +12436,7 @@
 "xpB" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock/dominian_corvette/aft_hangar,
+/obj/effect/map_effect/marker/airlock/external/dominian_corvette/aft_hangar,
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
@@ -12465,7 +12465,7 @@
 "xvb" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock/dominian_corvette/aft_port,
+/obj/effect/map_effect/marker/airlock/external/dominian_corvette/aft_port,
 /obj/structure/machinery/light/small{
 	dir = 4
 	},

--- a/maps/away/ships/dominia/dominian_corvette/dominian_corvette_landmarks.dm
+++ b/maps/away/ships/dominia/dominian_corvette/dominian_corvette_landmarks.dm
@@ -1,13 +1,13 @@
 // Maintenance airlocks
-/obj/effect/map_effect/marker/airlock/dominian_corvette/aft_hangar
+/obj/effect/map_effect/marker/airlock/external/dominian_corvette/aft_hangar
 	name = "Maintenance Hatch"
 	master_tag = "dominia_aft_hangar"
 
-/obj/effect/map_effect/marker/airlock/dominian_corvette/aft_starboard
+/obj/effect/map_effect/marker/airlock/external/dominian_corvette/aft_starboard
 	name = "Maintenance Hatch"
 	master_tag = "dominia_aft_starboard"
 
-/obj/effect/map_effect/marker/airlock/dominian_corvette/aft_port
+/obj/effect/map_effect/marker/airlock/external/dominian_corvette/aft_port
 	name = "Maintenance Hatch"
 	master_tag = "dominia_aft_port"
 

--- a/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel.dmm
+++ b/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel.dmm
@@ -71,7 +71,7 @@
 /area/ship/dominian_science_vessel/armory)
 "alp" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "portext"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
@@ -467,7 +467,7 @@
 /turf/simulated/wall/shuttle,
 /area/ship/dominian_science_vessel/mess)
 "aZo" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "portext"
 	},
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -697,7 +697,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_science_vessel/port_hall)
 "bRh" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "starboardext"
 	},
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
@@ -1205,7 +1205,7 @@
 /area/ship/dominian_science_vessel/quarters)
 "dnN" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "portext"
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
@@ -1224,7 +1224,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "starboardext"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
@@ -1605,7 +1605,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "shipexterior"
 	},
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -2446,7 +2446,7 @@
 /area/ship/dominian_science_vessel/officer)
 "hcG" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "portext"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
@@ -2473,7 +2473,7 @@
 "hhf" = (
 /obj/structure/machinery/door/airlock/external,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "shipexterior"
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
@@ -2773,7 +2773,7 @@
 /turf/simulated/floor/plating,
 /area/ship/dominian_science_vessel/aft_dock)
 "hOQ" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "portext"
 	},
 /obj/structure/machinery/airlock_sensor{
@@ -2886,7 +2886,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "starboardext"
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
@@ -3202,7 +3202,7 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/dominian_science_vessel/research)
 "iZU" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "starboardext"
 	},
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -3980,7 +3980,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 5
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "shipexterior"
 	},
 /obj/structure/machinery/airlock_sensor{
@@ -4391,7 +4391,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "starboardext"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
@@ -4956,7 +4956,7 @@
 /area/ship/dominian_science_vessel/showers)
 "oCX" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "shipexterior"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
@@ -5213,7 +5213,7 @@
 /area/ship/dominian_science_vessel/research)
 "pub" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "shipexterior"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
@@ -5285,7 +5285,7 @@
 /area/ship/dominian_science_vessel/research)
 "pDc" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "shipexterior"
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
@@ -6792,7 +6792,7 @@
 /area/ship/dominian_science_vessel/aft_dock)
 "uDy" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "portext"
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
@@ -6844,7 +6844,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "starboardext"
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,

--- a/maps/away/ships/dominia/dominian_unathi_privateer/dominian_unathi_privateer.dmm
+++ b/maps/away/ships/dominia/dominian_unathi_privateer/dominian_unathi_privateer.dmm
@@ -659,7 +659,7 @@
 	pixel_x = 12;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_3";
 	name = "airlock_kazhkz_3";
 	frequency = 2126
@@ -807,7 +807,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi/chapel)
 "gi" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_4";
 	name = "airlock_kazhkz_4";
 	frequency = 2222
@@ -1146,7 +1146,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_4";
 	name = "airlock_kazhkz_4";
 	frequency = 2222
@@ -1168,7 +1168,7 @@
 	dir = 4
 	},
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_1";
 	name = "airlock_kazhkz_1";
 	frequency = 1939
@@ -1626,7 +1626,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_4";
 	name = "airlock_kazhkz_4";
 	frequency = 2222
@@ -1676,7 +1676,7 @@
 	pixel_x = -12;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_4";
 	name = "airlock_kazhkz_4";
 	frequency = 2222
@@ -1693,7 +1693,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_1";
 	name = "airlock_kazhkz_1";
 	frequency = 1939
@@ -1828,7 +1828,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_2";
 	name = "airlock_kazhkz_2";
 	frequency = 1989
@@ -2468,7 +2468,7 @@
 	pixel_x = 12;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_4";
 	name = "airlock_kazhkz_4";
 	frequency = 2222
@@ -2572,7 +2572,7 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_2";
 	name = "airlock_kazhkz_2";
 	frequency = 1989
@@ -2786,7 +2786,7 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_4";
 	name = "airlock_kazhkz_4";
 	frequency = 2222
@@ -2814,7 +2814,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_3";
 	name = "airlock_kazhkz_3";
 	frequency = 2126
@@ -2919,7 +2919,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_3";
 	name = "airlock_kazhkz_3";
 	frequency = 2126
@@ -3845,7 +3845,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_1";
 	name = "airlock_kazhkz_1";
 	frequency = 1939
@@ -4498,7 +4498,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_2";
 	name = "airlock_kazhkz_2";
 	frequency = 1989
@@ -4882,7 +4882,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_4";
 	name = "airlock_kazhkz_4";
 	frequency = 2222
@@ -5013,7 +5013,7 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_1";
 	name = "airlock_kazhkz_1";
 	frequency = 1939
@@ -5200,7 +5200,7 @@
 	pixel_x = -12;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_3";
 	name = "airlock_kazhkz_3";
 	frequency = 2126
@@ -5442,7 +5442,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_2";
 	name = "airlock_kazhkz_2";
 	frequency = 1989
@@ -5621,7 +5621,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_3";
 	name = "airlock_kazhkz_3";
 	frequency = 2126
@@ -5751,7 +5751,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi/bridge)
 "Np" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_3";
 	name = "airlock_kazhkz_3";
 	frequency = 2126
@@ -5790,7 +5790,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_2";
 	name = "airlock_kazhkz_2";
 	frequency = 1989
@@ -5838,7 +5838,7 @@
 	pixel_x = 6;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_4";
 	name = "airlock_kazhkz_4";
 	frequency = 2222
@@ -6086,7 +6086,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_3";
 	name = "airlock_kazhkz_3";
 	frequency = 2126
@@ -6427,7 +6427,7 @@
 	pixel_y = -22;
 	pixel_x = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_1";
 	name = "airlock_kazhkz_1";
 	frequency = 1939
@@ -6700,7 +6700,7 @@
 	pixel_y = -22;
 	pixel_x = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_2";
 	name = "airlock_kazhkz_2";
 	frequency = 1989
@@ -6767,7 +6767,7 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_3";
 	name = "airlock_kazhkz_3";
 	frequency = 2126
@@ -7315,7 +7315,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kazhkz_1";
 	name = "airlock_kazhkz_1";
 	frequency = 1939

--- a/maps/away/ships/elyra/elyra_corvette/elyra_corvette.dmm
+++ b/maps/away/ships/elyra/elyra_corvette/elyra_corvette.dmm
@@ -192,7 +192,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1233;
 	master_tag = "airlock_elyra_corvette_port_2";
 	name = "airlock_elyra_corvette_port_2"
@@ -2315,7 +2315,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1232;
 	master_tag = "airlock_elyra_corvette_starboard_1";
 	name = "airlock_elyra_corvette_starboard_1"
@@ -2544,7 +2544,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1234;
 	master_tag = "airlock_elyra_corvette_starboard_2";
 	name = "airlock_elyra_corvette_starboard_2"
@@ -3679,7 +3679,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1231;
 	master_tag = "airlock_elyra_corvette_port_1";
 	name = "airlock_elyra_corvette_port_1"
@@ -4084,7 +4084,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1234;
 	master_tag = "airlock_elyra_corvette_starboard_2";
 	name = "airlock_elyra_corvette_starboard_2"
@@ -4318,7 +4318,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1232;
 	master_tag = "airlock_elyra_corvette_starboard_1";
 	name = "airlock_elyra_corvette_starboard_1"
@@ -5284,7 +5284,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1233;
 	master_tag = "airlock_elyra_corvette_port_2";
 	name = "airlock_elyra_corvette_port_2"
@@ -5740,7 +5740,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1231;
 	master_tag = "airlock_elyra_corvette_port_1";
 	name = "airlock_elyra_corvette_port_1"
@@ -7334,7 +7334,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1232;
 	master_tag = "airlock_elyra_corvette_starboard_1";
 	name = "airlock_elyra_corvette_starboard_1"
@@ -7533,7 +7533,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1233;
 	master_tag = "airlock_elyra_corvette_port_2";
 	name = "airlock_elyra_corvette_port_2"
@@ -8336,7 +8336,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1231;
 	master_tag = "airlock_elyra_corvette_port_1";
 	name = "airlock_elyra_corvette_port_1"
@@ -8539,7 +8539,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1234;
 	master_tag = "airlock_elyra_corvette_starboard_2";
 	name = "airlock_elyra_corvette_starboard_2"

--- a/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dmm
+++ b/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dmm
@@ -91,7 +91,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/port,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/port,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_salvager/mining)
 "ax" = (
@@ -308,7 +308,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/fore_upper_deck,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/fore_upper_deck,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_salvager/forehallway)
 "bf" = (
@@ -1093,7 +1093,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/starboard,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/starboard,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/mining)
 "eU" = (
@@ -1324,7 +1324,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/port,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/port,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_salvager/mining)
 "gb" = (
@@ -2042,7 +2042,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/fore_upper_deck,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/fore_upper_deck,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/forehallway)
 "jK" = (
@@ -2700,7 +2700,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/starboard,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/starboard,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_salvager/mining)
 "mL" = (
@@ -2796,7 +2796,7 @@
 	pixel_y = -8
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/fore_upper_deck,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/fore_upper_deck,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/forehallway)
 "nk" = (
@@ -3337,7 +3337,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/fore_upper_deck,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/fore_upper_deck,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_salvager/forehallway)
 "px" = (
@@ -4662,7 +4662,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/starboard,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/starboard,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/mining)
 "vk" = (
@@ -4908,7 +4908,7 @@
 	pixel_x = 8;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/port,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/port,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/mining)
 "ws" = (
@@ -6236,7 +6236,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/port,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/port,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/mining)
 "CK" = (
@@ -6839,7 +6839,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/port,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/port,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/mining)
 "FO" = (
@@ -7121,7 +7121,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/fore_upper_deck,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/fore_upper_deck,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/forehallway)
 "GW" = (
@@ -7721,7 +7721,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/fore_upper_deck,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/fore_upper_deck,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_salvager/forehallway)
 "Jw" = (
@@ -8306,7 +8306,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/starboard,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/starboard,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_salvager/mining)
 "Mh" = (
@@ -8628,7 +8628,7 @@
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/fore_upper_deck,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/fore_upper_deck,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/forehallway)
 "NF" = (
@@ -8718,7 +8718,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/port,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/port,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/mining)
 "Oi" = (
@@ -10686,7 +10686,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/starboard,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/starboard,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/mining)
 "XC" = (
@@ -10915,7 +10915,7 @@
 	pixel_x = -8;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/starboard,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/starboard,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_salvager/mining)
 "YU" = (
@@ -10977,7 +10977,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/fore_upper_deck,
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/fore_upper_deck,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_salvager/forehallway)
 "Zi" = (

--- a/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager_landmarks.dm
+++ b/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager_landmarks.dm
@@ -40,19 +40,19 @@
 
 // Non-docking airlocks
 
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/fore_upper_deck
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/fore_upper_deck
 	name = "Upper Deck Fore"
 	master_tag = "airlock_freebooter_salvager_upfore"
 
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/fore
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/fore
 	name = "Fore Airlock"
 	master_tag = "airlock_freebooter_salvager_fore"
 
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/port
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/port
 	name = "Port Airlock"
 	master_tag = "airlock_freebooter_salvager_port"
 
-/obj/effect/map_effect/marker/airlock/freebooter_salvager/starboard
+/obj/effect/map_effect/marker/airlock/external/freebooter_salvager/starboard
 	name = "Starboard Airlock"
 	master_tag = "airlock_freebooter_salvager_starboard"
 

--- a/maps/away/ships/freebooter/freebooter_ship/freebooter_ship_.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship/freebooter_ship_.dmm
@@ -443,7 +443,7 @@
 /obj/structure/sign/vacuum{
 	pixel_y = 30
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
 	},
@@ -507,7 +507,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
 	},
@@ -527,7 +527,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
 	},
@@ -592,7 +592,7 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
 	},
@@ -673,7 +673,7 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
 	},
@@ -834,7 +834,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
 	},
@@ -1653,7 +1653,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
 	},
@@ -1906,7 +1906,7 @@
 /area/ship/freebooter_ship/thruster1)
 "hQd" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
 	},
@@ -2307,7 +2307,7 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
 	},
@@ -2815,7 +2815,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
 	},
@@ -3478,7 +3478,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
 	},
@@ -4682,7 +4682,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
 	},
@@ -5388,7 +5388,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
 	},
@@ -5646,7 +5646,7 @@
 /area/ship/freebooter_ship/thruster2)
 "vDD" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
 	},
@@ -6218,7 +6218,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
 	},
@@ -6325,7 +6325,7 @@
 /area/ship/freebooter_ship/thruster1)
 "xQS" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
 	},

--- a/maps/away/ships/golden_deep/golden_deep.dmm
+++ b/maps/away/ships/golden_deep/golden_deep.dmm
@@ -2324,7 +2324,7 @@
 	pixel_x = -7;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/golden_deep/fore_port,
+/obj/effect/map_effect/marker/airlock/external/golden_deep/fore_port,
 /turf/simulated/floor/plating,
 /area/golden_deep/owned_lounge)
 "jP" = (
@@ -3902,7 +3902,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/golden_deep/d2_port_starboard,
+/obj/effect/map_effect/marker/airlock/external/golden_deep/d2_port_starboard,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/full,
@@ -5176,7 +5176,7 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/map_effect/marker/airlock/golden_deep/fore_starboard,
+/obj/effect/map_effect/marker/airlock/external/golden_deep/fore_starboard,
 /turf/simulated/floor/tiled/dark/full,
 /area/golden_deep/owned_lounge)
 "vo" = (
@@ -6375,7 +6375,7 @@
 	pixel_x = -7;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/golden_deep/fore_starboard,
+/obj/effect/map_effect/marker/airlock/external/golden_deep/fore_starboard,
 /turf/simulated/floor/plating,
 /area/golden_deep/owned_lounge)
 "AL" = (
@@ -6647,7 +6647,7 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/golden_deep/d2_port_starboard,
+/obj/effect/map_effect/marker/airlock/external/golden_deep/d2_port_starboard,
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	dir = 8;
 	pixel_x = 24;
@@ -6765,7 +6765,7 @@
 	pixel_x = -32;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock/golden_deep/fore_port,
+/obj/effect/map_effect/marker/airlock/external/golden_deep/fore_port,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
@@ -7737,7 +7737,7 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/map_effect/marker/airlock/golden_deep/fore_starboard,
+/obj/effect/map_effect/marker/airlock/external/golden_deep/fore_starboard,
 /turf/simulated/floor/tiled/dark/full,
 /area/golden_deep/owned_lounge)
 "FX" = (
@@ -8024,7 +8024,7 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/golden_deep/d2_aft_starboard,
+/obj/effect/map_effect/marker/airlock/external/golden_deep/d2_aft_starboard,
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/golden_deep/starboardmaints)
@@ -8911,7 +8911,7 @@
 	pixel_x = 6;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/golden_deep/bridge,
+/obj/effect/map_effect/marker/airlock/external/golden_deep/bridge,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
@@ -9245,7 +9245,7 @@
 	dir = 4;
 	must_start_working = 1
 	},
-/obj/effect/map_effect/marker/airlock/golden_deep/d2_aft_starboard,
+/obj/effect/map_effect/marker/airlock/external/golden_deep/d2_aft_starboard,
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	dir = 4;
 	pixel_x = -24;
@@ -10225,7 +10225,7 @@
 	pixel_x = 6;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/golden_deep/fore_port,
+/obj/effect/map_effect/marker/airlock/external/golden_deep/fore_port,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
@@ -10388,7 +10388,7 @@
 	pixel_x = -32;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock/golden_deep/bridge,
+/obj/effect/map_effect/marker/airlock/external/golden_deep/bridge,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
@@ -10428,7 +10428,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/golden_deep/d2_aft_starboard,
+/obj/effect/map_effect/marker/airlock/external/golden_deep/d2_aft_starboard,
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/golden_deep/starboardmaints)
@@ -11856,7 +11856,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/golden_deep/d2_port_starboard,
+/obj/effect/map_effect/marker/airlock/external/golden_deep/d2_port_starboard,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/full,
@@ -12249,7 +12249,7 @@
 	pixel_x = -7;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/golden_deep/bridge,
+/obj/effect/map_effect/marker/airlock/external/golden_deep/bridge,
 /turf/simulated/floor/plating,
 /area/golden_deep/accounting)
 "Yi" = (

--- a/maps/away/ships/golden_deep/golden_deep_landmarks.dm
+++ b/maps/away/ships/golden_deep/golden_deep_landmarks.dm
@@ -75,23 +75,23 @@
 	landmark_tag = "gd_dock5"
 
 // Non-docking airlocks.
-/obj/effect/map_effect/marker/airlock/golden_deep/bridge
+/obj/effect/map_effect/marker/airlock/external/golden_deep/bridge
 	name = "Bridge Airlock"
 	master_tag = "airlock_gd_bridge"
 
-/obj/effect/map_effect/marker/airlock/golden_deep/fore_port
+/obj/effect/map_effect/marker/airlock/external/golden_deep/fore_port
 	name = "Fore Port Airlock"
 	master_tag = "airlock_gd_fore_port"
 
-/obj/effect/map_effect/marker/airlock/golden_deep/fore_starboard
+/obj/effect/map_effect/marker/airlock/external/golden_deep/fore_starboard
 	name = "Fore Starboard Airlock"
 	master_tag = "airlock_gd_fore_starboard"
 
-/obj/effect/map_effect/marker/airlock/golden_deep/d2_aft_starboard
+/obj/effect/map_effect/marker/airlock/external/golden_deep/d2_aft_starboard
 	name = "Deck Two Aft Starboard Airlock"
 	master_tag = "airlock_gd_aft_starboard_d2"
 
-/obj/effect/map_effect/marker/airlock/golden_deep/d2_port_starboard
+/obj/effect/map_effect/marker/airlock/external/golden_deep/d2_port_starboard
 	name = "Deck Two Port Starboard Airlock"
 	master_tag = "airlock_gd_aft_port_d2"
 

--- a/maps/away/ships/hegemony/fishing_trawler/fishing_league_trawler.dmm
+++ b/maps/away/ships/hegemony/fishing_trawler/fishing_league_trawler.dmm
@@ -35,7 +35,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "fore_starboard_airlock";
 	name = "fore_starboard_airlock"
@@ -511,7 +511,7 @@
 /area/ship/fishing_trawler/engineering/Starboard)
 "eH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1005;
 	master_tag = "port_starboard_airlock";
 	name = "port_starboard_airlock"
@@ -641,7 +641,7 @@
 /obj/structure/machinery/light{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1005;
 	master_tag = "port_starboard_airlock";
 	name = "port_starboard_airlock"
@@ -1008,7 +1008,7 @@
 /turf/simulated/floor,
 /area/ship/fishing_trawler/engineering/Starboard)
 "jk" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "fore_starboard_airlock";
 	name = "fore_starboard_airlock"
@@ -1335,7 +1335,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "fore_starboard_airlock";
 	name = "fore_starboard_airlock"
@@ -1672,7 +1672,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1005;
 	master_tag = "port_starboard_airlock";
 	name = "port_starboard_airlock"
@@ -2198,7 +2198,7 @@
 /area/ship/fishing_trawler/bridge)
 "ri" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "fore_starboard_airlock";
 	name = "fore_starboard_airlock"
@@ -2899,7 +2899,7 @@
 	dir = 1;
 	pixel_y = -21
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "fore_starboard_airlock";
 	name = "fore_starboard_airlock"
@@ -3064,7 +3064,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1005;
 	master_tag = "port_starboard_airlock";
 	name = "port_starboard_airlock"
@@ -3587,7 +3587,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1005;
 	master_tag = "port_starboard_airlock";
 	name = "port_starboard_airlock"
@@ -4034,7 +4034,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "fore_starboard_airlock";
 	name = "fore_starboard_airlock"
@@ -4557,7 +4557,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1005;
 	master_tag = "port_starboard_airlock";
 	name = "port_starboard_airlock"
@@ -4769,7 +4769,7 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "fore_starboard_airlock";
 	name = "fore_starboard_airlock"
@@ -5064,7 +5064,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "fore_starboard_airlock";
 	name = "fore_starboard_airlock"
@@ -5494,7 +5494,7 @@
 /turf/simulated/floor/reinforced,
 /area/ship/fishing_trawler/engineering/port)
 "Qs" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1005;
 	master_tag = "port_starboard_airlock";
 	name = "port_starboard_airlock"
@@ -6327,7 +6327,7 @@
 /area/ship/fishing_trawler/engineering/Starboard)
 "Xf" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1005;
 	master_tag = "port_starboard_airlock";
 	name = "port_starboard_airlock"

--- a/maps/away/ships/hegemony/miners_guild/miners_guild_station.dmm
+++ b/maps/away/ships/hegemony/miners_guild/miners_guild_station.dmm
@@ -963,7 +963,7 @@
 	pixel_y = 28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_unathi_mining_guild_airlock_port";
 	name = "airlock_unathi_mining_guild_airlock_port"
 	},
@@ -1005,7 +1005,7 @@
 	pixel_y = 28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_unathi_mining_guild_airlock_port";
 	name = "airlock_unathi_mining_guild_airlock_port"
 	},
@@ -1135,7 +1135,7 @@
 	pixel_y = 28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_unathi_mining_guild_airlock_starboard";
 	name = "airlock_unathi_mining_guild_airlock_starboard"
 	},
@@ -1739,7 +1739,7 @@
 	pixel_x = -6
 	},
 /obj/structure/machinery/light/small/emergency,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_unathi_mining_guild_airlock_port";
 	name = "airlock_unathi_mining_guild_airlock_port"
 	},
@@ -3622,7 +3622,7 @@
 	pixel_x = -6
 	},
 /obj/structure/machinery/light/small/emergency,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_unathi_mining_guild_airlock_starboard";
 	name = "airlock_unathi_mining_guild_airlock_starboard"
 	},
@@ -5791,7 +5791,7 @@
 	pixel_y = -28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_unathi_mining_guild_airlock_port";
 	name = "airlock_unathi_mining_guild_airlock_port"
 	},

--- a/maps/away/ships/heph/cyclops/cyclops.dmm
+++ b/maps/away/ships/heph/cyclops/cyclops.dmm
@@ -32,7 +32,7 @@
 	dir = 1;
 	pixel_y = -20
 	},
-/obj/effect/map_effect/marker/airlock/heph_cyclops/starboard{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/starboard{
 	req_one_access = list(216)
 	},
 /obj/random/dirt_75,
@@ -201,7 +201,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1380
 	},
-/obj/effect/map_effect/marker/airlock/heph_cyclops/port{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/port{
 	req_one_access = list(216)
 	},
 /obj/random/dirt_75,
@@ -299,7 +299,7 @@
 	dir = 6
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/heph_cyclops/port{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/port{
 	req_one_access = list(216)
 	},
 /obj/effect/floor_decal/industrial/hatch_door/red{
@@ -331,7 +331,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
-/obj/effect/map_effect/marker/airlock/heph_cyclops/starboard{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/starboard{
 	req_one_access = list(216)
 	},
 /obj/effect/floor_decal/industrial/hatch_door/red{
@@ -632,7 +632,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/heph_cyclops/starboard{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/starboard{
 	req_one_access = list(216)
 	},
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -716,7 +716,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/heph_cyclops/starboard{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/starboard{
 	req_one_access = list(216)
 	},
 /obj/random/dirt_75,
@@ -826,7 +826,7 @@
 /obj/structure/machinery/light/small,
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/floor_decal/industrial/warning,
-/obj/effect/map_effect/marker/airlock/heph_cyclops/starboard{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/starboard{
 	req_one_access = list(216)
 	},
 /obj/random/dirt_75,
@@ -1167,7 +1167,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
-/obj/effect/map_effect/marker/airlock/heph_cyclops/starboard{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/starboard{
 	req_one_access = list(216)
 	},
 /obj/effect/floor_decal/industrial/hatch_door/red{
@@ -1382,7 +1382,7 @@
 	dir = 5
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/heph_cyclops/port{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/port{
 	req_one_access = list(216)
 	},
 /obj/effect/floor_decal/industrial/hatch_door/red{
@@ -1504,7 +1504,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/heph_cyclops/port{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/port{
 	req_one_access = list(216)
 	},
 /obj/effect/floor_decal/industrial/hatch_door/red{
@@ -2736,7 +2736,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/heph_cyclops/starboard{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/starboard{
 	req_one_access = list(216)
 	},
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
@@ -2988,7 +2988,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/heph_cyclops/port{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/port{
 	req_one_access = list(216)
 	},
 /obj/effect/floor_decal/industrial/hatch_door/red{
@@ -3399,7 +3399,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1380
 	},
-/obj/effect/map_effect/marker/airlock/heph_cyclops/port{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/port{
 	req_one_access = list(216)
 	},
 /obj/random/dirt_75,
@@ -3428,7 +3428,7 @@
 	pixel_y = -20
 	},
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/map_effect/marker/airlock/heph_cyclops/port{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/port{
 	req_one_access = list(216)
 	},
 /obj/random/dirt_75,
@@ -3485,7 +3485,7 @@
 /obj/effect/floor_decal/industrial/hatch_door/red{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/heph_cyclops/starboard{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/starboard{
 	req_one_access = list(216)
 	},
 /obj/random/dirt_75,
@@ -3533,7 +3533,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1380
 	},
-/obj/effect/map_effect/marker/airlock/heph_cyclops/port{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/port{
 	req_one_access = list(216)
 	},
 /obj/random/dirt_75,
@@ -4303,7 +4303,7 @@
 "KP" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/map_effect/marker/airlock/heph_cyclops/port{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/port{
 	req_one_access = list(216)
 	},
 /obj/random/dirt_75,
@@ -5619,7 +5619,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
-/obj/effect/map_effect/marker/airlock/heph_cyclops/port{
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/port{
 	req_one_access = list(216)
 	},
 /obj/random/dirt_75,

--- a/maps/away/ships/heph/cyclops/cyclops_mining_ship.dm
+++ b/maps/away/ships/heph/cyclops/cyclops_mining_ship.dm
@@ -167,11 +167,11 @@
 
 // airlocks
 
-/obj/effect/map_effect/marker/airlock/heph_cyclops/port
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/port
 	name = "Port Airlock"
 	master_tag = "airlock_cyclops_port"
 
-/obj/effect/map_effect/marker/airlock/heph_cyclops/starboard
+/obj/effect/map_effect/marker/airlock/external/heph_cyclops/starboard
 	name = "Starboard Airlock"
 	master_tag = "airlock_cyclops_starboard"
 

--- a/maps/away/ships/heph/heph_security/heph_security.dmm
+++ b/maps/away/ships/heph/heph_security/heph_security.dmm
@@ -1343,7 +1343,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1001;
 	master_tag = "airlock_heph_security_starb";
 	name = "airlock_heph_security_starb"
@@ -2796,7 +2796,7 @@
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/brig)
 "rz" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1001;
 	master_tag = "airlock_heph_security_starb";
 	name = "airlock_heph_security_starb"
@@ -2925,7 +2925,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1001;
 	master_tag = "airlock_heph_security_starb";
 	name = "airlock_heph_security_starb"
@@ -2973,7 +2973,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1001;
 	master_tag = "airlock_heph_security_starb";
 	name = "airlock_heph_security_starb"
@@ -4389,7 +4389,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1001;
 	master_tag = "airlock_heph_security_starb";
 	name = "airlock_heph_security_starb"
@@ -4698,7 +4698,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1001;
 	master_tag = "airlock_heph_security_starb";
 	name = "airlock_heph_security_starb"
@@ -4891,7 +4891,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1001;
 	master_tag = "airlock_heph_security_starb";
 	name = "airlock_heph_security_starb"
@@ -5734,7 +5734,7 @@
 /turf/simulated/floor/carpet/rubber,
 /area/heph_security_ship/brig)
 "NY" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1001;
 	master_tag = "airlock_heph_security_starb";
 	name = "airlock_heph_security_starb"

--- a/maps/away/ships/himeo/himeo_patrol_ship.dmm
+++ b/maps/away/ships/himeo/himeo_patrol_ship.dmm
@@ -1034,7 +1034,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = 23
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/starboard,
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/starboard,
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/aft)
 "el" = (
@@ -2991,7 +2991,7 @@
 	pixel_y = -6;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/aft,
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/aft,
 /obj/structure/machinery/light/small/emergency{
 	dir = 8
 	},
@@ -3017,7 +3017,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/starboard,
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/starboard,
 /obj/structure/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/aft)
@@ -3770,7 +3770,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = 23
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/fore{
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/fore{
 	req_one_access = list(253)
 	},
 /obj/structure/lattice/catwalk/indoor,
@@ -4002,7 +4002,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/starboard,
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/starboard,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
@@ -4234,7 +4234,7 @@
 /area/himeo_patrol_ship/thruster_port)
 "sa" = (
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/himeo_patrol/starboard,
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/starboard,
 /obj/structure/machinery/door/airlock/external/himeo_patrol{
 	dir = 4
 	},
@@ -5080,7 +5080,7 @@
 	dir = 4;
 	pixel_x = 8
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/fore{
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/fore{
 	req_one_access = list(253)
 	},
 /obj/structure/machinery/door/airlock/external/himeo_patrol{
@@ -5140,7 +5140,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/fore{
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/fore{
 	req_one_access = list(253)
 	},
 /obj/structure/machinery/light/small/emergency,
@@ -5553,7 +5553,7 @@
 	dir = 1;
 	pixel_x = 32
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/starboard,
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/starboard,
 /obj/structure/machinery/door/airlock/external/himeo_patrol{
 	dir = 4
 	},
@@ -5976,7 +5976,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/starboard,
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/starboard,
 /obj/structure/machinery/door/airlock/external/himeo_patrol{
 	dir = 4
 	},
@@ -6074,7 +6074,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock/himeo_patrol/deck_2/starboard{
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/deck_2/starboard{
 	req_one_access = list(253)
 	},
 /obj/structure/machinery/embedded_controller/radio/airlock/docking_port{
@@ -7224,7 +7224,7 @@
 /area/himeo_patrol_ship/blaster)
 "Ee" = (
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/himeo_patrol/starboard,
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/starboard,
 /obj/structure/machinery/access_button{
 	pixel_y = 28;
 	dir = 8;
@@ -7369,7 +7369,7 @@
 	dir = 10
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/himeo_patrol/starboard,
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/starboard,
 /obj/structure/machinery/door/airlock/external/himeo_patrol{
 	dir = 4
 	},
@@ -7749,7 +7749,7 @@
 	pixel_x = 32;
 	pixel_y = 8
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/fore{
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/fore{
 	req_one_access = list(253)
 	},
 /obj/structure/machinery/door/airlock/external/himeo_patrol,
@@ -9671,7 +9671,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/starboard,
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/starboard,
 /obj/structure/machinery/door/airlock/external/himeo_patrol{
 	dir = 4
 	},
@@ -9933,7 +9933,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/starboard,
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/starboard,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
@@ -10473,7 +10473,7 @@
 /turf/simulated/wall/shuttle/raider,
 /area/himeo_patrol_ship/hydroponics)
 "Sb" = (
-/obj/effect/map_effect/marker/airlock/himeo_patrol/fore{
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/fore{
 	req_one_access = list(253)
 	},
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux,
@@ -10741,7 +10741,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/deck_2/starboard{
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/deck_2/starboard{
 	req_one_access = list(253)
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
@@ -11190,7 +11190,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/starboard,
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/starboard,
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/aft)
 "UH" = (
@@ -11952,7 +11952,7 @@
 	pixel_x = 24;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/aft,
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/aft,
 /obj/structure/machinery/door/airlock/external/himeo_patrol,
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/generator)
@@ -12117,7 +12117,7 @@
 /obj/structure/sign/vacuum{
 	pixel_y = 32
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/starboard{
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/starboard{
 	req_one_access = list(253)
 	},
 /turf/simulated/floor/plating,
@@ -12287,7 +12287,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/deck_2/starboard{
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/deck_2/starboard{
 	req_one_access = list(253)
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
@@ -12314,7 +12314,7 @@
 	pixel_x = -24;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/himeo_patrol/aft,
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/aft,
 /obj/structure/machinery/door/airlock/external/himeo_patrol,
 /turf/simulated/floor/plating,
 /area/himeo_patrol_ship/generator)
@@ -12357,7 +12357,7 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock/himeo_patrol/fore{
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/fore{
 	req_one_access = list(253)
 	},
 /turf/simulated/floor/plating,

--- a/maps/away/ships/himeo/himeo_patrol_ship_landmarks.dm
+++ b/maps/away/ships/himeo/himeo_patrol_ship_landmarks.dm
@@ -41,21 +41,21 @@
 	base_turf = /turf/simulated/floor/reinforced/airless
 
 // Airlock markers, Deck 1
-/obj/effect/map_effect/marker/airlock/himeo_patrol/fore
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/fore
 	name = "Airlock, Fore"
 	master_tag = "airlock_himeo_patrol_fore"
 
-/obj/effect/map_effect/marker/airlock/himeo_patrol/aft
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/aft
 	name = "Airlock, Aft"
 	master_tag = "airlock_himeo_patrol_aft"
 
-/obj/effect/map_effect/marker/airlock/himeo_patrol/starboard
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/starboard
 	name = "Airlock, Starboard"
 	master_tag = "airlock_himeo_patrol_starboard"
 
 // Airlock markers, Deck 2
 
-/obj/effect/map_effect/marker/airlock/himeo_patrol/deck_2/starboard
+/obj/effect/map_effect/marker/airlock/external/himeo_patrol/deck_2/starboard
 	name = "Airlock, Starboard"
 	master_tag = "airlock_himeo_patrol_deck_2_starboard"
 

--- a/maps/away/ships/iac/iac_rescue_ship.dm
+++ b/maps/away/ships/iac/iac_rescue_ship.dm
@@ -268,11 +268,11 @@
 
 // airlocks
 
-/obj/effect/map_effect/marker/airlock/iac_rescue_ship/port
+/obj/effect/map_effect/marker/airlock/external/iac_rescue_ship/port
 	name = "Port Airlock"
 	master_tag = "airlock_iac_rescue_port"
 
-/obj/effect/map_effect/marker/airlock/iac_rescue_ship/starboard
+/obj/effect/map_effect/marker/airlock/external/iac_rescue_ship/starboard
 	name = "Starboard Airlock"
 	master_tag = "airlock_iac_rescue_stbd"
 

--- a/maps/away/ships/iac/iac_rescue_ship.dmm
+++ b/maps/away/ships/iac/iac_rescue_ship.dmm
@@ -840,7 +840,7 @@
 	pixel_x = 20
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/map_effect/marker/airlock/iac_rescue_ship/starboard{
+/obj/effect/map_effect/marker/airlock/external/iac_rescue_ship/starboard{
 	req_one_access = list(211)
 	},
 /turf/simulated/floor,
@@ -1732,7 +1732,7 @@
 	pixel_y = 28
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/iac_rescue_ship/port{
+/obj/effect/map_effect/marker/airlock/external/iac_rescue_ship/port{
 	req_one_access = list(211)
 	},
 /obj/effect/floor_decal/industrial/hatch_door/red{
@@ -3489,7 +3489,7 @@
 	pixel_x = -20
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/map_effect/marker/airlock/iac_rescue_ship/port{
+/obj/effect/map_effect/marker/airlock/external/iac_rescue_ship/port{
 	req_one_access = list(211)
 	},
 /turf/simulated/floor,
@@ -3910,7 +3910,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/iac_rescue_ship/starboard{
+/obj/effect/map_effect/marker/airlock/external/iac_rescue_ship/starboard{
 	req_one_access = list(211)
 	},
 /obj/effect/floor_decal/industrial/hatch_door/red,
@@ -4454,7 +4454,7 @@
 	pixel_x = 20
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/map_effect/marker/airlock/iac_rescue_ship/starboard{
+/obj/effect/map_effect/marker/airlock/external/iac_rescue_ship/starboard{
 	req_one_access = list(211)
 	},
 /turf/simulated/floor,
@@ -6024,7 +6024,7 @@
 	pixel_y = -10
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/iac_rescue_ship/port{
+/obj/effect/map_effect/marker/airlock/external/iac_rescue_ship/port{
 	req_one_access = list(211)
 	},
 /obj/effect/floor_decal/industrial/hatch_door/red,
@@ -6149,7 +6149,7 @@
 	pixel_y = 28
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/iac_rescue_ship/starboard{
+/obj/effect/map_effect/marker/airlock/external/iac_rescue_ship/starboard{
 	req_one_access = list(211)
 	},
 /obj/effect/floor_decal/industrial/hatch_door/red{
@@ -6483,7 +6483,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/iac_rescue_ship/port{
+/obj/effect/map_effect/marker/airlock/external/iac_rescue_ship/port{
 	req_one_access = list(211)
 	},
 /obj/effect/floor_decal/industrial/hatch_door/red,
@@ -6766,7 +6766,7 @@
 	pixel_y = -10
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/iac_rescue_ship/starboard{
+/obj/effect/map_effect/marker/airlock/external/iac_rescue_ship/starboard{
 	req_one_access = list(211)
 	},
 /obj/effect/floor_decal/industrial/hatch_door/red,
@@ -7863,7 +7863,7 @@
 /obj/structure/machinery/light/small/emergency{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/iac_rescue_ship/starboard{
+/obj/effect/map_effect/marker/airlock/external/iac_rescue_ship/starboard{
 	req_one_access = list(211)
 	},
 /turf/simulated/floor,
@@ -8597,7 +8597,7 @@
 	pixel_x = -20
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/map_effect/marker/airlock/iac_rescue_ship/port{
+/obj/effect/map_effect/marker/airlock/external/iac_rescue_ship/port{
 	req_one_access = list(211)
 	},
 /turf/simulated/floor,
@@ -9158,7 +9158,7 @@
 /obj/structure/machinery/light/small/emergency{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/iac_rescue_ship/port{
+/obj/effect/map_effect/marker/airlock/external/iac_rescue_ship/port{
 	req_one_access = list(211)
 	},
 /turf/simulated/floor,

--- a/maps/away/ships/idris/idris_cruiser.dmm
+++ b/maps/away/ships/idris/idris_cruiser.dmm
@@ -3386,7 +3386,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_idriscruiser_eng_port";
 	master_tag = "airlock_idriscruiser_eng_port"
 	},
@@ -6085,7 +6085,7 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "vL" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_idriscruiser_eng_port";
 	master_tag = "airlock_idriscruiser_eng_port"
 	},
@@ -10569,7 +10569,7 @@
 /turf/simulated/floor/carpet/green,
 /area/ship/idris_cruiser/great_room)
 "Mp" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_idriscruiser_eng_port";
 	master_tag = "airlock_idriscruiser_eng_port"
 	},

--- a/maps/away/ships/konyang/air_konyang/air_konyang.dmm
+++ b/maps/away/ships/konyang/air_konyang/air_konyang.dmm
@@ -387,7 +387,7 @@
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/air_konyang/rear_hall)
 "kG" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "air_konyang_1";
 	name = "air_konyang_1"
 	},
@@ -589,7 +589,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "air_konyang_1";
 	name = "air_konyang_1"
 	},
@@ -1011,7 +1011,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "air_konyang_1";
 	name = "air_konyang_1"
 	},
@@ -1117,7 +1117,7 @@
 /turf/simulated/floor/airless,
 /area/shuttle/air_konyang/mainroom)
 "BW" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "air_konyang_1";
 	name = "air_konyang_1"
 	},
@@ -1242,7 +1242,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/air_konyang/bridge)
 "FF" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "air_konyang_1";
 	name = "air_konyang_1"
 	},
@@ -1373,7 +1373,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "air_konyang_1";
 	name = "air_konyang_1"
 	},
@@ -1517,7 +1517,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "air_konyang_1";
 	name = "air_konyang_1"
 	},
@@ -1639,7 +1639,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/air_konyang/atmos)
 "PH" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "air_konyang_1";
 	name = "air_konyang_1"
 	},
@@ -1915,7 +1915,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "air_konyang_1";
 	name = "air_konyang_1"
 	},

--- a/maps/away/ships/konyang/kasf_ship/kasf_ship.dmm
+++ b/maps/away/ships/konyang/kasf_ship/kasf_ship.dmm
@@ -598,7 +598,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/kasf_corvette/starboardthrust)
 "dK" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kasf_port";
 	name = "airlock_kasf_port";
 	frequency = 2501
@@ -946,7 +946,7 @@
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 25
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kasf_starboard";
 	name = "airlock_kasf_starboard";
 	frequency = 2502
@@ -987,7 +987,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kasf_starboard";
 	name = "airlock_kasf_starboard";
 	frequency = 2502
@@ -1731,7 +1731,7 @@
 /turf/simulated/floor/tiled,
 /area/ship/kasf_corvette/forehall)
 "kK" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kasf_starboard";
 	name = "airlock_kasf_starboard";
 	frequency = 2502
@@ -2671,7 +2671,7 @@
 /turf/simulated/floor/airless,
 /area/ship/kasf_corvette/atmos)
 "qf" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kasf_port";
 	name = "airlock_kasf_port";
 	frequency = 2501
@@ -2688,7 +2688,7 @@
 /obj/structure/machinery/light/small/emergency{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kasf_port";
 	name = "airlock_kasf_port";
 	frequency = 2501
@@ -3480,7 +3480,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = -25
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kasf_port";
 	name = "airlock_kasf_port";
 	frequency = 2501
@@ -5301,7 +5301,7 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, airlock"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kasf_starboard";
 	name = "airlock_kasf_starboard";
 	frequency = 2502
@@ -5338,7 +5338,7 @@
 /turf/simulated/floor/plating,
 /area/ship/kasf_corvette/portwep)
 "Et" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kasf_starboard";
 	name = "airlock_kasf_starboard";
 	frequency = 2502
@@ -5393,7 +5393,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/kasf_shuttle)
 "EQ" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kasf_starboard";
 	name = "airlock_kasf_starboard";
 	frequency = 2502
@@ -6018,7 +6018,7 @@
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 25
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kasf_port";
 	name = "airlock_kasf_port";
 	frequency = 2501
@@ -6093,7 +6093,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = -25
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kasf_starboard";
 	name = "airlock_kasf_starboard";
 	frequency = 2502
@@ -6130,7 +6130,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kasf_port";
 	name = "airlock_kasf_port";
 	frequency = 2501
@@ -6607,7 +6607,7 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/kasf_corvette/portthrust)
 "Lm" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kasf_port";
 	name = "airlock_kasf_port";
 	frequency = 2501
@@ -8607,7 +8607,7 @@
 /obj/effect/landmark/entry_point/port{
 	name = "port, airlock"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kasf_port";
 	name = "airlock_kasf_port";
 	frequency = 2501
@@ -8753,7 +8753,7 @@
 /obj/structure/machinery/light/small/emergency{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_kasf_starboard";
 	name = "airlock_kasf_starboard";
 	frequency = 2502

--- a/maps/away/ships/konyang/konyang_wreck/konyang_wreck.dmm
+++ b/maps/away/ships/konyang/konyang_wreck/konyang_wreck.dmm
@@ -548,7 +548,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3002;
 	master_tag = "airlock_konyang_wreck";
 	name = "airlock_konyang_wreck"
@@ -973,7 +973,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/konyang_wreck/pod2)
 "hJ" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3002;
 	master_tag = "airlock_konyang_wreck";
 	name = "airlock_konyang_wreck"
@@ -1430,7 +1430,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3002;
 	master_tag = "airlock_konyang_wreck";
 	name = "airlock_konyang_wreck"
@@ -1857,7 +1857,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/konyang_wreck/pod1)
 "pW" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3002;
 	master_tag = "airlock_konyang_wreck";
 	name = "airlock_konyang_wreck"
@@ -4007,7 +4007,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/konyang_wreck/bridge)
 "Jb" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3002;
 	master_tag = "airlock_konyang_wreck";
 	name = "airlock_konyang_wreck"
@@ -4163,7 +4163,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3002;
 	master_tag = "airlock_konyang_wreck";
 	name = "airlock_konyang_wreck"
@@ -4627,7 +4627,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3002;
 	master_tag = "airlock_konyang_wreck";
 	name = "airlock_konyang_wreck"

--- a/maps/away/ships/lone_spacer/lone_spacer.dmm
+++ b/maps/away/ships/lone_spacer/lone_spacer.dmm
@@ -212,7 +212,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/lone_spacer,
+/obj/effect/map_effect/marker/airlock/external/lone_spacer,
 /obj/structure/machinery/airlock_sensor/airlock_exterior{
 	pixel_x = -27;
 	dir = 4
@@ -1077,7 +1077,7 @@
 "oZ" = (
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/map_effect/marker/airlock/lone_spacer,
+/obj/effect/map_effect/marker/airlock/external/lone_spacer,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/access_button{
 	pixel_x = -29;
@@ -1738,7 +1738,7 @@
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/effect/map_effect/marker/airlock/lone_spacer,
+/obj/effect/map_effect/marker/airlock/external/lone_spacer,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/access_button{
 	pixel_x = 27;

--- a/maps/away/ships/lone_spacer/lone_spacer_landmarks.dm
+++ b/maps/away/ships/lone_spacer/lone_spacer_landmarks.dm
@@ -6,7 +6,7 @@
 	cycle_to_external_air = TRUE
 
 // Secondary airlock
-/obj/effect/map_effect/marker/airlock/lone_spacer
+/obj/effect/map_effect/marker/airlock/external/lone_spacer
 	name = "Secondary Airlock"
 	master_tag = "airlock_lone_spacer"
 

--- a/maps/away/ships/orion/orion_express_ship/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship/orion_express_ship.dmm
@@ -1204,7 +1204,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_orion_ship_port";
 	name = "airlock_orion_ship_port";
 	frequency = 1004;
@@ -1486,7 +1486,7 @@
 	pixel_y = 25
 	},
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_orion_ship_starboard";
 	name = "airlock_orion_ship_starboard";
 	frequency = 1004;
@@ -2371,7 +2371,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_orion_ship_starboard";
 	name = "airlock_orion_ship_starboard";
 	frequency = 1004;
@@ -2733,7 +2733,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_orion_ship_starboard";
 	name = "airlock_orion_ship_starboard";
 	frequency = 1004;
@@ -2785,7 +2785,7 @@
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 25
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_orion_ship_port";
 	name = "airlock_orion_ship_port";
 	frequency = 1004;
@@ -3106,7 +3106,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_orion_ship_port";
 	name = "airlock_orion_ship_port";
 	frequency = 1004;
@@ -3144,7 +3144,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = 25
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_orion_ship_port";
 	name = "airlock_orion_ship_port";
 	frequency = 1004;
@@ -3320,7 +3320,7 @@
 /area/ship/orion/cargo)
 "lsl" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_orion_ship_starboard";
 	name = "airlock_orion_ship_starboard";
 	frequency = 1004;
@@ -5341,7 +5341,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_orion_ship_starboard";
 	name = "airlock_orion_ship_starboard";
 	frequency = 1004;
@@ -5610,7 +5610,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_orion_ship_starboard";
 	name = "airlock_orion_ship_starboard";
 	frequency = 1004;
@@ -5917,7 +5917,7 @@
 	pixel_y = 30
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_orion_ship_port";
 	name = "airlock_orion_ship_port";
 	frequency = 1004;
@@ -7296,7 +7296,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_orion_ship_port";
 	name = "airlock_orion_ship_port";
 	frequency = 1004;

--- a/maps/away/ships/orion/orion_miner/orion_miner.dm
+++ b/maps/away/ships/orion/orion_miner/orion_miner.dm
@@ -101,18 +101,18 @@
 	cycle_to_external_air = TRUE
 
 // Forward airlocks
-/obj/effect/map_effect/marker/airlock/orion_miner_port
+/obj/effect/map_effect/marker/airlock/external/orion_miner_port
 	name = "Port Fore Airlock"
 	master_tag = "port_orion_miner"
 	cycle_to_external_air = TRUE
 
-/obj/effect/map_effect/marker/airlock/orion_miner_starboard
+/obj/effect/map_effect/marker/airlock/external/orion_miner_starboard
 	name = "Starboard Fore Airlock"
 	master_tag = "stbd_orion_miner"
 	cycle_to_external_air = TRUE
 
 // Aft airlock
-/obj/effect/map_effect/marker/airlock/orion_miner_aft
+/obj/effect/map_effect/marker/airlock/external/orion_miner_aft
 	name = "Aft Airlock"
 	master_tag = "rear_orion_miner"
 	cycle_to_external_air = TRUE

--- a/maps/away/ships/orion/orion_miner/orion_miner.dmm
+++ b/maps/away/ships/orion/orion_miner/orion_miner.dmm
@@ -162,7 +162,7 @@
 	pixel_y = -28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_port,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_port,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
@@ -190,7 +190,7 @@
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/machinery/light,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/orion_miner_starboard,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_starboard,
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/orion_miner/corridor)
 "bO" = (
@@ -295,7 +295,7 @@
 	pixel_y = 28;
 	pixel_x = -6
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_port,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_port,
 /turf/simulated/floor/plating,
 /area/shuttle/orion_miner/corridor)
 "cg" = (
@@ -507,7 +507,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_aft,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_aft,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/airlock_sensor{
 	dir = 1;
@@ -647,7 +647,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = 22
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_port,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_port,
 /turf/simulated/floor/plating,
 /area/shuttle/orion_miner/corridor)
 "eM" = (
@@ -874,7 +874,7 @@
 	dir = 1
 	},
 /obj/structure/bed/handrail,
-/obj/effect/map_effect/marker/airlock/orion_miner_starboard,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_starboard,
 /turf/simulated/floor/plating,
 /area/shuttle/orion_miner/corridor)
 "gZ" = (
@@ -918,7 +918,7 @@
 	pixel_x = 24;
 	pixel_y = 23
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_starboard,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_starboard,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
@@ -1227,7 +1227,7 @@
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/machinery/light,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/orion_miner_port,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_port,
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/orion_miner/corridor)
 "kq" = (
@@ -1838,7 +1838,7 @@
 	pixel_y = 28;
 	pixel_x = 6
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_starboard,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_starboard,
 /turf/simulated/floor/plating,
 /area/shuttle/orion_miner/corridor)
 "pG" = (
@@ -1869,7 +1869,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/orion_miner_port,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_port,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
@@ -1948,7 +1948,7 @@
 /obj/structure/bed/handrail{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_starboard,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_starboard,
 /turf/simulated/floor/plating,
 /area/shuttle/orion_miner/corridor)
 "qk" = (
@@ -2054,7 +2054,7 @@
 	dir = 9
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/orion_miner_starboard,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_starboard,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
@@ -2143,7 +2143,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_aft,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_aft,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/access_button{
 	pixel_x = -12;
@@ -2168,7 +2168,7 @@
 /obj/structure/bed/handrail{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_port,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_port,
 /turf/simulated/floor/plating,
 /area/shuttle/orion_miner/corridor)
 "sz" = (
@@ -2214,7 +2214,7 @@
 /obj/structure/bed/handrail{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_aft,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_aft,
 /obj/effect/map_effect/marker_helper/airlock/out,
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 28;
@@ -2385,7 +2385,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_starboard,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_starboard,
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/orion_miner/corridor)
 "vQ" = (
@@ -2558,7 +2558,7 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/orion_miner_starboard,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_starboard,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
@@ -2961,7 +2961,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = 22
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_starboard,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_starboard,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
@@ -3153,7 +3153,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
-/obj/effect/map_effect/marker/airlock/orion_miner_port,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_port,
 /turf/simulated/floor/plating,
 /area/shuttle/orion_miner/corridor)
 "BU" = (
@@ -3244,7 +3244,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_aft,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_aft,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/access_button{
 	pixel_x = 28;
@@ -3288,7 +3288,7 @@
 	pixel_y = -28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_starboard,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_starboard,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
@@ -3323,7 +3323,7 @@
 	dir = 1
 	},
 /obj/structure/bed/handrail,
-/obj/effect/map_effect/marker/airlock/orion_miner_port,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_port,
 /turf/simulated/floor/plating,
 /area/shuttle/orion_miner/corridor)
 "Db" = (
@@ -3783,7 +3783,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
-/obj/effect/map_effect/marker/airlock/orion_miner_starboard,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_starboard,
 /turf/simulated/floor/plating,
 /area/shuttle/orion_miner/corridor)
 "GR" = (
@@ -4096,7 +4096,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_port,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_port,
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/orion_miner/corridor)
 "KB" = (
@@ -5191,7 +5191,7 @@
 	pixel_x = -24;
 	pixel_y = 23
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_port,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_port,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
@@ -5282,7 +5282,7 @@
 	dir = 5
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/orion_miner_port,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_port,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
@@ -5423,7 +5423,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_aft,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_aft,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = 28;
@@ -5574,7 +5574,7 @@
 /obj/structure/bed/handrail{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/orion_miner_aft,
+/obj/effect/map_effect/marker/airlock/external/orion_miner_aft,
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/orion_miner/main_engineering_port)

--- a/maps/away/ships/sadar_scout/sadar_scout.dmm
+++ b/maps/away/ships/sadar_scout/sadar_scout.dmm
@@ -104,7 +104,7 @@
 /area/shuttle/sadar_shuttle)
 "aQ" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4524;
 	master_tag = "airlock_sadar_scout_port_2";
 	name = "airlock_sadar_scout_port_2"
@@ -366,7 +366,7 @@
 	pixel_y = -22;
 	pixel_x = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4525;
 	master_tag = "airlock_sadar_scout_starboard_3";
 	name = "airlock_sadar_scout_starboard_3"
@@ -1156,7 +1156,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4526;
 	master_tag = "airlock_sadar_scout_port_3";
 	name = "airlock_sadar_scout_port_3"
@@ -1334,7 +1334,7 @@
 	pixel_y = -28
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4524;
 	master_tag = "airlock_sadar_scout_port_2";
 	name = "airlock_sadar_scout_port_2"
@@ -1594,7 +1594,7 @@
 	pixel_y = -6
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4527;
 	master_tag = "airlock_sadar_scout_cic";
 	name = "airlock_sadar_scout_cic"
@@ -1686,7 +1686,7 @@
 	pixel_y = -22;
 	pixel_x = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4521;
 	master_tag = "airlock_sadar_scout_starboard_1";
 	name = "airlock_sadar_scout_starboard_1"
@@ -1831,7 +1831,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4524;
 	master_tag = "airlock_sadar_scout_port_2";
 	name = "airlock_sadar_scout_port_2"
@@ -1967,7 +1967,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4523;
 	master_tag = "airlock_sadar_scout_starboard_2";
 	name = "airlock_sadar_scout_starboard_2"
@@ -1986,7 +1986,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4522;
 	master_tag = "airlock_sadar_scout_port_1";
 	name = "airlock_sadar_scout_port_1"
@@ -2444,7 +2444,7 @@
 /area/ship/sadar_scout/mainhall)
 "rS" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4523;
 	master_tag = "airlock_sadar_scout_starboard_2";
 	name = "airlock_sadar_scout_starboard_2"
@@ -2481,7 +2481,7 @@
 	pixel_y = -28
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4523;
 	master_tag = "airlock_sadar_scout_starboard_2";
 	name = "airlock_sadar_scout_starboard_2"
@@ -2506,7 +2506,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4524;
 	master_tag = "airlock_sadar_scout_port_2";
 	name = "airlock_sadar_scout_port_2"
@@ -2556,7 +2556,7 @@
 /area/shuttle/sadar_shuttle)
 "sE" = (
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4524;
 	master_tag = "airlock_sadar_scout_port_2";
 	name = "airlock_sadar_scout_port_2"
@@ -2716,7 +2716,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4523;
 	master_tag = "airlock_sadar_scout_starboard_2";
 	name = "airlock_sadar_scout_starboard_2"
@@ -3057,7 +3057,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4523;
 	master_tag = "airlock_sadar_scout_starboard_2";
 	name = "airlock_sadar_scout_starboard_2"
@@ -3299,7 +3299,7 @@
 	pixel_y = -28
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4523;
 	master_tag = "airlock_sadar_scout_starboard_2";
 	name = "airlock_sadar_scout_starboard_2"
@@ -3885,7 +3885,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4522;
 	master_tag = "airlock_sadar_scout_port_1";
 	name = "airlock_sadar_scout_port_1"
@@ -4026,7 +4026,7 @@
 	pixel_y = -28
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4525;
 	master_tag = "airlock_sadar_scout_starboard_3";
 	name = "airlock_sadar_scout_starboard_3"
@@ -4070,7 +4070,7 @@
 	pixel_y = -22;
 	pixel_x = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4522;
 	master_tag = "airlock_sadar_scout_port_1";
 	name = "airlock_sadar_scout_port_1"
@@ -4672,7 +4672,7 @@
 	pixel_y = -22;
 	pixel_x = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4526;
 	master_tag = "airlock_sadar_scout_port_3";
 	name = "airlock_sadar_scout_port_3"
@@ -4738,7 +4738,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4524;
 	master_tag = "airlock_sadar_scout_port_2";
 	name = "airlock_sadar_scout_port_2"
@@ -4830,7 +4830,7 @@
 	},
 /obj/structure/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4527;
 	master_tag = "airlock_sadar_scout_cic";
 	name = "airlock_sadar_scout_cic"
@@ -5142,7 +5142,7 @@
 	pixel_y = -28
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4524;
 	master_tag = "airlock_sadar_scout_port_2";
 	name = "airlock_sadar_scout_port_2"
@@ -5221,7 +5221,7 @@
 	pixel_y = 12
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4527;
 	master_tag = "airlock_sadar_scout_cic";
 	name = "airlock_sadar_scout_cic"
@@ -5282,7 +5282,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4521;
 	master_tag = "airlock_sadar_scout_starboard_1";
 	name = "airlock_sadar_scout_starboard_1"
@@ -5542,7 +5542,7 @@
 	pixel_y = -28
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4526;
 	master_tag = "airlock_sadar_scout_port_3";
 	name = "airlock_sadar_scout_port_3"
@@ -5559,7 +5559,7 @@
 /area/shuttle/sadar_shuttle)
 "PT" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4523;
 	master_tag = "airlock_sadar_scout_starboard_2";
 	name = "airlock_sadar_scout_starboard_2"
@@ -5803,7 +5803,7 @@
 /area/ship/sadar_scout/eva)
 "RA" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4524;
 	master_tag = "airlock_sadar_scout_port_2";
 	name = "airlock_sadar_scout_port_2"
@@ -6055,7 +6055,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4525;
 	master_tag = "airlock_sadar_scout_starboard_3";
 	name = "airlock_sadar_scout_starboard_3"
@@ -6079,7 +6079,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4521;
 	master_tag = "airlock_sadar_scout_starboard_1";
 	name = "airlock_sadar_scout_starboard_1"
@@ -6947,7 +6947,7 @@
 /area/ship/sadar_scout/med)
 "ZC" = (
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 4523;
 	master_tag = "airlock_sadar_scout_starboard_2";
 	name = "airlock_sadar_scout_starboard_2"

--- a/maps/away/ships/scc/scc_scout_ship.dmm
+++ b/maps/away/ships/scc/scc_scout_ship.dmm
@@ -51,7 +51,7 @@
 /obj/structure/machinery/light/small/emergency{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_fore_starboard";
 	name = "airlock_scc_scout_fore_starboard"
 	},
@@ -567,7 +567,7 @@
 	pixel_y = 28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_fore_starboard";
 	name = "airlock_scc_scout_fore_starboard"
 	},
@@ -871,7 +871,7 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_fore_starboard";
 	name = "airlock_scc_scout_fore_starboard"
 	},
@@ -1927,7 +1927,7 @@
 /obj/structure/machinery/access_button{
 	pixel_x = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_fore_starboard";
 	name = "airlock_scc_scout_fore_starboard"
 	},
@@ -1984,7 +1984,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/scc_scout_ship_shuttle/cargo)
 "lw" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_aft_port";
 	name = "airlock_scc_scout_aft_port"
 	},
@@ -2105,7 +2105,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/scc_scout_ship/eva)
 "lW" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_shuttle_side";
 	name = "airlock_scc_scout_shuttle_side"
 	},
@@ -2197,7 +2197,7 @@
 	},
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/warning/cee,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_shuttle_side";
 	name = "airlock_scc_scout_shuttle_side"
 	},
@@ -2815,7 +2815,7 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_shuttle_side";
 	name = "airlock_scc_scout_shuttle_side"
 	},
@@ -3220,7 +3220,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_shuttle_side";
 	name = "airlock_scc_scout_shuttle_side"
 	},
@@ -3432,7 +3432,7 @@
 /turf/space/dynamic,
 /area/ship/scc_scout_ship/maint_atmos)
 "tM" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_shuttle_side";
 	name = "airlock_scc_scout_shuttle_side"
 	},
@@ -3610,7 +3610,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/scc_scout_ship/eva)
 "uZ" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_aft_port";
 	name = "airlock_scc_scout_aft_port"
 	},
@@ -3845,7 +3845,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/red{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_shuttle_side";
 	name = "airlock_scc_scout_shuttle_side"
 	},
@@ -4027,7 +4027,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/scc_scout_ship_shuttle/cargo)
 "xz" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_shuttle_side";
 	name = "airlock_scc_scout_shuttle_side"
 	},
@@ -4214,7 +4214,7 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_fore_starboard";
 	name = "airlock_scc_scout_fore_starboard"
 	},
@@ -4274,7 +4274,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/scc_scout_ship/engineering_cargo)
 "zg" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_shuttle_side";
 	name = "airlock_scc_scout_shuttle_side"
 	},
@@ -5297,7 +5297,7 @@
 /turf/simulated/floor/plating,
 /area/ship/scc_scout_ship/maint_propulsion_starboard)
 "Hb" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_shuttle_side";
 	name = "airlock_scc_scout_shuttle_side"
 	},
@@ -5541,7 +5541,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/scc_scout_ship/hydroponics)
 "IB" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_shuttle_side";
 	name = "airlock_scc_scout_shuttle_side"
 	},
@@ -5765,7 +5765,7 @@
 	pixel_y = -6;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_fore_starboard";
 	name = "airlock_scc_scout_fore_starboard"
 	},
@@ -7121,7 +7121,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_shuttle_side";
 	name = "airlock_scc_scout_shuttle_side"
 	},
@@ -7633,7 +7633,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/scc_scout_ship/maint_propulsion_port)
 "Wm" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_scc_scout_aft_port";
 	name = "airlock_scc_scout_aft_port"
 	},

--- a/maps/away/ships/sol/sol_frigate/sol_frigate.dmm
+++ b/maps/away/ships/sol/sol_frigate/sol_frigate.dmm
@@ -279,7 +279,7 @@
 	pixel_y = 25
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/map_effect/marker/airlock/sol_frigate/mid_starboard,
+/obj/effect/map_effect/marker/airlock/external/sol_frigate/mid_starboard,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/sol_frigate/Port_docking_port)
@@ -2383,7 +2383,7 @@
 	pixel_x = -7
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/map_effect/marker/airlock/sol_frigate/mid_starboard,
+/obj/effect/map_effect/marker/airlock/external/sol_frigate/mid_starboard,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
@@ -6457,7 +6457,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/sol_frigate/mid_starboard,
+/obj/effect/map_effect/marker/airlock/external/sol_frigate/mid_starboard,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/sol_frigate/Port_docking_port)
 "Dj" = (

--- a/maps/away/ships/sol/sol_frigate/sol_frigateship_landmarks.dm
+++ b/maps/away/ships/sol/sol_frigate/sol_frigateship_landmarks.dm
@@ -1,5 +1,5 @@
 // Midships port airlock
-/obj/effect/map_effect/marker/airlock/sol_frigate/mid_starboard
+/obj/effect/map_effect/marker/airlock/external/sol_frigate/mid_starboard
 	name = "Midships port airlock"
 	master_tag = "solfrig_airlock"
 // --------

--- a/maps/away/ships/sol/sol_splf/splf_raider.dmm
+++ b/maps/away/ships/sol/sol_splf/splf_raider.dmm
@@ -699,7 +699,7 @@
 	must_start_working = 1
 	},
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/effect/map_effect/marker/airlock/splf_raider/mid_portside,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/mid_portside,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/splf_raider/central)
@@ -1463,7 +1463,7 @@
 	pixel_y = -25;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/mid_portside,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/mid_portside,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -2093,7 +2093,7 @@
 	pixel_y = -25;
 	pixel_x = 5
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/mid_portside,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/mid_portside,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/central)
@@ -2334,7 +2334,7 @@
 	pixel_y = -28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/aft_portside,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/aft_portside,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/central)
@@ -2555,7 +2555,7 @@
 	pixel_y = 28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/mid_portside,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/mid_portside,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -2756,7 +2756,7 @@
 	dir = 8;
 	pixel_x = 25
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/gunnery,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/gunnery,
 /turf/simulated/floor/plating,
 /area/splf_raider/gunnery)
 "qx" = (
@@ -3718,7 +3718,7 @@
 	must_start_working = 1
 	},
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/effect/map_effect/marker/airlock/splf_raider/mid_starboard,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/mid_starboard,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/splf_raider/central)
@@ -3788,7 +3788,7 @@
 	dir = 4;
 	pixel_x = -25
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/aft_portside,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/aft_portside,
 /turf/simulated/floor/plating,
 /area/splf_raider/central)
 "vO" = (
@@ -4623,7 +4623,7 @@
 	pixel_y = 28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/mid_starboard,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/mid_starboard,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
@@ -4741,7 +4741,7 @@
 	pixel_x = -27;
 	pixel_y = -8
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/gunnery,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/gunnery,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/gunnery)
@@ -5681,7 +5681,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 5
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/mid_starboard,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/mid_starboard,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/central)
@@ -5873,7 +5873,7 @@
 	dir = 8;
 	pixel_x = 25
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/aft_starboard,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/aft_starboard,
 /turf/simulated/floor/plating,
 /area/splf_raider/central)
 "HU" = (
@@ -5954,7 +5954,7 @@
 	pixel_y = -28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/aft_starboard,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/aft_starboard,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/central)
@@ -5970,7 +5970,7 @@
 	pixel_y = 8;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/gunnery,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/gunnery,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/gunnery)
@@ -6377,7 +6377,7 @@
 	must_start_working = 1
 	},
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/effect/map_effect/marker/airlock/splf_raider/aft_starboard,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/aft_starboard,
 /turf/simulated/floor/plating,
 /area/splf_raider/central)
 "KL" = (
@@ -6815,7 +6815,7 @@
 	pixel_y = 28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/aft_portside,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/aft_portside,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/central)
@@ -7691,7 +7691,7 @@
 	pixel_y = -25;
 	pixel_x = -7
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/mid_starboard,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/mid_starboard,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/central)
@@ -7820,7 +7820,7 @@
 	dir = 8
 	},
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/effect/map_effect/marker/airlock/splf_raider/gunnery,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/gunnery,
 /turf/simulated/floor/plating,
 /area/splf_raider/gunnery)
 "Th" = (
@@ -8386,7 +8386,7 @@
 	must_start_working = 1
 	},
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/effect/map_effect/marker/airlock/splf_raider/aft_portside,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/aft_portside,
 /turf/simulated/floor/plating,
 /area/splf_raider/central)
 "WE" = (
@@ -8623,7 +8623,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/mid_portside,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/mid_portside,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/central)
@@ -8798,7 +8798,7 @@
 	pixel_y = 28;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/aft_starboard,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/aft_starboard,
 /turf/simulated/floor/tiled/dark/full,
 /area/splf_raider/central)
 "YM" = (
@@ -8845,7 +8845,7 @@
 	pixel_y = -25;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/splf_raider/mid_starboard,
+/obj/effect/map_effect/marker/airlock/external/splf_raider/mid_starboard,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/dark/full,

--- a/maps/away/ships/sol/sol_splf/splf_raider_landmarks.dm
+++ b/maps/away/ships/sol/sol_splf/splf_raider_landmarks.dm
@@ -1,25 +1,25 @@
 // Aft airlocks
-/obj/effect/map_effect/marker/airlock/splf_raider/aft_starboard
+/obj/effect/map_effect/marker/airlock/external/splf_raider/aft_starboard
 	name = "Maintenance Hatch"
 	master_tag = "splf_aft_starboard"
 
-/obj/effect/map_effect/marker/airlock/splf_raider/aft_portside
+/obj/effect/map_effect/marker/airlock/external/splf_raider/aft_portside
 	name = "Maintenance Hatch"
 	master_tag = "splf_aft_port"
 // --------
 
 // Mid airlocks
-/obj/effect/map_effect/marker/airlock/splf_raider/mid_starboard
+/obj/effect/map_effect/marker/airlock/external/splf_raider/mid_starboard
 	name = "Maintenance Hatch"
 	master_tag = "splf_mid_starboard"
 
-/obj/effect/map_effect/marker/airlock/splf_raider/mid_portside
+/obj/effect/map_effect/marker/airlock/external/splf_raider/mid_portside
 	name = "Maintenance Hatch"
 	master_tag = "splf_mid_port"
 // --------
 
 // Gunnery airlock
-/obj/effect/map_effect/marker/airlock/splf_raider/gunnery
+/obj/effect/map_effect/marker/airlock/external/splf_raider/gunnery
 	name = "Maintenance Hatch"
 	master_tag = "splf_gunnery"
 // --------

--- a/maps/away/ships/sol/sol_ssrm/ssrm_ship.dmm
+++ b/maps/away/ships/sol/sol_ssrm/ssrm_ship.dmm
@@ -830,7 +830,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/ssrm_ship/fore,
+/obj/effect/map_effect/marker/airlock/external/ssrm_ship/fore,
 /turf/simulated/floor,
 /area/ship/ssrm_corvette/crew_lounge)
 "bPw" = (
@@ -1167,7 +1167,7 @@
 	req_access = list(203)
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/ssrm_ship/fore,
+/obj/effect/map_effect/marker/airlock/external/ssrm_ship/fore,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/ssrm_corvette/crew_lounge)
 "cGw" = (
@@ -1525,7 +1525,7 @@
 	pixel_y = -6
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock/ssrm_ship/fore,
+/obj/effect/map_effect/marker/airlock/external/ssrm_ship/fore,
 /turf/simulated/floor,
 /area/ship/ssrm_corvette/crew_lounge)
 "doU" = (
@@ -2590,7 +2590,7 @@
 	req_access = list(203)
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/ssrm_ship/aft,
+/obj/effect/map_effect/marker/airlock/external/ssrm_ship/aft,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/ssrm_corvette)
 "fmU" = (
@@ -2601,7 +2601,7 @@
 	req_access = list(203)
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/ssrm_ship/fore,
+/obj/effect/map_effect/marker/airlock/external/ssrm_ship/fore,
 /obj/structure/machinery/door/blast/regular/open{
 	dir = 4;
 	id = "ssrm_airlocks"
@@ -4856,7 +4856,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 10
 	},
-/obj/effect/map_effect/marker/airlock/ssrm_ship/fore,
+/obj/effect/map_effect/marker/airlock/external/ssrm_ship/fore,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/ssrm_corvette/crew_lounge)
 "kzm" = (
@@ -5610,7 +5610,7 @@
 	req_access = list(203)
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/ssrm_ship/aft,
+/obj/effect/map_effect/marker/airlock/external/ssrm_ship/aft,
 /obj/structure/machinery/door/blast/regular/open{
 	dir = 8;
 	id = "ssrm_airlocks"
@@ -6567,7 +6567,7 @@
 	pixel_y = -6
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock/ssrm_ship/aft,
+/obj/effect/map_effect/marker/airlock/external/ssrm_ship/aft,
 /turf/simulated/floor,
 /area/ship/ssrm_corvette)
 "oed" = (
@@ -6866,7 +6866,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/ssrm_ship/aft,
+/obj/effect/map_effect/marker/airlock/external/ssrm_ship/aft,
 /turf/simulated/floor,
 /area/ship/ssrm_corvette)
 "oSr" = (
@@ -8566,7 +8566,7 @@
 	pixel_y = 6;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/ssrm_ship/aft,
+/obj/effect/map_effect/marker/airlock/external/ssrm_ship/aft,
 /obj/structure/machinery/door/blast/regular/open{
 	dir = 8;
 	id = "ssrm_airlocks"
@@ -10333,7 +10333,7 @@
 /obj/structure/machinery/access_button{
 	pixel_x = -27
 	},
-/obj/effect/map_effect/marker/airlock/ssrm_ship/aft,
+/obj/effect/map_effect/marker/airlock/external/ssrm_ship/aft,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/ssrm_corvette)
 "xCY" = (

--- a/maps/away/ships/sol/sol_ssrm/ssrm_ship_landmarks.dm
+++ b/maps/away/ships/sol/sol_ssrm/ssrm_ship_landmarks.dm
@@ -1,11 +1,11 @@
 // Aft airlocks
-/obj/effect/map_effect/marker/airlock/ssrm_ship/aft
+/obj/effect/map_effect/marker/airlock/external/ssrm_ship/aft
 	name = "Maintenance Hatch"
 	master_tag = "ssrm_aft"
 // --------
 
 // Fore airlocks
-/obj/effect/map_effect/marker/airlock/ssrm_ship/fore
+/obj/effect/map_effect/marker/airlock/external/ssrm_ship/fore
 	name = "Maintenance Hatch"
 	master_tag = "ssrm_fore"
 // --------

--- a/maps/away/ships/tirakqi_smuggler/tirakqi_smuggler.dmm
+++ b/maps/away/ships/tirakqi_smuggler/tirakqi_smuggler.dmm
@@ -553,7 +553,7 @@
 	dir = 8;
 	pixel_y = -10
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tirakqi_smuggler_aft_starboard";
 	name = "airlock_tirakqi_smuggler_aft_starboard"
 	},
@@ -921,7 +921,7 @@
 	dir = 1;
 	pixel_y = 12
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tirakqi_smuggler_fore_starboard";
 	name = "airlock_tirakqi_smuggler_fore_starboard"
 	},
@@ -2848,7 +2848,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tirakqi_smuggler_fore_port";
 	name = "airlock_tirakqi_smuggler_fore_port"
 	},
@@ -3376,7 +3376,7 @@
 	pixel_y = 6;
 	pixel_x = -18
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tirakqi_smuggler_fore_starboard";
 	name = "airlock_tirakqi_smuggler_fore_starboard"
 	},
@@ -4207,7 +4207,7 @@
 	pixel_y = 6;
 	pixel_x = 18
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tirakqi_smuggler_fore_port";
 	name = "airlock_tirakqi_smuggler_fore_port"
 	},
@@ -4441,7 +4441,7 @@
 	pixel_x = 26;
 	pixel_y = -2
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tirakqi_smuggler_fore_starboard";
 	name = "airlock_tirakqi_smuggler_fore_starboard"
 	},
@@ -4880,7 +4880,7 @@
 	dir = 4;
 	pixel_y = 11
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tirakqi_smuggler_aft_port";
 	name = "airlock_tirakqi_smuggler_aft_port"
 	},
@@ -5678,7 +5678,7 @@
 	pixel_y = -6;
 	pixel_x = 18
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tirakqi_smuggler_aft_starboard";
 	name = "airlock_tirakqi_smuggler_aft_starboard"
 	},
@@ -5853,7 +5853,7 @@
 	dir = 8;
 	pixel_y = 10
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tirakqi_smuggler_aft_starboard";
 	name = "airlock_tirakqi_smuggler_aft_starboard"
 	},
@@ -6724,7 +6724,7 @@
 	pixel_y = -6;
 	pixel_x = -18
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tirakqi_smuggler_aft_port";
 	name = "airlock_tirakqi_smuggler_aft_port"
 	},
@@ -6988,7 +6988,7 @@
 	dir = 4;
 	pixel_y = -11
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tirakqi_smuggler_aft_port";
 	name = "airlock_tirakqi_smuggler_aft_port"
 	},
@@ -7317,7 +7317,7 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tirakqi_smuggler_fore_starboard";
 	name = "airlock_tirakqi_smuggler_fore_starboard"
 	},
@@ -7630,7 +7630,7 @@
 	dir = 1;
 	pixel_y = 12
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tirakqi_smuggler_fore_port";
 	name = "airlock_tirakqi_smuggler_fore_port"
 	},
@@ -7881,7 +7881,7 @@
 	pixel_x = -26;
 	pixel_y = -2
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tirakqi_smuggler_fore_port";
 	name = "airlock_tirakqi_smuggler_fore_port"
 	},

--- a/maps/away/ships/tramp_freighter/tramp_freighter.dmm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter.dmm
@@ -2061,7 +2061,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/tramp_freighter/port_small,
+/obj/effect/map_effect/marker/airlock/external/tramp_freighter/port_small,
 /turf/simulated/floor/plating,
 /area/tramp_freighter/engi)
 "kW" = (
@@ -4474,7 +4474,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = -25
 	},
-/obj/effect/map_effect/marker/airlock/tramp_freighter/port_small,
+/obj/effect/map_effect/marker/airlock/external/tramp_freighter/port_small,
 /turf/simulated/floor/plating,
 /area/tramp_freighter/engi)
 "wB" = (
@@ -4962,7 +4962,7 @@
 	pixel_y = 28
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/tramp_freighter/port_small,
+/obj/effect/map_effect/marker/airlock/external/tramp_freighter/port_small,
 /turf/simulated/floor/plating,
 /area/tramp_freighter/engi)
 "yS" = (
@@ -8623,7 +8623,7 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/tramp_freighter/starboard_small,
+/obj/effect/map_effect/marker/airlock/external/tramp_freighter/starboard_small,
 /turf/simulated/floor/plating,
 /area/tramp_freighter/equipment)
 "SH" = (
@@ -9541,7 +9541,7 @@
 	pixel_y = 28
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/tramp_freighter/starboard_small,
+/obj/effect/map_effect/marker/airlock/external/tramp_freighter/starboard_small,
 /turf/simulated/floor/plating,
 /area/tramp_freighter/equipment)
 "Xa" = (
@@ -9775,7 +9775,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = -25
 	},
-/obj/effect/map_effect/marker/airlock/tramp_freighter/starboard_small,
+/obj/effect/map_effect/marker/airlock/external/tramp_freighter/starboard_small,
 /turf/simulated/floor/plating,
 /area/tramp_freighter/equipment)
 "Yp" = (

--- a/maps/away/ships/tramp_freighter/tramp_freighter_landmarks.dm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter_landmarks.dm
@@ -89,11 +89,11 @@
 	landmark_tag = "nav_tramp_freighter_stbd_fore"
 
 //airlocks, non-docking
-/obj/effect/map_effect/marker/airlock/tramp_freighter/starboard_small
+/obj/effect/map_effect/marker/airlock/external/tramp_freighter/starboard_small
 	name = "Starboard, Small"
 	master_tag = "airlock_tramp_starboard"
 
-/obj/effect/map_effect/marker/airlock/tramp_freighter/port_small
+/obj/effect/map_effect/marker/airlock/external/tramp_freighter/port_small
 	name = "Port, Small"
 	master_tag = "airlock_tramp_port"
 

--- a/maps/away/ships/unathi_pirate/hiskyn/unathi_pirate_hiskyn.dmm
+++ b/maps/away/ships/unathi_pirate/hiskyn/unathi_pirate_hiskyn.dmm
@@ -216,7 +216,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1969;
 	master_tag = "airlock_hiskyn_1";
 	name = "airlock_hiskyn_1"
@@ -979,7 +979,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1969;
 	master_tag = "airlock_hiskyn_1";
 	name = "airlock_hiskyn_1"
@@ -1135,7 +1135,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1969;
 	master_tag = "airlock_hiskyn_1";
 	name = "airlock_hiskyn_1"
@@ -3113,7 +3113,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1969;
 	master_tag = "airlock_hiskyn_1";
 	name = "airlock_hiskyn_1"
@@ -4142,7 +4142,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/hiskyn_ship/engineering)
 "iWI" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1969;
 	master_tag = "airlock_hiskyn_1";
 	name = "airlock_hiskyn_1"
@@ -5100,7 +5100,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1969;
 	master_tag = "airlock_hiskyn_1";
 	name = "airlock_hiskyn_1"
@@ -6195,7 +6195,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/hiskyn_ship/thrustp)
 "snz" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1969;
 	master_tag = "airlock_hiskyn_1";
 	name = "airlock_hiskyn_1"
@@ -6644,7 +6644,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1969;
 	master_tag = "airlock_hiskyn_1";
 	name = "airlock_hiskyn_1"

--- a/maps/away/ships/unathi_pirate/tarwa/unathi_pirate_tarwa.dmm
+++ b/maps/away/ships/unathi_pirate/tarwa/unathi_pirate_tarwa.dmm
@@ -626,7 +626,7 @@
 /obj/structure/machinery/light{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tarwa_aft";
 	name = "airlock_tarwa_aft"
 	},
@@ -890,7 +890,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tarwa_stbd";
 	name = "airlock_tarwa_stbd"
 	},
@@ -1726,7 +1726,7 @@
 /area/tarwa_ship)
 "qt" = (
 /obj/structure/diona/bulb,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tarwa_stbd";
 	name = "airlock_tarwa_stbd"
 	},
@@ -2085,7 +2085,7 @@
 /obj/structure/machinery/access_button{
 	pixel_x = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tarwa_aft";
 	name = "airlock_tarwa_aft"
 	},
@@ -2256,7 +2256,7 @@
 	pixel_x = -28;
 	pixel_y = 12
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tarwa_aft";
 	name = "airlock_tarwa_aft"
 	},
@@ -2857,7 +2857,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tarwa_stbd";
 	name = "airlock_tarwa_stbd"
 	},
@@ -3417,7 +3417,7 @@
 	pixel_x = 20;
 	pixel_y = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tarwa_aft";
 	name = "airlock_tarwa_aft"
 	},
@@ -3693,7 +3693,7 @@
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/crew)
 "Il" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tarwa_aft";
 	name = "airlock_tarwa_aft"
 	},
@@ -4494,7 +4494,7 @@
 	name = "aft, airlock"
 	},
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tarwa_aft";
 	name = "airlock_tarwa_aft"
 	},
@@ -4573,7 +4573,7 @@
 /area/tarwa_ship/oldhangar)
 "PM" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tarwa_aft";
 	name = "airlock_tarwa_aft"
 	},
@@ -4584,7 +4584,7 @@
 /turf/space/transit/north,
 /area/space)
 "PP" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tarwa_stbd";
 	name = "airlock_tarwa_stbd"
 	},
@@ -4719,7 +4719,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_tarwa_aft";
 	name = "airlock_tarwa_aft"
 	},

--- a/maps/away/ships/xanu/xanu_frigate.dmm
+++ b/maps/away/ships/xanu/xanu_frigate.dmm
@@ -3175,7 +3175,7 @@
 	pixel_y = 28;
 	req_access = list(222)
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "xanufrigate_eng_airlock";
 	master_tag = "xanufrigate_eng_airlock"
 	},
@@ -13182,7 +13182,7 @@
 	pixel_x = 28;
 	req_access = list(222)
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "xanufrigate_eng_airlock";
 	master_tag = "xanufrigate_eng_airlock"
 	},
@@ -15180,7 +15180,7 @@
 	pixel_y = 10;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "xanufrigate_eng_airlock";
 	master_tag = "xanufrigate_eng_airlock"
 	},

--- a/maps/away/ships/yacht_civ/yacht_civ.dmm
+++ b/maps/away/ships/yacht_civ/yacht_civ.dmm
@@ -79,7 +79,7 @@
 	pixel_y = 28;
 	pixel_x = -6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_yacht_civ_mid";
 	name = "airlock_yacht_civ_mid";
 	req_one_access = null
@@ -741,7 +741,7 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_yacht_civ_hangar";
 	name = "airlock_yacht_civ_hangar";
 	req_one_access = null
@@ -1638,7 +1638,7 @@
 /obj/structure/machinery/light/small/emergency{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_yacht_civ_hangar";
 	name = "airlock_yacht_civ_hangar";
 	req_one_access = null
@@ -2277,7 +2277,7 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_yacht_civ_mid";
 	name = "airlock_yacht_civ_mid";
 	req_one_access = null
@@ -2938,7 +2938,7 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_yacht_civ_mid";
 	name = "airlock_yacht_civ_mid";
 	req_one_access = null
@@ -3588,7 +3588,7 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_yacht_civ_hangar";
 	name = "airlock_yacht_civ_hangar";
 	req_one_access = null

--- a/maps/helpers/guidelines/guidelines_airlocks.dmm
+++ b/maps/helpers/guidelines/guidelines_airlocks.dmm
@@ -6,7 +6,7 @@
 	pixel_y = -8
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "bx" = (
@@ -35,13 +35,13 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "dk" = (
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "du" = (
@@ -113,7 +113,7 @@
 	dir = 6
 	},
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/template_noop)
@@ -121,7 +121,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "gm" = (
@@ -149,7 +149,7 @@
 	pixel_x = -28
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/airless,
 /area/template_noop)
 "js" = (
@@ -168,21 +168,21 @@
 	pixel_x = 20;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "kg" = (
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "kx" = (
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "kZ" = (
@@ -224,7 +224,7 @@
 	pixel_y = 6;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	dir = 8;
 	pixel_y = 6;
@@ -265,7 +265,7 @@
 	dir = 4;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/template_noop,
 /area/template_noop)
 "oq" = (
@@ -285,7 +285,7 @@
 /obj/structure/machinery/door/airlock/external,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "oR" = (
@@ -293,12 +293,12 @@
 	dir = 8
 	},
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "pm" = (
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
@@ -310,7 +310,7 @@
 	pixel_x = -24
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/airless,
 /area/template_noop)
 "qk" = (
@@ -361,7 +361,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/airless,
 /area/template_noop)
 "qz" = (
@@ -372,7 +372,7 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "qS" = (
@@ -394,7 +394,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "so" = (
@@ -439,12 +439,12 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/airless,
 /area/template_noop)
 "vf" = (
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
@@ -455,7 +455,7 @@
 	pixel_x = 24;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/airless,
 /area/template_noop)
 "vW" = (
@@ -475,7 +475,7 @@
 	dir = 4
 	},
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/template_noop)
@@ -486,7 +486,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/access_button{
 	pixel_x = -12;
@@ -518,14 +518,14 @@
 	pixel_y = -8
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "zn" = (
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "zt" = (
@@ -580,13 +580,13 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "Bt" = (
 /obj/structure/machinery/door/airlock/external,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "BE" = (
@@ -605,7 +605,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 28;
 	pixel_x = -6
@@ -635,12 +635,12 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "EY" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/plating,
 /area/template_noop)
@@ -666,7 +666,7 @@
 	pixel_x = 28;
 	pixel_y = -8
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "HE" = (
@@ -686,7 +686,7 @@
 	dir = 4;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "Jx" = (
@@ -694,7 +694,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "Jy" = (
@@ -709,14 +709,14 @@
 /area/template_noop)
 "KX" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "Li" = (
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "Lt" = (
@@ -731,7 +731,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "LW" = (
@@ -742,7 +742,7 @@
 	pixel_x = -20;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "Nr" = (
@@ -756,7 +756,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/airless,
 /area/template_noop)
@@ -769,7 +769,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "OG" = (
@@ -785,7 +785,7 @@
 /obj/structure/machinery/access_button{
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/tiled/dark/full,
 /area/template_noop)
 "PU" = (
@@ -804,11 +804,11 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "Qs" = (
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
@@ -816,7 +816,7 @@
 /turf/simulated/floor/plating,
 /area/template_noop)
 "Qt" = (
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
@@ -826,7 +826,7 @@
 /obj/structure/machinery/door/airlock/external,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "Qw" = (
@@ -837,7 +837,7 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "QX" = (
@@ -848,7 +848,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/airless,
 /area/template_noop)
 "Rh" = (
@@ -858,7 +858,7 @@
 	pixel_y = -8
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "Ri" = (
@@ -869,7 +869,7 @@
 /obj/structure/machinery/access_button{
 	pixel_x = 28
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/template_noop)
@@ -877,7 +877,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/structure/machinery/airlock_sensor{
 	pixel_x = 20;
 	dir = 8
@@ -905,7 +905,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "TP" = (
@@ -919,7 +919,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/airless,
 /area/template_noop)
 "UO" = (
@@ -936,7 +936,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 5
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "Vv" = (
@@ -947,7 +947,7 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "VJ" = (
@@ -960,7 +960,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "VO" = (
@@ -1080,11 +1080,11 @@
 /area/template_noop)
 "WC" = (
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "WP" = (
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "WW" = (
@@ -1096,7 +1096,7 @@
 "Xv" = (
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/template_noop)
@@ -1110,7 +1110,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/access_button{
 	pixel_x = 12;
@@ -1133,7 +1133,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "Yo" = (
@@ -1159,14 +1159,14 @@
 	pixel_x = -20;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "YK" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "YM" = (
@@ -1182,7 +1182,7 @@
 	pixel_y = 12;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 "Ze" = (
@@ -1192,7 +1192,7 @@
 "ZE" = (
 /obj/structure/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /turf/simulated/floor/plating,
 /area/template_noop)
 

--- a/maps/random_ruins/exoplanets/asteroid/abandoned_prison/abandoned_prison.dmm
+++ b/maps/random_ruins/exoplanets/asteroid/abandoned_prison/abandoned_prison.dmm
@@ -1053,7 +1053,7 @@
 "nR" = (
 /obj/structure/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_prison_base";
 	master_tag = "airlock_prison_base"
 	},
@@ -1530,7 +1530,7 @@
 	pixel_y = -8
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_prison_base";
 	master_tag = "airlock_prison_base"
 	},
@@ -1862,7 +1862,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_prison_base";
 	master_tag = "airlock_prison_base"
 	},
@@ -3205,7 +3205,7 @@
 "RM" = (
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_prison_base";
 	master_tag = "airlock_prison_base"
 	},
@@ -3452,7 +3452,7 @@
 /area/abandoned_prison/exterior)
 "WL" = (
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_prison_base";
 	master_tag = "airlock_prison_base"
 	},
@@ -3542,7 +3542,7 @@
 	pixel_x = 20
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_prison_base";
 	master_tag = "airlock_prison_base"
 	},
@@ -3673,7 +3673,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_prison_base";
 	master_tag = "airlock_prison_base"
 	},
@@ -3683,7 +3683,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	name = "airlock_prison_base";
 	master_tag = "airlock_prison_base"
 	},

--- a/maps/random_ruins/exoplanets/asteroid/listening_post/listening_post_unique.dm
+++ b/maps/random_ruins/exoplanets/asteroid/listening_post/listening_post_unique.dm
@@ -41,7 +41,7 @@
 /area/listening_post/servers
 	name = "Listening Post Installation - Server Room"
 
-/obj/effect/map_effect/marker/airlock/listening_post
+/obj/effect/map_effect/marker/airlock/external/listening_post
 	name = "Entrance"
 	master_tag = "airlock_listening_post_ruin"
 	cycle_to_external_air = TRUE

--- a/maps/random_ruins/exoplanets/asteroid/listening_post/listening_post_unique.dmm
+++ b/maps/random_ruins/exoplanets/asteroid/listening_post/listening_post_unique.dmm
@@ -13,7 +13,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock/listening_post,
+/obj/effect/map_effect/marker/airlock/external/listening_post,
 /obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor,
 /area/listening_post/entrance)
@@ -22,7 +22,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock/listening_post,
+/obj/effect/map_effect/marker/airlock/external/listening_post,
 /obj/structure/machinery/airlock_sensor{
 	frequency = 1351;
 	id_tag = "listening_post_sensor";
@@ -35,7 +35,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock/listening_post,
+/obj/effect/map_effect/marker/airlock/external/listening_post,
 /obj/structure/machinery/light/small{
 	dir = 4;
 	must_start_working = 1
@@ -79,7 +79,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/listening_post/entrance)
 "al" = (
-/obj/effect/map_effect/marker/airlock/listening_post,
+/obj/effect/map_effect/marker/airlock/external/listening_post,
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
@@ -97,7 +97,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/listening_post,
+/obj/effect/map_effect/marker/airlock/external/listening_post,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/airlock_sensor/airlock_exterior{
 	pixel_y = 26
@@ -125,7 +125,7 @@
 /turf/simulated/wall/r_wall,
 /area/listening_post/entrance)
 "as" = (
-/obj/effect/map_effect/marker/airlock/listening_post,
+/obj/effect/map_effect/marker/airlock/external/listening_post,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/airlock_sensor/airlock_interior{
 	pixel_y = 24;
@@ -146,7 +146,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/listening_post/entrance)
 "av" = (
-/obj/effect/map_effect/marker/airlock/listening_post,
+/obj/effect/map_effect/marker/airlock/external/listening_post,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/access_button{
 	pixel_x = -26;
@@ -245,7 +245,7 @@
 "aN" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock/listening_post,
+/obj/effect/map_effect/marker/airlock/external/listening_post,
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	frequency = 1351;
 	id_tag = "listening_post_airlock";
@@ -374,7 +374,7 @@
 "bi" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock/listening_post,
+/obj/effect/map_effect/marker/airlock/external/listening_post,
 /obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor,
 /area/listening_post/entrance)
@@ -409,7 +409,7 @@
 "bs" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock/listening_post,
+/obj/effect/map_effect/marker/airlock/external/listening_post,
 /obj/structure/machinery/light/small{
 	dir = 4;
 	must_start_working = 1
@@ -924,7 +924,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/listening_post/washroom)
 "sl" = (
-/obj/effect/map_effect/marker/airlock/listening_post,
+/obj/effect/map_effect/marker/airlock/external/listening_post,
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/blood/drip,
@@ -1430,7 +1430,7 @@
 /turf/simulated/floor/exoplanet/plating,
 /area/listening_post/entrance)
 "MY" = (
-/obj/effect/map_effect/marker/airlock/listening_post,
+/obj/effect/map_effect/marker/airlock/external/listening_post,
 /obj/random/dirt_75,
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled/dark/full,

--- a/maps/random_ruins/exoplanets/burzsia/burzsia_mining.dm
+++ b/maps/random_ruins/exoplanets/burzsia/burzsia_mining.dm
@@ -43,7 +43,7 @@
 	icon_state = "anolab"
 
 // Airlock Marker
-/obj/effect/map_effect/marker/airlock/burzsia_mining
+/obj/effect/map_effect/marker/airlock/external/burzsia_mining
 	name = "Primary Airlock"
 	master_tag = "airlock_burzsia_mining_primary"
 	cycle_to_external_air = TRUE

--- a/maps/random_ruins/exoplanets/burzsia/burzsia_mining.dmm
+++ b/maps/random_ruins/exoplanets/burzsia/burzsia_mining.dmm
@@ -255,8 +255,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/burzsia_mining)
 "hs" = (
-/obj/effect/map_effect/marker/airlock/burzsia_mining,
-/obj/effect/map_effect/marker/airlock/burzsia_mining,
+/obj/effect/map_effect/marker/airlock/external/burzsia_mining,
+/obj/effect/map_effect/marker/airlock/external/burzsia_mining,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/door/airlock/external,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux,
@@ -341,7 +341,7 @@
 /turf/simulated/floor/plating,
 /area/burzsia_mining/engineering)
 "jA" = (
-/obj/effect/map_effect/marker/airlock/burzsia_mining,
+/obj/effect/map_effect/marker/airlock/external/burzsia_mining,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
@@ -638,7 +638,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/burzsia_mining/mess_hall)
 "pK" = (
-/obj/effect/map_effect/marker/airlock/burzsia_mining,
+/obj/effect/map_effect/marker/airlock/external/burzsia_mining,
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 8
 	},
@@ -894,7 +894,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/burzsia_mining)
 "vt" = (
-/obj/effect/map_effect/marker/airlock/burzsia_mining,
+/obj/effect/map_effect/marker/airlock/external/burzsia_mining,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux,
 /obj/structure/machinery/airlock_sensor{
@@ -1185,14 +1185,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/burzsia_mining/foreman)
 "Bn" = (
-/obj/effect/map_effect/marker/airlock/burzsia_mining,
+/obj/effect/map_effect/marker/airlock/external/burzsia_mining,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/burzsia_mining/mining)
 "Bo" = (
-/obj/effect/map_effect/marker/airlock/burzsia_mining,
+/obj/effect/map_effect/marker/airlock/external/burzsia_mining,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/door/airlock/external,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden,
@@ -1280,8 +1280,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/burzsia_mining/foreman)
 "DG" = (
-/obj/effect/map_effect/marker/airlock/burzsia_mining,
-/obj/effect/map_effect/marker/airlock/burzsia_mining,
+/obj/effect/map_effect/marker/airlock/external/burzsia_mining,
+/obj/effect/map_effect/marker/airlock/external/burzsia_mining,
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 8
 	},
@@ -1528,7 +1528,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/burzsia_mining)
 "JL" = (
-/obj/effect/map_effect/marker/airlock/burzsia_mining,
+/obj/effect/map_effect/marker/airlock/external/burzsia_mining,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
@@ -1644,7 +1644,7 @@
 	dir = 8;
 	must_start_working = 1
 	},
-/obj/effect/map_effect/marker/airlock/burzsia_mining,
+/obj/effect/map_effect/marker/airlock/external/burzsia_mining,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
@@ -1661,7 +1661,7 @@
 /turf/simulated/floor/plating,
 /area/burzsia_mining/mining)
 "MA" = (
-/obj/effect/map_effect/marker/airlock/burzsia_mining,
+/obj/effect/map_effect/marker/airlock/external/burzsia_mining,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 6
 	},
@@ -1834,7 +1834,7 @@
 /turf/simulated/floor,
 /area/burzsia_mining/engineering)
 "Qk" = (
-/obj/effect/map_effect/marker/airlock/burzsia_mining,
+/obj/effect/map_effect/marker/airlock/external/burzsia_mining,
 /obj/effect/map_effect/marker_helper/airlock/out,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
@@ -1976,7 +1976,7 @@
 	dir = 10
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/burzsia_mining,
+/obj/effect/map_effect/marker/airlock/external/burzsia_mining,
 /obj/structure/machinery/airlock_sensor{
 	dir = 1;
 	pixel_y = -20;
@@ -1986,7 +1986,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/burzsia_mining/mining)
 "TM" = (
-/obj/effect/map_effect/marker/airlock/burzsia_mining,
+/obj/effect/map_effect/marker/airlock/external/burzsia_mining,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},

--- a/maps/random_ruins/exoplanets/desert/desert_comms/desert_comms.dmm
+++ b/maps/random_ruins/exoplanets/desert/desert_comms/desert_comms.dmm
@@ -64,7 +64,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/full,
@@ -827,7 +827,7 @@
 	pixel_y = 7;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/decal/cleanable/dirt,
@@ -894,7 +894,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/full,
 /area/desert_comms)
@@ -1208,7 +1208,7 @@
 	pixel_y = 7;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/decal/cleanable/dirt,
@@ -1304,7 +1304,7 @@
 /area/desert_comms)
 "JX" = (
 /obj/structure/machinery/atmospherics/pipe/manifold/visible,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 4
 	},
@@ -1660,7 +1660,7 @@
 	dir = 4;
 	pixel_x = -25
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/full,
 /area/desert_comms)
@@ -2026,7 +2026,7 @@
 /area/desert_comms)
 "XR" = (
 /obj/structure/machinery/atmospherics/pipe/manifold4w/visible,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 4
 	},
@@ -2052,7 +2052,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/full,
 /area/desert_comms)

--- a/maps/random_ruins/exoplanets/grove/sdf_outpost/sdf_outpost.dmm
+++ b/maps/random_ruins/exoplanets/grove/sdf_outpost/sdf_outpost.dmm
@@ -94,7 +94,7 @@
 /turf/simulated/floor/exoplanet/plating,
 /area/grove_sdf_outpost)
 "hD" = (
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -455,7 +455,7 @@
 /obj/structure/machinery/airlock_sensor{
 	pixel_y = 38
 	},
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/decal/cleanable/dirt,
@@ -650,7 +650,7 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -836,7 +836,7 @@
 /turf/simulated/floor/tiled,
 /area/grove_sdf_outpost)
 "SE" = (
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
@@ -849,7 +849,7 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock,
+/obj/effect/map_effect/marker/airlock/external,
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/full,
 /area/grove_sdf_outpost)

--- a/maps/random_ruins/exoplanets/haneunim/haneunim_mining.dmm
+++ b/maps/random_ruins/exoplanets/haneunim/haneunim_mining.dmm
@@ -51,7 +51,7 @@
 /turf/simulated/floor/airless,
 /area/haneunim_mining)
 "da" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_haneunim_mining";
 	name = "airlock_haneunim_mining";
 	frequency = 1131
@@ -144,7 +144,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_haneunim_mining";
 	name = "airlock_haneunim_mining";
 	frequency = 1131
@@ -202,7 +202,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_haneunim_mining";
 	name = "airlock_haneunim_mining";
 	frequency = 1131
@@ -427,7 +427,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_haneunim_mining";
 	name = "airlock_haneunim_mining";
 	frequency = 1131
@@ -463,7 +463,7 @@
 /area/haneunim_mining)
 "Ck" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_haneunim_mining";
 	name = "airlock_haneunim_mining";
 	frequency = 1131
@@ -500,7 +500,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_haneunim_mining";
 	name = "airlock_haneunim_mining";
 	frequency = 1131
@@ -584,7 +584,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_haneunim_mining";
 	name = "airlock_haneunim_mining";
 	frequency = 1131
@@ -800,7 +800,7 @@
 /obj/structure/machinery/light/colored/dying{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_haneunim_mining";
 	name = "airlock_haneunim_mining";
 	frequency = 1131

--- a/maps/random_ruins/exoplanets/new_gibson/gibson_resupply.dmm
+++ b/maps/random_ruins/exoplanets/new_gibson/gibson_resupply.dmm
@@ -24,7 +24,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "gibson_resupply";
 	name = "gibson_resupply";
 	req_one_access = null
@@ -39,7 +39,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "gibson_resupply";
 	name = "gibson_resupply";
 	req_one_access = null
@@ -102,7 +102,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "gibson_resupply";
 	name = "gibson_resupply";
 	req_one_access = null
@@ -153,7 +153,7 @@
 	pixel_y = 5
 	},
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "gibson_resupply";
 	name = "gibson_resupply";
 	req_one_access = null
@@ -250,7 +250,7 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "gibson_resupply";
 	name = "gibson_resupply";
 	req_one_access = null
@@ -266,7 +266,7 @@
 /area/gibson_resupply)
 "PV" = (
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "gibson_resupply";
 	name = "gibson_resupply";
 	req_one_access = null
@@ -285,7 +285,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "gibson_resupply";
 	name = "gibson_resupply";
 	req_one_access = null
@@ -313,7 +313,7 @@
 /area/gibson_resupply)
 "UP" = (
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden/aux,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "gibson_resupply";
 	name = "gibson_resupply";
 	req_one_access = null

--- a/maps/random_ruins/exoplanets/raskara/raskara_okon.dmm
+++ b/maps/random_ruins/exoplanets/raskara/raskara_okon.dmm
@@ -574,7 +574,7 @@
 	},
 /area/raskara_okon)
 "hA" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_okon";
 	name = "airlock_okon";
 	frequency = 1004
@@ -2226,7 +2226,7 @@
 	},
 /area/raskara_okon/mess_hall)
 "AU" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_okon";
 	name = "airlock_okon";
 	frequency = 1004
@@ -2250,7 +2250,7 @@
 	},
 /area/raskara_okon)
 "Br" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_okon";
 	name = "airlock_okon";
 	frequency = 1004
@@ -2282,7 +2282,7 @@
 	},
 /area/raskara_okon/eva)
 "BU" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_okon";
 	name = "airlock_okon";
 	frequency = 1004
@@ -2577,7 +2577,7 @@
 	},
 /area/raskara_okon/laboratory)
 "Gy" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_okon";
 	name = "airlock_okon";
 	frequency = 1004
@@ -2988,7 +2988,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_okon";
 	name = "airlock_okon";
 	frequency = 1004
@@ -3614,7 +3614,7 @@
 	},
 /area/raskara_okon)
 "Ux" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_okon";
 	name = "airlock_okon";
 	frequency = 1004
@@ -3867,7 +3867,7 @@
 	},
 /area/raskara_okon/medbay)
 "Xk" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_okon";
 	name = "airlock_okon";
 	frequency = 1004

--- a/maps/random_ruins/exoplanets/uueoaesa/heph_mining_station.dmm
+++ b/maps/random_ruins/exoplanets/uueoaesa/heph_mining_station.dmm
@@ -388,7 +388,7 @@
 	},
 /area/heph_mining_station/mess)
 "ga" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_heph_uueoa";
 	name = "airlock_heph_uueoa";
@@ -1420,7 +1420,7 @@
 /turf/simulated/wall/shuttle/raider,
 /area/heph_mining_station/eva)
 "tH" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_heph_uueoa";
 	name = "airlock_heph_uueoa";
@@ -1463,7 +1463,7 @@
 /turf/simulated/wall/shuttle/raider,
 /area/heph_mining_station/mining)
 "vT" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_heph_uueoa";
 	name = "airlock_heph_uueoa";
@@ -1621,7 +1621,7 @@
 /turf/simulated/floor/airless,
 /area/heph_mining_station/mining)
 "yd" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_heph_uueoa";
 	name = "airlock_heph_uueoa";
@@ -1758,7 +1758,7 @@
 	},
 /area/heph_mining_station/storage)
 "zY" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_heph_uueoa";
 	name = "airlock_heph_uueoa";
@@ -2255,7 +2255,7 @@
 	},
 /area/heph_mining_station/entry)
 "IM" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_heph_uueoa";
 	name = "airlock_heph_uueoa";
@@ -2843,7 +2843,7 @@
 	},
 /area/heph_mining_station/mining)
 "Sk" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_heph_uueoa";
 	name = "airlock_heph_uueoa";
@@ -3193,7 +3193,7 @@
 	},
 /area/heph_mining_station/entry)
 "Zt" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_heph_uueoa";
 	name = "airlock_heph_uueoa";

--- a/maps/random_ruins/exoplanets/uueoaesa/heph_survey_post.dmm
+++ b/maps/random_ruins/exoplanets/uueoaesa/heph_survey_post.dmm
@@ -124,7 +124,7 @@
 	pixel_y = 32;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_heph_ruin";
 	name = "airlock_heph_ruin"
@@ -309,7 +309,7 @@
 /obj/structure/machinery/light/colored/dying{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_heph_ruin";
 	name = "airlock_heph_ruin"
@@ -341,7 +341,7 @@
 	pixel_x = -20;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_heph_ruin";
 	name = "airlock_heph_ruin"
@@ -422,7 +422,7 @@
 /turf/simulated/floor/plating,
 /area/heph_survey_post)
 "sc" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_heph_ruin";
 	name = "airlock_heph_ruin"
@@ -454,7 +454,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_heph_ruin";
 	name = "airlock_heph_ruin"
@@ -856,7 +856,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_heph_ruin";
 	name = "airlock_heph_ruin"
@@ -1072,7 +1072,7 @@
 	pixel_y = -6;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_heph_ruin";
 	name = "airlock_heph_ruin"
@@ -1152,7 +1152,7 @@
 	pixel_x = 28;
 	pixel_y = -8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_heph_ruin";
 	name = "airlock_heph_ruin"

--- a/maps/random_ruins/exoplanets/uueoaesa/miners_guild_outpost.dmm
+++ b/maps/random_ruins/exoplanets/uueoaesa/miners_guild_outpost.dmm
@@ -173,7 +173,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_guild_uueoa";
 	name = "airlock_guild_uueoa";
 	frequency = 1712
@@ -254,7 +254,7 @@
 	dir = 4
 	},
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_guild_uueoa";
 	name = "airlock_guild_uueoa";
 	frequency = 1712
@@ -287,7 +287,7 @@
 	},
 /area/miners_guild_outpost/quarters)
 "eg" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_guild_uueoa";
 	name = "airlock_guild_uueoa";
 	frequency = 1712
@@ -888,7 +888,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_guild_uueoa";
 	name = "airlock_guild_uueoa";
 	frequency = 1712
@@ -1179,7 +1179,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_guild_uueoa";
 	name = "airlock_guild_uueoa";
 	frequency = 1712
@@ -1493,7 +1493,7 @@
 /obj/structure/machinery/light{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_guild_uueoa";
 	name = "airlock_guild_uueoa";
 	frequency = 1712
@@ -1557,7 +1557,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_guild_uueoa";
 	name = "airlock_guild_uueoa";
 	frequency = 1712
@@ -1862,7 +1862,7 @@
 	pixel_x = -12;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_guild_uueoa";
 	name = "airlock_guild_uueoa";
 	frequency = 1712

--- a/maps/random_ruins/exoplanets/uueoaesa/pid_kois_farm.dmm
+++ b/maps/random_ruins/exoplanets/uueoaesa/pid_kois_farm.dmm
@@ -97,7 +97,7 @@
 /turf/simulated/floor/tiled/white,
 /area/pid_kois_farm)
 "gR" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1889;
 	master_tag = "airlock_klax";
 	name = "airlock_klax"
@@ -194,7 +194,7 @@
 /turf/simulated/floor/tiled,
 /area/pid_kois_farm)
 "kv" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1889;
 	master_tag = "airlock_klax";
 	name = "airlock_klax"
@@ -237,7 +237,7 @@
 /turf/simulated/floor/tiled,
 /area/pid_kois_farm)
 "mU" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1889;
 	master_tag = "airlock_klax";
 	name = "airlock_klax"
@@ -407,7 +407,7 @@
 /turf/simulated/floor/tiled,
 /area/pid_kois_farm)
 "tu" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1889;
 	master_tag = "airlock_klax";
 	name = "airlock_klax"
@@ -592,7 +592,7 @@
 /turf/simulated/floor/tiled,
 /area/pid_kois_farm)
 "Bn" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1889;
 	master_tag = "airlock_klax";
 	name = "airlock_klax"
@@ -867,7 +867,7 @@
 /turf/simulated/floor/tiled,
 /area/pid_kois_farm)
 "Pf" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1889;
 	master_tag = "airlock_klax";
 	name = "airlock_klax"
@@ -887,7 +887,7 @@
 /turf/simulated/floor/tiled,
 /area/pid_kois_farm)
 "Qh" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1889;
 	master_tag = "airlock_klax";
 	name = "airlock_klax"

--- a/maps/random_ruins/exoplanets/uueoaesa/sol_listening_post.dmm
+++ b/maps/random_ruins/exoplanets/uueoaesa/sol_listening_post.dmm
@@ -41,7 +41,7 @@
 /turf/simulated/wall/r_wall,
 /area/sol_listening_post)
 "cC" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2117;
 	master_tag = "airlock_sol_uueoa";
 	name = "airlock_sol_uueoa"
@@ -181,7 +181,7 @@
 /turf/simulated/floor/bluegrid/server,
 /area/sol_listening_post)
 "kF" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2117;
 	master_tag = "airlock_sol_uueoa";
 	name = "airlock_sol_uueoa"
@@ -259,7 +259,7 @@
 /turf/template_noop,
 /area/template_noop)
 "mY" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2117;
 	master_tag = "airlock_sol_uueoa";
 	name = "airlock_sol_uueoa"
@@ -526,7 +526,7 @@
 /turf/simulated/floor/shuttle/dark_blue,
 /area/sol_listening_post)
 "Bx" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2117;
 	master_tag = "airlock_sol_uueoa";
 	name = "airlock_sol_uueoa"
@@ -671,7 +671,7 @@
 /area/sol_listening_post)
 "JX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2117;
 	master_tag = "airlock_sol_uueoa";
 	name = "airlock_sol_uueoa"
@@ -788,7 +788,7 @@
 /turf/simulated/floor/tiled,
 /area/sol_listening_post)
 "RY" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2117;
 	master_tag = "airlock_sol_uueoa";
 	name = "airlock_sol_uueoa"

--- a/maps/runtime/runtime.dmm
+++ b/maps/runtime/runtime.dmm
@@ -1319,7 +1319,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "runtime_airlock_1_1";
 	name = "runtime_airlock_1_1"
 	},
@@ -2942,7 +2942,7 @@
 /turf/simulated/floor/plating,
 /area/runtime/floor_one/atmospherics)
 "nh" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "runtime_airlock_1_1";
 	name = "runtime_airlock_1_1"
 	},
@@ -3664,7 +3664,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "runtime_airlock_1_1";
 	name = "runtime_airlock_1_1"
 	},
@@ -3995,7 +3995,7 @@
 /turf/unsimulated/floor/dark_monotile,
 /area/runtime/floor_one/atmospherics)
 "tw" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "runtime_airlock_1_1";
 	name = "runtime_airlock_1_1"
 	},
@@ -4088,7 +4088,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "runtime_airlock_1_1";
 	name = "runtime_airlock_1_1"
 	},
@@ -4617,7 +4617,7 @@
 /turf/simulated/floor/reinforced/n20,
 /area/runtime/floor_one/atmospherics)
 "wY" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "runtime_airlock_1_1";
 	name = "runtime_airlock_1_1"
 	},
@@ -4770,7 +4770,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/runtime/floor_two/comms)
 "xU" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "runtime_airlock_1_1";
 	name = "runtime_airlock_1_1"
 	},
@@ -5527,7 +5527,7 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "runtime_airlock_1_1";
 	name = "runtime_airlock_1_1"
 	},
@@ -6000,7 +6000,7 @@
 /turf/simulated/floor/tiled/gridded,
 /area/runtime/floor_one/atmospherics)
 "Fm" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "runtime_airlock_1_1";
 	name = "runtime_airlock_1_1"
 	},
@@ -8565,7 +8565,7 @@
 /turf/space,
 /area/runtime/exterior)
 "TQ" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "runtime_airlock_1_1";
 	name = "runtime_airlock_1_1"
 	},

--- a/maps/sccv_horizon/sccv_horizon.dmm
+++ b/maps/sccv_horizon/sccv_horizon.dmm
@@ -988,14 +988,14 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sccv_intrepid_port";
 	name = "sccv_intrepid_port"
 	},
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 23
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sccv_intrepid_port";
 	name = "sccv_intrepid_port";
 	req_one_access = null
@@ -1176,7 +1176,7 @@
 /obj/structure/bed/handrail{
 	pixel_y = 2
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_shuttle_quark_aux";
 	name = "airlock_shuttle_quark_aux";
 	req_one_access = list(65,47,74)
@@ -1517,7 +1517,7 @@
 	pixel_y = 28;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_shuttle_quark_aux";
 	name = "airlock_shuttle_quark_aux";
 	req_one_access = list(65,47,74)
@@ -1794,7 +1794,7 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3002;
 	master_tag = "airlock_horizon_deck_2_port_1";
 	name = "airlock_horizon_deck_2_port_1"
@@ -1928,7 +1928,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3002;
 	master_tag = "airlock_horizon_deck_2_port_1";
 	name = "airlock_horizon_deck_2_port_1"
@@ -3092,7 +3092,7 @@
 	pixel_x = 12;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_propulsion_2";
 	name = "airlock_horizon_deck_1_aft_propulsion_2"
@@ -3482,7 +3482,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sccv_intrepid_starboard";
 	name = "sccv_intrepid_starboard";
 	req_one_access = null
@@ -4037,7 +4037,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2003;
 	master_tag = "airlock_horizon_deck_2_aft_indra";
 	name = "airlock_horizon_deck_2_aft_indra"
@@ -5685,7 +5685,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3002;
 	master_tag = "airlock_horizon_deck_2_port_1";
 	name = "airlock_horizon_deck_2_port_1"
@@ -10770,7 +10770,7 @@
 	dir = 4;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_propulsion_2";
 	name = "airlock_horizon_deck_1_aft_propulsion_2"
@@ -11042,7 +11042,7 @@
 /area/horizon/engineering/break_room)
 "bsu" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_horizon_bunker";
 	name = "airlock_horizon_bunker";
 	frequency = 1109;
@@ -12662,7 +12662,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_port_1";
 	name = "airlock_horizon_deck_1_aft_port_1"
@@ -16033,7 +16033,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_port_1";
 	name = "airlock_horizon_deck_1_aft_port_1"
@@ -17820,7 +17820,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "airlock_horizon_deck_1_fore_1";
 	name = "airlock_horizon_deck_1_fore_1"
@@ -18287,7 +18287,7 @@
 	},
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sccv_intrepid_starboard";
 	name = "sccv_intrepid_starboard";
 	req_one_access = null
@@ -19656,7 +19656,7 @@
 /area/shuttle/mercenary)
 "cBI" = (
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1001;
 	master_tag = "airlock_horizon_deck_3_aft_1";
 	name = "airlock_horizon_deck_3_aft_1"
@@ -20853,7 +20853,7 @@
 	pixel_x = 28;
 	pixel_y = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_propulsion_1";
 	name = "airlock_horizon_deck_1_aft_propulsion_1"
@@ -23129,7 +23129,7 @@
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "airlock_horizon_deck_1_fore_1";
 	name = "airlock_horizon_deck_1_fore_1"
@@ -24651,7 +24651,7 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2005;
 	master_tag = "airlock_horizon_deck_2_aft_sm";
 	name = "airlock_horizon_deck_2_aft_sm"
@@ -25542,7 +25542,7 @@
 	id = "intrepid_bay_outer";
 	name = "Intrepid Shutter"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sccv_intrepid_port";
 	name = "sccv_intrepid_port";
 	req_one_access = null
@@ -26734,7 +26734,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1001;
 	master_tag = "airlock_horizon_deck_3_aft_1";
 	name = "airlock_horizon_deck_3_aft_1"
@@ -29101,7 +29101,7 @@
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 23
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sccv_intrepid_starboard";
 	name = "sccv_intrepid_starboard";
 	req_one_access = null
@@ -30482,7 +30482,7 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2001;
 	master_tag = "airlock_horizon_deck_2_starboard_aft";
 	name = "airlock_horizon_deck_2_starboard_aft"
@@ -32991,7 +32991,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_propulsion_1";
 	name = "airlock_horizon_deck_1_aft_propulsion_1"
@@ -33010,7 +33010,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_horizon_bunker";
 	name = "airlock_horizon_bunker";
 	frequency = 1109;
@@ -34905,7 +34905,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_horizon_deck_3_aft_1";
 	name = "airlock_horizon_deck_3_aft_1";
 	frequency = 1001
@@ -36795,7 +36795,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "airlock_horizon_deck_1_fore_1";
 	name = "airlock_horizon_deck_1_fore_1"
@@ -43840,7 +43840,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_propulsion_2";
 	name = "airlock_horizon_deck_1_aft_propulsion_2"
@@ -45886,7 +45886,7 @@
 	dir = 1;
 	pixel_y = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_port_1";
 	name = "airlock_horizon_deck_1_aft_port_1"
@@ -49301,7 +49301,7 @@
 	pixel_x = -20;
 	pixel_y = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_starboard_1";
 	name = "airlock_horizon_deck_1_starboard_1"
@@ -49670,7 +49670,7 @@
 /obj/structure/machinery/access_button{
 	pixel_x = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1002;
 	master_tag = "airlock_horizon_deck_3_fore_starboard_1";
 	name = "airlock_horizon_deck_3_fore_starboard_1"
@@ -58809,7 +58809,7 @@
 /area/horizon/maintenance/deck_1/medical/cryo)
 "hDG" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3002;
 	master_tag = "airlock_horizon_deck_2_port_1";
 	name = "airlock_horizon_deck_2_port_1"
@@ -59210,7 +59210,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2001;
 	master_tag = "airlock_horizon_deck_2_starboard_aft";
 	name = "airlock_horizon_deck_2_starboard_aft"
@@ -60446,7 +60446,7 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_propulsion_1";
 	name = "airlock_horizon_deck_1_aft_propulsion_1"
@@ -65600,7 +65600,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_horizon_bunker";
 	name = "airlock_horizon_bunker";
 	frequency = 1109;
@@ -67727,7 +67727,7 @@
 	},
 /obj/structure/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_horizon_deck_3_aft_1";
 	name = "airlock_horizon_deck_3_aft_1";
 	frequency = 1001
@@ -68064,7 +68064,7 @@
 /area/horizon/maintenance/deck_2/wing/starboard)
 "iPo" = (
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2001;
 	master_tag = "airlock_horizon_deck_2_starboard_aft";
 	name = "airlock_horizon_deck_2_starboard_aft"
@@ -72806,7 +72806,7 @@
 /turf/simulated/floor/plating,
 /area/horizon/engineering/reactor/supermatter/mainchamber)
 "juR" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1002;
 	master_tag = "airlock_horizon_deck_3_fore_starboard_1";
 	name = "airlock_horizon_deck_3_fore_starboard_1"
@@ -74924,7 +74924,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1001;
 	master_tag = "airlock_horizon_deck_3_aft_1";
 	name = "airlock_horizon_deck_3_aft_1"
@@ -76675,7 +76675,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_shuttle_quark_aux";
 	name = "airlock_shuttle_quark_aux";
 	req_one_access = list(65,47,74)
@@ -83881,7 +83881,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1002;
 	master_tag = "airlock_horizon_deck_3_fore_starboard_1";
 	name = "airlock_horizon_deck_3_fore_starboard_1"
@@ -84887,7 +84887,7 @@
 "kWg" = (
 /obj/structure/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2005;
 	master_tag = "airlock_horizon_deck_2_aft_sm";
 	name = "airlock_horizon_deck_2_aft_sm"
@@ -85124,7 +85124,7 @@
 /area/horizon/operations/warehouse)
 "kXP" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_starboard_1";
 	name = "airlock_horizon_deck_1_starboard_1"
@@ -86051,7 +86051,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "airlock_horizon_deck_1_fore_1";
 	name = "airlock_horizon_deck_1_fore_1"
@@ -91359,7 +91359,7 @@
 	dir = 1
 	},
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_port_1";
 	name = "airlock_horizon_deck_1_aft_port_1"
@@ -96046,7 +96046,7 @@
 /obj/structure/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_starboard_1";
 	name = "airlock_horizon_deck_1_starboard_1"
@@ -98183,7 +98183,7 @@
 	id = "intrepid_bay_outer";
 	name = "Intrepid Shutter"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sccv_intrepid_port";
 	name = "sccv_intrepid_port";
 	req_one_access = null
@@ -98360,7 +98360,7 @@
 /area/horizon/rnd/test_range)
 "mKh" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "airlock_horizon_deck_1_fore_1";
 	name = "airlock_horizon_deck_1_fore_1"
@@ -99959,7 +99959,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_port_1";
 	name = "airlock_horizon_deck_1_aft_port_1"
@@ -101810,7 +101810,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_horizon_bunker";
 	name = "airlock_horizon_bunker";
 	frequency = 1109;
@@ -102488,7 +102488,7 @@
 	pixel_x = -12;
 	pixel_y = -28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_propulsion_2";
 	name = "airlock_horizon_deck_1_aft_propulsion_2"
@@ -103278,7 +103278,7 @@
 /area/horizon/holodeck/source_biesel)
 "ntb" = (
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3002;
 	master_tag = "airlock_horizon_deck_2_port_1";
 	name = "airlock_horizon_deck_2_port_1"
@@ -106244,7 +106244,7 @@
 	dir = 4;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_propulsion_1";
 	name = "airlock_horizon_deck_1_aft_propulsion_1"
@@ -107771,7 +107771,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/shuttle/mining)
 "nXR" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2001;
 	master_tag = "airlock_horizon_deck_2_starboard_aft";
 	name = "airlock_horizon_deck_2_starboard_aft"
@@ -109122,7 +109122,7 @@
 	pixel_x = -12;
 	pixel_y = -28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_port_1";
 	name = "airlock_horizon_deck_1_aft_port_1"
@@ -111726,7 +111726,7 @@
 /area/horizon/maintenance/substation/wing_port)
 "oxQ" = (
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2005;
 	master_tag = "airlock_horizon_deck_2_aft_sm";
 	name = "airlock_horizon_deck_2_aft_sm"
@@ -115675,7 +115675,7 @@
 	id = "intrepid_bay_outer";
 	name = "Intrepid Shutter"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sccv_intrepid_starboard";
 	name = "sccv_intrepid_starboard";
 	req_one_access = null
@@ -119242,7 +119242,7 @@
 /area/horizon/hangar/control)
 "pvV" = (
 /obj/structure/machinery/atmospherics/pipe/manifold4w/hidden,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_port_1";
 	name = "airlock_horizon_deck_1_aft_port_1"
@@ -119986,7 +119986,7 @@
 	pixel_x = -28;
 	pixel_y = 12
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3002;
 	master_tag = "airlock_horizon_deck_2_port_1";
 	name = "airlock_horizon_deck_2_port_1"
@@ -120312,7 +120312,7 @@
 	pixel_x = 20;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2001;
 	master_tag = "airlock_horizon_deck_2_starboard_aft";
 	name = "airlock_horizon_deck_2_starboard_aft"
@@ -120418,7 +120418,7 @@
 /area/horizon/rnd/telesci)
 "pCL" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2005;
 	master_tag = "airlock_horizon_deck_2_aft_sm";
 	name = "airlock_horizon_deck_2_aft_sm"
@@ -123586,7 +123586,7 @@
 /obj/structure/machinery/access_button{
 	pixel_x = -28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2001;
 	master_tag = "airlock_horizon_deck_2_starboard_aft";
 	name = "airlock_horizon_deck_2_starboard_aft"
@@ -124332,7 +124332,7 @@
 	pixel_x = 28;
 	pixel_y = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_port_1";
 	name = "airlock_horizon_deck_1_aft_port_1"
@@ -125324,7 +125324,7 @@
 	pixel_x = -28;
 	pixel_y = 12
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_propulsion_1";
 	name = "airlock_horizon_deck_1_aft_propulsion_1"
@@ -129476,7 +129476,7 @@
 /obj/structure/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1001;
 	master_tag = "airlock_horizon_deck_3_aft_1";
 	name = "airlock_horizon_deck_3_aft_1"
@@ -129705,7 +129705,7 @@
 /obj/structure/machinery/access_button{
 	pixel_x = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2005;
 	master_tag = "airlock_horizon_deck_2_aft_sm";
 	name = "airlock_horizon_deck_2_aft_sm"
@@ -132167,7 +132167,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sccv_intrepid_port";
 	name = "sccv_intrepid_port"
 	},
@@ -132175,7 +132175,7 @@
 	pixel_y = -24;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sccv_intrepid_port";
 	name = "sccv_intrepid_port";
 	req_one_access = null
@@ -133674,7 +133674,7 @@
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2005;
 	master_tag = "airlock_horizon_deck_2_aft_sm";
 	name = "airlock_horizon_deck_2_aft_sm"
@@ -135283,7 +135283,7 @@
 	pixel_y = -24;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sccv_intrepid_starboard";
 	name = "sccv_intrepid_starboard";
 	req_one_access = null
@@ -137170,7 +137170,7 @@
 	pixel_x = -20;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "airlock_horizon_deck_1_fore_1";
 	name = "airlock_horizon_deck_1_fore_1"
@@ -138577,7 +138577,7 @@
 	},
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sccv_intrepid_port";
 	name = "sccv_intrepid_port";
 	req_one_access = null
@@ -140998,7 +140998,7 @@
 	dir = 4;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_horizon_deck_3_aft_1";
 	name = "airlock_horizon_deck_3_aft_1";
 	frequency = 1001
@@ -143163,7 +143163,7 @@
 	dir = 4;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3002;
 	master_tag = "airlock_horizon_deck_2_port_1";
 	name = "airlock_horizon_deck_2_port_1"
@@ -144228,7 +144228,7 @@
 /area/horizon/maintenance/deck_2/wing/starboard)
 "sDk" = (
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1002;
 	master_tag = "airlock_horizon_deck_3_fore_starboard_1";
 	name = "airlock_horizon_deck_3_fore_starboard_1"
@@ -147282,7 +147282,7 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 3002;
 	master_tag = "airlock_horizon_deck_2_port_1";
 	name = "airlock_horizon_deck_2_port_1"
@@ -148242,7 +148242,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sccv_intrepid_port";
 	name = "sccv_intrepid_port";
 	req_one_access = null
@@ -149578,7 +149578,7 @@
 	frequency = 1380;
 	id_tag = "centcom_shuttle_dock_pump"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_horizon_bunker";
 	name = "airlock_horizon_bunker";
 	frequency = 1109;
@@ -149685,7 +149685,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1002;
 	master_tag = "airlock_horizon_deck_3_fore_starboard_1";
 	name = "airlock_horizon_deck_3_fore_starboard_1"
@@ -152733,7 +152733,7 @@
 	pixel_x = 6;
 	pixel_y = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2003;
 	master_tag = "airlock_horizon_deck_2_aft_indra";
 	name = "airlock_horizon_deck_2_aft_indra"
@@ -153380,7 +153380,7 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2001;
 	master_tag = "airlock_horizon_deck_2_starboard_aft";
 	name = "airlock_horizon_deck_2_starboard_aft"
@@ -153409,7 +153409,7 @@
 /obj/structure/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2003;
 	master_tag = "airlock_horizon_deck_2_aft_indra";
 	name = "airlock_horizon_deck_2_aft_indra"
@@ -160294,7 +160294,7 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2005;
 	master_tag = "airlock_horizon_deck_2_aft_sm";
 	name = "airlock_horizon_deck_2_aft_sm"
@@ -161117,7 +161117,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/shuttle/intrepid/flight_deck)
 "uMa" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1002;
 	master_tag = "airlock_horizon_deck_3_fore_starboard_1";
 	name = "airlock_horizon_deck_3_fore_starboard_1"
@@ -163876,7 +163876,7 @@
 	pixel_x = 20;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2005;
 	master_tag = "airlock_horizon_deck_2_aft_sm";
 	name = "airlock_horizon_deck_2_aft_sm"
@@ -164079,7 +164079,7 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1001;
 	master_tag = "airlock_horizon_deck_3_aft_1";
 	name = "airlock_horizon_deck_3_aft_1"
@@ -168545,7 +168545,7 @@
 	dir = 8
 	},
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_starboard_1";
 	name = "airlock_horizon_deck_1_starboard_1"
@@ -170246,7 +170246,7 @@
 /turf/simulated/floor/tiled,
 /area/horizon/operations/loading)
 "vYs" = (
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "airlock_horizon_deck_1_fore_1";
 	name = "airlock_horizon_deck_1_fore_1"
@@ -170345,7 +170345,7 @@
 	dir = 1
 	},
 /obj/structure/machinery/light/small,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "airlock_horizon_deck_1_fore_1";
 	name = "airlock_horizon_deck_1_fore_1"
@@ -174670,7 +174670,7 @@
 	pixel_x = 28;
 	pixel_y = 32
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "airlock_horizon_deck_1_fore_1";
 	name = "airlock_horizon_deck_1_fore_1"
@@ -176082,7 +176082,7 @@
 	dir = 4;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1004;
 	master_tag = "airlock_horizon_deck_1_fore_1";
 	name = "airlock_horizon_deck_1_fore_1"
@@ -178300,7 +178300,7 @@
 	id = "intrepid_bay_outer";
 	name = "Intrepid Shutter"
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "sccv_intrepid_starboard";
 	name = "sccv_intrepid_starboard";
 	req_one_access = null
@@ -180858,7 +180858,7 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 2001;
 	master_tag = "airlock_horizon_deck_2_starboard_aft";
 	name = "airlock_horizon_deck_2_starboard_aft"
@@ -182342,7 +182342,7 @@
 	dir = 10
 	},
 /obj/structure/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_starboard_1";
 	name = "airlock_horizon_deck_1_starboard_1"
@@ -184286,7 +184286,7 @@
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller{
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	frequency = 1003;
 	master_tag = "airlock_horizon_deck_1_aft_port_1";
 	name = "airlock_horizon_deck_1_aft_port_1"
@@ -185221,7 +185221,7 @@
 	pixel_y = 28;
 	pixel_x = 6
 	},
-/obj/effect/map_effect/marker/airlock{
+/obj/effect/map_effect/marker/airlock/external{
 	master_tag = "airlock_shuttle_quark_aux";
 	name = "airlock_shuttle_quark_aux";
 	req_one_access = list(65,47,74)


### PR DESCRIPTION
makes `/obj/effect/map_effect/marker/airlock` into `ABSTRACT_TYPE()`

for better organization and stuff

adds:
```
/// External airlock marker, for non-docking non-shuttle airlocks.
/// Just a plain external access airlock.
/obj/effect/map_effect/marker/airlock/external
```