### PR TITLE
Nerfs LWAPs

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -217,6 +217,19 @@
 		var/mob/M = target
 		M.confused += 8
 
+/obj/projectile/beam/stun
+	name = "stun beam"
+	icon_state = "stun"
+	damage = 1
+	sharp = FALSE
+	eyeblur = 1
+	agony = 45
+	damage_type = DAMAGE_BURN
+
+	muzzle_type = /obj/effect/projectile/muzzle/stun
+	tracer_type = /obj/effect/projectile/tracer/stun
+	impact_type = /obj/effect/projectile/impact/stun
+
 /obj/projectile/beam/disorient
 	name = "disorienting pulse"
 	icon_state = "stun"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -203,26 +203,19 @@
 	icon_state = "xray"
 	damage = 50
 	armor_penetration = 20
-	stun = 3
-	weaken = 3
-	stutter = 3
+	eyeblur = 16
+	stutter = 16
+	weaken = 1
 
 	muzzle_type = /obj/effect/projectile/muzzle/xray
 	tracer_type = /obj/effect/projectile/tracer/xray
 	impact_type = /obj/effect/projectile/impact/xray
 
-/obj/projectile/beam/stun
-	name = "stun beam"
-	icon_state = "stun"
-	damage = 1
-	sharp = FALSE
-	eyeblur = 1
-	agony = 45
-	damage_type = DAMAGE_BURN
-
-	muzzle_type = /obj/effect/projectile/muzzle/stun
-	tracer_type = /obj/effect/projectile/tracer/stun
-	impact_type = /obj/effect/projectile/impact/stun
+/obj/projectile/beam/sniper/on_hit(atom/target, blocked, def_zone)
+	. = ..()
+	if(ismob(target))
+		var/mob/M = target
+		M.confused += 8
 
 /obj/projectile/beam/disorient
 	name = "disorienting pulse"

--- a/html/changelogs/Fenodyree-LWAPNerf.yml
+++ b/html/changelogs/Fenodyree-LWAPNerf.yml
@@ -1,0 +1,6 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - balance: "The LWAP no longer stuns. It weakens for a single tick, causing you to drop what you are holding, then causes a short period of confusion. Also increased the eyeblur duration to match the confusion duration."


### PR DESCRIPTION
Reduces the LWAP stun to a single tick of weaken, just enough to make you drop what you are holding.

Replaces the long stun with a confusion effect, also increases the duration of the eyeblur to match the confusion.

https://github.com/user-attachments/assets/a5784929-f411-48a3-b757-2434210d1629

