### PR TITLE
Human Shield Facing

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -361,8 +361,6 @@
 			. = mob.SelfMove(new_loc, direct)
 
 		for (var/obj/item/grab/G in list(mob.l_hand, mob.r_hand))
-			if (G.state == GRAB_NECK)
-				mob.set_dir(REVERSE_DIR(direct))
 			G.affecting.set_glide_size(new_glide_size)
 			for (var/obj/item/grab/T in list(G.affecting.l_hand, G.affecting.r_hand))
 				T.adjust_position()

--- a/html/changelogs/Geeves-human-shield-facing.yml
+++ b/html/changelogs/Geeves-human-shield-facing.yml
@@ -1,0 +1,4 @@
+author: Geeves
+delete-after: True
+changes:
+  - qol: "Holding a human shield now keeps you and the shield facing the direction you move, or your locked direction when direction lock is enabled."


### PR DESCRIPTION
* Holding a human shield now keeps you and the shield facing the direction you move, or your locked direction when direction lock is enabled.