### PR TITLE
post—ADFT arc PsiProtect clean up/changes

### DIFF
--- a/code/datums/components/psionics/psiblock_drugs.dm
+++ b/code/datums/components/psionics/psiblock_drugs.dm
@@ -230,24 +230,6 @@
 	var/seizure_long_delay = seizure_warning_delay + 1 MINUTE
 	addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob/living/carbon/human, seizure), seizure_intensity), seizure_long_delay)
 
-/datum/component/timed_life/psiblock_drugs/yomi_genetics/cheap
-	min_tremor_time = 30 SECONDS
-	max_tremor_time = 2 MINUTES
-
-	min_seizure_time = 5 MINUTES
-	max_seizure_time = 30 MINUTES
-
-	telepathy_cancel_probability = 75
-	psi_sensitivity_modifier = -0.75
-	accuracy_penalty = 0.35
-	dispersion_penalty = 10
-	surgery_success_penalty = -20
-	seizure_intensity = 2
-
-/datum/component/timed_life/psiblock_drugs/yomi_genetics/cheap/Initialize(lifetime_seconds)
-	. = ..()
-	ongoing_effect_message = RISK_LOW + RISK_MEDIUM + RISK_HIGH
-
 /datum/component/timed_life/psiblock_drugs/yomi_genetics/expensive
 	min_tremor_time = 2 MINUTES
 	max_tremor_time = 5 MINUTES

--- a/code/game/objects/items/weapons/storage/pill_bottle.dm
+++ b/code/game/objects/items/weapons/storage/pill_bottle.dm
@@ -234,6 +234,6 @@
 	name = "bottle of PsiProtect Personalised pills"
 	desc = "A YomiGenetics high-precision, personalised drug tailored to a patient's genetic, neurological, and psionic profile. It uses Ranixidone as the active ingredient, delivered in gold nanoparticles with targeting ligands on the surface." \
 		+ "It is marketed towards those with psionic disorders, such as psionic echoes, and made available at discounted prices to Zeng-Hu-affiliated explorers of the Lemurian Sea. " \
-		+ "Thrice as expensive as other brands of ranixidone and market towards more affluent customers. " \
+		+ "Thrice as expensive as other brands of ranixidone and marketed towards more affluent customers. " \
 		+ "Nonetheless, it remains cheaper than the more elegant ZHP-MSV3 'Mindblankers'."
 	starts_with = list(/obj/item/reagent_containers/pill/psi_protect/yomi_genetics/expensive = 6)

--- a/code/game/objects/items/weapons/storage/pill_bottle.dm
+++ b/code/game/objects/items/weapons/storage/pill_bottle.dm
@@ -217,40 +217,23 @@
  * This version of the pill has no side effects, and is not intended to be spawned directly.
  */
 /obj/item/storage/pill_bottle/psi_protect
-	name = "bottle of Psi-protect pills"
+	name = "bottle of Ranixodone pills"
 	desc = "A high-precision, personalised drug tailored to a patient's genetic, neurological, and psionic profile. " \
 		+ "It is marketed towards those with psionic disorders, such as psionic echoes, and made available at discounted prices to Zeng-Hu-affiliated explorers of the Lemurian Sea."
 	starts_with = list(/obj/item/reagent_containers/pill/psi_protect = 6)
 
 /obj/item/storage/pill_bottle/psi_protect/yomi_genetics
