### PR TITLE
Slight refactor for wall colouring

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -645,6 +645,7 @@
 	// we limit to to 2 overlays, so 3 holes, to prevent decals from lagging the game
 	else if(length(bullet_mark.overlays) < 2)
 		var/image/bullet_overlay = image(bullet_mark.icon, icon_state = bullet_mark_icon_state, dir = bullet_mark_dir, pixel_x = p_x - bullet_mark.pixel_x, pixel_y = p_y - bullet_mark.pixel_y)
+		bullet_overlay.appearance_flags |= RESET_COLOR
 		bullet_mark.AddOverlays(bullet_overlay)
 
 /atom/proc/clear_bulletholes()

--- a/code/game/objects/items/tools/tools.dm
+++ b/code/game/objects/items/tools/tools.dm
@@ -324,7 +324,7 @@
 	if(welding_blind)
 		delay *= 3
 
-	var/image/welding_sparks = image('icons/effects/effects.dmi', welding_state)
+	var/image/welding_sparks = overlay_image('icons/effects/effects.dmi', welding_state, flags = RESET_COLOR)
 	welding_sparks.plane = ABOVE_LIGHTING_PLANE
 	target.AddOverlays(welding_sparks)
 	. = ..()

--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -2,27 +2,25 @@
 	if(!material)
 		return
 
-	if(reinf_material)
-		construction_stage = 6
-	else
-		construction_stage = null
-	if(!material)
-		material = GET_SINGLETON(MATERIAL_STEEL)
-	if(material)
-		explosion_resistance = material.explosion_resistance
-		if (material.wall_icon)
-			icon = material.wall_icon
+	explosion_resistance = material.explosion_resistance
+	if(material.wall_icon)
+		icon = material.wall_icon
+
+	if(!color && material.wall_colour)
+		color = material.wall_colour
 
 	if(reinf_material && reinf_material.explosion_resistance > explosion_resistance)
 		explosion_resistance = reinf_material.explosion_resistance
 
 	if(reinf_material)
+		construction_stage = 6
 		name = "reinforced [material.display_name] wall"
 		if(material.display_name == reinf_material.display_name)
 			desc = "It seems to be a section of hull reinforced and plated with [material.display_name]."
 		else
 			desc = "It seems to be a section of hull reinforced with [reinf_material.display_name] and plated with [material.display_name]."
 	else
+		construction_stage = null
 		name = "[material.display_name] wall"
 		desc = "It seems to be a section of hull plated with [material.display_name]."
 
@@ -101,6 +99,7 @@
 			overlay = damage_overlays.len
 
 		damage_image = damage_overlays[overlay]
+		damage_image.appearance_flags |= RESET_COLOR
 		overlays_to_add += damage_image
 
 	// Remove the existing damage overlay entirely and replace it with the newly-calculated one.

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -61,7 +61,7 @@
 	var/destruction_desc = "breaks apart"
 
 	// Icons
-	var/colour_blend = TRUE
+
 	/// Colour applied to products of this material.
 	var/icon_colour
 	/// Colour applied to walls specifically.
@@ -184,54 +184,18 @@
 	..()
 	if(!display_name)
 		display_name = name
+
 	if(!use_name)
 		use_name = display_name
+
 	if(!adjective_name)
 		adjective_name = display_name
+
 	if(!shard_icon)
 		shard_icon = shard_type
+
 	if(!icon_base)
 		world.log <<  "materials: [src] has unknown icon_base [icon_base]."
