### PR TITLE
Bit Faster Air Alarm Init

### DIFF
--- a/code/game/objects/structures/machinery/alarm.dm
+++ b/code/game/objects/structures/machinery/alarm.dm
@@ -359,7 +359,7 @@ pixel_x = 10;
 	TLV["temperature"] =	list(247, 273, 288, T0C+40) // Shouldn't go below 0
 
 /obj/structure/machinery/alarm/Destroy()
-	unregister_radio(src, frequency)
+	radio_connection = null
 	qdel(wires)
 	wires = null
 	return ..()
@@ -382,8 +382,7 @@ pixel_x = 10;
 		return
 
 	first_run()
-
-	set_frequency(frequency)
+	radio_connection = SSradio.return_frequency(frequency)
 
 	if(!mapload)
 		set_pixel_offsets()
@@ -597,11 +596,6 @@ pixel_x = 10;
 		if (I && I["timestamp"]+AALARM_REPORT_TIMEOUT/2 > world.time)
 			continue
 		send_signal(id_tag, list("status"))
-
-/obj/structure/machinery/alarm/proc/set_frequency(new_frequency)
-	SSradio.remove_object(src, frequency)
-	frequency = new_frequency
-	radio_connection = SSradio.add_object(src, frequency, RADIO_TO_AIRALARM)
 
 /**
  * Sends signal 'command' to 'target'. Returns 0 if no radio connection, 1 otherwise
@@ -1000,7 +994,7 @@ pixel_x = 10;
 					buildstage = 2
 					update_icon()
 					first_run()
-					set_frequency(frequency)
+					radio_connection = SSradio.return_frequency(frequency)
 				else
 					to_chat(user, SPAN_WARNING("You need 5 pieces of cable to do wire \the [src]."))
 				return TRUE

--- a/html/changelogs/hellfirejag-air-alarms-init.yml
+++ b/html/changelogs/hellfirejag-air-alarms-init.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Made air alarms take less time to init."


### PR DESCRIPTION
closes #23181 

Turns out this only dominates SSmachinery immediately at game start when air alarms briefly recursively ping themselves over the radio, so it'll top the profiler at the start of a round but then vanish after 10 or so minutes. It makes vents and scrubbers a tiny bit more expensive in their base frametime cost but not by much. 

I have tested to verify that this change isn't breaking air alarms, vents, or pumps.

<img width="798" height="903" alt="image" src="https://github.com/user-attachments/assets/e8cb30b5-fcc9-4629-ace3-f553017ba107" />
