### PR TITLE
Shuttle Rotation

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -3854,6 +3854,7 @@
 #include "code\modules\shuttles\shuttle_emergency.dm"
 #include "code\modules\shuttles\shuttle_ferry.dm"
 #include "code\modules\shuttles\shuttle_lift.dm"
+#include "code\modules\shuttles\shuttle_rotation.dm"
 #include "code\modules\shuttles\shuttle_specops.dm"
 #include "code\modules\shuttles\shuttle_supply.dm"
 #include "code\modules\shuttles\shuttles_multi.dm"

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -133,13 +133,32 @@
 	Turf manipulation
 */
 
+/**
+ * Rotates a pair of tile offsets clockwise around a shuttle landmark.
+ *
+ * Shuttle landmarks only support cardinal directions, so rotations are always
+ * in 90 degree increments.
+ */
+/proc/rotate_shuttle_offset(x_offset, y_offset, rotation)
+	switch(SIMPLIFY_DEGREES(rotation))
+		if(0)
+			return list(x_offset, y_offset)
+		if(90)
+			return list(y_offset, -x_offset)
+		if(180)
+			return list(-x_offset, -y_offset)
+		if(270)
+			return list(-y_offset, x_offset)
+	CRASH("Attempted to rotate a shuttle by a non-cardinal angle: [rotation].")
+
 //Returns an assoc list that describes how turfs would be changed if the
-//turfs in turfs_src were translated by shifting the src_origin to the dst_origin
-/proc/get_turf_translation(turf/src_origin, turf/dst_origin, list/turfs_src)
+//turfs in turfs_src were translated and rotated from src_origin to dst_origin.
+/proc/get_turf_translation(turf/src_origin, turf/dst_origin, list/turfs_src, rotation = 0)
 	var/list/turf_map = list()
 	for(var/turf/source in turfs_src)
-		var/x_pos = (source.x - src_origin.x)
-		var/y_pos = (source.y - src_origin.y)
+		var/list/rotated_offset = rotate_shuttle_offset(source.x - src_origin.x, source.y - src_origin.y, rotation)
+		var/x_pos = rotated_offset[1]
+		var/y_pos = rotated_offset[2]
 		var/z_pos = (source.z - src_origin.z)
 
 		var/turf/target = locate(dst_origin.x + x_pos, dst_origin.y + y_pos, dst_origin.z + z_pos)
@@ -149,7 +168,7 @@
 
 	return turf_map
 
-/proc/translate_turfs(var/list/translation, var/area/base_area = null, var/turf/base_turf, var/ignore_background)
+/proc/translate_turfs(var/list/translation, var/area/base_area = null, var/turf/base_turf, var/ignore_background, rotation = 0)
 	. = list()
 	for(var/turf/source in translation)
 
@@ -158,10 +177,10 @@
 		if(target)
 			if(base_area)
 				target.change_area(target.loc, get_area(source))
-				. += transport_turf_contents(source, target, ignore_background)
+				. += transport_turf_contents(source, target, ignore_background, rotation)
 				source.change_area(source.loc, base_area)
 			else
-				. += transport_turf_contents(source, target, ignore_background)
+				. += transport_turf_contents(source, target, ignore_background, rotation)
 
 	//change the old turfs
 	for(var/turf/source in translation)
@@ -174,7 +193,7 @@
 //Transports a turf from a source turf to a target turf, moving all of the turf's contents and making the target a copy of the source.
 //If ignore_background is set to true, turfs with TURF_FLAG_BACKGROUND set will only translate anchored contents.
 //Returns the new turf, or list(new turf, source) if a background turf was ignored and things may have been left behind.
-/proc/transport_turf_contents(turf/source, turf/target, ignore_background)
+/proc/transport_turf_contents(turf/source, turf/target, ignore_background, rotation = 0)
 	var/turf/new_turf
 
 	var/is_background = ignore_background && (source.turf_flags & TURF_FLAG_BACKGROUND)
@@ -184,6 +203,8 @@
 	else
 		new_turf = target.ChangeTurf(source.type, 1, 1)
 		new_turf.transport_properties_from(source)
+		if(rotation)
+			new_turf.shuttleRotate(rotation)
 
 	for(var/obj/O in source)
 		if(O.obj_flags & OBJ_FLAG_NOFALL)

--- a/code/controllers/subsystems/processing/shuttle.dm
+++ b/code/controllers/subsystems/processing/shuttle.dm
@@ -17,7 +17,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/list/lonely_shuttle_computers = list()   //shuttle computers that haven't been attached to their shuttles yet
 
-	var/list/landmarks_awaiting_sector = list()  //Stores automatic landmarks that are waiting for a sector to finish loading.
+	var/list/landmarks_awaiting_sector = list()  //Stores self-registering landmarks that are waiting for a sector to finish loading.
 	var/list/landmarks_still_needed = list()     //Stores landmark_tags that need to be assigned to the sector (landmark_tag = sector) when registered.
 	var/list/shuttles_to_initialize = list()     //A queue for shuttles to initialize at the appropriate time.
 	var/list/sectors_to_initialize               //Used to find all sector objects at the appropriate time.
@@ -130,7 +130,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/landmarks_to_check = landmarks_awaiting_sector.Copy()
 	for(var/thing in landmarks_to_check)
-		var/obj/effect/shuttle_landmark/automatic/landmark = thing
+		var/obj/effect/shuttle_landmark/landmark = thing
 		if(landmark.z in given_sector.map_z)
 			given_sector.add_landmark(landmark, landmark.shuttle_restricted)
 			landmarks_awaiting_sector -= landmark

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1295,9 +1295,11 @@
 	set_light_color(color)
 
 /**
- * Called when a movable is moved by a shuttle. Eventually, God willing, replace this with the TG shuttle version.
+ * Called when a movable is moved by a shuttle.
  */
