### PR TITLE
Permits bodyguard and diplomatic aides to be previewed in character setup

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -68,6 +68,8 @@
 	var/list/blacklisted_species = null
 	/// A blacklist of citizenships that can't be this job.
 	var/list/blacklisted_citizenship = list()
+	/// Whether the citizenship blacklist should prevent selecting this job in character setup.
+	var/check_citizenship_in_preferences = TRUE
 
 	/// The job name of the aide and bodyguard slots. Used for consulars and representatives.
 	var/aide_job

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -350,6 +350,7 @@
 	job_access = list(ACCESS_CONSULAR)
 	outfit = /obj/outfit/job/diplomatic_aide
 	blacklisted_citizenship = ALL_CITIZENSHIPS //removed based on consular citizensihp
+	check_citizenship_in_preferences = FALSE
 
 /datum/job/diplomatic_aide/get_outfit(mob/living/carbon/human/H, alt_title = null)
 	var/datum/citizenship/citizenship = SSrecords.citizenships[H.citizenship]
@@ -396,6 +397,7 @@
 	job_access = list(ACCESS_CONSULAR)
 	outfit = /obj/outfit/job/diplomatic_bodyguard
 	blacklisted_citizenship = ALL_CITIZENSHIPS //removed based on consular citizensihp
+	check_citizenship_in_preferences = FALSE
 
 /datum/job/diplomatic_bodyguard/get_outfit(mob/living/carbon/human/H, alt_title = null)
 	var/datum/citizenship/citizenship = SSrecords.citizenships[H.citizenship]
@@ -425,7 +427,7 @@
 	title = "Corporate Aide"
 	flag = GLOB.DIPLOMAT_AIDE
 	departments = SIMPLEDEPT(DEPARTMENT_COMMAND_SUPPORT)
-	department_flag = ENGSEC
+	department_flag = SERVICE
 	faction = "Station"
 	total_positions = 0 //manually opened by representative
 	spawn_positions = 0

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -123,18 +123,18 @@
 					log_debug(e.desc)
 
 	pref.alternate_option  = sanitize_integer(text2num(pref.alternate_option), 0, 1, initial(pref.alternate_option))
-	pref.job_civilian_high = sanitize_integer(text2num(pref.job_civilian_high), 0, 65535, initial(pref.job_civilian_high))
-	pref.job_civilian_med  = sanitize_integer(text2num(pref.job_civilian_med), 0, 65535, initial(pref.job_civilian_med))
-	pref.job_civilian_low  = sanitize_integer(text2num(pref.job_civilian_low), 0, 65535, initial(pref.job_civilian_low))
-	pref.job_medsci_high   = sanitize_integer(text2num(pref.job_medsci_high), 0, 65535, initial(pref.job_medsci_high))
-	pref.job_medsci_med    = sanitize_integer(text2num(pref.job_medsci_med), 0, 65535, initial(pref.job_medsci_med))
-	pref.job_medsci_low    = sanitize_integer(text2num(pref.job_medsci_low), 0, 65535, initial(pref.job_medsci_low))
-	pref.job_engsec_high   = sanitize_integer(text2num(pref.job_engsec_high), 0, 65535, initial(pref.job_engsec_high))
-	pref.job_engsec_med    = sanitize_integer(text2num(pref.job_engsec_med), 0, 65535, initial(pref.job_engsec_med))
-	pref.job_engsec_low    = sanitize_integer(text2num(pref.job_engsec_low), 0, 65535, initial(pref.job_engsec_low))
-	pref.job_event_high   = sanitize_integer(text2num(pref.job_event_high), 0, 65535, initial(pref.job_event_high))
-	pref.job_event_med    = sanitize_integer(text2num(pref.job_event_med), 0, 65535, initial(pref.job_event_med))
-	pref.job_event_low    = sanitize_integer(text2num(pref.job_event_low), 0, 65535, initial(pref.job_event_low))
+	pref.job_civilian_high = sanitize_integer(text2num(pref.job_civilian_high), 0, BITFIELDMAX, initial(pref.job_civilian_high))
+	pref.job_civilian_med  = sanitize_integer(text2num(pref.job_civilian_med), 0, BITFIELDMAX, initial(pref.job_civilian_med))
+	pref.job_civilian_low  = sanitize_integer(text2num(pref.job_civilian_low), 0, BITFIELDMAX, initial(pref.job_civilian_low))
+	pref.job_medsci_high   = sanitize_integer(text2num(pref.job_medsci_high), 0, BITFIELDMAX, initial(pref.job_medsci_high))
+	pref.job_medsci_med    = sanitize_integer(text2num(pref.job_medsci_med), 0, BITFIELDMAX, initial(pref.job_medsci_med))
+	pref.job_medsci_low    = sanitize_integer(text2num(pref.job_medsci_low), 0, BITFIELDMAX, initial(pref.job_medsci_low))
+	pref.job_engsec_high   = sanitize_integer(text2num(pref.job_engsec_high), 0, BITFIELDMAX, initial(pref.job_engsec_high))
+	pref.job_engsec_med    = sanitize_integer(text2num(pref.job_engsec_med), 0, BITFIELDMAX, initial(pref.job_engsec_med))
+	pref.job_engsec_low    = sanitize_integer(text2num(pref.job_engsec_low), 0, BITFIELDMAX, initial(pref.job_engsec_low))
+	pref.job_event_high   = sanitize_integer(text2num(pref.job_event_high), 0, BITFIELDMAX, initial(pref.job_event_high))
+	pref.job_event_med    = sanitize_integer(text2num(pref.job_event_med), 0, BITFIELDMAX, initial(pref.job_event_med))
+	pref.job_event_low    = sanitize_integer(text2num(pref.job_event_low), 0, BITFIELDMAX, initial(pref.job_event_low))
 
 
 	if (!pref.player_alt_titles)
@@ -222,7 +222,7 @@
 
 		if(species_restricted)
 			status = "SPECIES RESTRICTED"
-		else if(job.blacklisted_citizenship && (C.name in job.blacklisted_citizenship))
+		else if(job.check_citizenship_in_preferences && job.blacklisted_citizenship && (C.name in job.blacklisted_citizenship))
 			status = "BACKGROUND RESTRICTED"
 		else
 			var/list/missing_skills = list()

--- a/html/changelogs/AidePreview.yml
+++ b/html/changelogs/AidePreview.yml
@@ -1,0 +1,6 @@
+author: TheGreyWolf
+
+delete-after: True
+
+changes:
+  - rscadd: "It is now possible to preview bodyguards and diplomatic aides in char setup even if no slot is open."


### PR DESCRIPTION
Tested and confirmed working. This PR allows the bodyguard and diplomatic aide to be previewed and set up in character setup even if the slots have not yet been unlocked by a consular. The joining restrictions still remain as normal.