### PR TITLE
Remove unused shuttle vars (logging_home_tag)

### DIFF
--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -5,22 +5,28 @@
 	var/warmup_time = 0
 	var/moving_status = SHUTTLE_IDLE
 
-	var/list/shuttle_area //can be both single area type or a list of areas
-	var/obj/effect/shuttle_landmark/current_location //This variable is type-abused initially: specify the landmark_tag, not the actual landmark.
+	/// Can be both a single area type or a list of areas.
+	var/list/shuttle_area
+	/// This variable is type-abused initially: specify the landmark_tag, not the actual landmark.
+	var/obj/effect/shuttle_landmark/current_location
 	var/list/shuttle_computers = list()
 
-	var/arrive_time = 0	//the time at which the shuttle arrives when long jumping
+	/// The time at which the shuttle arrives when long jumping
+	var/arrive_time = 0
 	var/flags = 0
-	var/process_state = IDLE_STATE //Used with SHUTTLE_FLAGS_PROCESS, as well as to store current state.
+	/// Used with SHUTTLE_FLAGS_PROCESS, as well as to store current state.
+	var/process_state = IDLE_STATE
 	var/category = /datum/shuttle
-	var/multiz = 0	//how many multiz levels, starts at 0
+	/// how many multiz levels, starts at 0
+	var/multiz = 0
 
 	var/ceiling_type = /turf/simulated/floor/airless/ceiling
 
 	var/sound_takeoff = 'sound/effects/shuttle_takeoff.ogg'
 	var/sound_landing = 'sound/effects/shuttle_landing.ogg'
 
-	var/knockdown = TRUE //whether shuttle downs non-buckled_to people when it moves
+	/// Whether shuttle downs non-buckled_to people when it moves
+	var/knockdown = TRUE
 
 	/**
 	 * This shuttle will/won't be initialised automatically.
@@ -28,14 +34,11 @@
 	 * Useful for shuttles that are initialed by map_template loading, or shuttles that are created in-game or not used.
 	 */
 	var/defer_initialisation = FALSE
-	var/logging_home_tag   //Whether in-game logs will be generated whenever the shuttle leaves/returns to the landmark with this landmark_tag.
-	var/logging_access     //Controls who has write access to log-related stuff; should correlate with pilot access.
 
-	var/mothershuttle //tag of mothershuttle
-	var/motherdock    //tag of mothershuttle landmark, defaults to starting location
-
-	var/squishes = TRUE //decides whether or not things get squished when it moves.
-	var/cargo_elevator = FALSE // Snowflake variable for the cargo elevator. Decides whether you will take fall damage or not
+	/// Decides whether or not things get squished when it moves.
+	var/squishes = TRUE
+	/// Snowflake variable for the cargo elevator. Decides whether you will take fall damage or not.
+	var/cargo_elevator = FALSE
 
 /datum/shuttle/New(_name, var/obj/effect/shuttle_landmark/initial_location)
 	..()

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -35,6 +35,11 @@
 	 */
 	var/defer_initialisation = FALSE
 
+	/// Tag of mothershuttle
+	var/mothershuttle
+	/// Tag of mothershuttle landmark, defaults to starting location
+	var/motherdock
+
 	/// Decides whether or not things get squished when it moves.
 	var/squishes = TRUE
 	/// Snowflake variable for the cargo elevator. Decides whether you will take fall damage or not.

--- a/code/unit_tests/shuttle_tests.dm
+++ b/code/unit_tests/shuttle_tests.dm
@@ -17,17 +17,12 @@
 				found_current_location = TRUE
 			if(initial(landmark.landmark_tag) == initial(shuttle.landmark_transition))
 				found_transition_location = TRUE
-			if(initial(landmark.landmark_tag) == initial(shuttle.logging_home_tag))
-				found_logging_home_location = TRUE
 
 		if(initial(shuttle.current_location) && !found_current_location)
 			TEST_FAIL("Failed to find 'current_location' landmark for [shuttle].")
 			failed++
 		if(initial(shuttle.landmark_transition) && !found_transition_location)
 			TEST_FAIL("Failed to find 'landmark_transition' landmark for [shuttle].")
