### PR TITLE
Partial Understanding Upgrade

### DIFF
--- a/code/datums/langchat/langchat.dm
+++ b/code/datums/langchat/langchat.dm
@@ -128,7 +128,9 @@
 	for(var/mob/listener in listeners)
 		if(!LANGCHAT_CLIENT_ENABLED(listener) || listener.ear_deaf)
 			continue
-		var/perceived = msg.plain_text_for(listener)
+		// Maptext must stay plain before truncation; otherwise a cut HTML tag can
+		// appear literally above the speaker or expose hidden chat-only content.
+		var/perceived = strip_html_full(msg.plain_text_for(listener))
 		if(!length(perceived))
 			continue
 		var/list/group = groups[perceived]

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -154,6 +154,7 @@ GLOBAL_LIST_INIT(debug_verbs, list(
 	,/client/proc/disable_movement
 	,/client/proc/Zone_Info
 	,/client/proc/Test_ZAS_Connection
+	,/client/proc/test_partial_understanding
 	//,/client/proc/ZoneTick
 	,/client/proc/rebootAirMaster
 	,/client/proc/hide_debug_verbs
@@ -166,6 +167,24 @@ GLOBAL_LIST_INIT(debug_verbs, list(
 	,/client/proc/get_bad_doors
 	,/client/proc/analyze_openturf
 	))
+
+/client/proc/test_partial_understanding(var/mob/living/target as mob in view())
+	set category = "Debug"
+	set name = "Test Partial Understanding"
+	set desc = "Makes the selected mob speak a test sentence in Sinta'Azaziba."
+
+	if(!check_rights(R_DEBUG|R_DEV))
+		return
+	if(!istype(target))
+		return
+
+	var/datum/language/sinta_azaziba = GLOB.all_languages[LANGUAGE_AZAZIBA]
+	if(!sinta_azaziba)
+		to_chat(src, SPAN_WARNING("Sinta'Azaziba is not currently available."))
+		return
+
+	target.say("Hey there, this is a normal standard sentence that should take a while for you to understand.", sinta_azaziba)
+	log_admin("[key_name(src)] used the partial understanding test verb on [key_name(target)].")
 
 
 /client/proc/enable_debug_verbs()

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -1,4 +1,6 @@
 #define SCRAMBLE_CACHE_LEN 20
+#define PARTIAL_DECIPHER_BASE_DELAY (0.5 SECONDS)
+#define PARTIAL_DECIPHER_WORD_TIME (1.5 SECONDS)
 
 /*
 	Datum based languages. Easily editable and modular.
@@ -95,8 +97,9 @@
 
 	return "[trim(full_name)]"
 
-/// Scrambles the spoken line by looping through every word in the line, calling scramble_word, and then returning the final result
-/datum/language/proc/scramble(var/input, var/list/known_languages)
+/// Scrambles the spoken line by looping through every word in the line, calling scramble_word, and then returning the final result.
+/// If decipher_over_time is set, words missed through partial understanding are marked up so chat can reveal them over time.
+/datum/language/proc/scramble(var/input, var/list/known_languages, var/decipher_over_time = FALSE)
 
 	// the chance that someone will recognize one of the words
 	var/understand_chance = 0
@@ -115,6 +118,8 @@
 
 	// marks the start of a new sentence in the for loop
 	var/new_sentence = FALSE
+	// tracks only missed words so already-understood words do not delay deciphering
+	var/decipher_index = 0
 
 	// loop through the list of words, scrambling it if the listener doesn't understand it, just putting it in if they can partially understand it
 	var/word_index = 1
@@ -122,6 +127,17 @@
 		var/list/scramble_results = process_word_prescramble(word, "[word] ", word_index, new_sentence, understand_chance, music_notes)
 		var/new_word = scramble_results[1]
 		new_sentence = scramble_results[2]
+		if(decipher_over_time && understand_chance && trim(new_word) != word)
+			var/decipher_delay = PARTIAL_DECIPHER_BASE_DELAY + (decipher_index * PARTIAL_DECIPHER_WORD_TIME)
+			decipher_index++
+			var/initial_word = trim(new_word)
+			var/deciphered_word = word
+			if(word_index == 1)
+				initial_word = capitalize(initial_word)
+				deciphered_word = capitalize(deciphered_word)
+			var/decipher_delay_seconds = decipher_delay / 10
+			var/decipher_duration_seconds = PARTIAL_DECIPHER_WORD_TIME / 10
+			new_word = "<span class='language-decipher' data-decipher-delay='[decipher_delay]' data-decipher-duration='[PARTIAL_DECIPHER_WORD_TIME]' style='--decipher-delay: [decipher_delay_seconds]s; --decipher-duration: [decipher_duration_seconds]s'><span class='language-decipher-initial'>[initial_word]</span><span class='language-decipher-scramble'>[initial_word]</span><span class='language-decipher-solution'>[deciphered_word]</span></span> "
 		scrambled_text += new_word
 		word_index++
 
@@ -200,6 +216,9 @@
 
 /datum/language/proc/scrambled_word_size_requirement(var/input_size)
 	return input_size
+
+#undef PARTIAL_DECIPHER_BASE_DELAY
+#undef PARTIAL_DECIPHER_WORD_TIME
 
 /datum/language/proc/format_message(message, verb)
 	return "[verb], <span class='message'>[colourize("\"[capitalize(message)]\"")]</span>"

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -471,8 +471,8 @@
 	return pick(GLOB.ai_names)
 
 // we're trimming out the punctuation and not readding it, so we need to readd it at the very end
-/datum/language/machine/scramble(var/input, var/list/known_languages)
-	. = ..()
+/datum/language/machine/scramble(var/input, var/list/known_languages, var/decipher_over_time = FALSE)
+	. = ..(input, known_languages, decipher_over_time)
 	return formalize_text(.)
 
 /datum/language/machine/process_word_prescramble(var/original_word, var/new_word, var/word_index, var/new_sentence, var/understand_chance, var/list/music_notes)

--- a/code/modules/mob/say_message/say_message.dm
+++ b/code/modules/mob/say_message/say_message.dm
@@ -60,7 +60,7 @@
 	var/cap_next = TRUE
 	for(var/datum/say_segment/segment as anything in segments)
 		var/is_emote = (segment.language?.flags & INNATE) ? TRUE : FALSE
-		var/rendered = segment.plain_text_for(listener, speaker)
+		var/rendered = segment.plain_text_for(listener, speaker, TRUE)
 		if(clarity == CLARITY_FAINT && !is_emote)
 			rendered = length(rendered) ? stars(rendered) : ""
 		rendered = trim(rendered)	// Strip whitespace for quoting. We'll re-add it later.

--- a/code/modules/mob/say_message/say_segment.dm
+++ b/code/modules/mob/say_message/say_segment.dm
@@ -13,7 +13,8 @@
 	src.language = language
 
 /// Returns the segment as the given listener perceives it.
-/datum/say_segment/proc/plain_text_for(mob/listener, mob/speaker)
+/// decipher_over_time should only be enabled for HTML chat output.
+/datum/say_segment/proc/plain_text_for(mob/listener, mob/speaker, decipher_over_time = FALSE)
 	if(language && (language.flags & KNOWONLYHEAR) && !listener.say_understands(speaker, language))
 		return ""
 	var/rendered = text
@@ -21,5 +22,5 @@
 		if((!speaker || (listener.sdisabilities & BLIND) || listener.blinded || !(speaker in view(listener))) && !isghost(listener))
 			rendered = stars(rendered)
 	if(!(language && (language.flags & INNATE)) && !listener.say_understands(speaker, language))
-		rendered = language ? language.scramble(rendered, listener.languages) : stars(rendered)
+		rendered = language ? language.scramble(rendered, listener.languages, decipher_over_time) : stars(rendered)
 	return rendered

--- a/html/changelogs/geeves-partial_understanding.yml
+++ b/html/changelogs/geeves-partial_understanding.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Partial understanding now allows you to fully comprehend messages, it just takes a few seconds to decipher. The odd spacing between larger and smaller scrambles is to prevent your lines from jumping in a fast moving chat."
+  - bugfix: "Stuff like spans and classes will no longer appear in overhead chat messages."

--- a/tgui/packages/tgui-panel/chat/renderer.tsx
+++ b/tgui/packages/tgui-panel/chat/renderer.tsx
@@ -401,6 +401,60 @@ class ChatRenderer {
         // Payload is HTML
         else if (message.html) {
           node.innerHTML = message.html;
+
+          // The scrambling layer is positioned over layout copies of both
+          // versions, allowing its letters to change without reflowing chat.
+          const decipherNodes =
+            node.querySelectorAll<HTMLElement>('.language-decipher');
+          for (const decipherNode of decipherNodes) {
+            const scrambleWord = decipherNode.querySelector<HTMLElement>(
+              '.language-decipher-scramble',
+            );
+            const solution = decipherNode.querySelector<HTMLElement>(
+              '.language-decipher-solution',
+            );
+            const delay = Number(decipherNode.dataset.decipherDelay);
+            const duration = Number(decipherNode.dataset.decipherDuration);
+            if (
+              !scrambleWord ||
+              !solution ||
+              !Number.isFinite(delay) ||
+              !Number.isFinite(duration)
+            ) {
+              continue;
+            }
+            setTimeout(() => {
+              const finalText = solution.textContent || '';
+              const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+              const startedAt = Date.now();
+              const interval = setInterval(() => {
+                const progress = Math.min(
+                  (Date.now() - startedAt) / (duration * 100),
+                  1,
+                );
+                const resolvedCharacters = Math.floor(
+                  finalText.length * progress,
+                );
+                scrambleWord.textContent = Array.from(finalText)
+                  .map((character, index) => {
+                    if (
+                      index < resolvedCharacters ||
+                      !/[a-z0-9]/i.test(character)
+                    ) {
+                      return character;
+                    }
+                    return characters[
+                      Math.floor(Math.random() * characters.length)
+                    ];
+                  })
+                  .join('');
+
+                if (progress >= 1) {
+                  clearInterval(interval);
+                }
+              }, 50);
+            }, delay * 100);
+          }
         } else {
           logger.error('Error: message is missing text payload', message);
         }

--- a/tgui/packages/tgui-panel/chat/renderer.tsx
+++ b/tgui/packages/tgui-panel/chat/renderer.tsx
@@ -404,8 +404,9 @@ class ChatRenderer {
 
           // The scrambling layer is positioned over layout copies of both
           // versions, allowing its letters to change without reflowing chat.
-          const decipherNodes =
-            node.querySelectorAll<HTMLElement>('.language-decipher');
+          const decipherNodes = (
+            node as HTMLElement
+          ).querySelectorAll<HTMLElement>('.language-decipher');
           for (const decipherNode of decipherNodes) {
             const scrambleWord = decipherNode.querySelector<HTMLElement>(
               '.language-decipher-scramble',

--- a/tgui/packages/tgui-panel/styles/components/Chat.scss
+++ b/tgui/packages/tgui-panel/styles/components/Chat.scss
@@ -86,3 +86,59 @@
   border-left: 2px solid var(--highlight-background-color, #ffdd44);
   padding-left: 0.5em;
 }
+
+// Both versions share the same grid cell, reserving the larger width before
+// deciphering starts so replacing a word never reflows the chat line.
+.language-decipher {
+  display: inline-grid;
+  position: relative;
+  vertical-align: baseline;
+
+  &-initial,
+  &-solution {
+    grid-area: 1 / 1;
+  }
+}
+
+.language-decipher-initial {
+  animation: language-decipher-hide 0s linear var(--decipher-delay) forwards;
+}
+
+.language-decipher-scramble {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  visibility: hidden;
+  white-space: nowrap;
+  animation: language-decipher-scramble-visibility var(--decipher-duration)
+    linear var(--decipher-delay) forwards;
+}
+
+.language-decipher-solution {
+  visibility: hidden;
+  animation: language-decipher-show 0s linear
+    calc(var(--decipher-delay) + var(--decipher-duration)) forwards;
+}
+
+@keyframes language-decipher-scramble-visibility {
+  0%,
+  99.999% {
+    visibility: visible;
+  }
+
+  100% {
+    visibility: hidden;
+  }
+}
+
+@keyframes language-decipher-hide {
+  to {
+    visibility: hidden;
+  }
+}
+
+@keyframes language-decipher-show {
+  to {
+    visibility: visible;
+  }
+}


### PR DESCRIPTION
* Partial understanding now allows you to fully comprehend messages, it just takes a few seconds to decipher. The odd spacing between larger and smaller scrambles is to prevent your lines from jumping in a fast moving chat.
* Stuff like spans and classes will no longer appear in overhead chat messages.


Video below was made before the overhead chat fix was implemented.

https://github.com/user-attachments/assets/55c2d9e9-fbcd-4b1b-83c8-eb886b89a550

AI usage disclosure: The code here was created using GPT 5.6 Sol.