### PR TITLE
Conveyor Belt Processing Kill

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -70,9 +70,10 @@
 	// machine process
 	// move items to the target location
 /obj/structure/machinery/conveyor/process()
-	if(stat & (BROKEN | NOPOWER))
-		return
-	if(!operating || conveying)
+	if (!operating)
+		return PROCESS_KILL
+
+	if((stat & (BROKEN | NOPOWER)) || conveying)
 		return
 
 	if (!loc)
@@ -179,6 +180,8 @@
 	if(id != match_id)
 		return
 	operable = op
+	if (operable)
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 	update()
 	var/obj/structure/machinery/conveyor/C = locate() in get_step(src, stepdir)

--- a/html/changelogs/hellfirejag-conveyor-belt-processing.yml
+++ b/html/changelogs/hellfirejag-conveyor-belt-processing.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Made conveyor belts only process when actually on."


### PR DESCRIPTION
Pretty simple, conveyor belts were in the machinery processing list even when off. This PR makes them no longer do that.

<img width="331" height="411" alt="image" src="https://github.com/user-attachments/assets/000c3366-acc6-4b32-90e6-1c7d2182223e" />
