### PR TITLE
Airlock Controller Stuff

### DIFF
--- a/code/game/objects/structures/machinery/doors/airlock.dm
+++ b/code/game/objects/structures/machinery/doors/airlock.dm
@@ -918,6 +918,7 @@ About the new airlock wires panel:
 		ai_action_timer = null
 	if(isAllPowerLoss() && electrified_until) // Disable electricity if required
 		electrify(0)
+	send_status()
 
 /obj/structure/machinery/door/airlock/proc/loseBackupPower()
 	backup_power_lost_until = backupPowerCablesCut() ? -1 : world.time + SecondsToTicks(60)
@@ -930,6 +931,7 @@ About the new airlock wires panel:
 		ai_action_timer = null
 	if(isAllPowerLoss() && electrified_until) // Disable electricity if required
 		electrify(0)
+	send_status()
 
 /obj/structure/machinery/door/airlock/proc/regainMainPower()
 	if(!mainPowerCablesCut())
@@ -938,12 +940,14 @@ About the new airlock wires panel:
 		if(!backup_power_lost_until)
 			backup_power_lost_until = -1
 		update_icon()
+	send_status()
 
 /obj/structure/machinery/door/airlock/proc/regainBackupPower()
 	if(!backupPowerCablesCut())
 		// Restore backup power only if main power is offline, otherwise permanently disable
 		backup_power_lost_until = main_power_lost_until == 0 ? -1 : 0
 		update_icon()
+	send_status()
 
 /obj/structure/machinery/door/airlock/proc/electrify(var/duration, var/feedback = 0)
 	var/message = ""
@@ -2156,6 +2160,7 @@ About the new airlock wires panel:
 		revert_powerloss_manual_override = FALSE
 		INVOKE_ASYNC(src, TYPE_PROC_REF(/obj/structure/machinery/door, close), 1)
 	update_icon()
+	send_status()
 
 /obj/structure/machinery/door/airlock/proc/prison_open()
 	if(bracer)

--- a/code/game/objects/structures/machinery/doors/airlock_control.dm
+++ b/code/game/objects/structures/machinery/doors/airlock_control.dm
@@ -10,11 +10,17 @@
 	var/tmp/waiting_for_roundstart
 
 /obj/structure/machinery/door/airlock/receive_signal(datum/signal/signal)
-	if (!arePowerSystemsOn()) return //no power
-
 	if(!signal || signal.encryption) return
 
 	if(id_tag != signal.data["tag"] || !signal.data["command"]) return
+
+	// Status requests need to work while the door is unpowered so that remote
+	// controllers can distinguish a power failure from a closed, locked door.
+	if(signal.data["command"] == "update")
+		send_status()
+		return
+
+	if (!arePowerSystemsOn()) return //no power
 
 	cur_command = signal.data["command"]
 	execute_current_command()
@@ -112,6 +118,7 @@
 
 		signal.data["door_status"] = density?("closed"):("open")
 		signal.data["lock_status"] = locked?("locked"):("unlocked")
+		signal.data["power"] = arePowerSystemsOn()
 
 		if (bumped)
 			signal.data["bumped_with_access"] = 1

--- a/code/game/objects/structures/machinery/embedded_controller/airlock_controllers.dm
+++ b/code/game/objects/structures/machinery/embedded_controller/airlock_controllers.dm
@@ -53,17 +53,26 @@
 /obj/structure/machinery/embedded_controller/radio/airlock/advanced_airlock_controller/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "AirlockConsoleAdvanced", name, ui_x=470, ui_y=290)
+		ui = new(user, src, "AirlockConsoleAdvanced", name, ui_x=470, ui_y=390)
 		ui.open()
 
 /obj/structure/machinery/embedded_controller/radio/airlock/advanced_airlock_controller/ui_data(mob/user)
 	var/list/data = list()
 
+	data["controller_powered"] = !(stat & NOPOWER)
 	data["chamber_pressure"] = round(program.memory["chamber_sensor_pressure"])
+	data["cycle_status"] = program.memory["cycle_status"]
+	data["exterior_door_state"] = program.memory["exterior_status"]["state"]
+	data["exterior_door_lock"] = program.memory["exterior_status"]["lock"]
+	data["exterior_door_power"] = program.memory["exterior_status"]["power"]
 	data["has_exterior_sensor"] = has_exterior_sensor
 	data["external_pressure"] = round(program.memory["external_sensor_pressure"])