-/atom/movable/proc/afterShuttleMove(obj/effect/shuttle_landmark/destination)
+/atom/movable/proc/afterShuttleMove(obj/effect/shuttle_landmark/destination, rotation = 0)
+	if(rotation && isturf(loc))
+		shuttleRotate(rotation)
 	if(light)
 		update_light()
 

--- a/code/game/turfs/simulated/shuttle_turfs.dm
+++ b/code/game/turfs/simulated/shuttle_turfs.dm
@@ -202,7 +202,7 @@
 	atmos_canpass = CANPASS_DENSITY
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED|OBJ_FLAG_NOFALL
 
-/obj/structure/shuttle_part/afterShuttleMove(obj/effect/shuttle_landmark/destination)
+/obj/structure/shuttle_part/afterShuttleMove(obj/effect/shuttle_landmark/destination, rotation)
 	. = ..()
 	if(outside_part)
 		var/turf/target_turf = get_turf(src)
@@ -221,7 +221,7 @@
 	can_be_unanchored = FALSE
 	var/outside_window = FALSE
 
-/obj/structure/window/shuttle/unique/afterShuttleMove(obj/effect/shuttle_landmark/destination)
+/obj/structure/window/shuttle/unique/afterShuttleMove(obj/effect/shuttle_landmark/destination, rotation)
 	. = ..()
 	if(outside_window)
 		var/turf/target_turf = get_turf(src)

--- a/code/modules/overmap/ship_weaponry/_ship_gun.dm
+++ b/code/modules/overmap/ship_weaponry/_ship_gun.dm
@@ -7,6 +7,7 @@
 	anchored = TRUE
 	density = TRUE
 	health = 1000
+	rotate_icon_with_shuttle = TRUE
 	var/heavy_firing_sound = 'sound/weapons/gunshot/ship_weapons/120mm_mortar.ogg' //The sound in the immediate firing area. Very loud.
 	var/light_firing_sound = 'sound/effects/explosionfar.ogg' //The sound played when you're a few walls away. Kind of loud.
 	var/projectile_type = /obj/projectile/ship_ammo

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -621,6 +621,7 @@
 /obj/structure/machinery/shipsensors/strong/scc_shuttle //Exclusively for the Horizon scout shuttle.
 	icon_state = "sensors"
 	icon = 'icons/obj/spaceship/scc/shuttle_sensors.dmi'
