### PR TITLE
Fix Showers Again

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -143,6 +143,10 @@
 	var/is_washing = 0
 	var/list/temperature_settings = list("normal" = 310, "boiling" = T0C+100, "freezing" = T0C)
 	var/datum/looping_sound/showering/soundloop
+	/// The amount of time a shower will stay on before shutting itself off.
+	var/leave_on_time = 5 MINUTES
+	/// The REALTIMEOFDAY at which a shower will turn itself off.
+	VAR_PRIVATE/shut_off_time = 0
 
 /obj/structure/shower/mechanics_hints(mob/user, distance, is_adjacent)
 	. += ..()
@@ -179,7 +183,8 @@
 	on = !on
 	update_icon()
 	if(on)
-		START_PROCESSING(SSmachinery, src)
+		shut_off_time = leave_on_time + REALTIMEOFDAY
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 		if (M.loc == loc)
 			wash(M)
 			process_heat(M)
@@ -272,6 +277,9 @@
 
 /obj/structure/machinery/shower/process()
 	if(!on)
+		return PROCESS_KILL
+	if (REALTIMEOFDAY > shut_off_time)
+		on = FALSE
 		return PROCESS_KILL
 	wash_floor()
 	if(!mobpresent)

--- a/html/changelogs/hellfirejag-fix-showers.yml
+++ b/html/changelogs/hellfirejag-fix-showers.yml
@@ -1,0 +1,5 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed showers not cleaning things."
+  - rscadd: "Showers now turn themselves off after 5 minutes to conserve water (and CPU time)"


### PR DESCRIPTION
My last PR broke showers because I used the wrong start processing macro, as I discovered while working on gas canisters. This PR fixes showers so that they actually clean again. This time I've tested my PR and attached screenshots to prove it works. While I was at it, I added a simple functionality for showers to automatically turn themselves off after 5 minutes. Ostensibly so that they won't process forever after turned on.

Dirty character, showers are off, 4943 processing machines.

<img width="1905" height="983" alt="image" src="https://github.com/user-attachments/assets/d587f100-9bb7-4548-94d1-ea859d1e9b9e" />

Shower turned on, 4944 processing machines.

<img width="1246" height="323" alt="image" src="https://github.com/user-attachments/assets/45a8c5a8-56eb-48bd-8e49-19be01dde9ac" />

Character steps into shower, and is cleaned. 

<img width="1708" height="728" alt="image" src="https://github.com/user-attachments/assets/de19b097-bc0c-40c3-9ccb-512c93ddf89e" />

verifying shut off time is set.

<img width="1030" height="497" alt="image" src="https://github.com/user-attachments/assets/c9150554-9ae4-405c-9f94-5a847ad645ae" />