+	data["interior_door_state"] = program.memory["interior_status"]["state"]
+	data["interior_door_lock"] = program.memory["interior_status"]["lock"]
+	data["interior_door_power"] = program.memory["interior_status"]["power"]
 	data["has_interior_sensor"] = has_interior_sensor
 	data["internal_pressure"] = round(program.memory["internal_sensor_pressure"])
+	data["pump_status"] = program.memory["pump_status"]
 	data["processing"] = program.memory["processing"]
 	data["purge"] = program.memory["purge"]
 	data["secure"] = program.memory["secure"]
@@ -87,13 +96,22 @@
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "AirlockConsoleStandard", name, ui_x=470, ui_y=290)
+		ui = new(user, src, "AirlockConsoleStandard", name, ui_x=470, ui_y=330)
 		ui.open()
 
 /obj/structure/machinery/embedded_controller/radio/airlock/airlock_controller/ui_data(mob/user)
 	var/list/data = list()
 
+	data["controller_powered"] = !(stat & NOPOWER)
 	data["chamber_pressure"] = round(program.memory["chamber_sensor_pressure"])
+	data["cycle_status"] = program.memory["cycle_status"]
+	data["exterior_door_state"] = program.memory["exterior_status"]["state"]
+	data["exterior_door_lock"] = program.memory["exterior_status"]["lock"]
+	data["exterior_door_power"] = program.memory["exterior_status"]["power"]
+	data["interior_door_state"] = program.memory["interior_status"]["state"]
+	data["interior_door_lock"] = program.memory["interior_status"]["lock"]
+	data["interior_door_power"] = program.memory["interior_status"]["power"]
+	data["pump_status"] = program.memory["pump_status"]
 	data["processing"] = program.memory["processing"]
 
 	return data

--- a/code/game/objects/structures/machinery/embedded_controller/airlock_program.dm
+++ b/code/game/objects/structures/machinery/embedded_controller/airlock_program.dm
@@ -35,9 +35,10 @@
 	memory["chamber_sensor_pressure"] = ONE_ATMOSPHERE
 	memory["external_sensor_pressure"] = 0					//assume vacuum for simple airlock controller
 	memory["internal_sensor_pressure"] = ONE_ATMOSPHERE
-	memory["exterior_status"] = list(state = "closed", lock = "locked")		//assume closed and locked in case the doors dont report in
-	memory["interior_status"] = list(state = "closed", lock = "locked")
+	memory["exterior_status"] = list(state = "closed", lock = "locked", power = null)		//assume closed and locked in case the doors dont report in
+	memory["interior_status"] = list(state = "closed", lock = "locked", power = null)
 	memory["pump_status"] = "unknown"
+	memory["cycle_status"] = "Idle"
 	memory["target_pressure"] = ONE_ATMOSPHERE
 	memory["purge"] = 0
 	memory["secure"] = 0
@@ -59,6 +60,7 @@
 		memory["secure"] = controller.tag_secure
 		addtimer(CALLBACK(src, PROC_REF(signalDoor), tag_exterior_door, "update"), 1 SECONDS)
 		addtimer(CALLBACK(src, PROC_REF(signalDoor), tag_interior_door, "update"), 1 SECONDS)
+		addtimer(CALLBACK(src, PROC_REF(requestPumpStatus), tag_airpump), 1 SECONDS)
 
 /datum/computer/file/embedded_program/airlock/receive_signal(datum/signal/signal, receive_method, receive_param)
 	var/receive_tag = signal.data["tag"]
@@ -77,10 +79,14 @@
 	else if(receive_tag==tag_exterior_door)
 		memory["exterior_status"]["state"] = signal.data["door_status"]
 		memory["exterior_status"]["lock"] = signal.data["lock_status"]
+		if("power" in signal.data)
+			memory["exterior_status"]["power"] = signal.data["power"]
 
 	else if(receive_tag==tag_interior_door)
 		memory["interior_status"]["state"] = signal.data["door_status"]
 		memory["interior_status"]["lock"] = signal.data["lock_status"]
+		if("power" in signal.data)
+			memory["interior_status"]["power"] = signal.data["power"]
 
 	else if(receive_tag==tag_airpump || receive_tag==tag_pump_out_internal)
 		if(signal.data["power"])
@@ -262,6 +268,21 @@
 
 	memory["processing"] = (state != target_state)
 
