### PR TITLE
General Atmos Devices Processing

### DIFF
--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -105,7 +105,9 @@
 	update_underlays()
 
 /obj/structure/machinery/atmospherics/binary/passive_gate/process()
-	..()
+	. = ..()
+	if (!unlocked)
+		return PROCESS_KILL
 
 	if (broadcast_status_next_process)
 		broadcast_status()
@@ -113,9 +115,6 @@
 
 	last_flow_rate = 0
 	last_mole_transfer = 0
-
-	if(!unlocked)
-		return 0
 
 	var/output_starting_pressure = XGM_PRESSURE(air2)
 	var/input_starting_pressure = XGM_PRESSURE(air1)
@@ -199,9 +198,13 @@
 
 	if("power" in signal.data)
 		unlocked = text2num(signal.data["power"])
+		if (unlocked)
+			START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 	if("power_toggle" in signal.data)
 		unlocked = !unlocked
+		if (unlocked)
+			START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 	if("set_target_pressure" in signal.data)
 		var/set_pressure = text2num(signal.data["set_target_pressure"])
@@ -256,6 +259,8 @@
 	switch(action)
 		if("toggle_valve")
 			unlocked = !unlocked
+			if (unlocked)
+				START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 			. = TRUE
 		if("pressure")
 			var/pressure = params["pressure"]

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -116,11 +116,14 @@ Thus, the two variables affect pump operation are set in New():
 	update_underlays()
 
 /obj/structure/machinery/atmospherics/binary/pump/process()
+	if (!use_power)
+		return PROCESS_KILL
+
 	last_power_draw = 0
 	last_flow_rate = 0
 	last_mole_transfer = 0
 
-	if((stat & (NOPOWER|BROKEN)) || !use_power)
+	if((stat & (NOPOWER|BROKEN)))
 		return
 
 	if (broadcast_status_next_process)
@@ -295,3 +298,8 @@ Thus, the two variables affect pump operation are set in New():
 		new /obj/item/pipe(loc, make_from=src)
 		qdel(src)
 		return TRUE
+
+/obj/structure/machinery/atmospherics/binary/pump/update_use_power(new_use_power)
+	. = ..()
+	if (use_power)
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)

--- a/code/modules/atmospherics/components/omni_devices/filter.dm
+++ b/code/modules/atmospherics/components/omni_devices/filter.dm
@@ -64,8 +64,9 @@
 	return 0
 
 /obj/structure/machinery/atmospherics/omni/filter/process()
-	if(!..())
-		return 0
+	. = ..()
+	if(!. || . == PROCESS_KILL)
+		return .
 
 	var/datum/gas_mixture/output_air = output.air	//BYOND doesn't like referencing "output.air.return_pressure()" so we need to make a direct reference
 	var/datum/gas_mixture/input_air = input.air		// it's completely happy with them if they're in a loop though i.e. "P.air.return_pressure()"... *shrug*

--- a/code/modules/atmospherics/components/omni_devices/mixer.dm
+++ b/code/modules/atmospherics/components/omni_devices/mixer.dm
@@ -104,8 +104,9 @@
 	return 0
 
 /obj/structure/machinery/atmospherics/omni/mixer/process()
-	if(!..())
-		return 0
+	. = ..()
+	if(!. || . == PROCESS_KILL)
+		return .
 
 	//Figure out the amount of moles to transfer
 	var/transfer_moles = 0

--- a/code/modules/atmospherics/components/omni_devices/omni_base.dm
+++ b/code/modules/atmospherics/components/omni_devices/omni_base.dm
@@ -66,6 +66,8 @@
 	return
 
 /obj/structure/machinery/atmospherics/omni/process()
+	if (!use_power)
+		return PROCESS_KILL
 	last_power_draw = 0
 	last_flow_rate = 0
 	last_mole_transfer = 0
@@ -73,7 +75,7 @@
 	if(error_check())
 		update_use_power(POWER_USE_OFF)
 
-	if((stat & (NOPOWER|BROKEN)) || !use_power)
+	if((stat & (NOPOWER|BROKEN)))
 		return 0
 	return 1
 
