### PR TITLE
Remove Shower Processing

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -179,6 +179,7 @@
 	on = !on
 	update_icon()
 	if(on)
+		START_PROCESSING(SSmachinery, src)
 		if (M.loc == loc)
 			wash(M)
 			process_heat(M)
@@ -271,7 +272,7 @@
 
 /obj/structure/machinery/shower/process()
 	if(!on)
-		return
+		return PROCESS_KILL
 	wash_floor()
 	if(!mobpresent)
 		return

--- a/html/changelogs/hellfirejag-kill-shower-processing.yml
+++ b/html/changelogs/hellfirejag-kill-shower-processing.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Made showers no longer require always processing."


### PR DESCRIPTION
There's about ~5500 processing entries in the Machinery subsystem, at any given point showers are about 50 of them. This PR just makes it so that showers that aren't on automatically remove themselves from processing to free up time for the machinery subsystem.