-			failed++
-		if(initial(shuttle.logging_home_tag) && !found_logging_home_location)
-			TEST_FAIL("Failed to find 'logging_home_tag' landmark for [shuttle].")
 			failed++
 
 	if(failed)

--- a/code/unit_tests/shuttle_tests.dm
+++ b/code/unit_tests/shuttle_tests.dm
@@ -10,7 +10,6 @@
 		// Check start location and transition locations exist
 		var/found_current_location = FALSE
 		var/found_transition_location = FALSE
-		var/found_logging_home_location = FALSE
 		for(var/L in subtypesof(/obj/effect/shuttle_landmark))
 			var/obj/effect/shuttle_landmark/landmark = L
 			if(initial(landmark.landmark_tag) == initial(shuttle.current_location))

--- a/html/changelogs/DreamySkrell-shuttle-stuff-6.yml
+++ b/html/changelogs/DreamySkrell-shuttle-stuff-6.yml
@@ -1,0 +1,7 @@
+
+author: DreamySkrell
+
+delete-after: True
+
+changes:
+  - refactor: "Removes unused shuttle vars."

--- a/maps/away/away_site/cult_base/cult_base_.dm
+++ b/maps/away/away_site/cult_base/cult_base_.dm
@@ -100,7 +100,6 @@
 	landmark_transition = "nav_cult_base_shuttle_transit"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_cult_base_dock_hangar"
 	defer_initialisation = TRUE
 
 /obj/effect/map_effect/marker/airlock/shuttle/cult_base_shuttle

--- a/maps/away/away_site/pirate_base/pirate_base.dm
+++ b/maps/away/away_site/pirate_base/pirate_base.dm
@@ -74,7 +74,6 @@
 	landmark_transition = "nav_transit_pirate_ship"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_pirate_ship"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/pirate_ship/hangar

--- a/maps/away/away_site/racers/racers.dm
+++ b/maps/away/away_site/racers/racers.dm
@@ -64,7 +64,6 @@
 	current_location = "nav_red_racer_hangar"
 	landmark_transition = "nav_red_racer_transit"
 	fuel_consumption = 2
-	logging_home_tag = "nav_red_racer_hangar"
 	range = 1
 	defer_initialisation = TRUE
 
@@ -91,7 +90,6 @@
 	current_location = "nav_blue_racer_hangar"
 	landmark_transition = "nav_blue_racer_transit"
 	fuel_consumption = 2
-	logging_home_tag = "nav_blue_racer_hangar"
 	range = 1
 	defer_initialisation = TRUE
 

--- a/maps/away/away_site/tajara/mining_jack/mining_jack.dm
+++ b/maps/away/away_site/tajara/mining_jack/mining_jack.dm
@@ -90,5 +90,4 @@
 	landmark_transition = "nav_transit_tajara_mining_jack"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_tajara_mining_jack"
 	defer_initialisation = TRUE

--- a/maps/away/away_site/tajara/peoples_station/peoples_station.dm
+++ b/maps/away/away_site/tajara/peoples_station/peoples_station.dm
@@ -109,7 +109,6 @@
 	range = 1
 	fuel_consumption = 2
 	dock_target = "peoples_station_fang"
-	logging_home_tag = "nav_hangar_peoples_station_fang"
 	defer_initialisation = TRUE
 
 //transport shuttle
@@ -142,7 +141,6 @@
 	dock_target = "peoples_station_transport"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_peoples_station_transport"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/peoples_station_transport/hangar

--- a/maps/away/away_site/tajara/saniorios_outpost/saniorios_outpost.dm
+++ b/maps/away/away_site/tajara/saniorios_outpost/saniorios_outpost.dm
@@ -83,7 +83,6 @@
 	landmark_transition = "nav_transit_saniorios_outpost"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_saniorios_outpost"
 	dock_target = "saniorios_outpost"
 	defer_initialisation = TRUE
 