+	rotate_icon_with_shuttle = TRUE
 	component_types = list(
 		/obj/item/circuitboard/shipsensors/strong/scc,
 		/obj/item/stock_parts/subspace/ansible,

--- a/code/modules/overmap/ships/identification.dm
+++ b/code/modules/overmap/ships/identification.dm
@@ -79,6 +79,7 @@
 /obj/structure/machinery/iff_beacon/horizon/shuttle
 	icon = 'icons/obj/spaceship/scc/helm_pieces.dmi'
 	icon_state = "iff"
+	rotate_icon_with_shuttle = TRUE
 
 /obj/structure/machinery/iff_beacon/name_change
 	can_change_name = TRUE

--- a/code/modules/shieldgen/energy_field.dm
+++ b/code/modules/shieldgen/energy_field.dm
@@ -202,5 +202,5 @@
 
 	return (!density || air_group)
 
-/obj/effect/energy_field/afterShuttleMove(obj/effect/shuttle_landmark/destination)
+/obj/effect/energy_field/afterShuttleMove(obj/effect/shuttle_landmark/destination, rotation)
 	qdel_self()

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -79,7 +79,10 @@
 
 	if(auto_register)
 		var/obj/effect/overmap/visitable/map_origin = GLOB.map_sectors["[z]"]
-		map_origin.add_landmark(src, shuttle_restricted)
+		if(map_origin)
+			map_origin.add_landmark(src, shuttle_restricted)
+		else
+			LAZYDISTINCTADD(SSshuttle.landmarks_awaiting_sector, src)
 
 /obj/effect/shuttle_landmark/forceMove(atom/destination)
 	var/obj/effect/overmap/visitable/map_origin = GLOB.map_sectors["[z]"]
@@ -98,8 +101,9 @@
 /obj/effect/shuttle_landmark/proc/is_valid(var/datum/shuttle/shuttle)
 	if(shuttle.current_location == src)
 		return FALSE
+	var/rotation = shuttle.get_rotation(src)
 	for(var/area/A in shuttle.shuttle_area)
-		var/list/translation = get_turf_translation(get_turf(shuttle.current_location), get_turf(src), A.contents)
+		var/list/translation = get_turf_translation(get_turf(shuttle.current_location), get_turf(src), A.contents, rotation)
 		if(check_collision(list_values(translation)))
 			return FALSE
 	var/conn = GetConnectedZlevels(z)
@@ -110,8 +114,9 @@
 
 /obj/effect/shuttle_landmark/proc/deploy_landing_indicators(var/datum/shuttle/shuttle)
 	LAZYINITLIST(landing_indicators)
+	var/rotation = shuttle.get_rotation(src)
 	for(var/area/A in shuttle.shuttle_area)
-		var/list/translation = get_turf_translation(get_turf(shuttle.current_location), get_turf(src), A.contents)
+		var/list/translation = get_turf_translation(get_turf(shuttle.current_location), get_turf(src), A.contents, rotation)
 		for(var/target_turf in list_values(translation))
 			landing_indicators += new /obj/effect/shuttle_warning(target_turf)
 

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -165,13 +165,14 @@
 	if(current_location.cannot_depart(src))
 		return FALSE
 	testing("[src] moving to [destination]. Areas are [english_list(shuttle_area)]")
+	var/rotation = get_rotation(destination)
 	var/list/translation = list()
 	for(var/area/A in shuttle_area)
 		testing("Moving [A]")
-		translation += get_turf_translation(get_turf(current_location), get_turf(destination), A.contents)
+		translation += get_turf_translation(get_turf(current_location), get_turf(destination), A.contents, rotation)
 	var/old_location = current_location
 	GLOB.shuttle_pre_move_event.raise_event(src, old_location, destination)
-	shuttle_moved(destination, translation)
+	shuttle_moved(destination, translation, rotation)
 	GLOB.shuttle_moved_event.raise_event(src, old_location, destination)
 	destination.shuttle_arrived(src)
 	return TRUE
@@ -179,7 +180,7 @@
 //just moves the shuttle from A to B, if it can be moved
 //A note to anyone overriding move in a subtype. shuttle_moved() must absolutely not, under any circumstances, fail to move the shuttle.
 //If you want to conditionally cancel shuttle launches, that logic must go in short_jump(), long_jump() or attempt_move()
-/datum/shuttle/proc/shuttle_moved(var/obj/effect/shuttle_landmark/destination, var/list/turf_translation)
+/datum/shuttle/proc/shuttle_moved(var/obj/effect/shuttle_landmark/destination, var/list/turf_translation, rotation = 0)
 
 	if((flags & SHUTTLE_FLAGS_ZERO_G))
 		var/new_grav = 1
@@ -244,7 +245,7 @@
 		for(var/obj/structure/cable/C in A)
 			powernets |= C.powernet
 
-	translate_turfs(turf_translation, current_location.base_area, current_location.base_turf, TRUE)
+	translate_turfs(turf_translation, current_location.base_area, current_location.base_turf, TRUE, rotation)
 	current_location = destination
 
 	// if there's a zlevel above our destination, paint in a ceiling on it so we retain our air
@@ -262,7 +263,7 @@
 
 	for(var/area/sub_area in shuttle_area)
 		for(var/atom/movable/movable in sub_area)
-			movable.afterShuttleMove(destination)
+			movable.afterShuttleMove(destination, rotation)
 
 	// Remove all powernets that were affected, and rebuild them.
 	var/list/cables = list()
@@ -317,6 +318,12 @@
 
 /datum/shuttle/proc/on_move_interim()
 	return
+
+/// Returns the clockwise rotation needed to align the shuttle with destination.
+/datum/shuttle/proc/get_rotation(obj/effect/shuttle_landmark/destination)
+	if(!(current_location.dir in GLOB.cardinals) || !(destination.dir in GLOB.cardinals))
+		CRASH("Shuttle [name] attempted to move between non-cardinal landmarks: [current_location] and [destination].")
+	return SIMPLIFY_DEGREES(dir2angle(destination.dir) - dir2angle(current_location.dir))
 
 /datum/shuttle/proc/remove_shuttle_area(area/area_to_remove)
 	UnregisterSignal(area_to_remove, COMSIG_QDELETING)

--- a/code/modules/shuttles/shuttle_lift.dm
+++ b/code/modules/shuttles/shuttle_lift.dm
@@ -30,8 +30,9 @@
 
 /datum/shuttle/autodock/ferry/lift/proc/obstruction_check(var/obj/effect/shuttle_landmark/start, var/obj/effect/shuttle_landmark/destination)
 	var/list/translation = list()
+	var/rotation = get_rotation(destination)
 	for(var/area/A in shuttle_area)
-		translation += get_turf_translation(get_turf(current_location), get_turf(destination), A.contents)
+		translation += get_turf_translation(get_turf(current_location), get_turf(destination), A.contents, rotation)
 
 	for(var/turf/src_turf in translation)
 		var/turf/dst_turf = translation[src_turf]

--- a/code/modules/shuttles/shuttle_rotation.dm
+++ b/code/modules/shuttles/shuttle_rotation.dm
@@ -1,0 +1,171 @@
+/*
+ * Shuttle rotation callbacks.
+ *
+ * These are based on /tg/'s shuttleRotate callbacks, adapted to Aurora's
+ * area-and-landmark shuttle movement system.
+ */
+
+/// Rotates every cardinal direction present in a direction bitmask.
+/proc/rotate_cardinal_bitmask(direction, rotation)
+	var/rotated_direction = direction & ~(NORTH|SOUTH|EAST|WEST)
+	for(var/cardinal in GLOB.cardinals)
+		if(direction & cardinal)
+			rotated_direction |= angle2dir(dir2angle(cardinal) + rotation)
+	return rotated_direction
+
+/atom
+	/// Rotates this atom's rendered icon as a flat image when its shuttle turns.
+	/// Intended for icon-state mosaics that do not provide directional frames.
+	var/rotate_icon_with_shuttle = FALSE
+
+/atom/proc/shuttleRotate(rotation)
+	rotation = SIMPLIFY_DEGREES(rotation)
+	if(!rotation)
+		return
+
+	set_dir(angle2dir(dir2angle(dir) + rotation))
+
+	if(smoothing_flags)
+		QUEUE_SMOOTH(src)
+
+	// A map-level icon override on an opted-in family may itself be directional,
+	// such as the Canary's nozzle sprites. In that case set_dir() is sufficient.
+	if(rotate_icon_with_shuttle && icon == initial(icon))
+		var/list/icon_dimensions = get_icon_dimensions(icon)
+		var/icon_width = icon_dimensions["width"]
+		var/icon_height = icon_dimensions["height"]
+
+		// Rotate the rendered icon's center around the center of its turf. Raw
+		// pixel-offset rotation only works for 32x32 icons. A transform rotates
+		// around the original icon canvas center, so its unrotated dimensions
+		// remain the pixel-offset anchor even after a 90-degree turn.
+		var/center_x = pixel_x + icon_width * 0.5 - world.icon_size * 0.5
+		var/center_y = pixel_y + icon_height * 0.5 - world.icon_size * 0.5
+		var/list/rotated_center = rotate_shuttle_offset(center_x, center_y, rotation)
+		pixel_x = rotated_center[1] + world.icon_size * 0.5 - icon_width * 0.5
+		pixel_y = rotated_center[2] + world.icon_size * 0.5 - icon_height * 0.5
+
+		var/matrix/rotation_matrix = matrix(transform)
+		rotation_matrix.Turn(rotation)
+		transform = rotation_matrix
+	else
+		// Pixel offsets on ordinary 32x32 directional sprites rotate directly.
+		var/list/rotated_offset = rotate_shuttle_offset(pixel_x, pixel_y, rotation)
+		pixel_x = rotated_offset[1]
+		pixel_y = rotated_offset[2]
+
+/atom/movable/shuttleRotate(rotation)
+	var/old_bound_x = bound_x
+	var/old_bound_y = bound_y
+	var/old_bound_width = bound_width
+	var/old_bound_height = bound_height
+
+	. = ..()
+
+	// BYOND does not rotate rectangular collision bounds when dir changes.
+	for(var/turn_count in 1 to SIMPLIFY_DEGREES(rotation) / 90)
+		var/new_bound_x = old_bound_y
+		var/new_bound_y = ICON_SIZE_Y - old_bound_x - old_bound_width
+		var/new_bound_width = old_bound_height
+		var/new_bound_height = old_bound_width
+
+		old_bound_x = new_bound_x
+		old_bound_y = new_bound_y
+		old_bound_width = new_bound_width
+		old_bound_height = new_bound_height
+
+	bound_x = old_bound_x
+	bound_y = old_bound_y
+	bound_width = old_bound_width
+	bound_height = old_bound_height
+
+// Floor decals are cached images baked in their mapped orientation. Copy and
+// rotate them instead of mutating the shared cache entry.
+/turf/simulated/floor/shuttleRotate(rotation)
+	. = ..()
+	if(!LAZYLEN(decals))
+		return
+
+	var/list/rotated_decals = list()
+	for(var/image/decal as anything in decals)
+		var/mutable_appearance/rotated_decal = new /mutable_appearance(decal)
+		var/matrix/rotation_matrix = matrix(rotated_decal.transform)
+		rotation_matrix.Turn(rotation)
+		rotated_decal.transform = rotation_matrix
+
+		var/list/rotated_offset = rotate_shuttle_offset(rotated_decal.pixel_x, rotated_decal.pixel_y, rotation)
+		rotated_decal.pixel_x = rotated_offset[1]
+		rotated_decal.pixel_y = rotated_offset[2]
+		rotated_decals += rotated_decal
+
+	decals = rotated_decals
+	ClearOverlays()
+	update_icon()
+
+// Mobs keep their pixel offsets, and buckled mobs are oriented by their buckle.
+/mob/shuttleRotate(rotation)
+	if(!buckled_to)
+		set_dir(angle2dir(dir2angle(dir) + rotation))
+
+// Aurora airlock icons are 64x64 and use a fixed -16,-16 centering offset in
+// every direction. Rotating that offset shifts the rendered door off its turf.
+/obj/structure/machinery/door/airlock/shuttleRotate(rotation)
+	var/old_pixel_x = pixel_x
+	var/old_pixel_y = pixel_y
+	. = ..()
+	pixel_x = old_pixel_x
+	pixel_y = old_pixel_y
+
+/obj/structure/cable/shuttleRotate(rotation)
+	. = ..()
+	d1 = rotate_cardinal_bitmask(d1, rotation)
+	d2 = rotate_cardinal_bitmask(d2, rotation)
+	update_icon()
+
+/obj/structure/disposalpipe/shuttleRotate(rotation)
+	. = ..()
+	dpdir = rotate_cardinal_bitmask(dpdir, rotation)
+
+/obj/structure/machinery/atmospherics/shuttleRotate(rotation)
+	var/old_dir = dir
+	. = ..()
+	set_dir(rotate_cardinal_bitmask(old_dir, rotation))
+	initialize_directions = rotate_cardinal_bitmask(initialize_directions, rotation)
+	queue_icon_update()
+	update_underlays()
+
+// SCC shuttle hulls are assembled from single-direction 32x32 icon-state
+// mosaics. Opt in at the family level so existing and future variants inherit
+// rotation without needing their own shuttleRotate() override.
+/turf/simulated/wall/shuttle/unique/scc
+	rotate_icon_with_shuttle = TRUE
+
+/obj/structure/shuttle_part/scc
+	rotate_icon_with_shuttle = TRUE
+
+/obj/structure/window/shuttle/unique/scc
+	rotate_icon_with_shuttle = TRUE
+
+// Cockpit consoles are 32x64 single-direction sprites. Their left/right state
+// selects the layout variant, not a directional frame, so set_dir() alone
+// cannot turn them with the shuttle.
+/obj/structure/machinery/computer/ship/engines/cockpit
+	rotate_icon_with_shuttle = TRUE
+
+/obj/structure/machinery/computer/ship/helm/cockpit
+	rotate_icon_with_shuttle = TRUE
+
+/obj/structure/machinery/computer/ship/navigation/cockpit
+	rotate_icon_with_shuttle = TRUE
+
+/obj/structure/machinery/computer/ship/sensors/cockpit
+	rotate_icon_with_shuttle = TRUE
+
+/obj/structure/machinery/computer/ship/targeting/cockpit
+	rotate_icon_with_shuttle = TRUE
+
+/obj/structure/machinery/computer/shuttle_control/explore/canary
+	rotate_icon_with_shuttle = TRUE
+
+/obj/structure/machinery/computer/shuttle_control/explore/mining_shuttle
+	rotate_icon_with_shuttle = TRUE

--- a/code/unit_tests/shuttle_tests.dm
+++ b/code/unit_tests/shuttle_tests.dm
@@ -35,3 +35,29 @@
 	else
 		TEST_PASS("All shuttle transition and start location landmarks were found.")
 	return TRUE
+
+/datum/unit_test/shuttle_rotation
+	name = "SHUTTLE: Landmark-relative offsets rotate clockwise."
+	groups = list("generic")
+
+/datum/unit_test/shuttle_rotation/start_test()
+	var/list/north = rotate_shuttle_offset(2, 1, 0)
+	var/list/east = rotate_shuttle_offset(2, 1, 90)
+	var/list/south = rotate_shuttle_offset(2, 1, 180)
+	var/list/west = rotate_shuttle_offset(2, 1, 270)
+
+	if(!((north[1] == 2) && (north[2] == 1)))
+		TEST_FAIL("Zero-degree shuttle offset was [english_list(north)], expected 2, 1.")
+		return TRUE
+	if(!((east[1] == 1) && (east[2] == -2)))
+		TEST_FAIL("90-degree shuttle offset was [english_list(east)], expected 1, -2.")
+		return TRUE
+	if(!((south[1] == -2) && (south[2] == -1)))
+		TEST_FAIL("180-degree shuttle offset was [english_list(south)], expected -2, -1.")
+		return TRUE
+	if(!((west[1] == -1) && (west[2] == 2)))
+		TEST_FAIL("270-degree shuttle offset was [english_list(west)], expected -1, 2.")
+		return TRUE
+
+	TEST_PASS("Shuttle offsets rotated correctly for every cardinal orientation.")
+	return TRUE

--- a/html/changelogs/geeves-shuttle_rotation.yml
+++ b/html/changelogs/geeves-shuttle_rotation.yml
@@ -1,0 +1,4 @@
+author: Geeves
+delete-after: True
+changes:
+  - rscadd: "Shuttles can now rotate to match differently oriented docking landmarks, allowing them to use docks that face another direction."

--- a/maps/runtime/code/runtime.dm
+++ b/maps/runtime/code/runtime.dm
@@ -32,10 +32,10 @@
 	station_type  = "dumpster"
 
 	//If you're testing overmap stuff, remove the conditional definition
-	#if defined(UNIT_TEST)
+	// #if defined(UNIT_TEST)
 	use_overmap = TRUE
 	overmap_size = 35
-	#endif
+	// #endif
 
 	shuttle_docked_message = "Attention all hands: Jump preparation complete. The bluespace drive is now spooling up, secure all stations for departure. Time to jump: approximately %ETA%."
 	shuttle_leaving_dock = "Attention all hands: Jump initiated, exiting bluespace in %ETA%."

--- a/maps/runtime/runtime.dmm
+++ b/maps/runtime/runtime.dmm
@@ -100,6 +100,20 @@
 /obj/structure/machinery/floodlight,
 /turf/simulated/floor/tiled/gridded,
 /area/runtime/floor_one/main)
