### PR TITLE
Makes unathi able to drink ethanol and eat nutriments

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -203,19 +203,15 @@ ABSTRACT_TYPE(/singleton/reagent/alcohol)
 		if(!has_valid_aug && (alien == IS_VAURCA || (istype(P) && P.stage >= 3)))//Vaurca are damaged instead of getting nutrients, but they can still get drunk
 			M.adjustToxLoss(3 * removed * (strength / 100))
 
-		if (!has_valid_aug && alien == IS_UNATHI) //unathi are poisoned by alcohol as well
-			M.adjustToxLoss(3 * removed * (strength / 100))
-
-		if (has_valid_aug | alien != IS_UNATHI)
-			M.intoxication += (strength / 100) * removed * 6
-			if (druggy != 0)
-				M.druggy = max(M.druggy, druggy)
-			if (halluci)
-				M.hallucination = max(M.hallucination, halluci)
-			if(caffeine)
-				M.add_chemical_effect(CE_PULSE, caffeine*2)
-			M.adjustNutritionLoss(-nutriment_factor * removed)
-			M.adjustHydrationLoss(-hydration_factor * removed)
+		M.intoxication += (strength / 100) * removed * 6
+		if (druggy != 0)
+			M.druggy = max(M.druggy, druggy)
+		if (halluci)
+			M.hallucination = max(M.hallucination, halluci)
+		if(caffeine)
+			M.add_chemical_effect(CE_PULSE, caffeine*2)
+		M.adjustNutritionLoss(-nutriment_factor * removed)
+		M.adjustHydrationLoss(-hydration_factor * removed)
 
 	if (adj_temp > 0 && M.bodytemperature < targ_temp) // 310 is the normal bodytemp. 310.055
 		M.bodytemperature = min(targ_temp, M.bodytemperature + (adj_temp * TEMPERATURE_DAMAGE_COEFFICIENT))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drink/generic_food.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drink/generic_food.dm
@@ -54,8 +54,10 @@
 	var/obj/item/organ/internal/parasite/P = M.internal_organs_by_name["blackkois"]
 	if((alien == IS_VAURCA) || (istype(P) && P.stage >= 3))
 		M.adjustToxLoss(1.5 * removed)
-	else if(alien != IS_UNATHI)
-		digest(M,removed, holder = holder)
+	var/efficiency = 1
+	if(alien == IS_UNATHI)
+		efficiency = 0.5
+	digest(M, removed * efficiency, holder = holder)
 
 /singleton/reagent/nutriment/proc/digest(var/mob/living/carbon/M, var/removed, var/datum/reagents/holder)
 	M.heal_organ_damage(regen_factor * removed, 0)
@@ -102,7 +104,7 @@
 
 /singleton/reagent/nutriment/protein/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(alien && alien == IS_UNATHI)
-		digest(M,removed, holder = holder)
+		digest(M, removed * 2, holder = holder)
 		return
 	if(HAS_TRAIT(M, TRAIT_ORIGIN_NO_ANIMAL_PROTEIN) && !vegan)
 		if(prob(2))

--- a/html/changelogs/UnathiDrinking.yml
+++ b/html/changelogs/UnathiDrinking.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Unathi can now drink regular ethanol based booze."
+  - rscadd: "Unathi now get half nutriment from regular nutriments, and double from protein."


### PR DESCRIPTION
Per unathi lore's request.
Unathi can now eat nutriments, but it has half efficiency, while protein was upgraded to double efficiency.
They can now also drink ethanol with no issues. Note they had an existing ethanol weakness making them 20% more vulnerable to it compared to humans.