### PR TITLE
Railing layering fix

### DIFF
--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -167,7 +167,7 @@
 /obj/structure/railing/update_icon(var/update_neighbors = TRUE)
 	NeighborsCheck(update_neighbors)
 	CutOverlays()
-	if(dir == SOUTH)
+	if(dir != NORTH)
 		layer = ABOVE_ABOVE_HUMAN_LAYER
 	else
 		layer = initial(layer)

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -168,7 +168,7 @@
 	NeighborsCheck(update_neighbors)
 	CutOverlays()
 	if(dir == SOUTH)
-		layer = ABOVE_HUMAN_LAYER
+		layer = ABOVE_ABOVE_HUMAN_LAYER
 	else
 		layer = initial(layer)
 	if(!neighbor_status || !anchored)

--- a/html/changelogs/hazelmouse-railinglayeringfix.yml
+++ b/html/changelogs/hazelmouse-railinglayeringfix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "South-facing platforms no longer layer over south-facing railings."


### PR DESCRIPTION
Shifts south-facing railings up a tiny bit, so they no longer layer over south-facing platforms on the same turf.

Old:
<img width="736" height="310" alt="image" src="https://github.com/user-attachments/assets/1290d14e-51e4-443c-ab1f-5fe39a620936" />

New:
<img width="813" height="335" alt="image" src="https://github.com/user-attachments/assets/aa3424c6-fbe6-4a61-9f38-9e571c54351b" />