+"an" = (
+/obj/structure/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the AI core maintenance door.";
+	id = "runtime_blastdoors";
+	name = "Runtime Safety Blast Doors";
+	pixel_y = 4;
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/machinery/atmospherics/pipe/simple/hidden{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/full,
+/area/runtime/floor_two/main)
 "ao" = (
 /obj/effect/floor_decal/corner_wide/paleblue/full,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -121,6 +135,30 @@
 /obj/structure/machinery/light/floor,
 /turf/simulated/floor/tiled/bitile,
 /area/runtime/floor_one/main)
+"aq" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/machinery/camera/network/civilian_main{
+	c_tag = "Upper Floor 3";
+	dir = 8
+	},
+/obj/structure/machinery/atmospherics/pipe/simple/hidden{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/runtime/floor_two/main)
+"ar" = (
+/obj/structure/machinery/atmospherics/pipe/simple/hidden{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/full,
+/area/runtime/floor_two/main)
+"as" = (
+/obj/structure/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
+/area/runtime/floor_two/main)
 "at" = (
 /obj/effect/shuttle_landmark/supply/horizon/dock{
 	dir = 1
@@ -128,6 +166,12 @@
 /obj/structure/railing/retractable,
 /turf/simulated/floor/tiled/dark/full,
 /area/runtime/floor_one/main)
+"au" = (
+/obj/structure/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/full,
+/area/runtime/floor_one/construction)
 "av" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/full,
@@ -727,7 +771,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock/docking/runtime/dock,
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/north,
 /turf/simulated/floor/plating,
 /area/runtime/floor_two/main)
 "ca" = (
@@ -1262,6 +1306,14 @@
 	},
 /turf/simulated/floor/tiled/gridded,
 /area/runtime/floor_one/main)
+"dB" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/west,
+/turf/simulated/floor/airless,
+/area/runtime/floor_one/construction)
 "dC" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