--- a/maps/away/away_site/tajara/scrapper/scrapper.dm
+++ b/maps/away/away_site/tajara/scrapper/scrapper.dm
@@ -86,7 +86,6 @@
 	landmark_transition = "nav_transit_tajara_scrapper"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_tajara_scrapper"
 	defer_initialisation = TRUE
 
 

--- a/maps/away/away_site/tajara/taj_safehouse/tajara_safehouse.dm
+++ b/maps/away/away_site/tajara/taj_safehouse/tajara_safehouse.dm
@@ -75,7 +75,6 @@
 	landmark_transition = "nav_transit_tajara_safehouse"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_tajara_safehouse"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/tajara_safehouse_shuttle/hangar

--- a/maps/away/away_site/uueoaesa/reclamation/ihss_reclamation.dm
+++ b/maps/away/away_site/uueoaesa/reclamation/ihss_reclamation.dm
@@ -114,7 +114,6 @@
 	dock_target = "airlock_reclamation_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_ihss_reclamation_shuttle"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/ihss_reclamation_shuttle

--- a/maps/away/away_site/uueoaesa/tret/tret_industrial_complex_.dm
+++ b/maps/away/away_site/uueoaesa/tret/tret_industrial_complex_.dm
@@ -103,7 +103,6 @@
 	shuttle_area = list(/area/shuttle/tret_industrial/main, /area/shuttle/tret_industrial/propulsion)
 	dock_target = "airlock_tret_industrial_shuttle"
 	current_location = "nav_tret_industrial_dock_outpost_1"
-	logging_home_tag = "nav_tret_industrial_dock_outpost_1"
 	landmark_transition = "nav_tret_industrial_shuttle_transit"
 	range = 1
 	fuel_consumption = 2

--- a/maps/away/scenarios/decrepit_shipyard/decrepit_shipyard.dm
+++ b/maps/away/scenarios/decrepit_shipyard/decrepit_shipyard.dm
@@ -94,7 +94,6 @@
 	dock_target = "airlock_decrepit_shipyard_shuttle_docking"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_decrepit_shipyard_drydock"
 	defer_initialisation = TRUE
 
 // Shuttle starting landmark

--- a/maps/away/ships/biesel/tcaf_corvette/tcaf_corvette.dm
+++ b/maps/away/ships/biesel/tcaf_corvette/tcaf_corvette.dm
@@ -113,7 +113,6 @@
 	dock_target = "airlock_tcaf_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_tcaf"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/tcaf_shuttle/hangar

--- a/maps/away/ships/coc/coc_ranger/coc_ship.dm
+++ b/maps/away/ships/coc/coc_ranger/coc_ship.dm
@@ -218,7 +218,6 @@
 	dock_target = "ranger_shuttle_dock2"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_ranger"
 	// defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/ranger_shuttle/hangar

--- a/maps/away/ships/coc/coc_scarab/coc_scarab.dm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab.dm
@@ -159,7 +159,6 @@
 	landmark_transition = "nav_scarab_transit"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_scarab_start"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/coc_scarab/shuttle_start

--- a/maps/away/ships/coc/coc_surveyor/coc_surveyor.dm
+++ b/maps/away/ships/coc/coc_surveyor/coc_surveyor.dm
@@ -110,7 +110,6 @@
 	landmark_transition = "nav_transit_survey_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_survey"
 	dock_target = "surveyor_shuttle"
 	defer_initialisation = TRUE
 

--- a/maps/away/ships/coc/gadpathur_patrol/gadpathur_patrol.dm
+++ b/maps/away/ships/coc/gadpathur_patrol/gadpathur_patrol.dm
@@ -116,7 +116,6 @@
 	dock_target = "gadpathur_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_gadpathur_corvette_shuttle"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/gadpathur_shuttle/dock

--- a/maps/away/ships/dominia/dominian_corvette/dominian_corvette_shuttle.dm
+++ b/maps/away/ships/dominia/dominian_corvette/dominian_corvette_shuttle.dm
@@ -31,7 +31,6 @@
 	dock_target = "dominian_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_dominia"
 	defer_initialisation = TRUE
 
 // Hangar marker