-	name = "bottle of Psi-protect Personalized pills"
-	desc = "A YomiGenetics high-precision, personalised drug tailored to a patient's genetic, neurological, and psionic profile. " \
-		+ "It is marketed towards those with psionic disorders, such as psionic echoes, and made available at discounted prices to Zeng-Hu-affiliated explorers of the Lemurian Sea."
+	name = "bottle of Ranixodone pills"
+	desc = "A YomiGenetics counter-psionic drug that broadly blocks neural pathways in the zona bovinae associated with psionic sensitivity. " \
+		+ "It is marketed towards those with psionic disorders, such as psionic echoes, and made available at discounted prices to Zeng-Hu-affiliated explorers of the Lemurian Sea. " \
+		+ "It has been improved upon and is significantly safer than the pilot 'PsiProtect Broad Use' brand that was mired in a Spur-wide 2468 scandal, with the appropriate side-effect" \
+		+ "warnings this time around (including seizures)."
 	starts_with = list(/obj/item/reagent_containers/pill/psi_protect/yomi_genetics = 6)
 
-/obj/item/storage/pill_bottle/psi_protect/yomi_genetics/cheap
-	name = "bottle of Psi-protect Broad-Use pills"
-	desc = "A cheaper, broad-targetting drug under the PsiProtect brand, with a more brute-force mechanism and only requiring the most basic of psionic profiling tests. " \
-		+ "This one has long stopped being prescribed or marketed, but is available at clearance prices."
-	starts_with = list(/obj/item/reagent_containers/pill/psi_protect/yomi_genetics/cheap = 6)
-
 /obj/item/storage/pill_bottle/psi_protect/yomi_genetics/expensive
-	name = "bottle of Psi-protect Personalized Gold pills"
-	desc = "A high-precision, personalised drug tailored to a patient's genetic, neurological, and psionic profile. " \
+	name = "bottle of PsiProtect Personalised pills"
+	desc = "A YomiGenetics high-precision, personalised drug tailored to a patient's genetic, neurological, and psionic profile. It uses Ranixidone as the active ingredient, delivered in gold nanoparticles with targeting ligands on the surface." \
 		+ "It is marketed towards those with psionic disorders, such as psionic echoes, and made available at discounted prices to Zeng-Hu-affiliated explorers of the Lemurian Sea. " \
-		+ "This one is thrice as expensive, for more affluent customers, and requiring more genetic and neurological profiling. " \
+		+ "Thrice as expensive as other brands of ranixidone and market towards more affluent customers. " \
 		+ "Nonetheless, it remains cheaper than the more elegant ZHP-MSV3 'Mindblankers'."
 	starts_with = list(/obj/item/reagent_containers/pill/psi_protect/yomi_genetics/expensive = 6)
-
-/obj/item/paper/fluff/psiprotect_memo
-	name = "psiprotect memo"
-	desc = "A memo left behind by another pharmacist."
-	info = "\
-		<br>\
-		MEMO: PSI-PROTECT PILLS \
-		<br>\
-		<br>\
-		Our bulk PsiProtect Broad Use resupply has arrived for prescription refills and any emergency ADPI prescriptions.\
-		They were going at clearance prices so we have enough stored in the warehouse for the entire operation!<br><br>\
-		Personalised variants will continue to be mailed individually to patients (no wonder the price, on top of all the tests!).<br>\
-		- S"

--- a/code/modules/client/preference_setup/loadout/items/drugs_meds.dm
+++ b/code/modules/client/preference_setup/loadout/items/drugs_meds.dm
@@ -216,14 +216,13 @@
 	gear_tweaks += new /datum/gear_tweak/path(legal_rec)
 
 /datum/gear/drugs_meds/psi_pills
-	display_name = "psi-protect pill selection"
-	description = "Select from the different kinds of YomiGenetics Psi-protect pills, used to protect against Acute Debilitating Psionic Interference and to treat other psionic related conditions such as psionic echoes."
+	display_name = "anti-psionic pill selection"
+	description = "Select from the different kinds of YomiGenetics I&R anti-psionic pills, used to protect against certain psionic disorders, such as psionic echoes and ADPI."
 	path = /obj/item/storage/pill_bottle/psi_protect/yomi_genetics
 
 /datum/gear/drugs_meds/psi_pills/New()
 	..()
 	var/list/psipills = list()