@@ -1294,6 +1346,20 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/runtime/floor_two/main)
+"dI" = (
+/obj/structure/machinery/door/airlock/external/blue{
+	dir = 4
+	},
+/obj/structure/machinery/access_button{
+	pixel_x = 9;
+	pixel_y = 33;
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/west,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/shuttle_landmark/runtime/dock/west,
+/turf/simulated/floor/tiled/dark/full,
+/area/runtime/floor_one/construction)
 "dL" = (
 /obj/structure/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -2240,6 +2306,18 @@
 	},
 /turf/simulated/floor/tiled/gridded,
 /area/runtime/floor_one/atmospherics)
+"jg" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/structure/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_y = 24;
+	pixel_x = 10
+	},
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/west,
+/turf/simulated/floor/airless,
+/area/runtime/floor_one/construction)
 "ji" = (
 /obj/structure/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 1
@@ -2576,7 +2654,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock/docking/runtime/dock,
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/north,
 /turf/simulated/floor/plating,
 /area/runtime/floor_two/main)
 "lk" = (
@@ -2844,6 +2922,15 @@
 	},
 /turf/simulated/floor/airless,
 /area/runtime/floor_one/atmospherics)
+"mz" = (
+/obj/structure/machinery/door/airlock/external/blue{
+	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/south,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/shuttle_landmark/runtime/dock/south,
+/turf/simulated/floor/tiled/dark/full,
+/area/runtime/floor_two/main)
 "mA" = (
 /obj/structure/railing/mapped/no_density/low,
 /turf/simulated/floor/airless,
@@ -2971,6 +3058,17 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/supply/dock)
+"nm" = (
+/obj/structure/machinery/door/airlock/external/blue{
+	dir = 1
+	},
+/obj/structure/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/south,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/tiled/dark/full,
+/area/runtime/floor_two/main)
 "np" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -3323,6 +3421,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/runtime/floor_two/bridge)
