### PR TITLE
Stops IPC from dying instantly to fire and makes burn damage slower

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1506,12 +1506,13 @@
 	if(..())
 		return
 
-	var/burn_temperature = fire_burn_temperature()
+	var/burn_temperature = fire_burn_temperature(environment)
 	var/thermal_protection = get_heat_protection(burn_temperature)
 
-	// Increment bodytemp up by up to BODYTEMP_HEATING_MAX C / sec, as modified by thermal protection.
+	// Increment body temperature by up to BODYTEMP_HEATING_MAX K/sec, as modified by thermal protection.
 	if (thermal_protection < 1 && bodytemperature < burn_temperature)
-		bodytemperature += round(BODYTEMP_HEATING_MAX * (1-thermal_protection) * 20 * seconds_per_tick, 1)
+		var/temperature_increase = round(BODYTEMP_HEATING_MAX * (1 - thermal_protection) * seconds_per_tick, 1)
+		bodytemperature = min(bodytemperature + temperature_increase, burn_temperature)
 
 /mob/living/carbon/human/rejuvenate()
 	restore_blood()

--- a/code/modules/organs/internal/species/machine/cooling_unit.dm
+++ b/code/modules/organs/internal/species/machine/cooling_unit.dm
@@ -139,9 +139,12 @@
 
 	var/datum/gas_mixture/ambient = T.return_air()
 	// Too much heat is bad for the cooling unit.
-	if(owner.bodytemperature > species.heat_level_1)
-		if(prob(owner.bodytemperature * 0.1))
-			take_internal_damage(owner.bodytemperature * 0.01)
+	var/excess_temperature = owner.bodytemperature - species.heat_level_1
+	if(excess_temperature > 0)
+		var/damage_probability = min(excess_temperature * 0.5, 100)
+		if(SPT_PROB(damage_probability, seconds_per_tick))
+			var/heat_damage = max(excess_temperature * 0.01, 1)
+			take_internal_damage(heat_damage * seconds_per_tick)
 
 	var/temperature_change = passive_temp_change * seconds_per_tick
 	if(owner.wear_suit)

--- a/html/changelogs/BurnThatIPC.yml
+++ b/html/changelogs/BurnThatIPC.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - balance: "Changed some fire balance to make temp increase slower."


### PR DESCRIPTION
This changes some of the heating and IPC related damage calculations for their cooler. The effect should be that people heat up a bit slower while on fire and for a naked IPC with an air cooler to have around 10 second until their cooler takes damage, roughly 20 seconds before the cooler has taken a lot of damage.

To be testmerged by lore request to get an idea how the new changes do in active gameplay.