--- a/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel.dm
+++ b/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel.dm
@@ -132,7 +132,6 @@
 	dock_target = "airlock_dominian_science_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_dominian_science_vessel"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/dominian_science_shuttle/hangar

--- a/maps/away/ships/dominia/dominian_unathi_privateer/dominian_unathi_privateer.dm
+++ b/maps/away/ships/dominia/dominian_unathi_privateer/dominian_unathi_privateer.dm
@@ -105,7 +105,6 @@
 	dock_target = "airlock_kazhkz_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_kazhkz"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/dominian_unathi_shuttle/hangar

--- a/maps/away/ships/dpra/hailstorm/hailstorm_shuttle.dm
+++ b/maps/away/ships/dpra/hailstorm/hailstorm_shuttle.dm
@@ -31,7 +31,6 @@
 	dock_target = "hailstorm_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_hailstorm"
 	defer_initialisation = TRUE
 // --------
 

--- a/maps/away/ships/einstein/ee_spy_ship.dm
+++ b/maps/away/ships/einstein/ee_spy_ship.dm
@@ -100,7 +100,6 @@
 	landmark_transition = "nav_transit_ee_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_ee"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/ee_shuttle/hangar

--- a/maps/away/ships/elyra/elyra_corvette/elyra_corvette.dm
+++ b/maps/away/ships/elyra/elyra_corvette/elyra_corvette.dm
@@ -142,7 +142,6 @@
 	landmark_transition = "nav_transit_elyran_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_elyra"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/elyran_shuttle/hangar

--- a/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
+++ b/maps/away/ships/freebooter/freebooter_salvager/freebooter_salvager.dm
@@ -92,7 +92,6 @@
 	dock_target = "airlock_freebooter_salvager_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "freebooter_salvager_nav_hangar"
 	defer_initialisation = TRUE
 
 // shuttle airlock

--- a/maps/away/ships/freebooter/freebooter_ship/freebooter_ship_.dm
+++ b/maps/away/ships/freebooter/freebooter_ship/freebooter_ship_.dm
@@ -111,7 +111,6 @@
 	landmark_transition = "nav_transit_freebooter_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_freebooter"
 	defer_initialisation = TRUE
 
 /obj/item/paper/fluff/freeboter_ship/captain_note

--- a/maps/away/ships/golden_deep/golden_deep.dm
+++ b/maps/away/ships/golden_deep/golden_deep.dm
@@ -92,7 +92,6 @@
 	dock_target = "airlock_golden_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "gd_nav_hangar"
 	defer_initialisation = TRUE
 
 /obj/effect/map_effect/marker/airlock/shuttle/golden_deep

--- a/maps/away/ships/hegemony/fishing_trawler/fishing_league_trawler.dm
+++ b/maps/away/ships/hegemony/fishing_trawler/fishing_league_trawler.dm
@@ -94,5 +94,4 @@
 	landmark_transition = "fishing_trawler_transit"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "fishing_trawler_shuttle"
 	defer_initialisation = TRUE

--- a/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dm
+++ b/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dm
@@ -117,7 +117,6 @@
 	dock_target = "airlock_hegemony_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hegemony_corvette_shuttle"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/hegemony_shuttle/transit

--- a/maps/away/ships/hegemony/merchants_guild/merchant_freighter.dm
+++ b/maps/away/ships/hegemony/merchants_guild/merchant_freighter.dm
@@ -108,7 +108,6 @@
 	dock_target = "merchant_guild_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "merchantsguild_nav_hangar"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/merchants_guild_shuttle/hangar

--- a/maps/away/ships/hegemony/miners_guild/miners_guild_station.dm
+++ b/maps/away/ships/hegemony/miners_guild/miners_guild_station.dm
@@ -121,7 +121,6 @@
 	dock_target = "airlock_guild_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "miners_guild_navhangar"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/miners_guild/hangar

--- a/maps/away/ships/heph/cyclops/cyclops_mining_ship.dm
+++ b/maps/away/ships/heph/cyclops/cyclops_mining_ship.dm
@@ -149,7 +149,6 @@
 	dock_target = "airlock_shuttle_cyclops"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_cyclops"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/cyclops_shuttle/hangar