+"pA" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/structure/machinery/airlock_sensor{
+	pixel_x = -9;
+	pixel_y = 26
+	},
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/west,
+/turf/simulated/floor/airless,
+/area/runtime/floor_one/construction)
 "pD" = (
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 5
@@ -3360,6 +3467,15 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/runtime/floor_one/atmospherics)
+"pU" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/south,
+/obj/structure/machinery/light/small/emergency{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor/airless,
+/area/runtime/floor_two/main)
 "pV" = (
 /obj/structure/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 10
@@ -3841,6 +3957,20 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/runtime/floor_two/main)
+"sD" = (
+/obj/structure/machinery/door/airlock/external/blue{
+	dir = 4
+	},
+/obj/structure/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/west,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/structure/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/runtime/floor_one/construction)
 "sE" = (
 /obj/structure/machinery/atmospherics/portables_connector{
 	dir = 8
@@ -4381,6 +4511,14 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/runtime/floor_one/main)
+"vv" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/west,
+/obj/structure/machinery/light/small/emergency{
+	pixel_y = -21
+	},
+/turf/simulated/floor/airless,
+/area/runtime/floor_one/construction)
 "vw" = (
 /obj/structure/machinery/door/firedoor{
 	dir = 4
@@ -4479,12 +4617,10 @@
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/runtime/floor_one/atmospherics)
 "wi" = (
-/obj/structure/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/runtime/floor_two/main)
+/obj/structure/machinery/atmospherics/portables_connector,
+/obj/structure/machinery/atmospherics/pipe/tank/air,
+/turf/simulated/floor/tiled/full,
+/area/runtime/floor_one/construction)
 "wj" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -4961,7 +5097,7 @@
 /obj/structure/machinery/door/airlock/external/blue{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/docking/runtime/dock,
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/north,
 /turf/simulated/floor/tiled/dark/full,
 /area/runtime/floor_two/main)
 "yW" = (
@@ -5671,17 +5807,6 @@
 	},
 /turf/simulated/floor/tiled/gridded,
 /area/runtime/floor_one/atmospherics)
-"Di" = (
-/obj/structure/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for the AI core maintenance door.";
-	id = "runtime_blastdoors";
-	name = "Runtime Safety Blast Doors";
-	pixel_y = 4;
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/full,
-/area/runtime/floor_two/main)
 "Dl" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -5953,14 +6078,6 @@
 	},
 /turf/simulated/floor/tiled/gridded,
 /area/runtime/floor_one/atmospherics)