-	psipills["Psi-protect Broad-Use pills"] = /obj/item/storage/pill_bottle/psi_protect/yomi_genetics/cheap
-	psipills["Psi-protect Personalized pills"] = /obj/item/storage/pill_bottle/psi_protect/yomi_genetics
-	psipills["Psi-protect Personalized Gold pills"] = /obj/item/storage/pill_bottle/psi_protect/yomi_genetics/expensive
+	psipills["Ranixidone pills"] = /obj/item/storage/pill_bottle/psi_protect/yomi_genetics
+	psipills["PsiProtect Personalised pills"] = /obj/item/storage/pill_bottle/psi_protect/yomi_genetics/expensive
 	gear_tweaks += new /datum/gear_tweak/path(psipills)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
@@ -849,8 +849,8 @@
 	. = ..()
 
 /singleton/reagent/drugs/psiblock
-	name = "PsiProtect"
-	description = "A drug that provides temporary protection against psionic effects. It is marketed towards explorers intending to enter or travel near to the Lemurian Sea."
+	name = "Ranixidone"
+	description = "A drug that provides temporary protection against psionic effects. It is marketed towards Lemurian Sea explorers and those with psionic disorders."
 	color = "#b0b0b0"
 	taste_description = "inexplicably the color grey itself, then all other tastes fade into nothingness"
 	initial_effect_message_list = null
@@ -864,9 +864,6 @@
 
 /singleton/reagent/drugs/psiblock/yomi_genetics
 	component_to_add = /datum/component/timed_life/psiblock_drugs/yomi_genetics
-
-/singleton/reagent/drugs/psiblock/yomi_genetics/cheap
-	component_to_add = /datum/component/timed_life/psiblock_drugs/yomi_genetics/cheap
 
 /singleton/reagent/drugs/psiblock/yomi_genetics/expensive
 	component_to_add = /datum/component/timed_life/psiblock_drugs/yomi_genetics/expensive

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -759,6 +759,14 @@
 	catalysts = list(/singleton/reagent/sodium = 5)
 	result_amount = 1
 
+/datum/chemical_reaction/psiblock
+	name = "Ranixidone"
+	id = "ranixidone"
+	result = /singleton/reagent/drugs/psiblock/yomi_genetics
+	required_reagents = list(/singleton/reagent/drugs/mindbreaker = 1, /singleton/reagent/drugs/impedrezene = 2, /singleton/reagent/wulumunusha = 2)
+	catalysts = list(/singleton/reagent/toxin/phoron = 5)
+	result_amount = 3
+
 //Mental Medication
 
 /datum/chemical_reaction/corophenidate

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -413,7 +413,7 @@
 	reagents_to_add = list(/singleton/reagent/drugs/psilocybin = 5)
 
 /obj/item/reagent_containers/pill/psi_protect
-	name = "5u Psi-protect Pill"
+	name = "5u Ranixidone Pill"
 	desc = "A pill used to protect against ADPI and treat various psionic disorders"
 	icon_state = "pill10"
 	reagents_to_add = list(/singleton/reagent/drugs/psiblock = 5)
@@ -421,8 +421,5 @@
 /obj/item/reagent_containers/pill/psi_protect/yomi_genetics
 	reagents_to_add = list(/singleton/reagent/drugs/psiblock/yomi_genetics = 5)
 
-/obj/item/reagent_containers/pill/psi_protect/yomi_genetics/cheap
-	reagents_to_add = list(/singleton/reagent/drugs/psiblock/yomi_genetics/cheap = 5)
-
 /obj/item/reagent_containers/pill/psi_protect/yomi_genetics/expensive
-	reagents_to_add = list(/singleton/reagent/drugs/psiblock/yomi_genetics/expensive = 5)
+	reagents_to_add = list(/singleton/reagent/drugs/psiblock/yomi_genetics/expensive = 5, /singleton/reagent/gold = 1)