--- a/maps/away/ships/heph/heph_security/heph_security.dm
+++ b/maps/away/ships/heph/heph_security/heph_security.dm
@@ -102,7 +102,6 @@
 	dock_target = "airlock_heph_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "hephsec_shuttle"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/hephsec_shuttle

--- a/maps/away/ships/himeo/himeo_patrol_ship.dm
+++ b/maps/away/ships/himeo/himeo_patrol_ship.dm
@@ -90,7 +90,6 @@
 	dock_target = "airlock_himeo_patrol_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "himeo_patrol_nav_dock"
 	defer_initialisation = TRUE
 
 /obj/effect/map_effect/marker/airlock/shuttle/himeo_patrol_ship

--- a/maps/away/ships/iac/iac_rescue_ship.dm
+++ b/maps/away/ships/iac/iac_rescue_ship.dm
@@ -246,7 +246,6 @@
 
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_iac"
 
 	defer_initialisation = TRUE
 

--- a/maps/away/ships/idris/idris_cruiser.dm
+++ b/maps/away/ships/idris/idris_cruiser.dm
@@ -96,6 +96,5 @@
 	landmark_transition = "nav_idris_cruiser_transit"
 	range = 1
 	fuel_consumption = 1
-	logging_home_tag = "nav_idris_cruiser_stbd_aft"
 	defer_initialisation = TRUE
 

--- a/maps/away/ships/kataphracts/kataphract_ship.dm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dm
@@ -127,7 +127,6 @@
 	landmark_transition = "nav_kataphract_transport_transit"
 	range = 2 // It's a big boy
 	fuel_consumption = 4
-	logging_home_tag = "nav_hangar_kataphract_shuttle"
 	defer_initialisation = TRUE
 
 /obj/effect/map_effect/marker/airlock/shuttle/kataphract_shuttle

--- a/maps/away/ships/konyang/air_konyang/air_konyang.dm
+++ b/maps/away/ships/konyang/air_konyang/air_konyang.dm
@@ -53,7 +53,6 @@
 	current_location = "nav_air_konyang_start"
 	dock_target = "airlock_air_konyang"
 	landmark_transition = "nav_air_konyang_transit"
-	logging_home_tag = "nav_air_konyang_start"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/ship/air_konyang

--- a/maps/away/ships/konyang/einstein_shuttle/einstein_shuttle.dm
+++ b/maps/away/ships/konyang/einstein_shuttle/einstein_shuttle.dm
@@ -94,7 +94,6 @@
 	landmark_transition = "nav_transit_einstein"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_start_einstein"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/ship/einstein_shuttle

--- a/maps/away/ships/konyang/ipc_refugee/ipc_refugee_ship.dm
+++ b/maps/away/ships/konyang/ipc_refugee/ipc_refugee_ship.dm
@@ -149,7 +149,6 @@
 	landmark_transition = "nav_transit_ipc_refugee_shuttle"
 	range = 1
 	fuel_consumption = 4 // very old, so not as efficient as other shuttles
-	logging_home_tag = "nav_hangar_ipc_refugee"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/ipc_refugee_shuttle/hangar

--- a/maps/away/ships/konyang/kasf_ship/kasf_ship.dm
+++ b/maps/away/ships/konyang/kasf_ship/kasf_ship.dm
@@ -154,7 +154,6 @@
 	landmark_transition = "nav_transit_kasf_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_kasf"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/kasf_shuttle/hangar

--- a/maps/away/ships/konyang/water_barge/water_barge.dm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dm
@@ -105,7 +105,6 @@
 	dock_target = "airlock_waterbarge_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_water_barge_hangar"
 	defer_initialisation = TRUE
 
 /obj/structure/machinery/computer/shuttle_control/explore/water_barge_shuttle

--- a/maps/away/ships/lone_spacer/lone_spacer.dm
+++ b/maps/away/ships/lone_spacer/lone_spacer.dm
@@ -60,7 +60,6 @@
 	current_location = "nav_lone_spacer_space"
 	dock_target = "lone_spacer"
 	landmark_transition = "nav_lone_spacer_transit"