-"EQ" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/machinery/camera/network/civilian_main{
-	c_tag = "Upper Floor 3";
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/runtime/floor_two/main)
 "ET" = (
 /obj/effect/decal/curb,
 /obj/effect/floor_decal/corner/brown{
@@ -6200,10 +6317,10 @@
 	icon_state = "1-2"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/docking/runtime/dock,
 /obj/structure/machinery/door/airlock/external/blue{
 	dir = 1
 	},
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/north,
 /turf/simulated/floor/tiled/dark/full,
 /area/runtime/floor_two/main)
 "GC" = (
@@ -6276,10 +6393,12 @@
 /area/runtime/floor_one/atmospherics)
 "GY" = (
 /obj/structure/machinery/light/small/emergency{
-	dir = 4
+	dir = 4;
+	pixel_x = 11
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock/docking/runtime/dock,
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/north,
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/north,
 /turf/simulated/floor/plating,
 /area/runtime/floor_two/main)
 "Hb" = (
@@ -6977,7 +7096,7 @@
 	pixel_y = 10
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/map_effect/marker/airlock/docking/runtime/dock,
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/north,
 /turf/simulated/floor/plating,
 /area/runtime/floor_two/main)
 "Ky" = (
@@ -7183,6 +7302,22 @@
 	},
 /turf/simulated/floor/airless,
 /area/runtime/floor_one/atmospherics)
+"LS" = (
+/obj/structure/machinery/door/airlock/external/blue{
+	dir = 4
+	},
+/obj/structure/machinery/access_button{
+	pixel_x = -10;
+	pixel_y = -30;
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/west,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/structure/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/runtime/floor_one/construction)
 "LU" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -7209,7 +7344,7 @@
 /obj/structure/machinery/door/airlock/external/blue{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/docking/runtime/dock,
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/north,
 /turf/simulated/floor/tiled/dark/full,
 /area/runtime/floor_two/main)
 "Ma" = (
@@ -7634,6 +7769,19 @@
 	},
 /turf/simulated/floor/tiled/gridded,
 /area/runtime/floor_one/atmospherics)
+"ON" = (
+/obj/structure/machinery/door/airlock/external/blue{
+	dir = 1
+	},
+/obj/structure/machinery/access_button{
+	pixel_x = 30;
+	pixel_y = 11;
+	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/south,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/tiled/dark/full,
+/area/runtime/floor_two/main)
 "OT" = (
 /obj/structure/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 9
@@ -7740,12 +7888,6 @@
 /obj/effect/floor_decal/industrial/hatch_small/yellow,
 /turf/simulated/floor/tiled/gridded,
 /area/runtime/floor_one/atmospherics)
-"PP" = (
-/obj/structure/machinery/atmospherics/pipe/simple/hidden{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/full,
-/area/runtime/floor_two/main)
 "PS" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 8
@@ -8037,6 +8179,14 @@
 	},
 /turf/simulated/floor/airless,
 /area/runtime/floor_one/atmospherics)
+"Rg" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 2
+	},
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/south,
+/turf/simulated/floor/airless,
+/area/runtime/floor_two/main)
 "Rh" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/railing/mapped{
@@ -9003,6 +9153,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/runtime/floor_two/main)
+"Ws" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/structure/machinery/airlock_sensor{
+	pixel_x = -25;
+	pixel_y = -6;
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/south,
+/turf/simulated/floor/airless,
+/area/runtime/floor_two/main)
 "Wx" = (
 /obj/structure/tank_wall/phoron{
 	density = 0;
@@ -9030,13 +9190,11 @@
 	pixel_x = 30;
 	pixel_y = -2
 	},
-/obj/effect/map_effect/marker/airlock/docking/runtime/dock,
-/obj/effect/shuttle_landmark/runtime/dock{
-	dir = 1
-	},
 /obj/structure/machinery/door/airlock/external/blue{
 	dir = 1
 	},
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/north,
+/obj/effect/shuttle_landmark/runtime/dock/north,
 /turf/simulated/floor/tiled/dark/full,
 /area/runtime/floor_two/main)
 "WM" = (
@@ -9332,6 +9490,21 @@
 	},
 /turf/simulated/floor/tiled/gridded,
 /area/runtime/floor_one/warehouse)
+"Ym" = (
+/obj/structure/machinery/door/airlock/external/blue{
+	dir = 1
+	},
+/obj/structure/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/structure/machinery/access_button{
+	pixel_x = -30;
+	pixel_y = -2
+	},
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/south,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/tiled/dark/full,
+/area/runtime/floor_two/main)
 "Yn" = (
 /obj/structure/railing/mapped/no_density/low{
 	dir = 8
@@ -9438,6 +9611,28 @@
 	},
 /turf/simulated/floor/tiled/gridded,
 /area/runtime/floor_two/comms)
+"YZ" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 2
+	},
+/obj/structure/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_x = -24;
+	dir = 4;
+	pixel_y = 10
+	},
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/south,
+/turf/simulated/floor/airless,
+/area/runtime/floor_two/main)
+"Za" = (
+/obj/structure/machinery/door/airlock/external/blue{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/west,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/tiled/dark/full,
+/area/runtime/floor_one/construction)
 "Zi" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/machinery/telecomms/broadcaster/preset_right,
@@ -19508,8 +19703,8 @@ aa
 aa
 aa
 fG
-CB
-CB
+wi
+au
 CB
 CB
 CB
@@ -19766,8 +19961,8 @@ aa
 aa
 fG
 fG
-fG
-fG
+sD
+LS
 fG
 fG
 fG
@@ -20022,10 +20217,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+fG
+jg
+dB
+fG
 aa
 aa
 aa
@@ -20279,10 +20474,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+fG
+pA
+vv
+fG
 aa
 aa
 aa
@@ -20536,10 +20731,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+fG
+dI
+Za
+fG
 aa
 aa
 aa
@@ -77860,9 +78055,9 @@ uh
 Tn
 BQ
 pI
-pI
-ci
 Uf
+ci
+pI
 pI
 TH
 pI
@@ -82229,7 +82424,7 @@ uh
 uh
 uh
 BQ
-Jf
+ZG
 lB
 rA
 Pt
@@ -82739,9 +82934,9 @@ uh
 uh
 uh
 uh
-uh
-uh
-uh
+BQ
+BQ
+BQ
 BQ
 Jf
 wo
@@ -82996,11 +83191,11 @@ uh
 uh
 uh
 uh
-uh
-uh
-uh
-BQ
-ZG
+mz
+Ws
+YZ
+Ym
+Jf
 Wh
 Px
 BO
@@ -83253,17 +83448,17 @@ uh
 uh
 uh
 uh
-uh
-uh
-uh
-BQ
-Di
-EQ
-pI
-pI
-wi
-PP
-PP
+ON
+pU
+Rg
+nm
+an
+aq
+ar
+ar
+as
+ar
+ar
 yg
 iy
 LY
@@ -83510,9 +83705,9 @@ uh
 uh
 uh
 uh
-uh
-uh
-uh
+BQ
+BQ
+BQ
 BQ
 BQ
 zd

--- a/maps/runtime/runtime.dmm
+++ b/maps/runtime/runtime.dmm
@@ -3961,9 +3961,6 @@
 /obj/structure/machinery/door/airlock/external/blue{
 	dir = 4
 	},
-/obj/structure/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
 /obj/effect/map_effect/marker/airlock/docking/runtime/dock/west,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/structure/machinery/atmospherics/pipe/manifold/hidden{

--- a/maps/runtime/runtime.dmm
+++ b/maps/runtime/runtime.dmm
@@ -8178,9 +8178,7 @@
 /area/runtime/floor_one/atmospherics)
 "Rg" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2
-	},
+/obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/map_effect/marker/airlock/docking/runtime/dock/south,
 /turf/simulated/floor/airless,
 /area/runtime/floor_two/main)
