### PR TITLE
Improves industrial frame IPC move speed

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
@@ -146,7 +146,7 @@
 	grab_mod = 0.8 // Big, easy to grab onto
 	resist_mod = 10 // Good luck wrestling against this powerhouse.
 
-	slowdown = 3
+	slowdown = 2
 
 	blurb = "The first commercialized attempt Hephaestus Industries made at an industrial-type IPC. Designed for extra durability and increased weight loads, the first generation Industrial was considered a success, though it possessed some issues. A limited power cell and actuators designed for heavy lifting and not locomotion resulted in a slow and frequently charging machine. A special addition to the chassis makes up for these drawbacks - the ability to simply slot a suit cooling unit onto the model's back and make use of its built-in heat transferal conduits, allowing the Industrial to perform EVA without any extra peripherals such as a voidsuit."
 
@@ -348,7 +348,7 @@
 
 	unarmed_types = list(/datum/unarmed_attack/industrial/heavy, /datum/unarmed_attack/palm/industrial)
 
-	slowdown = 2
+	slowdown = 1
 	brute_mod = 0.9
 	grab_mod = 0.7 // Bulkier and bigger than the G1
 	resist_mod = 12 // Overall stronger than G1
@@ -513,7 +513,7 @@
 	heat_level_3 = 2800  //RaceDefault 2400 Default 2800
 
 	heat_discomfort_level = 600
-	slowdown = 3
+	slowdown = 2
 
 	eyes = "xion_eyes"
 	flags = IS_IPC

--- a/html/changelogs/ElorgRHG-industrial-frame-IPC-slowdown-tweak.yml
+++ b/html/changelogs/ElorgRHG-industrial-frame-IPC-slowdown-tweak.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: ElorgRHG
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Improves industrial frame IPC movespeed, reducing G2 slowdown from 2 to 1, and G1 and Xion slowdown from 3 to 2."


### PR DESCRIPTION
Slowdown changes (lower values means faster move speed):
- G2 frame IPCs now have a slowdown value of 1, changed from 2
- G1 frame IPCs now have a slowdown value of 2, changed from 3
- Xion frame IPCs now have a slowdown value of 2, changed from 3

These numbers are _hopefully_ malleable, but they seem fine as is. 

<hr>

Compared to some of our other species:
- Dionae: 1.6 slowdown
- Vaurca bulwarks and breeders: 2 slowdown
- Azaziba Unathi: 0.5 slowdown

<hr>

Changelog:
>   - rscadd: "Improves industrial frame IPC movespeed, reducing G2 slowdown from 2 to 1, and G1 and Xion slowdown from 3 to 2."