-	logging_home_tag = "nav_lone_spacer_space"
 	defer_initialisation = TRUE
 
 // Main shuttle landmark

--- a/maps/away/ships/nka/nka_merchant/nka_merchant.dm
+++ b/maps/away/ships/nka/nka_merchant/nka_merchant.dm
@@ -108,7 +108,6 @@
 	dock_target = "nka_merchant_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_nka_merchant_shuttle"
 	defer_initialisation = TRUE
 
 /obj/effect/map_effect/marker/airlock/shuttle/nka_merchant_shuttle

--- a/maps/away/ships/orion/orion_express_ship/orion_express_ship.dm
+++ b/maps/away/ships/orion/orion_express_ship/orion_express_ship.dm
@@ -278,7 +278,6 @@
 	landmark_transition = "nav_transit_orion_express"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_orion_express"
 	dock_target = "orion_shuttle"
 	defer_initialisation = TRUE
 

--- a/maps/away/ships/orion/orion_miner/orion_miner.dm
+++ b/maps/away/ships/orion/orion_miner/orion_miner.dm
@@ -78,7 +78,6 @@
 	current_location = "nav_orion_miner_space"
 	dock_target = "orion_miner"
 	landmark_transition = "nav_orion_miner_transit"
-	logging_home_tag = "nav_orion_miner_space"
 	defer_initialisation = TRUE
 
 // Main shuttle landmark

--- a/maps/away/ships/pra/database_freighter/database_freighter.dm
+++ b/maps/away/ships/pra/database_freighter/database_freighter.dm
@@ -112,7 +112,6 @@
 	landmark_transition = "nav_transit_database_freighter_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_database_freighter_shuttle"
 	defer_initialisation = TRUE
 
 /obj/effect/map_effect/marker/airlock/shuttle/database_freighter_shuttle

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dm
@@ -105,7 +105,6 @@
 	dock_target = "headmaster_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_headmaster"
 	defer_initialisation = TRUE
 
 // Hangar marker

--- a/maps/away/ships/sadar_scout/sadar_scout.dm
+++ b/maps/away/ships/sadar_scout/sadar_scout.dm
@@ -178,7 +178,6 @@
 	landmark_transition = "nav_transit_sadar_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_sadar_scout"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/sadar_shuttle/hangar

--- a/maps/away/ships/scc/scc_scout_ship.dm
+++ b/maps/away/ships/scc/scc_scout_ship.dm
@@ -102,7 +102,6 @@
 	landmark_transition = "nav_scc_scout_shuttle_transit"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_scc_scout_shuttle_dock"
 	defer_initialisation = TRUE
 
 /obj/effect/map_effect/marker/airlock/shuttle/scc_scout_ship

--- a/maps/away/ships/sol/sol_frigate/sol_frigateship_shuttle.dm
+++ b/maps/away/ships/sol/sol_frigate/sol_frigateship_shuttle.dm
@@ -36,7 +36,6 @@
 	dock_target = "sol_light_interceptor"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_solfrig"
 	defer_initialisation = TRUE
 // --------
 

--- a/maps/away/ships/sol/sol_merc/fsf_patrol_ship.dm
+++ b/maps/away/ships/sol/sol_merc/fsf_patrol_ship.dm
@@ -134,7 +134,6 @@
 	landmark_transition = "nav_transit_fsf_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_fsf"
 	dock_target = "airlock_fsf_shuttle"
 	defer_initialisation = TRUE
 

--- a/maps/away/ships/sol/sol_pirate/sfa_patrol_ship.dm
+++ b/maps/away/ships/sol/sol_pirate/sfa_patrol_ship.dm
@@ -199,7 +199,6 @@
 	landmark_transition = "nav_transit_sfa_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_sfa"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/sfa_shuttle/hangar

--- a/maps/away/ships/sol/sol_splf/splf_raider_shuttle.dm
+++ b/maps/away/ships/sol/sol_splf/splf_raider_shuttle.dm
@@ -36,7 +36,6 @@
 	dock_target = "splf_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_splf"
 	defer_initialisation = TRUE
 // --------
 

