### PR TITLE
Fixes scanning and external repairs of IPC on surgical chairs

### DIFF
--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -104,6 +104,7 @@
 	name = "Place Item in Cavity"
 	priority = 0
 	allowed_tools = list(/obj/item = 100)
+	blocks_normal_attack = FALSE
 	base_surgery_time = 8 SECONDS
 	skill_requirements = alist(SURGERY_SKILL_COMPONENT = SKILL_LEVEL_TRAINED)
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -6,6 +6,8 @@
 
 	/// type path referencing tools that can be used for this step, and how well are they suited for it
 	var/list/allowed_tools = null
+	/// Whether tools accepted by this step should have their normal attack blocked when the step cannot be performed.
+	var/blocks_normal_attack = TRUE
 	/// type paths referencing races that this step applies to.
 	var/list/allowed_species = null
 	var/list/disallowed_species = list("Nymph")
@@ -130,7 +132,8 @@
 		var/singleton/surgery_step/S = all_surgeries[decl]
 		if(!S.tool_quality(tool))
 			continue
-		is_surgery_tool = TRUE
+		if(S.blocks_normal_attack)
+			is_surgery_tool = TRUE
 		if(S.can_use(user, M, zone, tool))
 			LAZYSET(possible_surgeries, S, TRUE)
 
@@ -144,7 +147,12 @@
 
 	// We didn't find a surgery, or decided not to perform one.
 	if(!istype(S))
-		if(is_surgery_tool || (tool.item_flags & ITEM_FLAG_SURGERY)) //Is this supposed to be used for surgery?
+		var/can_repair_externally = FALSE
+		if(istype(tool, /obj/item/weldingtool) && ishuman(M))
+			var/mob/living/carbon/human/human_target = M
+			var/obj/item/organ/external/affected = human_target.get_organ(zone)
+			can_repair_externally = affected?.status & ORGAN_ASSISTED
+		if((is_surgery_tool && !can_repair_externally) || (tool.item_flags & ITEM_FLAG_SURGERY)) //Is this supposed to be used for surgery?
 			to_chat(user, SPAN_WARNING("You aren't sure what you could do to \the [M] with \the [tool]."))
 			return TRUE
 		return FALSE //Just do the normal use for the tool instead

--- a/html/changelogs/IPCRepairFixOooops.yml
+++ b/html/changelogs/IPCRepairFixOooops.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed a bug preventing scanning and using a welder on an IPC in a surgical chair."


### PR DESCRIPTION
Fixes some issues introduced in a recent PR regarding IPC and and other people on surgical tables, preventing using a welder on their external limbs and the robotic analyzer, potentially more.