### PR TITLE
RIG Storage Passthrough

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/storage.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/storage.dm
@@ -25,6 +25,9 @@
 
 	. = ..()
 
+/obj/item/rig_module/storage/accepts_item(obj/item/input_item, mob/living/user)
+	return pockets.attackby(input_item, user)
+
 /obj/item/rig/mouse_drop_dragged(atom/over, mob/user, src_location, over_location, params)
 	var/obj/item/rig_module/storage/storage = locate() in installed_modules
 	if(storage && !storage.pockets.handle_mousedrop(user, over))

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -133,6 +133,10 @@
 
 	var/ui_configure_ref
 
+/obj/item/rig/mechanics_hints(mob/user, distance, is_adjacent)
+	. += ..()
+	. += "<ul><li><b>Using:</b> Place the hardsuit on your back, open the Hardsuit tab, then click Engage/Disengage Hardsuit.</li><li><b>Removing:</b> Click Engage/Disengage Hardsuit again, then remove the hardsuit from your back once it disengages.</li><li><b>Storage:</b> If the suit has storage and an item fits, clicking the hardsuit with that item will place it inside. To open the storage, hold the hardsuit and click it with an empty hand, or middle-click it while standing nearby.</li><li><b>Maintenance:</b> Use a crowbar to open or close the maintenance panel. When the panel is open, a screwdriver removes the battery or upgrades, a wrench removes the air tank, and wirecutters or a multitool provide access to the wires.</li></ul>"
+
 /obj/item/rig/get_examine_text(mob/user, distance, is_adjacent, infix, suffix)
 	. = ..()
 	if(wearer)

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -208,7 +208,14 @@
 	for(var/obj/item/rig_module/module in installed_modules)
 		if(module.accepts_item(attacking_item, user)) //Item is handled in this proc
 			return
-	..()
+
+	// If the item was not used by the hardsuit or one of its modules, pass the
+	// interaction through to the mounted storage.
+	var/obj/item/rig_module/storage/storage = locate() in installed_modules
+	if(storage)
+		return storage.pockets.attackby(attacking_item, user)
+
+	return ..()
 
 
 /obj/item/rig/attack_hand(var/mob/user)

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -57,8 +57,11 @@
 
 	if(open)
 
-		// Hacking.
-		wires.interact(user)
+		// Wirecutters and multitools should always interact with the wiring while
+		// the maintenance panel is open.
+		if(attacking_item.tool_behaviour == TOOL_WIRECUTTER || attacking_item.tool_behaviour == TOOL_MULTITOOL)
+			wires.interact(user)
+			return
 
 		// Air tank.
 		if(istype(attacking_item,/obj/item/tank)) //Todo, some kind of check for suits without integrated air supplies.
@@ -190,6 +193,7 @@
 					removed.removed()
 					installed_modules -= removed
 					update_icon()
+			return
 
 		else if(istype(attacking_item,/obj/item/stack/nanopaste)) //EMP repair
 			var/obj/item/stack/S = attacking_item
@@ -200,20 +204,13 @@
 					malfunction_delay = 0
 				else
 					to_chat(user, SPAN_WARNING("\The [S] is empty!"))
-
-		return
+			return
 
 	// If we've gotten this far, all we have left to do before we pass off to root procs
 	// is check if any of the loaded modules want to use the item we've been given.
 	for(var/obj/item/rig_module/module in installed_modules)
 		if(module.accepts_item(attacking_item, user)) //Item is handled in this proc
 			return
-
-	// If the item was not used by the hardsuit or one of its modules, pass the
-	// interaction through to the mounted storage.
-	var/obj/item/rig_module/storage/storage = locate() in installed_modules
-	if(storage)
-		return storage.pockets.attackby(attacking_item, user)
 
 	return ..()
 

--- a/html/changelogs/geeves-rig_passthrough.yml
+++ b/html/changelogs/geeves-rig_passthrough.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - qol: "Clicking a hardsuit with an item now attempts to place it into the suit's mounted storage, unless the item is used to interact with the hardsuit or one of its modules."
+  - qol: "Added helpful examine text to hardsuits, describing how to use them."

--- a/html/changelogs/geeves-rig_passthrough.yml
+++ b/html/changelogs/geeves-rig_passthrough.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - qol: "Clicking a hardsuit with an item now attempts to place it into the suit's mounted storage, unless the item is used to interact with the hardsuit or one of its modules."


### PR DESCRIPTION
* Clicking a hardsuit with an item now attempts to place it into the suit's mounted storage, unless the item is used to interact with the hardsuit or one of its modules.
* Added helpful examine text to hardsuits, describing how to use them.

<img width="900" height="297" alt="image" src="https://github.com/user-attachments/assets/d26e7756-6cea-46c0-9060-1ab8b912466d" />
