### PR TITLE
Reduces volume of gravity gen + telecomms hub

### DIFF
--- a/code/datums/looping_sounds/machinery_sounds.dm
+++ b/code/datums/looping_sounds/machinery_sounds.dm
@@ -73,9 +73,9 @@
 	mid_length = 1.8 SECONDS
 	extra_range = MEDIUM_RANGE_SOUND_EXTRARANGE
 	ignore_walls = FALSE
-	volume = 35
-	falloff_exponent = 5
-	falloff_distance = 3
+	volume = 3
+	falloff_exponent = 8
+	falloff_distance = 2
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /datum/looping_sound/computer
@@ -104,8 +104,8 @@
 /datum/looping_sound/gravgen
 	mid_sounds = list('sound/machines/gravgen/gravgen_mid1.ogg' = 1, 'sound/machines/gravgen/gravgen_mid2.ogg' = 1, 'sound/machines/gravgen/gravgen_mid3.ogg' = 1, 'sound/machines/gravgen/gravgen_mid4.ogg' = 1)
 	mid_length = 1.8 SECONDS
-	extra_range = 10
-	volume = 70
+	extra_range = MEDIUM_RANGE_SOUND_EXTRARANGE
+	volume = 20
 	ignore_walls = FALSE
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/game/objects/structures/machinery/telecomms/machines/hub.dm
+++ b/code/game/objects/structures/machinery/telecomms/machines/hub.dm
@@ -19,6 +19,7 @@
 	active_power_usage = 5 KILO WATTS
 	circuitboard = "/obj/item/circuitboard/telecomms/hub"
 	netspeed = 40
+	produces_sound = TRUE
 
 /obj/structure/machinery/telecomms/hub/receive_information(datum/signal/signal, obj/structure/machinery/telecomms/machine_from)
 	if(!is_freq_listening(signal))

--- a/code/game/objects/structures/machinery/telecomms/machines/hub.dm
+++ b/code/game/objects/structures/machinery/telecomms/machines/hub.dm
@@ -19,7 +19,6 @@
 	active_power_usage = 5 KILO WATTS
 	circuitboard = "/obj/item/circuitboard/telecomms/hub"
 	netspeed = 40
-	produces_sound = TRUE
 
 /obj/structure/machinery/telecomms/hub/receive_information(datum/signal/signal, obj/structure/machinery/telecomms/machine_from)
 	if(!is_freq_listening(signal))

--- a/html/changelogs/hazelmouse-savingmyears.yml
+++ b/html/changelogs/hazelmouse-savingmyears.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
+  - rscdel: "Killed innocent kittens."

--- a/html/changelogs/hazelmouse-savingmyears.yml
+++ b/html/changelogs/hazelmouse-savingmyears.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: rattydew
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -55,5 +55,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
-  - rscdel: "Killed innocent kittens."
+  - qol: "Significantly reduced the volume and range of the telecommunications hub and gravity generator sounds."


### PR DESCRIPTION
Both of these are currently extremely loud with a much wider falloff than the rooms they're in, meaning that while you can't hear them across rooms in-game due to them not ignoring walls, you'll be hearing them an entire viewport away if you're a ghost. This reduces volume to something less ear-shredding and fall-off to something more sane.