### PR TITLE
removes the napalm grenades from secure tech storage

### DIFF
--- a/html/changelogs/no-more-napalm-for-you.yml
+++ b/html/changelogs/no-more-napalm-for-you.yml
@@ -1,0 +1,6 @@
+author: kermit
+
+delete-after: True
+
+changes:
+  - rscdel: "Removes the napalm grenades from Secure Tech Storage."

--- a/maps/sccv_horizon/sccv_horizon.dmm
+++ b/maps/sccv_horizon/sccv_horizon.dmm
@@ -9248,15 +9248,7 @@
 	name = "Storage";
 	req_one_access = list(20,30,56)
 	},
-/obj/item/grenade/napalm{
-	pixel_y = 4;
-	pixel_x = -8
-	},
-/obj/item/grenade/napalm{
-	pixel_x = 8;
-	pixel_y = 4
-	},
-/obj/item/grenade/napalm,
+/obj/item/fuel_assembly/supermatter,
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/storage/secure/tech_vault)
 "biH" = (
@@ -64246,7 +64238,6 @@
 /obj/random/finances{
 	pixel_y = 11
 	},
-/obj/item/fuel_assembly/supermatter,
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/storage/secure/tech_vault)
 "isn" = (


### PR DESCRIPTION
there is no acceptable IC use-case for these by the horizon to justify them being available at round start and, if there is ever a grave enough situation to warrant them, science can make them instead