### PR TITLE
Yeet Gas Canister Processing

### DIFF
--- a/code/game/objects/structures/machinery/atmoalter/canister.dm
+++ b/code/game/objects/structures/machinery/atmoalter/canister.dm
@@ -370,7 +370,7 @@ update_flag
 		update_icon()
 
 /obj/structure/machinery/portable_atmospherics/canister/process()
-	if (destroyed || (!air_contents.react() && !valve_open && !holding))
+	if (destroyed || (!air_contents.react() && !valve_open && !holding && !connected_port))
 		return PROCESS_KILL
 
 	if(valve_open)

--- a/code/game/objects/structures/machinery/atmoalter/canister.dm
+++ b/code/game/objects/structures/machinery/atmoalter/canister.dm
@@ -370,10 +370,8 @@ update_flag
 		update_icon()
 
 /obj/structure/machinery/portable_atmospherics/canister/process()
-	if (destroyed)
+	if (destroyed || (!air_contents.react() && !valve_open && !holding))
 		return PROCESS_KILL
-
-	..()
 
 	if(valve_open)
 		var/datum/gas_mixture/environment
@@ -393,14 +391,13 @@ update_flag
 			var/returnval = pump_gas_passive(src, air_contents, environment, transfer_moles)
 			if(returnval >= 0)
 				src.update_icon()
+				SStgui.update_uis(src)
 
 	if(XGM_PRESSURE(air_contents) < 1)
 		can_label = 1
 	else
 		can_label = 0
 
-	// Cooking up air cans - add phoron and oxygen, then heat above PHORON_MINIMUM_BURN_TEMPERATURE
-	air_contents.react()
 
 /obj/structure/machinery/portable_atmospherics/canister/return_air()
 	return air_contents
@@ -434,6 +431,7 @@ update_flag
 					release_log += "Valve was <b>opened</b> by [key_name(admin)] (aghost), starting the transfer into the <span class='warning'><b>air</b></span><br>"
 					log_open(admin)
 			valve_open = !valve_open
+			START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 /obj/structure/machinery/portable_atmospherics/canister/attackby(obj/item/attacking_item, mob/user)
 	if(istype(attacking_item, /obj/item/mecha_equipment/clamp))
@@ -461,6 +459,7 @@ update_flag
 			var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
 			thejetpack.merge(removed)
 			to_chat(user, "You pulse-pressurize your jetpack from the tank.")
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 		return TRUE
 
 	..()
@@ -518,6 +517,7 @@ update_flag
 					release_log += "Valve was <b>opened</b> by [usr] ([usr.ckey]), starting the transfer into the <span class='warning'><b>air</b></span><br>"
 					log_open()
 			valve_open = !valve_open
+			START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 			. = TRUE
 
 		if("remove_tank")
@@ -585,6 +585,7 @@ update_flag
 	update_connected_network()
 	update_icon()
 	SStgui.update_uis(src)
+	START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 /**
  * Dirty way to fill room with gas. However it is a bit easier to do than creating some floor/engine/n2o -rastaf0

--- a/code/game/objects/structures/machinery/atmoalter/meter.dm
+++ b/code/game/objects/structures/machinery/atmoalter/meter.dm
@@ -111,28 +111,28 @@
 
 /obj/structure/machinery/meter/process()
 	update_icon()
-	if (!target || (stat & (BROKEN|NOPOWER)))
+	if (!target || (stat & (BROKEN|NOPOWER)) || !frequency)
 		return FALSE
 	var/datum/gas_mixture/environment = target.return_air()
 	if(!environment)
 		return FALSE
 	var/env_pressure = XGM_PRESSURE(environment)
 
-	if(frequency)
-		var/datum/radio_frequency/radio_connection = SSradio.return_frequency(frequency)
+	var/datum/radio_frequency/radio_connection = SSradio.return_frequency(frequency)
 
-		if(!radio_connection) return
+	if(!radio_connection)
+		return
 
-		var/datum/signal/signal = new
-		signal.source = src
-		signal.transmission_method = TRANSMISSION_RADIO
-		signal.data = list(
-			"tag" = id,
-			"device" = "AM",
-			"pressure" = round(env_pressure),
-			"sigtype" = "status"
-		)
-		radio_connection.post_signal(src, signal)
+	var/datum/signal/signal = new
+	signal.source = src
+	signal.transmission_method = TRANSMISSION_RADIO
+	signal.data = list(
+		"tag" = id,
+		"device" = "AM",
+		"pressure" = round(env_pressure),
+		"sigtype" = "status"
+	)
+	radio_connection.post_signal(src, signal)
 
 /obj/structure/machinery/meter/Click()
 	if(istype(usr, /mob/living/silicon/ai)) // ghosts can call ..() for examine

--- a/code/game/objects/structures/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/objects/structures/machinery/atmoalter/portable_atmospherics.dm
@@ -123,6 +123,7 @@
 		src.holding = T
 		update_icon()
 		SStgui.update_uis(src)
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 		return TRUE
 
 	else if (attacking_item.tool_behaviour == TOOL_WRENCH)
@@ -141,6 +142,7 @@
 					attacking_item.play_tool_sound(get_turf(src), 50)
 					update_icon()
 					SStgui.update_uis(src)
+					START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 					return TRUE
 				else
 					to_chat(user, SPAN_NOTICE("\The [src] failed to connect to the port."))

--- a/html/changelogs/hellfirejag-gas-can-processing-yeet.yml
+++ b/html/changelogs/hellfirejag-gas-can-processing-yeet.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed gas canisters needing to always process forever."


### PR DESCRIPTION
closes #23171 

This PR makes it so that gas canisters no longer require "always processing". There's roughly 500 canisters at any given point in time constantly processing, out of ~5300 objects in the machinery subsystem. This PR therefore removes about 10% of the entries in the machinery subsystem.

I have tested this.

<img width="1293" height="787" alt="image" src="https://github.com/user-attachments/assets/b14508d1-9eef-49ef-b12f-42461c561032" />
