### PR TITLE
Stops IPC from being smacked by wrongly selected surgery tools and adds IPC facial repair surgery

### DIFF
--- a/code/datums/skills/occupational/operations.dm
+++ b/code/datums/skills/occupational/operations.dm
@@ -30,7 +30,7 @@
 			+ " - Cutting someone out of a hardsuit." \
 			+ " - Fully opening or closing mechanical parts to access internal systems, allowing repairs to any amount of damage.<br>" \
 			+ " - Repairing, removing, or adding mechanical organs.<br>" \
-			+ " - Facial Reconstructions performed on Shell IPCs.<br>" \
+			+ " - Facial reconstructions performed on IPCs.<br>" \
 			+ " - Attaching mechanical limbs (including to organics).<br>" \
 			+ " - Re-attach (organic) limbs. Robotic limbs require the Robotics skill instead.<br>" \
 			+ " - Perform all forms of internal repairs to IPCs.<br>" \
@@ -44,7 +44,7 @@
 			+ " - Cutting someone out of a hardsuit." \
 			+ " - Fully opening or closing mechanical parts to access internal systems, allowing repairs to any amount of damage.<br>" \
 			+ " - Repairing, removing, or adding mechanical organs.<br>" \
-			+ " - Facial Reconstructions performed on Shell IPCs.<br>" \
+			+ " - Facial reconstructions performed on IPCs.<br>" \
 			+ " - Attaching mechanical limbs (including to organics).<br>" \
 			+ " - Re-attach (organic) limbs. Robotic limbs require the Robotics skill instead.<br>" \
 			+ " - Perform all forms of internal repairs to IPCs.<br>" \

--- a/code/modules/surgery/facial_surgery.dm
+++ b/code/modules/surgery/facial_surgery.dm
@@ -139,7 +139,7 @@
 	return ..() && target_zone == BP_MOUTH
 
 /singleton/surgery_step/robotics/face/reconstruct_chassis
-	name = "Reconstruct Chassis Face"
+	name = "Reconstruct Faceplate"
 	allowed_tools = list(
 		/obj/item/stack/material/steel = 100
 	)
@@ -160,8 +160,8 @@
 
 /singleton/surgery_step/robotics/face/reconstruct_chassis/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message(
-		SPAN_NOTICE("[user] begins reshaping a steel sheet to reconstruct [target]'s mangled face."),
-		SPAN_NOTICE("You begin reshaping a steel sheet to reconstruct [target]'s mangled face.")
+		SPAN_NOTICE("[user] begins reshaping a steel sheet to reconstruct [target]'s mangled face plating."),
+		SPAN_NOTICE("You begin reshaping a steel sheet to reconstruct [target]'s mangled face plating.")
 	)
 	..()
 
@@ -175,13 +175,13 @@
 	head.disfigured = FALSE
 	target.update_body()
 	user.visible_message(
-		SPAN_NOTICE("[user] finishes reconstructing [target]'s chassis face."),
-		SPAN_NOTICE("You successfully reconstruct [target]'s chassis face.")
+		SPAN_NOTICE("[user] finishes reconstructing [target]'s faceplate."),
+		SPAN_NOTICE("You successfully reconstruct [target]'s faceplate.")
 	)
 
 /singleton/surgery_step/robotics/face/reconstruct_chassis/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message(
-		SPAN_WARNING("[user] fails to properly shape the replacement plating for [target]'s face."),
+		SPAN_WARNING("[user] fails to properly shape the replacement plating for [target]'s faceplate."),
 		SPAN_WARNING("You fail to properly shape the replacement facial plating.")
 	)
 

--- a/code/modules/surgery/facial_surgery.dm
+++ b/code/modules/surgery/facial_surgery.dm
@@ -138,6 +138,53 @@
 /singleton/surgery_step/robotics/face/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target_zone == BP_MOUTH
 
