### PR TITLE
Fixes slime cells not charging PSUs (cellracks)

### DIFF
--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -11,6 +11,7 @@
 	icon_state = "gsmes"
 	var/cells_amount = 0
 	var/capacitors_amount = 0
+	var/self_charge_rate = 0
 
 	component_types = list(
 		/obj/item/circuitboard/batteryrack,
@@ -23,6 +24,7 @@
 	..()
 	capacitors_amount = 0
 	cells_amount = 0
+	self_charge_rate = 0
 
 	var/max_level = 0 //for both input and output
 	for(var/obj/item/stock_parts/capacitor/CP in component_parts)
@@ -35,11 +37,16 @@
 	for(var/obj/item/cell/PC in component_parts)
 		C += PC.maxcharge
 		cells_amount++
+		self_charge_rate += (PC.self_charge_percentage * PC.maxcharge) / 100
 	capacity = C * 40   //Basic cells are such crap. Hyper cells needed to get on normal SMES levels.
+
+/obj/structure/machinery/power/smes/batteryrack/process()
+	..()
+	if (input_attempt)
+		charge = min(capacity, charge + self_charge_rate)
 
 /obj/structure/machinery/power/smes/batteryrack/chargedisplay()
 	return round(4 * charge/(capacity ? capacity : 5e6))
-
 
 /obj/structure/machinery/power/smes/batteryrack/attackby(obj/item/attacking_item, mob/user) //these can only be moved by being reconstructed, solves having to remake the powernet.
 	..() //SMES attackby for now handles screwdriver, cable coils and wirecutters, no need to repeat that here
@@ -145,6 +152,7 @@
 
 #define SMESRATE 0.05			// rate of internal charge to external power
 /obj/structure/machinery/power/smes/batteryrack/makeshift/process()
+	.=..()
 	if(stat & BROKEN)	return
 
 	//store machine state to see if we need to update the icon overlays

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -40,6 +40,8 @@
 		var/recharge_for_this_process = round(recharge_amount_per_second * (seconds_per_tick / 10)) // divides seconds_per_tick by 10 to turn deciseconds into seconds
 		// finally, charge the cell
 		give(recharge_for_this_process)
+	else
+		return PROCESS_KILL //Cells that don't self charge don't need to process.
 	if (charge >= maxcharge)
 		return PROCESS_KILL // No need to constantly process self-charging cells that are full.
 
@@ -57,7 +59,6 @@
 
 	if(charge <= 0)
 		return 0
-	START_PROCESSING(SSprocessing, src) // Always attempt at least one process if the battery level is ever reduced.
 	var/cell_amt = power * CELLRATE
 
 	return use(cell_amt) / CELLRATE
@@ -89,12 +90,18 @@
 	if (QDELING(src))
 		return 0
 
+	if (amount <= 0)
+		return 0
+
 	if(rigged && amount > 0)
 		explode()
 		return 0
 	var/used = min(charge, amount)
+	update_icon()
 	charge -= used
 	SEND_SIGNAL(src, COMSIG_CELL_CHARGE, charge)
+	if (used > 0 && self_charge_percentage && charge < maxcharge)
+		START_PROCESSING(SSprocessing, src) // Always attempt at least one process if the battery level is ever reduced.
 	return used
 
 // Checks if the specified amount can be provided. If it can, it removes the amount
@@ -107,6 +114,11 @@
 /obj/item/cell/proc/give(var/amount)
 	if (QDELING(src))
 		return 0
+
+	if (amount <= 0)
+		return 0
+
+	update_icon()
 
 	if(rigged && amount > 0)
 		explode()
@@ -200,9 +212,9 @@
 	if(isrobot(loc))
 		var/mob/living/silicon/robot/R = loc
 		severity *= R.cell_emp_mult
-
 	if(severity)
-		charge -= rand(0, (maxcharge / severity))
+		var/used = rand(0, (maxcharge / severity))
+		use(used)
 	if (charge < 0)
 		charge = 0
 	SEND_SIGNAL(src, COMSIG_CELL_CHARGE, charge)
@@ -222,6 +234,8 @@
 	charge -= maxcharge / divisor
 	if (charge < 0)
 		charge = 0
+	if(self_charge_percentage && charge < maxcharge)
+		START_PROCESSING(SSprocessing, src) // Always attempt at least one process if the battery level is ever reduced.
 	SEND_SIGNAL(src, COMSIG_CELL_CHARGE, charge)
 
 /obj/item/cell/ex_act(severity)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -90,14 +90,10 @@
 	if (QDELING(src))
 		return 0
 
-	if (amount <= 0)
-		return 0
-
 	if(rigged && amount > 0)
 		explode()
 		return 0
 	var/used = min(charge, amount)
-	update_icon()
 	charge -= used
 	SEND_SIGNAL(src, COMSIG_CELL_CHARGE, charge)
 	if (used > 0 && self_charge_percentage && charge < maxcharge)
@@ -114,11 +110,6 @@
 /obj/item/cell/proc/give(var/amount)
 	if (QDELING(src))
 		return 0
-
-	if (amount <= 0)
-		return 0
-
-	update_icon()
 
 	if(rigged && amount > 0)
 		explode()

--- a/html/changelogs/Fenodyree-FixesSelfChargingCells.yml
+++ b/html/changelogs/Fenodyree-FixesSelfChargingCells.yml
@@ -1,0 +1,6 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes self charging cells (slime cores) not recharging themselves in hardsuits."

--- a/html/changelogs/Fenodyree-SlimeCellPSUFix.yml
+++ b/html/changelogs/Fenodyree-SlimeCellPSUFix.yml
@@ -1,0 +1,6 @@
+author: Fenodyree
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes self charging powercells (slime cells) not charging the PSU."


### PR DESCRIPTION
changes:
  - bugfix: "Fixes self charging powercells (slime cells) not charging the PSU."


The slime cells will only start to charge the PSU if charging is enabled, this is so that it doesn't immediately prevent you adding more cells to the rack.