### PR TITLE
Pain Hotfixes

### DIFF
--- a/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
@@ -292,7 +292,7 @@
 		. += "You have enough biomass to grow!"
 
 //Overriding this function from /mob/living/carbon/alien/life.dm
-/mob/living/carbon/alien/diona/handle_regular_status_updates()
+/mob/living/carbon/alien/diona/handle_regular_status_updates(seconds_per_tick)
 	if(status_flags & GODMODE)
 		return FALSE
 

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -33,7 +33,7 @@
 	adjustToxLoss(-(rads))
 	return
 
-/mob/living/carbon/alien/handle_regular_status_updates()
+/mob/living/carbon/alien/handle_regular_status_updates(seconds_per_tick)
 
 	if(status_flags & GODMODE)	return 0
 
@@ -55,10 +55,10 @@
 			blinded = 1
 			set_stat(UNCONSCIOUS)
 			if(getHalLoss() > 0)
-				adjustHalLoss(-0.03)
+				adjustHalLoss(-0.3 * seconds_per_tick)
 
 		if(sleeping)
-			adjustHalLoss(-0.03)
+			adjustHalLoss(-0.3 * seconds_per_tick)
 			if (mind)
 				if(mind.active && client != null)
 					sleeping = max(sleeping-1, 0)
@@ -66,12 +66,12 @@
 			set_stat(UNCONSCIOUS)
 		else if(resting)
 			if(getHalLoss() > 0)
-				adjustHalLoss(-0.03)
+				adjustHalLoss(-0.3 * seconds_per_tick)
 
 		else
 			set_stat(CONSCIOUS)
 			if(getHalLoss() > 0)
-				adjustHalLoss(-0.01)
+				adjustHalLoss(-0.1 * seconds_per_tick)
 
 		// Eyes and blindness.
 		if(!has_eyes())

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -95,7 +95,7 @@
 
 	return //TODO: DEFERRED
 
-/mob/living/carbon/brain/handle_regular_status_updates()	//TODO: comment out the unused bits >_>
+/mob/living/carbon/brain/handle_regular_status_updates(seconds_per_tick)	//TODO: comment out the unused bits >_>
 	updatehealth()
 
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -799,7 +799,7 @@
 
 	return //TODO: DEFERRED
 
-/mob/living/carbon/human/handle_regular_status_updates()
+/mob/living/carbon/human/handle_regular_status_updates(seconds_per_tick)
 	if(!handle_some_updates())
 		return 0
 
@@ -843,7 +843,7 @@
 					sleeping_msg_debounce = TRUE
 					to_chat(src, EXAMINE_BLOCK_BLUE(SPAN_NOTICE(FONT_LARGE("You are now unconscious. You will not remember anything you see, hear, or feel happening around you until you regain consciousness."))))
 
-			adjustHalLoss(-0.03)
+			adjustHalLoss(-0.3 * seconds_per_tick)
 			if (species.tail)
 				animate_tail_reset()
 			if(prob(2) && is_asystole() && isSynthetic())
@@ -883,11 +883,11 @@
 			dizziness = max(0, dizziness - 15)
 			jitteriness = max(0, jitteriness - 15)
 			drowsiness = max(0, drowsiness - 5)
-			adjustHalLoss(-0.03)
+			adjustHalLoss(-0.3)
 		else
 			dizziness = max(0, dizziness - 3)
 			jitteriness = max(0, jitteriness - 3)
-			adjustHalLoss(-0.01)
+			adjustHalLoss(-0.1)
 
 		//Other
 		handle_statuses()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -883,11 +883,11 @@
 			dizziness = max(0, dizziness - 15)
 			jitteriness = max(0, jitteriness - 15)
 			drowsiness = max(0, drowsiness - 5)
-			adjustHalLoss(-0.3)
+			adjustHalLoss(-0.3 * seconds_per_tick)
 		else
 			dizziness = max(0, dizziness - 3)
 			jitteriness = max(0, jitteriness - 3)
-			adjustHalLoss(-0.1)
+			adjustHalLoss(-0.1 * seconds_per_tick)
 
 		//Other
 		handle_statuses()

--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -90,7 +90,7 @@
 
 	return //TODO: DEFERRED
 
-/mob/living/carbon/slime/handle_regular_status_updates()
+/mob/living/carbon/slime/handle_regular_status_updates(seconds_per_tick)
 
 	src.blinded = null
 

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -17,7 +17,7 @@
 
 	blinded = 0 // Placing this here just show how out of place it is.
 
-	if(handle_regular_status_updates())
+	if(handle_regular_status_updates(seconds_per_tick))
 		handle_status_effects()
 
 	if(stat != DEAD)
@@ -67,7 +67,7 @@
 			stop_pulling()
 
 //This updates the health and status of the mob (conscious, unconscious, dead)
-/mob/living/proc/handle_regular_status_updates()
+/mob/living/proc/handle_regular_status_updates(seconds_per_tick)
 	updatehealth()
 	if(stat != DEAD)
 		if(paralysis)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -466,7 +466,7 @@
 //Easiest to check this here, then check again in the robot proc.
 //Standard robots use config for crit, which is somewhat excessive for these guys.
 //Drones killed by damage will gib.
-/mob/living/silicon/robot/drone/handle_regular_status_updates()
+/mob/living/silicon/robot/drone/handle_regular_status_updates(seconds_per_tick)
 	if(health <= -maxhealth && src.stat != DEAD)
 		gib()
 		return

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -8,7 +8,7 @@
 
 	//Status updates, death etc.
 	clamp_values()
-	handle_regular_status_updates()
+	handle_regular_status_updates(seconds_per_tick)
 	handle_actions()
 
 	if(client)
@@ -73,7 +73,7 @@
 			lights_on = 0
 			set_light(0)
 
-/mob/living/silicon/robot/handle_regular_status_updates()
+/mob/living/silicon/robot/handle_regular_status_updates(seconds_per_tick)
 	if(camera && !scrambled_codes)
 		if(stat == DEAD || wires.is_cut(WIRE_CAMERA))
 			camera.set_status(0)

--- a/html/changelogs/hellfirejag-pain-hotfix.yml
+++ b/html/changelogs/hellfirejag-pain-hotfix.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Made passive pain recovery 10x as fast and tick-invariant."


### PR DESCRIPTION
Pain recovery over time was tweaked too low for the get_pain() PR.
I also made it tick invariant so it's actually -0.6 pain per second (which is equivalent to shaving off 1 point of brute damage per second) for a resting character, and 1/3rd of a point of brute per second if not resting.