--- a/html/changelogs/kermit-psiprotect-cleanup.yml
+++ b/html/changelogs/kermit-psiprotect-cleanup.yml
@@ -5,5 +5,5 @@ delete-after: True
 changes:
   - rscdel: "Removes PsiProtect Broad Use."
   - rscadd: "Merges the PsiProtect Personalised variants into one loadout only brand, inheriting PsiProtect Personalised Gold's mechanics."
-  - rsdadd: "Adds the non-branded active ingredient behind PsiProtect, Ranixidone, which can be made in the Pharmacy (1u Mindbreaker, 2u Impederezene, 2u Wulumunusha, 5u Phoron Catalyst = 3u Ranixidone) and which inherits the standard PsiProtect Personalised mechanics."
+  - rscadd: "Adds the non-branded active ingredient behind PsiProtect, Ranixidone, which can be made in the Pharmacy (1u Mindbreaker, 2u Impederezene, 2u Wulumunusha, 5u Phoron Catalyst = 3u Ranixidone) and which inherits the standard PsiProtect Personalised mechanics."
   - rscdel: "Removes the mapped in PsiProtect and included memo from the Pharmacy."

--- a/html/changelogs/kermit-psiprotect-cleanup.yml
+++ b/html/changelogs/kermit-psiprotect-cleanup.yml
@@ -1,0 +1,9 @@
+author: kermit
+
+delete-after: True
+
+changes:
+  - rscdel: "Removes PsiProtect Broad Use."
+  - rscadd: "Merges the PsiProtect Personalised variants into one loadout only brand, inheriting PsiProtect Personalised Gold's mechanics."
+  - rsdadd: "Adds the non-branded active ingredient behind PsiProtect, Ranixidone, which can be made in the Pharmacy (1u Mindbreaker, 2u Impederezene, 2u Wulumunusha, 5u Phoron Catalyst = 3u Ranixidone) and which inherits the standard PsiProtect Personalised mechanics."
+  - rscdel: "Removes the mapped in PsiProtect and included memo from the Pharmacy."

--- a/maps/sccv_horizon/sccv_horizon.dmm
+++ b/maps/sccv_horizon/sccv_horizon.dmm
@@ -106219,18 +106219,6 @@
 	dir = 4
 	},
 /obj/structure/table/rack/retail_shelf,
-/obj/item/storage/pill_bottle/psi_protect/yomi_genetics/cheap{
-	pixel_x = -11;
-	pixel_y = 18
-	},
-/obj/item/storage/pill_bottle/psi_protect/yomi_genetics/cheap{
-	pixel_x = -4;
-	pixel_y = 18
-	},
-/obj/item/storage/pill_bottle/psi_protect/yomi_genetics/cheap{
-	pixel_x = -11;
-	pixel_y = 14
-	},
 /obj/structure/sign/poster/medical/bay_39{
 	pixel_x = 28
 	},
@@ -142248,10 +142236,6 @@
 	pixel_x = 6;
 	pixel_y = -1;
 	req_access = list(33)
-	},
-/obj/item/paper/fluff/psiprotect_memo{
-	pixel_x = -4;
-	pixel_y = -4
 	},
 /turf/simulated/floor/tiled/white,
 /area/horizon/medical/pharmacy)


### PR DESCRIPTION
- removes PsiProtect Broad Use, which was entirely an arc feature only.
- merges the Personalised variants into a single PsiProtect Personalised, inherting the mechanics of PsiProtect Personalised Gold. kept for psionic disorders RP and remains loadout only
- adds the active ingredient (Ranixidone) as a separate reagent, inheriting the mechanics of PsiProtect Personalised. available in loadout but can also be synthesised, recipe: 1u Mindbreaker Toxin, 2u Impedrezene, 2u Wulumunusha, 5u Phoron Catalyst = 3u Ranixidone.
- unmaps the PsiProtect pill bottles that were available in the Pharmacy, as well as the memo provided alongside them
- some other misc tweaks to names / descriptions / pill contents