@@ -9610,9 +9608,7 @@
 /area/runtime/floor_two/comms)
 "YZ" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/structure/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2
-	},
+/obj/structure/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/structure/machinery/embedded_controller/radio/airlock/docking_port{
 	pixel_x = -24;
 	dir = 4;

--- a/maps/runtime/runtime_overmap.dm
+++ b/maps/runtime/runtime_overmap.dm
@@ -37,26 +37,70 @@
 	move_time = 90
 	shuttle_area = list(/area/shuttle/runtime)
 	dock_target = "airlock_runtime_shuttle"
-	current_location = "nav_runtime_dock"
+	current_location = "nav_runtime_dock_north"
 	landmark_transition = "nav_transit_runtime"
-	logging_home_tag = "nav_runtime_dock"
+	logging_home_tag = "nav_runtime_dock_north"
 	range = 1
 	fuel_consumption = 4
 	ceiling_type = /turf/simulated/floor/shuttle_ceiling
 
-/obj/effect/shuttle_landmark/runtime/dock
-	name = "Runtime Dock"
-	landmark_tag = "nav_runtime_dock"
-	docking_controller = "nav_runtime_dock"
+ABSTRACT_TYPE(/obj/effect/shuttle_landmark/runtime/dock)
 	base_area = /area/space
 	base_turf = /turf/simulated/floor/airless
 	movable_flags = MOVABLE_FLAG_EFFECTMOVE
+	auto_register = TRUE
+	shuttle_restricted = "WhileTrue"
+
+/obj/effect/shuttle_landmark/runtime/dock/north
+	name = "Runtime Dock - North Facing"
+	dir = NORTH
+	landmark_tag = "nav_runtime_dock_north"
+	docking_controller = "nav_runtime_dock_north"
+
+/obj/effect/shuttle_landmark/runtime/dock/east
+	name = "Runtime Dock - East Facing"
+	dir = EAST
+	landmark_tag = "nav_runtime_dock_east"
+	docking_controller = "nav_runtime_dock_east"
+
+/obj/effect/shuttle_landmark/runtime/dock/south
+	name = "Runtime Dock - South Facing"
+	dir = SOUTH
+	landmark_tag = "nav_runtime_dock_south"
+	docking_controller = "nav_runtime_dock_south"
+
+/obj/effect/shuttle_landmark/runtime/dock/west
+	name = "Runtime Dock - West Facing"
+	dir = WEST
+	landmark_tag = "nav_runtime_dock_west"
+	docking_controller = "nav_runtime_dock_west"
 
 // runtime dock airlocks
-/obj/effect/map_effect/marker/airlock/docking/runtime/dock
-	name = "Shuttle Dock"
-	landmark_tag = "nav_runtime_dock"
-	master_tag = "nav_runtime_dock"
+ABSTRACT_TYPE(/obj/effect/map_effect/marker/airlock/docking/runtime/dock)
+
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/north
+	name = "Shuttle Dock - North Facing"
+	dir = NORTH
+	landmark_tag = "nav_runtime_dock_north"
+	master_tag = "nav_runtime_dock_north"
+
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/east
+	name = "Shuttle Dock - East Facing"
+	dir = EAST
+	landmark_tag = "nav_runtime_dock_east"
+	master_tag = "nav_runtime_dock_east"
+
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/south
+	name = "Shuttle Dock - South Facing"
+	dir = SOUTH
+	landmark_tag = "nav_runtime_dock_south"
+	master_tag = "nav_runtime_dock_south"
+
+/obj/effect/map_effect/marker/airlock/docking/runtime/dock/west
+	name = "Shuttle Dock - West Facing"
+	dir = WEST
+	landmark_tag = "nav_runtime_dock_west"
+	master_tag = "nav_runtime_dock_west"
 
 // runtime shuttle airlocks
 /obj/effect/map_effect/marker/airlock/shuttle/runtime


### PR DESCRIPTION
* Shuttles can now rotate to match differently oriented docking landmarks, allowing them to use docks that face another direction.

<img width="654" height="904" alt="image" src="https://github.com/user-attachments/assets/5460f9c5-9756-4302-a5ca-0c52cfc404e8" />
<img width="880" height="621" alt="image" src="https://github.com/user-attachments/assets/253c5f74-117c-4701-b24a-8123ce690381" />

AI usage disclosure: The code here was created using GPT 5.6 Sol.