### PR TITLE
Kitchen mapping fix

### DIFF
--- a/html/changelogs/rattydew-mappingerrors.yml
+++ b/html/changelogs/rattydew-mappingerrors.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: rattydew
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Resolved a few mapping errors introduced in recent Horizon remaps."

--- a/maps/sccv_horizon/sccv_horizon.dmm
+++ b/maps/sccv_horizon/sccv_horizon.dmm
@@ -21930,14 +21930,6 @@
 /area/horizon/medical/hallway/upper)
 "cSu" = (
 /obj/structure/machinery/alarm/south,
-/obj/structure/machinery/button/remote/blast_door{
-	name = "Dividing Door Control";
-	dir = 8;
-	id = "service_divider_shutter";
-	pixel_x = -21;
-	pixel_y = 28;
-	req_one_access = list(25,28)
-	},
 /obj/structure/machinery/alarm/south,
 /obj/structure/machinery/appliance/cooker/microwave{
 	pixel_y = 7
@@ -37012,7 +37004,7 @@
 	icon_state = "pipe-c-yellow";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/full,
+/turf/simulated/floor/tiled/dark,
 /area/horizon/service/bar)
 "eQv" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -40597,7 +40589,7 @@
 /obj/structure/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/service/bar)
 "fpb" = (
 /obj/structure/filingcabinet/chestdrawer{
@@ -48533,17 +48525,9 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/obj/structure/machinery/button/remote/blast_door{
-	name = "Dividing Door Control";
-	dir = 4;
-	id = "service_divider_shutter";
-	pixel_x = 22;
-	pixel_y = 28;
-	req_one_access = list(25,28)
-	},
 /obj/effect/floor_decal/industrial/outline_straight/service,
 /obj/structure/disposalpipe/segment/mainline,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/service/bar)
 "grc" = (
 /obj/structure/grille,


### PR DESCRIPTION
Removes the two floating buttons left in the recent kitchen remap, and swaps out a misplaced full tile.

<img width="196" height="138" alt="image" src="https://github.com/user-attachments/assets/38b763d4-5117-481a-8fc3-a1d7ca3da577" />
