### PR TITLE
Hardsuit fixes

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -1067,6 +1067,8 @@
 
 	if(user.in_throw_mode && (isturf(target) || isturf(target.loc)) && user.throw_item(target)) //Prevents throwing items while remaining cloaked.
 		attack_disrupt_check()
+		user.throw_mode_off()
+		return COMSIG_MOB_CANCEL_CLICKON
 
 	if(ismob(target)) //This doesn't prevent guns firing at turfs, that is handled in /obj/item/gun/proc/handle_post_fire
 		if(target != user)

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -231,7 +231,7 @@
 	chest_type = /obj/item/clothing/suit/lightrig/offworlder
 	glove_type = null
 	boot_type = null
-	cell_draw_rate = CHARGE_DRAIN_DEFAULT
+	cell_draw_rate = CHARGE_DRAIN_LOW
 
 	initial_modules = list(
 		/obj/item/rig_module/device/healthscanner,

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -231,6 +231,7 @@
 	chest_type = /obj/item/clothing/suit/lightrig/offworlder
 	glove_type = null
 	boot_type = null
+	cell_draw_rate = CHARGE_DRAIN_DEFAULT
 
 	initial_modules = list(
 		/obj/item/rig_module/device/healthscanner,

--- a/html/changelogs/fabiank3-hardsuit-fixes.yml
+++ b/html/changelogs/fabiank3-hardsuit-fixes.yml
@@ -1,0 +1,7 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed hardsuit click handler not resetting throw mode, resulting in throw mode staying toggle on when wearing a hardsuit."
+  - bugfix: "Fixed too high passive power draw for exo-stellar suits by reducing passive cell draw rate."


### PR DESCRIPTION
# Summary

This PR fixes the throw mode not toggling of after throws while wearing a hardsuits, resulting in item-switching behavior and other click-handler issues. It additionally reduces the power draw of exo-stellar suits, requiring too many charges without much reason.