### PR TITLE
LWAP Nerf

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -203,8 +203,6 @@
 	icon_state = "xray"
 	damage = 50
 	armor_penetration = 20
-	stun = 3
-	weaken = 3
 	stutter = 3
 
 	muzzle_type = /obj/effect/projectile/muzzle/xray

--- a/html/changelogs/geeves-lwap_nerf.yml
+++ b/html/changelogs/geeves-lwap_nerf.yml
@@ -1,0 +1,4 @@
+author: Geeves
+delete-after: True
+changes:
+  - balance: "The LWAP sniper rifle no longer stuns the target when hitting them."


### PR DESCRIPTION
* The LWAP sniper rifle no longer stuns the target when hitting them.

I used this during the event and realized that it absolutely friggin sucks to be hit and hard-stunned stunned from offscreen. The fact that the weapon has a scope already makes it supremely powerful.