### PR TITLE
Adds a small examine indicator for ghostrole groups

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -44,6 +44,10 @@
 	var/assigned_role
 	var/special_role
 
+	/// Used in ghostroles to help them recognize their group upon examine.
+	var/recognition_group
+	var/recognition_message
+
 	var/role_alt_title
 
 	var/datum/job/assigned_job
@@ -501,6 +505,8 @@
 /datum/mind/proc/reset()
 	assigned_role =   null
 	special_role =    null
+	recognition_group = null
+	recognition_message = null
 	role_alt_title =  null
 	assigned_job =    null
 	//faction =       null //Uncommenting this causes a compile error due to 'undefined type', fucked if I know.

--- a/code/modules/ghostroles/spawner/human/human.dm
+++ b/code/modules/ghostroles/spawner/human/human.dm
@@ -27,6 +27,10 @@
 	var/assigned_role = null
 	var/special_role = null
 	var/faction = null
+	/// Shared identifier for ghostroles that should recognize one another. If null, no group is assigned.
+	var/recognition_group = null
+	/// Examine text shown about this role to other members of the relevant recognition group.
+	var/recognition_message = null
 
 	/// Culture restrictions for this spawner. Use types. Make sure that there is at least one culture per allowed species!
 	var/list/culture_restriction = list()
@@ -138,10 +142,15 @@
 	if(assigned_role)
 		M.mind.assigned_role = assigned_role
 		M.mind.role_alt_title = assigned_role
+
 	if(special_role)
 		M.mind.special_role = special_role
+
 	if(faction)
 		M.faction = faction
+
+	M.mind.recognition_group = recognition_group
+	M.mind.recognition_message = recognition_message
 
 	//Move the mob
 	M.forceMove(T)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -432,6 +432,10 @@
 		var/obj/item/grab/G = get_active_hand()
 		msg += SPAN_ALERT(FONT_LARGE("\n[get_pronoun("He")] is biting [G.affecting]'[G.affecting.get_pronoun("end")] neck!"))
 
+	// recognition message for ghostroles, so they can recongize one another
+	if(isliving(user) && user != src && mind?.recognition_group && mind.recognition_group == user.mind?.recognition_group && mind.recognition_message)
+		msg += SPAN_GOOD("[mind.recognition_message]\n")
+
 	if(pose)
 		if(findtext(pose, ".", length(pose)) == 0 && findtext(pose, "!", length(pose)) == 0 && findtext(pose, "?", length(pose)) == 0)
 			pose = addtext(pose, ".") // Makes sure all emotes end with punctuation.

--- a/html/changelogs/kano-role-recognition.yml
+++ b/html/changelogs/kano-role-recognition.yml
@@ -1,4 +1,4 @@
 author: kano
 delete-after: True
 changes:
-  - rscadd: "Added the ability for ghostroles to recognize their group in the examine test, if such group defined in the ghostrole spawner."
+  - rscadd: "Added the ability for ghostroles to recognize their group in the examine text, if such group defined in the ghostrole spawner."

--- a/html/changelogs/kano-role-recognition.yml
+++ b/html/changelogs/kano-role-recognition.yml
@@ -1,0 +1,4 @@
+author: kano
+delete-after: True
+changes:
+  - rscadd: "Added the ability for ghostroles to recognize their group in the examine test, if such group defined in the ghostrole spawner."


### PR DESCRIPTION
## About PR

Adds the ability for ghostroles to recognize their group in the examine text, if such group defined in the ghostrole spawner

## Images

<img width="1516" height="401" alt="img1" src="https://github.com/user-attachments/assets/7f4a34e3-92c1-464a-af02-2f888c3f6f86" />
<img width="1615" height="616" alt="img2" src="https://github.com/user-attachments/assets/5e1c8da3-21c7-4dd5-8445-25e6722c4f26" />
