### PR TITLE
Refactor Exoplanet Flora

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet_flora.dm
+++ b/code/modules/overmap/exoplanets/exoplanet_flora.dm
@@ -55,14 +55,97 @@
 
 /obj/effect/landmark/exoplanet_spawn/plant/do_spawn(var/obj/effect/overmap/visitable/sector/exoplanet/planet)
 	if(length(planet.small_flora_seeds))
-		var/seed_path = pick(planet.small_flora_seeds)
-		new /obj/structure/machinery/portable_atmospherics/hydroponics/soil/invisible(get_turf(src), seed_path, TRUE)
+		var/datum/seed/seed_pick = pick(planet.small_flora_seeds)
+		new /obj/structure/flora/harvestable(get_turf(src), seed_pick)
 
 /obj/effect/landmark/exoplanet_spawn/large_plant
 	name = "spawn exoplanet large plant"
 
 /obj/effect/landmark/exoplanet_spawn/large_plant/do_spawn(var/obj/effect/overmap/visitable/sector/exoplanet/planet)
 	if(length(planet.big_flora_seeds))
-		var/seed_path = pick(planet.big_flora_seeds)
-		new /obj/structure/machinery/portable_atmospherics/hydroponics/soil/invisible(get_turf(src), seed_path, TRUE)
+		var/datum/seed/seed_pick = pick(planet.big_flora_seeds)
+		new /obj/structure/flora/harvestable(get_turf(src), seed_pick)
 
+/**
+ * Lightweight harvestable plant for exoplanets
+ * We can assert that since these grew on a planet that the seed is pre-adapted to during exoplanet generation
+ * That the plant has no reason at all that it shouldn't be able to survive in the generated climate.
+ * Therefore to save on processing costs, we just make a static object that can be harvested just like a botany plant
+ * Except its completely missing the entire atmos-code-intensive processing costs that are normally associated with botany code.
+ */
+/obj/structure/flora/harvestable
+	name = "plant"
+	desc = "A wild plant."
+	icon = 'icons/obj/seeds.dmi'
+	icon_state = "blank"
+	density = FALSE
+	/// The seed datum this plant grows from.
+	var/datum/seed/seed
+
+/obj/structure/flora/harvestable/Initialize(var/newloc, var/datum/seed/newseed)
+	. = ..()
+	if(!newseed)
+		return INITIALIZE_HINT_QDEL
+	seed = newseed
+	name = seed.display_name
+	pixel_x = rand(-5, 5)
+	pixel_y = rand(-5, 5)
+
+	// Large plants (trees) are dense and opaque.
+	if(GET_SEED_TRAIT(seed, TRAIT_LARGE))
+		density = TRUE
+		opacity = TRUE
+
+	update_icon()
+
+	// Apply bioluminescence.
+	if(GET_SEED_TRAIT(seed, TRAIT_BIOLUM))
+		var/pwr
+		if(GET_SEED_TRAIT(seed, TRAIT_BIOLUM_PWR) == 0)
+			pwr = GET_SEED_TRAIT(seed, TRAIT_BIOLUM)
+		else
+			pwr = GET_SEED_TRAIT(seed, TRAIT_BIOLUM_PWR)
+		var/clr = GET_SEED_TRAIT(seed, TRAIT_BIOLUM_COLOUR)
+		set_light(GET_SEED_TRAIT(seed, TRAIT_POTENCY) / 10, pwr, clr)
+
+/obj/structure/flora/harvestable/update_icon()
+	ClearOverlays()
+	if(!seed)
+		return
+	// Ensure growth stages are calculated.
+	if(!seed.growth_stages)
+		seed.update_growth_stages()
+	// Render the fully-grown plant icon.
+	var/image/plant_overlay = seed.get_icon(seed.growth_stages)
+	AddOverlays(plant_overlay)
+	// Render the harvestable product overlay.
+	var/ikey = "[GET_SEED_TRAIT(seed, TRAIT_PRODUCT_ICON)]"
+	var/cache_key = "product-[ikey]-[GET_SEED_TRAIT(seed, TRAIT_PLANT_COLOUR)]"
+	var/image/harvest_overlay = SSplants.plant_icon_cache[cache_key]
+	if(!harvest_overlay)
+		harvest_overlay = image('icons/obj/hydroponics_products.dmi', "[ikey]")
+		harvest_overlay.color = GET_SEED_TRAIT(seed, TRAIT_PRODUCT_COLOUR)
+		SSplants.plant_icon_cache[cache_key] = harvest_overlay
+	AddOverlays(harvest_overlay)
+
+/obj/structure/flora/harvestable/attack_hand(mob/user)
+	if(!seed)
+		to_chat(user, SPAN_NOTICE("There is nothing to harvest."))
+		return
+	if(!Adjacent(user))
+		return
+	if(seed.harvest(user))
+		qdel(src)
+
+/obj/structure/flora/harvestable/examine(mob/user)
+	. = ..()
+	if(seed)
+		. += SPAN_NOTICE("You could harvest this plant.")
+
+/obj/structure/flora/harvestable/Destroy()
+	// Check if we're masking a decal that needs to be visible again.
+	for(var/obj/effect/plant/plant in get_turf(src))
+		if(plant.invisibility == INVISIBILITY_MAXIMUM)
+			plant.set_invisibility(initial(plant.invisibility))
+	seed = null
+	return ..()

--- a/code/modules/overmap/exoplanets/exoplanet_flora.dm
+++ b/code/modules/overmap/exoplanets/exoplanet_flora.dm
@@ -137,7 +137,7 @@
 	if(seed.harvest(user))
 		qdel(src)
 
-/obj/structure/flora/harvestable/examine(mob/user)
+/obj/structure/flora/harvestable/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)
 	. = ..()
 	if(seed)
 		. += SPAN_NOTICE("You could harvest this plant.")

--- a/html/changelogs/hellfirejag-xenoflora-perf-refactor.yml
+++ b/html/changelogs/hellfirejag-xenoflora-perf-refactor.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed exoplanet xenoflora requiring extremely expensive processing."


### PR DESCRIPTION
Exoplanets that generate flora generated roughly ~1000 invisible hydroponics trays, which having a SINGLE such planet accounted for >30% of the entire cost of the Machinery subsystem. Not to mention that they would routinely HAMMER the atmos system by spamming gas changes to their surroundings(which forced planet airmixtures to recalculate effects). This PR changes exoplanet flora to instead use an extremely basic static object that can be harvested exactly like a botany plant, using the very same "fully grown" images that such plants would use. 

Except unlike a botany plant, xenoflora harvestables have completely zero processing. They spawn only on an exoplanet, and the seed datum they use is generated solely for that exoplanet, with plant traits tailored to it, such that the plant was already 100% guaranteed to be capable of surviving and growing on the planet it spawned on. The fruits harvested from them can't be used to create these static plants, they work just like any other hydroponics fruit, EG you would have to either plant them in a garden plot on the planet you found them, or simulate their original environment using a hydro tray.

I have actually tested this PR to verify that it works.

https://github.com/user-attachments/assets/99898b3d-be3c-4d84-b4bd-211746831511

<img width="1885" height="981" alt="image" src="https://github.com/user-attachments/assets/b8f4c1c1-4fe9-40af-afa1-c6618605ad23" />

AI usage disclosure: The code for this was created in-part using Claude Opus 4.6.