### PR TITLE
Allows turning down the lore radio volume and changes its chat appearance

### DIFF
--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -20,6 +20,7 @@
 #define SPAN_SOGHUN(str) ("<span class='soghun'>" + str + "</span>")
 #define SPAN_VOTE(str) ("<span class='vote'>" + str + "</span>")
 #define SPAN_HEAR(str) ("<span class='hear'>" + str + "</span>")
+#define SPAN_LORE_RADIO(str) ("<span class='lore-radio'>" + str + "</span>")
 #define SPAN_STYLE(style, str) "<span style=\"[style]\">[str]</span>"
 #define SPAN_COLOR(color, str) SPAN_STYLE("color: [color]", "[str]")
 #define SPAN_CAUTION(str) ("<span class='caution'>" + str + "</span>")

--- a/code/game/objects/items/lore_radio.dm
+++ b/code/game/objects/items/lore_radio.dm
@@ -10,6 +10,8 @@
 	var/receiving = FALSE
 	var/current_station = null
 	var/starts_on = FALSE //so you can map it and have it broadcast without anyone turning it on
+	/// Low volume suppresses chat output while retaining overhead messages.
+	var/low_volume = FALSE
 
 /obj/item/lore_radio/Initialize()
 	. = ..()
@@ -20,11 +22,17 @@
 		toggle_receiving()
 	RegisterSignal(SSdcs, COMSIG_GLOB_LORE_RADIO_BROADCAST, PROC_REF(relay_lore_radio))
 
-/obj/item/lore_radio/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
+/obj/item/lore_radio/mechanics_hints(mob/user, distance, is_adjacent)
 	. = ..()
-	to_chat(user, SPAN_NOTICE("\The [src] is turned [receiving ? "on" : "off"]."))
+	. += "Alt-click to turn it on and off."
+	. += "Ctrl-click to switch between normal and low volume."
+
+/obj/item/lore_radio/feedback_hints(mob/user, distance, is_adjacent)
+	. = ..()
+	. += "\The [src] is turned [receiving ? "on" : "off"]."
 	if(current_station)
-		to_chat(user, SPAN_NOTICE("\The [src] is listening to \the [current_station] radio station."))
+		. += "\The [src] is listening to \the [current_station] radio station."
+	. += "Its volume is set to [low_volume ? "low" : "normal"]."
 
 /obj/item/lore_radio/attack_self(var/mob/user)
 	var/list/possible_stations = get_possible_stations()
@@ -36,6 +44,12 @@
 
 /obj/item/lore_radio/AltClick(var/mob/user)
 	toggle_receiving(user)
+
+/obj/item/lore_radio/CtrlClick(mob/user)
+	if(Adjacent(user))
+		low_volume = !low_volume
+		user.visible_message("<b>[user]</b> turns \the [src]'s volume [low_volume ? "down" : "up"].", SPAN_NOTICE("You turn \the [src]'s volume [low_volume ? "down" : "up"]."), range = 3)
+		return
 
 /obj/item/lore_radio/proc/get_possible_stations()
 	var/list/possible_stations = list(WEATHER_RADIO_CHANNEL)
@@ -62,9 +76,10 @@
 		return
 
 	if(radio_message)
-		output_spoken_message(radio_message)
+		output_spoken_message(radio_message, display_chat = !low_volume, chat_class = "lore-radio")
 	else
-		audible_message("The [SPAN_BOLD("[name]")] only emits white noise...") // using name instead of src so it doesn't add a bolded The or whatever, better control of what displays
+		if(!low_volume)
+			audible_message("<span class='lore-radio'>The [SPAN_BOLD("[name]")] only emits white noise...</span>") // using name instead of src so it doesn't add a bolded The or whatever, better control of what displays
 
 /// Listens to when a weather change on this Z-level is broadcasted from a configured weather reader (survey probe), and reads it aloud
 /obj/item/lore_radio/proc/relay_weather_broadcast(var/datum/source, var/z_level, var/singleton/state_transition/weather/weather_transition, var/time_to_transition, var/broadcast_message)
@@ -78,6 +93,6 @@
 	if(!(z_level in connected_z_levels))
 		return
 
-	output_spoken_message(broadcast_message)
+	output_spoken_message(broadcast_message, display_chat = !low_volume, chat_class = "lore-radio")
 
 #undef WEATHER_RADIO_CHANNEL

--- a/code/game/objects/items/lore_radio.dm
+++ b/code/game/objects/items/lore_radio.dm
@@ -51,6 +51,9 @@
 		user.visible_message("<b>[user]</b> turns \the [src]'s volume [low_volume ? "down" : "up"].", SPAN_NOTICE("You turn \the [src]'s volume [low_volume ? "down" : "up"]."), range = 3)
 		return
 
+/obj/item/lore_radio/format_spoken_chat_message(var/message)
+	return SPAN_LORE_RADIO(message)
+
 /obj/item/lore_radio/proc/get_possible_stations()
 	var/list/possible_stations = list(WEATHER_RADIO_CHANNEL)
 	if(SSatlas.current_sector?.lore_radio_stations)
@@ -76,10 +79,10 @@
 		return
 
 	if(radio_message)
-		output_spoken_message(radio_message, display_chat = !low_volume, chat_class = "lore-radio")
+		output_spoken_message(radio_message, display_chat = !low_volume)
 	else
 		if(!low_volume)
