### PR TITLE
Getmore snack rebalance

### DIFF
--- a/code/game/objects/structures/machinery/vending/snacks.dm
+++ b/code/game/objects/structures/machinery/vending/snacks.dm
@@ -99,8 +99,11 @@
 
 /obj/structure/machinery/vending/snack/low_supply
 	products = list(
+		/obj/item/reagent_containers/food/snacks/candy = 2,
+		/obj/item/reagent_containers/food/snacks/chocolatebar = 2,
 		/obj/item/reagent_containers/food/drinks/dry_ramen = 4,
 		/obj/item/reagent_containers/food/snacks/chips = 1,
+		/obj/item/reagent_containers/food/snacks/cheesiehonkers = 1,
 		/obj/item/reagent_containers/food/snacks/sosjerky = 2,
 		/obj/item/reagent_containers/food/snacks/no_raisin = 4,
 		/obj/item/storage/box/fancy/vkrexitaffy = 3,

--- a/code/game/objects/structures/machinery/vending/snacks.dm
+++ b/code/game/objects/structures/machinery/vending/snacks.dm
@@ -99,11 +99,8 @@
 
 /obj/structure/machinery/vending/snack/low_supply
 	products = list(
-		/obj/item/reagent_containers/food/snacks/candy = 2,
-		/obj/item/reagent_containers/food/snacks/chocolatebar = 2,
 		/obj/item/reagent_containers/food/drinks/dry_ramen = 4,
 		/obj/item/reagent_containers/food/snacks/chips = 1,
-		/obj/item/reagent_containers/food/snacks/cheesiehonkers = 1,
 		/obj/item/reagent_containers/food/snacks/sosjerky = 2,
 		/obj/item/reagent_containers/food/snacks/no_raisin = 4,
 		/obj/item/storage/box/fancy/vkrexitaffy = 3,
@@ -141,6 +138,10 @@
 
 /obj/structure/machinery/vending/snack/horizon
 	products = list(
+		/obj/item/reagent_containers/food/snacks/candy = 6,
+		/obj/item/reagent_containers/food/snacks/chocolatebar = 6,
+		/obj/item/reagent_containers/food/snacks/whitechocolate/wrapped = 2,
+		/obj/item/clothing/mask/chewable/candy/lolli = 2,
 		/obj/item/reagent_containers/food/drinks/dry_ramen = 6,
 		/obj/item/reagent_containers/food/snacks/sosjerky = 6,
 		/obj/item/reagent_containers/food/snacks/spacetwinkie = 6,

--- a/code/modules/cooking/machinery/commissary.dm
+++ b/code/modules/cooking/machinery/commissary.dm
@@ -422,7 +422,6 @@
 		/obj/item/reagent_containers/food/snacks/packaged_microwave_mac_and_cheeze = 3,
 		/obj/item/reagent_containers/food/snacks/packaged_microwave_fiery_mac_and_cheeze = 3,
 		/obj/item/storage/box/fancy/packaged_burger = 3,
-		/obj/item/storage/box/fancy/packaged_mossburger = 2,
 		/obj/item/reagent_containers/food/snacks/quick_curry = 3,
 		/obj/item/reagent_containers/food/snacks/hv_dinner = 3,
 		/obj/item/storage/box/fancy/toptarts_strawberry = 3,

--- a/html/changelogs/example.yml
+++ b/html/changelogs/example.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: Tomixcomics
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -55,5 +55,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
-  - rscdel: "Killed innocent kittens."
+  - balance: "Adds back a couple of the removed items to the Getmore snack vending machines."
+  - rscdel: "Removed the mossburger from the comissary restock packs since it's not supposed to be easily available outside of Konyang."

--- a/html/changelogs/example.yml
+++ b/html/changelogs/example.yml
@@ -56,4 +56,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - balance: "Adds back a couple of the removed items to the Getmore snack vending machines."
-  - rscdel: "Removed the mossburger from the comissary restock packs since it's not supposed to be easily available outside of Konyang."
+  - rscdel: "Removed the mossburger from the commissary restock packs since it's not supposed to be easily available outside of Konyang."

--- a/html/changelogs/tomixcomics-PR.yml
+++ b/html/changelogs/tomixcomics-PR.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: Tomixcomics
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -55,5 +55,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
-  - rscdel: "Killed innocent kittens."
+  - balance: "Adds back a couple of the removed items to the Getmore snack vending machines."
+  - rscdel: "Removed the mossburger from the commissary restock packs since it's not supposed to be easily available outside of Konyang."


### PR DESCRIPTION
-Puts a few of the snacks that were removed from the vending machine in favor of the commissary back into it (namely chocolate bars, Lollipops, and candy bars)
-Removes the microwave mossburger from the commissary restock pack since it's supposed to be difficult to find outside of Konyang according to it's description.