### PR TITLE
Fixes grabbing forcing people to stand up

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -924,7 +924,10 @@
 	for(var/obj/item/grab/G as anything in grabbed_by)
 		if(G.wielded || G.state >= GRAB_AGGRESSIVE)
 			canmove = FALSE
-			lying = G.wielded || (G.state >= GRAB_NECK && G.force_down)
+			if(G.wielded)
+				lying = TRUE
+			else if(G.state >= GRAB_NECK)
+				lying = G.force_down
 			found_grab = TRUE
 			break
 	var/mob/living/carbon/human/H = astype(src)

--- a/html/changelogs/GrabStandingFix.yml
+++ b/html/changelogs/GrabStandingFix.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed grabbing forcing people to stand up. Now they only stand up with a neck grab, if the grabber attempts to move."


### PR DESCRIPTION
This prevents grabbing someone on the floor from forcing them to stand up. They will still stand up if a neck grab is used and the grabber then moves.

Disclaimer: Sol 5.6 was used purely to locate the sources of the issue. The code was handled by me.