### PR TITLE
Slight decloner damage nerf, Tumors are now a chance

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1694,7 +1694,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	var/last_gene_dam = genetic_degradation
 	genetic_degradation = min(100,max(0,genetic_degradation + amount))
 	if(genetic_degradation > 10)
-		owner.infest_with_parasite(owner, BP_TUMOUR_SPREADING, src)
+		owner.infest_with_parasite(owner, BP_TUMOUR_SPREADING, src, (genetic_degradation + 10)) //Guarantees at least one tumour if you reach maximum degredation.
 	if(genetic_degradation > 20)
 		if(!(status & ORGAN_MUTATED) && prob(genetic_degradation))
 			mutate()

--- a/code/modules/projectiles/modular/laser_components.dm
+++ b/code/modules/projectiles/modular/laser_components.dm
@@ -472,7 +472,7 @@
 	name = "decloner modulator"
 	desc = "Modulates the beam into firing highly radioactive particulates."
 	projectile = /obj/projectile/energy/declone
-	damage = 0.5
+	damage = 0.4
 	icon_state = "decloner"
 	firing_sound = 'sound/weapons/pulse3.ogg'
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 4, TECH_POWER = 3)

--- a/html/changelogs/Fednodyree-DeclonerNerf.yml
+++ b/html/changelogs/Fednodyree-DeclonerNerf.yml
@@ -1,0 +1,7 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - balance: "Reduced the genetic damage of the decloner module by 20%."
+  - balance: "Genetic damage is now a chance to spawn a tumour, rather than a guaranteed tumour at 10% damage.  The chance is equal to 10 + the amount of genetic damage.  This means that at 100% genetic damage, you are guaranteed to spawn a tumour."


### PR DESCRIPTION
Reduces decloner damage so it falls just under the threshold to give a tumor, on all but the most powerful guns.

Tumors from genetic damage are now also a chance, rather than guaranteed at any genetic damage over 10.
You are guaranteed to have at least one tumor if your limb reaches maximum genetic damage.