-/*
-	var/skip_blend = FALSE
-	switch (icon_base)
-		if ("solid")
-			wall_icon = 'icons/turf/smooth/composite_solid_color.dmi'
-		if ("stone")
-			wall_icon = 'icons/turf/smooth/composite_stone.dmi'
-			multipart_reinf_icon = 'icons/turf/smooth/composite_stone_reinf.dmi'
-		if ("metal")
-			wall_icon = 'icons/turf/smooth/composite_metal.dmi'
-		if ("wood")
-			wall_icon = 'icons/turf/smooth/composite_wood.dmi'
-		if ("cult")
-			wall_icon = 'icons/turf/smooth/cult_wall.dmi'
-			skip_blend = TRUE
-		if ("arust")
-			wall_icon = 'icons/turf/smooth/rusty_wall.dmi'
-			skip_blend = TRUE
-		if ("biomass")
-			wall_icon = 'icons/turf/smooth/diona_wall.dmi'
-			skip_blend = TRUE
-		if ("vaurca")
-			wall_icon = 'icons/turf/smooth/vaurca_wall.dmi'
-			skip_blend = TRUE
-		if ("shuttle")
-			skip_blend = TRUE
-		if ("skrell")
-			skip_blend = TRUE
-		if("concrete")
-			wall_icon = 'icons/turf/smooth/concrete_wall.dmi'
-			skip_blend = TRUE
-		else
-			world.log <<  "materials: [src] has unknown icon_base [icon_base]."*/
-	var/blend_colour = wall_colour ? wall_colour : icon_colour
-	if (wall_icon && blend_colour && colour_blend)
-		wall_icon = new(wall_icon)
-		wall_icon.Blend(blend_colour, ICON_MULTIPLY)
-		if (multipart_reinf_icon)
-			multipart_reinf_icon = new(multipart_reinf_icon)
-			multipart_reinf_icon.Blend(blend_colour, ICON_MULTIPLY)
 
 /singleton/material/Destroy(force)
 	stack_trace("Someone tried to delete a /material.")
@@ -498,7 +462,6 @@
 	wall_icon = 'icons/turf/smooth/diona_wall.dmi'
 	table_icon = 'icons/obj/structure/tables/diona_table.dmi'
 	icon_base = "biomass"
-	colour_blend = FALSE
 	integrity = 100
 	weight = 23
 	value = 5
@@ -949,7 +912,6 @@
 	display_name = "daemon stone"
 	icon_base = "cult"
 	wall_icon = 'icons/turf/smooth/cult_wall.dmi'
-	colour_blend = FALSE
 	icon_colour = COLOR_CULT
 	reinf_icon = "reinf_cult"
 	dooropen_noise = 'sound/effects/doorcreaky.ogg'
@@ -1198,7 +1160,6 @@
 	icon_colour = "#1C7400"
 	icon_base = "vaurca"
 	wall_icon = 'icons/turf/smooth/vaurca_wall.dmi'
-	colour_blend = FALSE
 	integrity = 400
 	melting_point = 6000
 	explosion_resistance = 25
@@ -1214,7 +1175,6 @@
 	reinf_icon = "no_sprite"//placeholder
 	icon_base = "shuttle"
 	//wall_icon = 'icons/turf/smooth/composite_solid_color.dmi'
-	colour_blend = FALSE
 	integrity = 1200
 	melting_point = 6000       // Hull plating.
 	explosion_resistance = 200 // Hull plating.
@@ -1228,7 +1188,6 @@
 	table_icon = 'icons/obj/structure/tables/skrell_table.dmi'
 	display_name = "superadvanced alloy"
 	weight = 23
-	colour_blend = FALSE
 	icon_colour = null
 	icon_base = "skrell"
 

--- a/html/changelogs/kano-colorable-walls.yml
+++ b/html/changelogs/kano-colorable-walls.yml
@@ -1,0 +1,4 @@
+author: kano
+delete-after: True
+changes:
+  - code_imp: "Materials no longer cache pre-coloured wall icons."


### PR DESCRIPTION
## About PR

- Materials no longer cache pre-coloured icons, instead this is handled by color var. This will allow mappers to colour walls more conveniently without resorting to code crimes

- Clears some repetitive checks in the wall code

- Adds RESET_COLOR flag to some wall overlays, so they don't inherit the walls' color

Tested the init time with and without the changes on horizon map several times, with away sites disabled. There's no change in speed
