### PR TITLE
Airlock Controllers Fix

### DIFF
--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -200,15 +200,16 @@
 
 /obj/structure/machinery/atmospherics/unary/vent_pump/process(seconds_per_tick)
 	. = ..()
+
+	if (broadcast_status_next_process)
+		broadcast_status()
+		broadcast_status_next_process = FALSE
+
 	if (!use_power || welded)
 		return PROCESS_KILL
 
 	if(stat & (NOPOWER|BROKEN))
 		return 0
-
-	if (broadcast_status_next_process)
-		broadcast_status()
-		broadcast_status_next_process = FALSE
 
 	if (hibernate > world.time)
 		return 1

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -183,6 +183,11 @@
 
 /obj/structure/machinery/atmospherics/unary/vent_scrubber/process()
 	. = ..()
+
+	if (broadcast_status_next_process)
+		broadcast_status()
+		broadcast_status_next_process = FALSE
+
 	if (!use_power || welded)
 		return PROCESS_KILL
 
@@ -191,10 +196,6 @@
 
 	if (!node)
 		update_use_power(POWER_USE_OFF)
-
-	if (broadcast_status_next_process)
-		broadcast_status()
-		broadcast_status_next_process = FALSE
 
 	if((stat & (NOPOWER|BROKEN)) || !loc)
 		return 0

--- a/html/changelogs/hellfirejag-airlock-controller-fixes.yml
+++ b/html/changelogs/hellfirejag-airlock-controller-fixes.yml
@@ -1,0 +1,4 @@
+author: Hellfirejag
+delete-after: True
+changes:
+  - bugfix: "Fixed an issue where airlock controllers failed to fully cycle pumps."


### PR DESCRIPTION
This was a bug with airlock controllers caused by the aggressive exit in pumps forcing the pump to finish processing before it could reply to the airlock controller that it was done. 