+	switch(state)
+		if(STATE_PREPARE)
+			memory["cycle_status"] = "Securing Doors"
+		if(STATE_DEPRESSURIZE)
+			memory["cycle_status"] = memory["purge"] ? "Purging" : "Depressurizing"
+		if(STATE_PRESSURIZE)
+			memory["cycle_status"] = "Pressurizing"
+		else
+			if(target_state == TARGET_INOPEN)
+				memory["cycle_status"] = "Cycling to Interior"
+			else if(target_state == TARGET_OUTOPEN)
+				memory["cycle_status"] = "Cycling to Exterior"
+			else
+				memory["cycle_status"] = "Idle"
+
 	return 1
 
 //these are here so that other types don't have to make so many assumptions about our implementation
@@ -317,6 +338,15 @@
 		"power" = power,
 		"direction" = direction,
 		"set_external_pressure" = pressure
+	)
+	post_signal(signal)
+
+/datum/computer/file/embedded_program/airlock/proc/requestPumpStatus(tag)
+	var/datum/signal/signal = new
+	signal.data = list(
+		"tag" = tag,
+		"sigtype" = "command",
+		"status" = 1
 	)
 	post_signal(signal)
 

--- a/html/changelogs/geeves-airlock_controller_stuff.yml
+++ b/html/changelogs/geeves-airlock_controller_stuff.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - qol: "Airlock controllers now display controller and door power, door and bolt status, pump activity, the current cycle phase, and unresponsive equipment."

--- a/tgui/packages/tgui/interfaces/AirlockConsoleAdvanced.tsx
+++ b/tgui/packages/tgui/interfaces/AirlockConsoleAdvanced.tsx
@@ -5,18 +5,55 @@ import {
   ProgressBar,
   Section,
 } from 'tgui-core/components';
