### PR TITLE
Fixes elevator walls appearing with greyscale sprites

### DIFF
--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -762,6 +762,7 @@
 	display_name = "elevator paneling"
 	stack_type = null
 	icon_colour = "#666666"
+	wall_colour = "#666666"
 	wall_icon = 'icons/turf/smooth/composite_solid_color.dmi'
 	integrity = 1200
 	melting_point = 6000

--- a/html/changelogs/kano-elevatorium-fix.yml
+++ b/html/changelogs/kano-elevatorium-fix.yml
@@ -1,0 +1,4 @@
+author: kano
+delete-after: True
+changes:
+  - bugfix: "Fixed elevator walls appearing with greyscale sprites."


### PR DESCRIPTION
## About PR

An oversight from #23123, gives a `wall_colour ` to elevator material