-			audible_message("<span class='lore-radio'>The [SPAN_BOLD("[name]")] only emits white noise...</span>") // using name instead of src so it doesn't add a bolded The or whatever, better control of what displays
+			audible_message(SPAN_LORE_RADIO("The [SPAN_BOLD("[name]")] only emits white noise...")) // using name instead of src so it doesn't add a bolded The or whatever, better control of what displays
 
 /// Listens to when a weather change on this Z-level is broadcasted from a configured weather reader (survey probe), and reads it aloud
 /obj/item/lore_radio/proc/relay_weather_broadcast(var/datum/source, var/z_level, var/singleton/state_transition/weather/weather_transition, var/time_to_transition, var/broadcast_message)
@@ -93,6 +96,6 @@
 	if(!(z_level in connected_z_levels))
 		return
 
-	output_spoken_message(broadcast_message, display_chat = !low_volume, chat_class = "lore-radio")
+	output_spoken_message(broadcast_message, display_chat = !low_volume)
 
 #undef WEATHER_RADIO_CHANNEL

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -399,8 +399,12 @@
 	clean_blood()
 	color = initial(color)
 
-/obj/proc/output_spoken_message(var/message, var/message_verb = "transmits", var/display_overhead = TRUE, var/overhead_time = 2 SECONDS)
-	audible_message("\The <b>[src.name]</b> [message_verb], \"[message]\"")
+/obj/proc/output_spoken_message(var/message, var/message_verb = "transmits", var/display_overhead = TRUE, var/overhead_time = 2 SECONDS, var/display_chat = TRUE, var/chat_class)
+	if(display_chat)
+		var/rendered_message = "\The <b>[src.name]</b> [message_verb], \"[message]\""
+		if(chat_class)
+			rendered_message = "<span class='[chat_class]'>[rendered_message]</span>"
+		audible_message(rendered_message)
 	if(display_overhead)
 		var/list/hearers = get_hearers_in_view(7, src)
 		var/list/clients_in_hearers = list()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -399,11 +399,10 @@
 	clean_blood()
 	color = initial(color)
 
-/obj/proc/output_spoken_message(var/message, var/message_verb = "transmits", var/display_overhead = TRUE, var/overhead_time = 2 SECONDS, var/display_chat = TRUE, var/chat_class)
+/obj/proc/output_spoken_message(var/message, var/message_verb = "transmits", var/display_overhead = TRUE, var/overhead_time = 2 SECONDS, var/display_chat = TRUE)
 	if(display_chat)
 		var/rendered_message = "\The <b>[src.name]</b> [message_verb], \"[message]\""
-		if(chat_class)
-			rendered_message = "<span class='[chat_class]'>[rendered_message]</span>"
+		rendered_message = format_spoken_chat_message(rendered_message)
 		audible_message(rendered_message)
 	if(display_overhead)
 		var/list/hearers = get_hearers_in_view(7, src)
@@ -413,6 +412,10 @@
 				clients_in_hearers += mob.client
 		if(length(clients_in_hearers))
 			langchat_speech(message, hearers)
+
+/// Override to apply object-specific formatting to spoken chat output without affecting overhead messages.
+/obj/proc/format_spoken_chat_message(var/message)
+	return message
 
 /// Override this to customize the effects an activated signaler has.
 /obj/proc/do_signaler()

--- a/code/modules/background/space_sectors/space_sector.dm
+++ b/code/modules/background/space_sectors/space_sector.dm
@@ -231,7 +231,7 @@
 			broadcast_info[RADIO_NEXT_BROADCAST] = world.time + 30 SECONDS // give it a bit of a breather if we've exhausted all the messages
 		else
 			broadcast_info[RADIO_BROADCAST_INDEX]++
-			broadcast_info[RADIO_NEXT_BROADCAST] = world.time + (rand(6, 10) SECONDS) // otherwise, throw in a randomish delay (considering we're on SSprocessing, it'll uusssuaaalllyyy be about 2 seconds at minimum)
+			broadcast_info[RADIO_NEXT_BROADCAST] = world.time + (rand(10, 14) SECONDS) // otherwise, throw in a randomish delay (considering we're on SSprocessing, it'll uusssuaaalllyyy be about 2 seconds at minimum)
 
 /datum/space_sector/proc/get_chat_description()
 	return "<hr><div align='center'><hr1><B>Current Sector: [name]!</B></hr1><br><i>[description]</i><hr></div>"

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -53,6 +53,7 @@ em						{font-style: normal;font-weight: bold;}
 .radio					{color: #008000;}
 .deptradio				{color: #ff00ff;}	/* when all other department colors fail */
 .newscaster				{color: #750000;}
+.lore-radio				{color: #666666; font-size: 90%;}
 
 /* Radio Channels */
 .comradio				{color: #193A7A;}

--- a/html/changelogs/LoreRadioChanges.yml
+++ b/html/changelogs/LoreRadioChanges.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "Changed the color of the lore radio in chat and added the ability to turn down the volume to hide the chat messages while keeping the overhead talking."

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -451,6 +451,11 @@ em {
 .newscaster {
   color: #b43c3c;
 }
+.lore-radio {
+  color: #aaaaaa;
+  font-size: 90%;
+}
+
 /* Radio Channels */
 .comradio {
   color: #5b8deb;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -464,6 +464,10 @@ em {
 .newscaster {
   color: #750000;
 }
+.lore-radio {
+  color: #666666;
+  font-size: 90%;
+}
 
 /* Radio Channels */
 .comradio {


### PR DESCRIPTION
This makes it less distracting and allows to also set it as background noise without occupying chat.
The time between the chat messages were also slightly increased, to make it less spammy.
<img width="901" height="220" alt="image" src="https://github.com/user-attachments/assets/e3982a59-a3e6-4758-857d-8274e046c623" />
<img width="900" height="134" alt="image" src="https://github.com/user-attachments/assets/96802421-21c7-4472-a68c-17e5e098044c" />