+import type { BooleanLike } from 'tgui-core/react';
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
 
 export type AdvancedAirlockConsoleData = {
   chamber_pressure: number;
+  controller_powered: BooleanLike;
+  cycle_status: string;
+  exterior_door_lock: string;
+  exterior_door_power?: BooleanLike;
+  exterior_door_state: string;
   has_exterior_sensor: boolean;
   external_pressure: number;
+  interior_door_lock: string;
+  interior_door_power?: BooleanLike;
+  interior_door_state: string;
   has_interior_sensor: boolean;
   internal_pressure: number;
+  pump_status: 'off' | 'release' | 'siphon' | 'unknown';
   processing: boolean;
   purge: boolean;
   secure: boolean;
+};
+
+const doorStatus = (state: string, lock: string, power?: BooleanLike) => {
+  if (power === undefined || power === null) {
+    return 'No Response';
+  }
+  return `${state === 'open' ? 'Open' : 'Closed'} / ${lock === 'locked' ? 'Bolted' : 'Unbolted'} (${power ? 'Online' : 'No Power'})`;
+};
+
+const doorColor = (state: string, power?: BooleanLike) => {
+  if (power === undefined || power === null) {
+    return 'yellow';
+  }
+  return !power ? 'red' : state === 'open' ? 'yellow' : 'green';
+};
+
+const pumpStatus = (status: AdvancedAirlockConsoleData['pump_status']) => {
+  switch (status) {
+    case 'release':
+      return 'Pressurizing';
+    case 'siphon':
+      return 'Depressurizing';
+    case 'off':
+      return 'Off';
+    default:
+      return 'No Response';
+  }
 };
 
 export const AirlockConsoleAdvanced = (props) => {
@@ -28,6 +65,47 @@ export const AirlockConsoleAdvanced = (props) => {
         <Section title="Status">
           <Box>
             <LabeledList>
+              <LabeledList.Item
+                label="Controller Power"
+                color={data.controller_powered ? 'green' : 'red'}
+              >
+                {data.controller_powered ? 'Online' : 'No Power'}
+              </LabeledList.Item>
+              <LabeledList.Item
+                label="Cycle"
+                color={data.processing ? 'yellow' : 'green'}
+              >
+                {data.cycle_status}
+              </LabeledList.Item>
+              <LabeledList.Item label="Pump">
+                {pumpStatus(data.pump_status)}
+              </LabeledList.Item>
+              <LabeledList.Item
+                label="Exterior Door"
+                color={doorColor(
+                  data.exterior_door_state,
+                  data.exterior_door_power,
+                )}
+              >
+                {doorStatus(
+                  data.exterior_door_state,
+                  data.exterior_door_lock,
+                  data.exterior_door_power,
+                )}
+              </LabeledList.Item>
+              <LabeledList.Item
+                label="Interior Door"
+                color={doorColor(
+                  data.interior_door_state,
+                  data.interior_door_power,
+                )}
+              >
+                {doorStatus(
+                  data.interior_door_state,
+                  data.interior_door_lock,
+                  data.interior_door_power,
+                )}
+              </LabeledList.Item>
               <LabeledList.Item label="External Pressure">
                 {data.has_exterior_sensor ? (
                   <ProgressBar

--- a/tgui/packages/tgui/interfaces/AirlockConsoleStandard.tsx
+++ b/tgui/packages/tgui/interfaces/AirlockConsoleStandard.tsx
@@ -5,12 +5,49 @@ import {
   ProgressBar,
   Section,
 } from 'tgui-core/components';
+import type { BooleanLike } from 'tgui-core/react';
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
 
 export type StandardAirlockConsoleData = {
   chamber_pressure: number;
+  controller_powered: BooleanLike;
+  cycle_status: string;
+  exterior_door_lock: string;
+  exterior_door_power?: BooleanLike;
+  exterior_door_state: string;
+  interior_door_lock: string;
+  interior_door_power?: BooleanLike;
+  interior_door_state: string;
+  pump_status: 'off' | 'release' | 'siphon' | 'unknown';
   processing: boolean;
+};
+
+const doorStatus = (state: string, lock: string, power?: BooleanLike) => {
+  if (power === undefined || power === null) {
+    return 'No Response';
+  }
+  return `${state === 'open' ? 'Open' : 'Closed'} / ${lock === 'locked' ? 'Bolted' : 'Unbolted'} (${power ? 'Online' : 'No Power'})`;
+};
+
+const doorColor = (state: string, power?: BooleanLike) => {
+  if (power === undefined || power === null) {
+    return 'yellow';
+  }
+  return !power ? 'red' : state === 'open' ? 'yellow' : 'green';
+};
+
+const pumpStatus = (status: StandardAirlockConsoleData['pump_status']) => {
+  switch (status) {
+    case 'release':
+      return 'Pressurizing';
+    case 'siphon':
+      return 'Depressurizing';
+    case 'off':
+      return 'Off';
+    default:
+      return 'No Response';
+  }
 };
 
 export const AirlockConsoleStandard = (props) => {
@@ -22,6 +59,47 @@ export const AirlockConsoleStandard = (props) => {
         <Section title="Status">
           <Box>
             <LabeledList>
+              <LabeledList.Item
+                label="Controller Power"
+                color={data.controller_powered ? 'green' : 'red'}
+              >
+                {data.controller_powered ? 'Online' : 'No Power'}
+              </LabeledList.Item>
+              <LabeledList.Item
+                label="Cycle"
+                color={data.processing ? 'yellow' : 'green'}
+              >
+                {data.cycle_status}
+              </LabeledList.Item>
+              <LabeledList.Item label="Pump">
+                {pumpStatus(data.pump_status)}
+              </LabeledList.Item>
+              <LabeledList.Item
+                label="Exterior Door"
+                color={doorColor(
+                  data.exterior_door_state,
+                  data.exterior_door_power,
+                )}
+              >
+                {doorStatus(
+                  data.exterior_door_state,
+                  data.exterior_door_lock,
+                  data.exterior_door_power,
+                )}
+              </LabeledList.Item>
+              <LabeledList.Item
+                label="Interior Door"
+                color={doorColor(
+                  data.interior_door_state,
+                  data.interior_door_power,
+                )}
+              >
+                {doorStatus(
+                  data.interior_door_state,
+                  data.interior_door_lock,
+                  data.interior_door_power,
+                )}
+              </LabeledList.Item>
               <LabeledList.Item label="Chamber Pressure">
                 <ProgressBar
                   ranges={{


### PR DESCRIPTION
* Airlock controllers now display controller and door power, door and bolt status, pump activity, the current cycle phase, and unresponsive equipment.

<img width="508" height="350" alt="image" src="https://github.com/user-attachments/assets/06200c0b-10ce-4b7a-8b26-ec3fb5df753f" />
<img width="488" height="339" alt="image" src="https://github.com/user-attachments/assets/4dca7188-baf7-4abc-a241-a20fe3610ca0" />


AI usage disclosure: The code for the tweaks here was created using GPT 5.6 Sol.