@@ -281,3 +283,8 @@
 		to_chat(user, SPAN_WARNING("Access denied."))
 		return
 	Topic(src, list("power" = "1"))
+
+/obj/structure/machinery/atmospherics/omni/update_use_power(new_use_power)
+	. = ..()
+	if (use_power)
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)

--- a/code/modules/atmospherics/components/omni_devices/omni_base.dm
+++ b/code/modules/atmospherics/components/omni_devices/omni_base.dm
@@ -74,6 +74,7 @@
 
 	if(error_check())
 		update_use_power(POWER_USE_OFF)
+		return 0
 
 	if((stat & (NOPOWER|BROKEN)))
 		return 0

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -128,9 +128,13 @@
 	add_fingerprint(usr)
 
 /obj/structure/machinery/atmospherics/unary/freezer/process(seconds_per_tick)
-	..()
+	. = ..()
+	if (!use_power)
+		cooling = 0
+		update_icon()
+		return PROCESS_KILL
 
-	if(stat & (NOPOWER|BROKEN) || !use_power)
+	if(stat & (NOPOWER|BROKEN))
 		cooling = 0
 		update_icon()
 		return
@@ -189,3 +193,8 @@
 		return TRUE
 
 	return ..()
+
+/obj/structure/machinery/atmospherics/unary/freezer/update_use_power(new_use_power)
+	. = ..()
+	if (use_power)
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)

--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -74,9 +74,13 @@
 
 
 /obj/structure/machinery/atmospherics/unary/heater/process()
-	..()
+	. = ..()
+	if (!use_power)
+		heating = 0
+		update_icon()
+		return PROCESS_KILL
 
-	if(stat & (NOPOWER|BROKEN) || !use_power)
+	if(stat & (NOPOWER|BROKEN))
 		heating = 0
 		update_icon()
 		return
@@ -174,3 +178,8 @@
 		return TRUE
 
 	return ..()
+
+/obj/structure/machinery/atmospherics/unary/heater/update_use_power(new_use_power)
+	. = ..()
+	if (use_power)
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -55,7 +55,9 @@
 		update_icon()
 
 /obj/structure/machinery/atmospherics/unary/outlet_injector/process()
-	..()
+	. = ..()
+	if (!use_power)
+		return PROCESS_KILL
 
 	last_power_draw = 0
 	last_flow_rate = 0
@@ -65,7 +67,7 @@
 		broadcast_status()
 		broadcast_status_next_process = FALSE
 
-	if((stat & (NOPOWER|BROKEN)) || !use_power)
+	if((stat & (NOPOWER|BROKEN)))
 		return
 
 	var/power_draw = -1
@@ -177,3 +179,8 @@
 
 /obj/structure/machinery/atmospherics/unary/outlet_injector/aux
 	connect_types = CONNECT_TYPE_AUX
+
+/obj/structure/machinery/atmospherics/unary/outlet_injector/update_use_power(new_use_power)
+	. = ..()
+	if (use_power)
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -198,17 +198,13 @@
 /obj/structure/machinery/atmospherics/unary/vent_pump/hide()
 	queue_icon_update()
 
-/obj/structure/machinery/atmospherics/unary/vent_pump/proc/can_pump()
+/obj/structure/machinery/atmospherics/unary/vent_pump/process(seconds_per_tick)
+	. = ..()
+	if (!use_power || welded)
+		return PROCESS_KILL
+
 	if(stat & (NOPOWER|BROKEN))
 		return 0
-	if(!use_power)
-		return 0
-	if(welded)
-		return 0
-	return 1
-
-/obj/structure/machinery/atmospherics/unary/vent_pump/process(seconds_per_tick)
-	..()
 
 	if (broadcast_status_next_process)
 		broadcast_status()
@@ -219,8 +215,6 @@
 
 	if (!node)
 		update_use_power(POWER_USE_OFF)
-	if(!can_pump())
-		return 0
 
 	if(!loc) return FALSE
 
@@ -390,6 +384,8 @@
 				if(!src || !WT.isOn())
 					return TRUE
 				welded = !welded
