### PR TITLE
Fix Ping storyteller veb logging

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -310,4 +310,4 @@
 
 	COOLDOWN_START(src, storyteller_ping_cooldown, 1 MINUTES)
 	to_chat(src, SPAN_NOTICE("Your ping has been sent to the storyteller."))
-	log_admin("(STORYTELLER PING) [mob.name]/[key] : [message]")
+	log_and_message_admins("(STORYTELLER PING) [mob.name]/[key] : [message]")

--- a/html/changelogs/fabiank3-fix-st-ping-log.yml
+++ b/html/changelogs/fabiank3-fix-st-ping-log.yml
@@ -1,0 +1,6 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - admin: "Fixed missing chat log for the Ping Storyteller verb."


### PR DESCRIPTION
# Summary

This PR adds a admin chat log to the ping storyteller verb.

The verb already logged the contents, but wasn't visible in staff chat.