+/singleton/surgery_step/robotics/face/reconstruct_chassis
+	name = "Reconstruct Chassis Face"
+	allowed_tools = list(
+		/obj/item/stack/material/steel = 100
+	)
+	base_surgery_time = 10 SECONDS
+	skill_requirements = alist(ROBOTICS_SKILL_COMPONENT = SKILL_LEVEL_TRAINED)
+	skill_diff_fail_modifier = SURGERY_DIFFICULTY_MEDIUM
+
+/singleton/surgery_step/robotics/face/reconstruct_chassis/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	if(!..() || !isipc(target) || target.get_species() == SPECIES_IPC_SHELL)
+		return FALSE
+
+	var/obj/item/organ/external/head/head = target.get_organ(target_zone)
+	if(head.open != ORGAN_ENCASED_RETRACTED)
+		return FALSE
+
+	var/obj/item/stack/material/steel/steel = tool
+	return head?.disfigured && steel.get_amount() >= 5
+
+/singleton/surgery_step/robotics/face/reconstruct_chassis/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] begins reshaping a steel sheet to reconstruct [target]'s mangled face."),
+		SPAN_NOTICE("You begin reshaping a steel sheet to reconstruct [target]'s mangled face.")
+	)
+	..()
+
+/singleton/surgery_step/robotics/face/reconstruct_chassis/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/head/head = target.get_organ(target_zone)
+	var/obj/item/stack/material/steel/steel = tool
+	if(!head?.disfigured || !steel.use(5))
+		to_chat(user, SPAN_WARNING("You can no longer complete the facial reconstruction."))
+		return
+
+	head.disfigured = FALSE
+	target.update_body()
+	user.visible_message(
+		SPAN_NOTICE("[user] finishes reconstructing [target]'s chassis face."),
+		SPAN_NOTICE("You successfully reconstruct [target]'s chassis face.")
+	)
+
+/singleton/surgery_step/robotics/face/reconstruct_chassis/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	user.visible_message(
+		SPAN_WARNING("[user] fails to properly shape the replacement plating for [target]'s face."),
+		SPAN_WARNING("You fail to properly shape the replacement facial plating.")
+	)
+
 /singleton/surgery_step/robotics/face/synthskinopen
 	name = "Retract facial incisions"
 	allowed_tools = list(

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -124,10 +124,14 @@
 
 	// What surgeries does our tool/target enable?
 	var/list/possible_surgeries
+	var/is_surgery_tool = FALSE
 	var/list/all_surgeries = GET_SINGLETON_SUBTYPE_MAP(/singleton/surgery_step)
 	for(var/decl in all_surgeries)
 		var/singleton/surgery_step/S = all_surgeries[decl]
-		if(S.tool_quality(tool) && S.can_use(user, M, zone, tool))
+		if(!S.tool_quality(tool))
+			continue
+		is_surgery_tool = TRUE
+		if(S.can_use(user, M, zone, tool))
 			LAZYSET(possible_surgeries, S, TRUE)
 
 	// Which surgery, if any, do we actually want to do?
@@ -140,7 +144,7 @@
 
 	// We didn't find a surgery, or decided not to perform one.
 	if(!istype(S))
-		if(tool.item_flags & ITEM_FLAG_SURGERY) //Is this supposed to be used for surgery?
+		if(is_surgery_tool || (tool.item_flags & ITEM_FLAG_SURGERY)) //Is this supposed to be used for surgery?
 			to_chat(user, SPAN_WARNING("You aren't sure what you could do to \the [M] with \the [tool]."))
 			return TRUE
 		return FALSE //Just do the normal use for the tool instead

--- a/html/changelogs/IPCSurgeryFix.yml
+++ b/html/changelogs/IPCSurgeryFix.yml
@@ -1,0 +1,7 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Non-synthskin IPC can now have their faces fixed."
+  - bugfix: "Using the wrong tool for an IPC surgery will no longer smack them with said item."


### PR DESCRIPTION
IPC faceplates can be repaired with 5 sheets of steel, by targetting the mouth after opening up the head. This does not work on synthskin, as they have a separate surgery for it.
Additionally IPC will no longer get randomly smacked if one guesses the next surgery tool wrong, assuming one is on help intent.