### PR TITLE
Yeet Portable Atmos Processing

### DIFF
--- a/code/game/objects/structures/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/objects/structures/machinery/atmoalter/portable_atmospherics.dm
@@ -11,6 +11,7 @@
 
 	var/start_pressure = ONE_ATMOSPHERE
 	var/maximum_pressure = 90 * ONE_ATMOSPHERE
+	var/connect_automatically = TRUE
 
 /obj/structure/machinery/portable_atmospherics/Destroy()
 	disconnect()
@@ -24,9 +25,10 @@
 	air_contents.volume = volume
 	air_contents.temperature = T20C
 
-	var/obj/structure/machinery/atmospherics/portables_connector/port = locate() in loc
-	if(port)
-		connect(port)
+	if (connect_automatically)
+		var/obj/structure/machinery/atmospherics/portables_connector/port = locate() in loc
+		if(port)
+			connect(port)
 
 /obj/structure/machinery/portable_atmospherics/canister/Initialize()
 	..()
@@ -69,6 +71,7 @@
 	connected_port = new_port
 	connected_port.connected_device = src
 	connected_port.toggle_process()
+	START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 	anchored = 1 //Prevent movement
 
@@ -142,7 +145,6 @@
 					attacking_item.play_tool_sound(get_turf(src), 50)
 					update_icon()
 					SStgui.update_uis(src)
-					START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 					return TRUE
 				else
 					to_chat(user, SPAN_NOTICE("\The [src] failed to connect to the port."))

--- a/code/game/objects/structures/machinery/atmoalter/pump.dm
+++ b/code/game/objects/structures/machinery/atmoalter/pump.dm
@@ -17,6 +17,7 @@
 
 	power_rating = 7500 //7500 W ~ 10 HP
 	power_losses = 150
+	connect_automatically = FALSE
 
 /obj/structure/machinery/portable_atmospherics/powered/pump/mechanics_hints(mob/user, distance, is_adjacent)
 	. += ..()
@@ -68,7 +69,18 @@
 	SStgui.update_uis(src)
 
 /obj/structure/machinery/portable_atmospherics/powered/pump/process()
-	..()
+	. = ..()
+	// A majority of all pumps are completely idle for an overwhelming majority of the round.
+	// If a pump falls down in a forest and nobody is around to hear it, does it make a sound?
+	if (!connected_port && !holding && (!on || !cell || !cell.charge))
+		last_flow_rate = 0
+		last_power_draw = 0
+		last_mole_transfer = 0
+		update_icon()
+		src.updateDialog()
+		SStgui.update_uis(src)
+		return PROCESS_KILL
+
 	var/power_draw = -1
 
 	if(on && cell && cell.charge)
@@ -167,6 +179,8 @@
 		if("power")
 			on = !on
 			. = TRUE
+			if (on)
+				START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 		if("direction")
 			direction_out = !direction_out
 			. = TRUE

--- a/code/game/objects/structures/machinery/atmoalter/scrubber.dm
+++ b/code/game/objects/structures/machinery/atmoalter/scrubber.dm
@@ -13,6 +13,7 @@
 
 	power_rating = 7500 //7500 W ~ 10 HP
 	power_losses = 150
+	connect_automatically = FALSE
 
 	var/minrate = 0
 	var/maxrate = PRESSURE_ONE_THOUSAND
@@ -57,7 +58,17 @@
 	return
 
 /obj/structure/machinery/portable_atmospherics/powered/scrubber/process()
-	..()
+	. = ..()
+	// A majority of all scrubbers are completely idle for an overwhelming majority of the round.
+	// If a scrubber falls down in a forest and nobody is around to hear it, does it make a sound?
+	if (!connected_port && !holding && (!on || !cell || !cell.charge))
+		last_flow_rate = 0
+		last_power_draw = 0
+		last_mole_transfer = 0
+		update_icon()
+		src.updateDialog()
+		SStgui.update_uis(src)
+		return PROCESS_KILL
 
 	var/power_draw = -1
 
@@ -142,6 +153,8 @@
 		on = !on
 		update_icon()
 		. = TRUE
+		if (on)
+			START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 	if(action=="removeTank")
 		if(holding)
 			holding.forceMove(loc)

--- a/code/modules/atmospherics/components/portables_connector.dm
+++ b/code/modules/atmospherics/components/portables_connector.dm
@@ -68,8 +68,9 @@
 		STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 /obj/structure/machinery/atmospherics/portables_connector/process()
-	if(network)
-		network.update = 1
+	if(!network || !connected_device)
+		return PROCESS_KILL
+	network.update = 1
 
 // Housekeeping and pipe network stuff below
 /obj/structure/machinery/atmospherics/portables_connector/network_expand(datum/pipe_network/new_network, obj/structure/machinery/atmospherics/pipe/reference)

--- a/html/changelogs/hellfirejag-portable-atmos-processing-yeet.yml
+++ b/html/changelogs/hellfirejag-portable-atmos-processing-yeet.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Made portable air pumps, scrubbers, and air connectors no longer require always-processing."


### PR DESCRIPTION
Follow-up to the Canisters processing tweaks, this PR gives a more comprehensive treatment to Portable Atmos devices by making the full family, Portable Pumps, Portable Scrubbers, and Connectors all no longer require always-processing.

This amounted to a reduction of a bit more than 500 machines no longer needed to be in the SSmachinery queue. 

I did a lot of manual testing to verify that all 4 devices in question consistently and correctly re-enter processing when they're actively being used, and exit when they're done working.

<img width="881" height="41" alt="image" src="https://github.com/user-attachments/assets/7674f696-05ea-4c72-8769-c5dad205ff4b" />
