### PR TITLE
Adds the ability to upgrade the material silos

### DIFF
--- a/code/modules/research/material_silo.dm
+++ b/code/modules/research/material_silo.dm
@@ -4,6 +4,9 @@
 	icon_state = "silo"
 
 	idle_power_usage = 30 WATTS
+	component_types = list(
+		/obj/item/stock_parts/matter_bin = 3
+	)
 
 	/// Total material capacity, measured in material units.
 	var/max_material_storage = 800000
@@ -24,11 +27,20 @@
 
 /obj/structure/machinery/r_n_d/material_silo/upgrade_hints(mob/user, distance, is_adjacent)
 	. += ..()
+	. += "- Upgraded <b>matter bins</b> will increase the shared material storage capacity."
 	. += SPAN_NOTICE("\t- The shared storage capacity is <b>[max_material_storage / SHEET_MATERIAL_AMOUNT]</b> sheets.")
 
 /obj/structure/machinery/r_n_d/material_silo/Initialize(mapload, d, populate_components, is_internal)
 	. = ..()
 	update_icon()
+
+/obj/structure/machinery/r_n_d/material_silo/RefreshParts()
+	..()
+	var/matter_bin_rating = 0
+	for(var/obj/item/stock_parts/matter_bin/matter_bin in component_parts)
+		matter_bin_rating += matter_bin.rating
+	max_material_storage = initial(max_material_storage) * matter_bin_rating / 3
+	update_linked_uis()
 
 /obj/structure/machinery/r_n_d/material_silo/update_icon()
 	. = ..()

--- a/html/changelogs/MaterialUpgrade.yml
+++ b/html/changelogs/MaterialUpgrade.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Material silos can now be upgraded. Each tier is equal to 400 sheets worth of storage."


### PR DESCRIPTION
I forgot it in the original implementation. Now it is possible to upgrade the components. It uses 3 matter bins and each tier provides 400 sheet storage.
so all level 1 bins gives 400, all level 2 gives 800 and all level 3 gives 1200.