### PR TITLE
Nerfs mech frag grenades

### DIFF
--- a/code/game/objects/items/weapons/grenades/fragmentation.dm
+++ b/code/game/objects/items/weapons/grenades/fragmentation.dm
@@ -78,7 +78,7 @@
 	var/num_fragments = 70  //total number of fragments produced by the grenade
 	var/fragment_damage = 10
 	var/damage_step = 2      //projectiles lose a fragment each time they travel this distance. Can be a non-integer.
-	var/explosion_size = 3   //size of the center explosion
+	var/explosion_size = 2   //size of the center explosion
 
 	//The radius of the circle used to launch projectiles. Lower values mean less projectiles are used but if set too low gaps may appear in the spread pattern
 	var/spread_range = 7

--- a/code/modules/heavy_vehicle/equipment/combat.dm
+++ b/code/modules/heavy_vehicle/equipment/combat.dm
@@ -236,16 +236,15 @@
 
 	release_force = 5
 	throw_distance = 7
-	proj = 5
-	max_proj = 5
-	proj_gen_time = 300
-
+	proj = 3
+	max_proj = 3
+	proj_gen_time = 400
 
 /obj/item/gun/launcher/mech/mountedgl/consume_next_projectile()
 	if(proj < 1)
 		return null
 	var/obj/item/grenade/g = new grenade_type(src)
-	g.det_time = 10
+	g.det_time = 20
 	g.activate(null)
 	proj--
 	addtimer(CALLBACK(src, PROC_REF(regen_proj)), proj_gen_time, TIMER_UNIQUE)

--- a/html/changelogs/Fenodyree-MechGrenadeLauncherNerf.yml
+++ b/html/changelogs/Fenodyree-MechGrenadeLauncherNerf.yml
@@ -1,0 +1,8 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - balance: "Increases the detonation time of mech launched grenades to 2 seconds, from 1 second."
+  - balance: "Decreased the magazine size of mech frag grenade launchers from 5 to 3. Also reduced their reload speed by 20%."
+  - balance: "Reduced the light explosion radius of frag grenades from 3 to 2."


### PR DESCRIPTION
Increases the delay before mech launched grenades detonate from 1 to 2 seconds. Gives someone who's really paying attention enough time to dodge if it's dropped directly on top of them.

Decreased the magazine size, 5 restocking grenades that can be rapid fired is absurdly powerful.
Its now 3 on a slightly longer reload time.

Finally, reduced the light explosion size from 3 to 2 tiles.
Light explosions have a 50% chance to stun, frags don't need to stun everyone near them, they already kill everyone near them.

Also means they won't detonate the INDRA from the deck above with the celular explosions.