--- a/maps/away/ships/sol/sol_ssrm/ssrm_ship_shuttle.dm
+++ b/maps/away/ships/sol/sol_ssrm/ssrm_ship_shuttle.dm
@@ -28,7 +28,6 @@
 	dock_target = "airlock_ssrm_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_ssrm_dock"
 	defer_initialisation = TRUE
 
 // Docking Port marker

--- a/maps/away/ships/tajara/circus/adhomian_circus.dm
+++ b/maps/away/ships/tajara/circus/adhomian_circus.dm
@@ -107,7 +107,6 @@
 	landmark_transition = "nav_transit_adhomian_circus_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_adhomian_circus_shuttle"
 	defer_initialisation = TRUE
 
 /obj/effect/map_effect/marker/airlock/shuttle/adhomian_circus_shuttle

--- a/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dm
+++ b/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dm
@@ -103,7 +103,6 @@
 	landmark_transition = "nav_transit_tajaran_smuggler_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_tajaran_smuggler_shuttle"
 	defer_initialisation = TRUE
 
 /obj/effect/map_effect/marker/airlock/shuttle/tajaran_smuggler_shuttle

--- a/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler_landmarks.dm
+++ b/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler_landmarks.dm
@@ -45,7 +45,6 @@
 	landmark_transition = "nav_transit_tajaran_smuggler_cargo"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_tajaran_smuggler_cargo"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/tajaran_smuggler_cargo/hangar

--- a/maps/away/ships/tirakqi_smuggler/tirakqi_smuggler.dm
+++ b/maps/away/ships/tirakqi_smuggler/tirakqi_smuggler.dm
@@ -135,7 +135,6 @@
 	landmark_transition = "nav_transit_tirakqi_smuggler_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_tirakqi_shuttle"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/tirakqi_smuggler_shuttle/hangar

--- a/maps/away/ships/tramp_freighter/tramp_freighter.dm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter.dm
@@ -98,5 +98,4 @@
 	landmark_transition = "nav_transit_freighter_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_tramp_start"
 	defer_initialisation = TRUE

--- a/maps/away/ships/unathi_pirate/hiskyn/unathi_pirate_hiskyn.dm
+++ b/maps/away/ships/unathi_pirate/hiskyn/unathi_pirate_hiskyn.dm
@@ -120,7 +120,6 @@
 	dock_target = "airlock_hiskyn_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_dock_hiskyn"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/hiskyn_shuttle/dock

--- a/maps/away/ships/unathi_pirate/izharshan/unathi_pirate_izharshan.dm
+++ b/maps/away/ships/unathi_pirate/izharshan/unathi_pirate_izharshan.dm
@@ -107,7 +107,6 @@
 	current_location = "nav_izharshan_space"
 	dock_target = "unathi_pirate_izharshan"
 	landmark_transition = "nav_izharshan_transit"
-	logging_home_tag = "nav_izharshan_space"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/ship/unathi_pirate_izharshan

--- a/maps/away/ships/unathi_pirate/tarwa/unathi_pirate_tarwa.dm
+++ b/maps/away/ships/unathi_pirate/tarwa/unathi_pirate_tarwa.dm
@@ -108,7 +108,6 @@
 	dock_target = "airlock_tarwa_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_tarwa"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/tarwa_shuttle/hangar

--- a/maps/away/ships/voidtamer/trader/voidtamer_trader.dm
+++ b/maps/away/ships/voidtamer/trader/voidtamer_trader.dm
@@ -106,7 +106,6 @@
 	landmark_transition = "nav_transit_voidtamer_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_voidtamer_shuttle_dock"
 	defer_initialisation = TRUE
 	dock_target = "voidtamer_trade_ship_shuttle"
 

--- a/maps/away/ships/wildlands_militia/militia_ship.dm
+++ b/maps/away/ships/wildlands_militia/militia_ship.dm
@@ -100,7 +100,6 @@
 	landmark_transition = "nav_transit_militia_shuttle"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_militia"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/militia_shuttle/hangar