+				if (!welded)
+					START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 				update_icon()
 				playsound(src, 'sound/items/welder_pry.ogg', 50, 1)
 				user.visible_message(SPAN_NOTICE("\The [user] [welded ? "welds \the [src] shut" : "unwelds \the [src]"]."), \
@@ -418,6 +414,7 @@
 			playsound(loc, 'sound/weapons/smash.ogg', 60, TRUE)
 			if(i == cut_amount)
 				welded = FALSE
+				START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 				spark(get_turf(src), 3, GLOB.alldirs)
 				playsound(loc, 'sound/items/welder_pry.ogg', 50, TRUE)
 				update_icon()
@@ -459,6 +456,11 @@
 	..()
 	if(old_stat != stat)
 		update_icon()
+
+/obj/structure/machinery/atmospherics/unary/vent_pump/update_use_power(new_use_power)
+	. = ..()
+	if (use_power)
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 #undef DEFAULT_PRESSURE_DELTA
 

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -182,7 +182,9 @@
 	return 1
 
 /obj/structure/machinery/atmospherics/unary/vent_scrubber/process()
-	..()
+	. = ..()
+	if (!use_power || welded)
+		return PROCESS_KILL
 
 	if (hibernate > world.time)
 		return 1
@@ -194,7 +196,7 @@
 		broadcast_status()
 		broadcast_status_next_process = FALSE
 
-	if((!use_power || (stat & (NOPOWER|BROKEN)) || !loc) || welded)
+	if((stat & (NOPOWER|BROKEN)) || !loc)
 		return 0
 
 	var/datum/gas_mixture/environment = loc.return_air()
@@ -399,6 +401,8 @@
 			return
 
 		welded = !welded
+		if (!welded)
+			START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 		update_icon()
 		user.visible_message(SPAN_NOTICE("\The [user] [welded ? "welds \the [src] shut" : "unwelds \the [src]"]."), \
 								SPAN_NOTICE("You [welded ? "weld \the [src] shut" : "unweld \the [src]"]."), \
@@ -421,9 +425,15 @@
 			playsound(loc, 'sound/weapons/smash.ogg', 60, TRUE)
 			if(i == cut_amount)
 				welded = FALSE
+				START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 				spark(get_turf(src), 3, GLOB.alldirs)
 				playsound(loc, 'sound/items/welder_pry.ogg', 50, TRUE)
 				update_icon()
 		return TRUE
 
 	return ..()
+
+/obj/structure/machinery/atmospherics/unary/vent_scrubber/update_use_power(new_use_power)
+	. = ..()
+	if (use_power)
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)

--- a/html/changelogs/hellfirejag-atmos-devices-processing.yml
+++ b/html/changelogs/hellfirejag-atmos-devices-processing.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Made most atmos devices no longer require always-processing."


### PR DESCRIPTION
This PR makes it so that most stationary atmos devices no longer need to always stay in processing. I have actually tested all of these. Screenshots attached to demonstrate the testing.

Pumps

<img width="1251" height="600" alt="image" src="https://github.com/user-attachments/assets/a831b1bb-05b1-4e55-a527-0c208d7323d7" />

Cooling Machines

<img width="1373" height="482" alt="image" src="https://github.com/user-attachments/assets/c6c0a1e5-83b5-4e4b-b285-dd23760bb221" />

Passive Valves

<img width="1241" height="320" alt="image" src="https://github.com/user-attachments/assets/9c6f648c-e4f9-44e1-9c62-b07b5dd73831" />

Filters

<img width="966" height="735" alt="image" src="https://github.com/user-attachments/assets/b0c0b4ba-9c1f-4068-b8d2-bb1a71b02b84" />

Heaters

<img width="663" height="468" alt="image" src="https://github.com/user-attachments/assets/b5bc7415-3f8f-41fe-be71-d5c71387eab4" />

Pumps and Scrubbers

<img width="755" height="534" alt="image" src="https://github.com/user-attachments/assets/4d3560cc-a871-456a-83cf-2792d126a8f5" />

<img width="639" height="586" alt="image" src="https://github.com/user-attachments/assets/39cd3a24-5d68-47be-840b-725702ae7b42" />

<img width="188" height="405" alt="image" src="https://github.com/user-attachments/assets/f0ad3956-a1ce-4b97-a7f6-93bf4b5d64b6" />