--- a/maps/away/ships/xanu/xanu_frigate.dm
+++ b/maps/away/ships/xanu/xanu_frigate.dm
@@ -111,7 +111,6 @@
 	landmark_transition = "xanufrigate_transit_b"
 	range = 1
 	fuel_consumption = 1
-	logging_home_tag = "xanufrigate_hangar"
 	defer_initialisation = TRUE
 
 //Boarder
@@ -152,5 +151,4 @@
 	landmark_transition = "xanufrigate_transit_a"
 	range = 1
 	fuel_consumption = 1
-	logging_home_tag = "xanufrigate_aft"
 	defer_initialisation = TRUE

--- a/maps/away/ships/yacht_civ/yacht_civ_.dm
+++ b/maps/away/ships/yacht_civ/yacht_civ_.dm
@@ -117,7 +117,6 @@
 	landmark_transition = "nav_yacht_civ_shuttle_transit"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_yacht_civ_shuttle_dock"
 	defer_initialisation = TRUE
 
 /obj/effect/map_effect/marker/airlock/shuttle/yacht_civ_shuttle

--- a/maps/random_ruins/exoplanets/haneunim/haneunim_crash.dm
+++ b/maps/random_ruins/exoplanets/haneunim/haneunim_crash.dm
@@ -47,7 +47,6 @@
 	landmark_transition = "nav_transit_haneunim_crash"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_start_haneunim_crash"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/haneunim_crash/start

--- a/maps/random_ruins/exoplanets/konyang/pirate_outpost.dm
+++ b/maps/random_ruins/exoplanets/konyang/pirate_outpost.dm
@@ -56,7 +56,6 @@
 	landmark_transition = "nav_transit_konyang_pirate"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_start_konyang_pirate"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/konyang_pirate/start

--- a/maps/random_ruins/exoplanets/uueoaesa/kazhkz_crash.dm
+++ b/maps/random_ruins/exoplanets/uueoaesa/kazhkz_crash.dm
@@ -45,7 +45,6 @@
 	landmark_transition = "nav_transit_kazhkz_crash"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_start_kazhkz_crash"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/kazhkz_crash

--- a/maps/runtime/runtime_overmap.dm
+++ b/maps/runtime/runtime_overmap.dm
@@ -39,7 +39,6 @@
 	dock_target = "airlock_runtime_shuttle"
 	current_location = "nav_runtime_dock"
 	landmark_transition = "nav_transit_runtime"
-	logging_home_tag = "nav_runtime_dock"
 	range = 1
 	fuel_consumption = 4
 	ceiling_type = /turf/simulated/floor/shuttle_ceiling

--- a/maps/sccv_horizon/code/sccv_horizon_shuttles.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_shuttles.dm
@@ -112,7 +112,6 @@
 	landmark_transition = "nav_transit_intrepid"
 	range = 2
 	fuel_consumption = 4
-	logging_home_tag = "nav_hangar_intrepid"
 
 /obj/effect/shuttle_landmark/intrepid/hangar
 	name = "First Deck Intrepid Hangar Bay"
@@ -136,7 +135,6 @@
 	landmark_transition = "nav_transit_canary"
 	range = 2
 	fuel_consumption = 4
-	logging_home_tag = "nav_hangar_canary"
 
 /obj/effect/shuttle_landmark/canary/hangar
 	name = "First Deck Canary Hangar Bay"
@@ -160,7 +158,6 @@
 	landmark_transition = "nav_transit_quark"
 	range = 1
 	fuel_consumption = 3
-	logging_home_tag = "nav_hangar_quark"
 
 /obj/effect/shuttle_landmark/quark/hangar
 	name = "First Deck Quark Hangar Bay"
@@ -184,7 +181,6 @@
 	landmark_transition = "nav_transit_mining"
 	range = 1
 	fuel_consumption = 2
-	logging_home_tag = "nav_hangar_mining"
 
 /obj/effect/shuttle_landmark/mining/hangar
 	name = "First Deck Spark Hangar Bay"


### PR DESCRIPTION
changes:
  - refactor: "Removes unused shuttle vars."

logging_home_tag
logging_access

literally not used
but for all these years everyone was setting them on new offships
useless
confusing
die